### PR TITLE
fix(defi): keep a typed unstake amount across the late auto-compound balance load

### DIFF
--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionScreen.swift
@@ -18,7 +18,8 @@ struct UnstakeTransactionScreen: View {
             availableAmount: viewModel.availableAmount,
             percentageSelected: $viewModel.percentageSelected,
             percentageFieldType: .slider,
-            amountField: viewModel.amountField
+            amountField: viewModel.amountField,
+            isContinueDisabled: viewModel.isContinueDisabled
         ) {
             guard let transactionBuilder = viewModel.transactionBuilder else { return }
             onVerify(transactionBuilder)

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
@@ -40,6 +40,15 @@ enum THORChainAutocompoundBalance {
     }
 }
 
+/// The main actor is already inferred here — `Form` is `@MainActor` and the
+/// conformance is stated on the declaration — but it is spelled out because the
+/// invariant is load-bearing and arrives from another file: every stored property
+/// is either a `@Published` the sheet renders from or the `Coin` SwiftData
+/// `@Model` the builders read. Moving that conformance into an extension would
+/// silently drop the isolation and leave a `@Model` on whatever thread the
+/// balance read resumed on. Costs the network read nothing: the reader is a
+/// non-isolated async function, so it runs off the main actor either way.
+@MainActor
 final class UnstakeTransactionViewModel: ObservableObject, Form {
     let coin: Coin
     let vault: Vault
@@ -267,9 +276,13 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
     }
 
     func fetchAutocompoundBalance() async {
+        // Both `Coin` reads are taken here, before the suspension: the reader is
+        // strings-in/`Decimal`-out precisely so the network hop never carries a
+        // `@Model` across it.
         let ticker = coin.ticker
+        let address = coin.address
         do {
-            guard let amount = try await readAutocompoundBalance(ticker, coin.address) else { return }
+            guard let amount = try await readAutocompoundBalance(ticker, address) else { return }
             autocompoundBalance = coin.valueWithDecimals(value: amount)
             autocompoundBalanceDidLoad = true
         } catch {

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
@@ -90,7 +90,13 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
         availableAmount = availableToUnstake ?? coin.stakedBalanceDecimal
         setupAmountField()
 
-        guard isAutocompound else { return }
+        // Started for exactly the positions the receipt balance funds — the same
+        // predicate that disables Continue and blocks the builder — so a sheet can
+        // never be left waiting on a balance it never asked for. bRUNE is what
+        // separates that from `isAutocompound`: it spends receipt units whichever
+        // card opened the sheet, so keying the read on the compound flag alone
+        // would leave a bonded one permanently unable to build.
+        guard isFundedFromReceiptBalance else { return }
         autocompoundLoadTask = Task { @MainActor [weak self] in
             await self?.fetchAutocompoundBalance()
             self?.applyLoadedAutocompoundBalance()

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
@@ -11,6 +11,35 @@ import OSLog
 
 private let logger = Log.send.viewModel
 
+/// Reads a position's auto-compound receipt balance, in the position's base
+/// units, or `nil` for a ticker that has no receipt to read.
+///
+/// Injected so the ordering of that read against user input is controllable —
+/// the whole point of the unstake sheet's balance load is that it can land
+/// after the user has typed. Strings in, `Decimal` out keeps `Coin` (a SwiftData
+/// `@Model`) off the boundary.
+typealias AutocompoundBalanceReader = (_ ticker: String, _ address: String) async throws -> Decimal?
+
+/// The production read behind the auto-compound ceiling: THORChain's per-position
+/// receipt endpoints.
+enum THORChainAutocompoundBalance {
+    static func read(ticker: String, address: String) async throws -> Decimal? {
+        switch ticker.uppercased() {
+        case "TCY":
+            return try await ThorchainService.shared.fetchTcyAutoCompoundAmount(address: address)
+        case "BRUNE":
+            return try await ThorchainService.shared.fetchBRuneAutoCompoundAmount(address: address)
+        case "RUJI":
+            // The sRUJI receipt share balance — what `liquid.unbond` spends. Not a
+            // display value: shares are worth more than 1 RUJI each and drift
+            // further apart as the pool compounds.
+            return try await ThorchainService.shared.fetchRujiStakingReceiptAmount(address: address)
+        default:
+            return nil
+        }
+    }
+}
+
 final class UnstakeTransactionViewModel: ObservableObject, Form {
     let coin: Coin
     let vault: Vault
@@ -19,7 +48,10 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
 
     @Published var percentageSelected: Double? = 100
     @Published var availableAmount: Decimal = 0
-    var autocompoundBalance: Decimal = 0
+    /// Published because `isContinueDisabled` is derived from it, and a read that
+    /// *failed* moves nothing else — without this the button would keep rendering
+    /// against the state the last redraw happened to see.
+    @Published var autocompoundBalance: Decimal = 0
     @Published var validForm: Bool = false
     @Published var amountField = FormField(label: "amount".localized)
 
@@ -28,14 +60,29 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
         amountField
     ]
 
+    /// The in-flight receipt-balance read, so a caller can await the revision
+    /// instead of racing it.
+    private(set) var autocompoundLoadTask: Task<Void, Never>?
+    /// Whether the receipt read completed. A failed read reports zero exactly as
+    /// an empty position does, and only one of the two may lower the ceiling.
+    private var autocompoundBalanceDidLoad = false
+    private let readAutocompoundBalance: AutocompoundBalanceReader
+
     var formCancellable: AnyCancellable?
     var cancellables = Set<AnyCancellable>()
 
-    init(coin: Coin, vault: Vault, isAutocompound: Bool, availableToUnstake: Decimal? = nil) {
+    init(
+        coin: Coin,
+        vault: Vault,
+        isAutocompound: Bool,
+        availableToUnstake: Decimal? = nil,
+        readAutocompoundBalance: @escaping AutocompoundBalanceReader = THORChainAutocompoundBalance.read
+    ) {
         self.coin = coin
         self.vault = vault
         self.isAutocompound = isAutocompound
         self.availableToUnstake = availableToUnstake
+        self.readAutocompoundBalance = readAutocompoundBalance
     }
 
     func onLoad() {
@@ -43,13 +90,51 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
         availableAmount = availableToUnstake ?? coin.stakedBalanceDecimal
         setupAmountField()
 
-        if isAutocompound {
-            Task { @MainActor in
-                await fetchAutocompoundBalance()
-                guard receiptBalanceIsAvailableAmount else { return }
-                self.availableAmount = autocompoundBalance
-                self.setupAmountField()
-            }
+        guard isAutocompound else { return }
+        autocompoundLoadTask = Task { @MainActor [weak self] in
+            await self?.fetchAutocompoundBalance()
+            self?.applyLoadedAutocompoundBalance()
+        }
+    }
+
+    /// Folds a ceiling that arrived from the network into a field the user may
+    /// already have typed into.
+    ///
+    /// Deliberately *not* `setupAmountField()`: that resets `percentageSelected`
+    /// to 100, and the amount is derived from the percentage, so re-running it
+    /// would replace a typed value — or a percentage the user dragged — with the
+    /// whole position, purely on network timing. Moving only the ceiling lets
+    /// `AmountTextField` resolve both cases the way it already does on any
+    /// `availableAmount` change: a selected percentage re-derives the amount from
+    /// the corrected ceiling, and a typed amount is left alone while
+    /// ``percentageFromAmount`` re-derives its fraction against that ceiling.
+    private func applyLoadedAutocompoundBalance() {
+        // A read that failed reports zero. Adopting it would drop the ceiling to
+        // zero, reject whatever is in the field and dead-end the sheet on a
+        // figure that was never real — strictly worse than the card figure it
+        // replaced. A read that completed is allowed to lower the ceiling,
+        // because then the position really is that small.
+        guard receiptBalanceIsAvailableAmount, autocompoundBalanceDidLoad else { return }
+        availableAmount = autocompoundBalance
+        amountField.validators = [AmountBalanceValidator(balance: availableAmount)]
+
+        // The form pipeline only re-validates when a field's *value* changes.
+        // With a percentage selected the view is about to rewrite the field from
+        // the new ceiling and the pipeline will pick that up; when the user
+        // typed, the value stays put, so the revised validator has to drive its
+        // own validation or `validForm` keeps answering against the replaced
+        // ceiling — and a lowered ceiling would let an over-balance amount
+        // through.
+        guard percentageSelected == nil else { return }
+        revalidateAmount()
+    }
+
+    private func revalidateAmount() {
+        do {
+            try amountField.validateErrors()
+            validForm = true
+        } catch {
+            validForm = false
         }
     }
 
@@ -66,12 +151,17 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
     var transactionBuilder: TransactionBuilder? {
         validateErrors()
         guard validForm else { return nil }
+        // Every auto-compound redemption is funded from the receipt balance, and
+        // a zero there means the read is still in flight, failed, or the position
+        // is empty. All three build a wasm execute carrying no funds, which the
+        // user can sign and pay a fee for while nothing moves.
+        guard !isFundedFromReceiptBalance || autocompoundBalance > 0 else { return nil }
 
         switch coin.ticker.uppercased() {
         case "TCY":
             return TCYUnstakeTransactionBuilder(
                 coin: coin,
-                percentage: Int(percentageSelected ?? percentageFromAmount),
+                percentage: Int(resolvedPercentage),
                 autoCompoundAmount: autocompoundBalance,
                 sendMaxAmount: isMaxAmount,
                 isAutoCompound: isAutocompound
@@ -79,7 +169,7 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
         case "BRUNE":
             return BRUNEUnstakeTransactionBuilder(
                 coin: coin,
-                percentage: Int(percentageSelected ?? percentageFromAmount),
+                percentage: Int(resolvedPercentage),
                 autoCompoundAmount: autocompoundBalance,
                 sendMaxAmount: isMaxAmount
             )
@@ -90,15 +180,9 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
             // `account.withdraw`. Both arrive here on the RUJI coin because the
             // compounded card maps sRUJI back to its bond coin.
             if isAutocompound {
-                // The redemption spends receipt shares, and unlike TCY/bRUNE the
-                // share balance is not what bounds the amount field — so nothing
-                // else stops a zero here. A zero means the read is still in flight,
-                // failed, or the position is empty; all three would build a wasm
-                // execute carrying no funds.
-                guard autocompoundBalance > 0 else { return nil }
                 return RUJILiquidUnbondTransactionBuilder(
                     coin: coin,
-                    percentage: Int(percentageSelected ?? percentageFromAmount),
+                    percentage: Int(resolvedPercentage),
                     receiptShares: autocompoundBalance,
                     sendMaxAmount: isMaxAmount
                 )
@@ -112,11 +196,50 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
         case "CACAO":
             return CacaoUnstakeTransactionBuilder(
                 coin: coin,
-                bps: Int(percentageSelected ?? percentageFromAmount) * 100,
+                bps: Int(resolvedPercentage) * 100,
             )
         default:
             return nil
         }
+    }
+
+    /// Whether the message this position unstakes with is funded from the
+    /// auto-compound receipt balance, and so cannot be built before that balance
+    /// has been read. sRUJI's redemption is the clearest case — the share balance
+    /// is not what bounds the amount field, so nothing else stops a zero — but
+    /// sTCY and ybRUNE fund their `liquid.unbond` from it just the same.
+    private var isFundedFromReceiptBalance: Bool {
+        switch coin.ticker.uppercased() {
+        case "TCY", "RUJI":
+            return isAutocompound
+        case "BRUNE":
+            // bRUNE is only ever staked through the ybRUNE compound position, so
+            // its unstake always spends receipt units.
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Whether no amount at all can be withdrawn yet, so Continue reads as
+    /// disabled instead of silently refusing. An auto-compound redemption is
+    /// funded from the receipt balance, so while that read is in flight — or
+    /// after it failed — there is nothing to sign no matter what the field says.
+    var isContinueDisabled: Bool {
+        isFundedFromReceiptBalance && autocompoundBalance <= 0
+    }
+
+    /// The percentage of the position the transaction withdraws.
+    ///
+    /// The percentage control and the amount field are two views of one value and
+    /// exactly one of them owns it at a time: `AmountTextField` clears
+    /// `percentageSelected` the moment the field is edited by hand, so a selected
+    /// percentage means the field was derived from it, and its absence means the
+    /// user typed and the percentage is derived back from the field. Derived
+    /// against whatever ceiling is in force *now*, which is what lets a balance
+    /// that lands late correct the fraction rather than the amount.
+    var resolvedPercentage: Double {
+        percentageSelected ?? percentageFromAmount
     }
 
     var percentageFromAmount: Double {
@@ -138,39 +261,19 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
     }
 
     func fetchAutocompoundBalance() async {
-        switch coin.ticker.uppercased() {
-        case "TCY":
-            let amount: Decimal
-            do {
-                amount = try await ThorchainService.shared.fetchTcyAutoCompoundAmount(address: coin.address)
-            } catch {
-                logger.error("Failed to fetch TCY autocompound balance: \(error.localizedDescription, privacy: .private)")
-                amount = .zero
-            }
-            self.autocompoundBalance = coin.valueWithDecimals(value: amount)
-        case "BRUNE":
-            let amount: Decimal
-            do {
-                amount = try await ThorchainService.shared.fetchBRuneAutoCompoundAmount(address: coin.address)
-            } catch {
-                logger.error("Failed to fetch ybRUNE autocompound balance: \(error.localizedDescription, privacy: .private)")
-                amount = .zero
-            }
-            self.autocompoundBalance = coin.valueWithDecimals(value: amount)
-        case "RUJI":
-            // The sRUJI receipt share balance — what `liquid.unbond` spends. Not a
-            // display value: shares are worth more than 1 RUJI each and drift
-            // further apart as the pool compounds.
-            let amount: Decimal
-            do {
-                amount = try await ThorchainService.shared.fetchRujiStakingReceiptAmount(address: coin.address)
-            } catch {
-                logger.error("Failed to fetch sRUJI receipt balance: \(error.localizedDescription, privacy: .private)")
-                amount = .zero
-            }
-            self.autocompoundBalance = coin.valueWithDecimals(value: amount)
-        default:
-            break
+        let ticker = coin.ticker
+        do {
+            guard let amount = try await readAutocompoundBalance(ticker, coin.address) else { return }
+            autocompoundBalance = coin.valueWithDecimals(value: amount)
+            autocompoundBalanceDidLoad = true
+        } catch {
+            logger.error(
+                "Failed to fetch \(ticker, privacy: .public) autocompound balance: \(error.localizedDescription, privacy: .private)"
+            )
+            // Written together with the balance, always, so the flag cannot end up
+            // describing a value that a later failure has since zeroed.
+            autocompoundBalance = .zero
+            autocompoundBalanceDidLoad = false
         }
     }
 }

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/UnstakeAsyncBalanceLoadTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/UnstakeAsyncBalanceLoadTests.swift
@@ -1,0 +1,409 @@
+//
+//  UnstakeAsyncBalanceLoadTests.swift
+//  VultisigAppTests
+//
+//  The unstake sheet opens with the ceiling the DeFi card was showing and then
+//  revises it from the network for an auto-compound position. The user can type
+//  in the meantime — on a slow connection that is exactly what they do — so the
+//  ordering these tests pin is: type first, balance lands second. What the user
+//  entered has to survive it, and the transaction built afterwards has to be the
+//  one the field is showing.
+//
+//  The read is injected and gated rather than slept on, so the ordering under
+//  test is the ordering that actually runs.
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class UnstakeAsyncBalanceLoadTests: XCTestCase {
+
+    /// Holds the balance read open until the test says otherwise. Latching, so it
+    /// does not matter whether the read reaches the gate before or after it is
+    /// opened — there is no race to lose.
+    private actor BalanceReadGate {
+        private var isOpen = false
+        private var waiting: CheckedContinuation<Void, Never>?
+
+        func wait() async {
+            guard !isOpen else { return }
+            await withCheckedContinuation { continuation in
+                waiting = continuation
+            }
+        }
+
+        func open() {
+            isOpen = true
+            waiting?.resume()
+            waiting = nil
+        }
+    }
+
+    private enum ReadOutcome {
+        case succeeds(baseUnits: Decimal)
+        case fails
+    }
+
+    private struct ReadFailure: Error {}
+
+    /// Every auto-compound card that reaches the async revision, with the coin the
+    /// unstake sheet is actually opened on (the compounded card maps its receipt
+    /// back to the bond coin).
+    private static let autocompoundCoins: [CoinMeta] = [
+        TokensStore.tcy,
+        TokensStore.brune,
+        TokensStore.ruji
+    ]
+
+    private func makeCoin(_ meta: CoinMeta) -> Coin {
+        Coin(
+            asset: meta,
+            address: "thor1fixtureunstakevaultaddress000000000000",
+            hexPublicKey: "02" + String(repeating: "00", count: 32)
+        )
+    }
+
+    private func makeViewModel(
+        coin: CoinMeta,
+        vault: Vault,
+        availableToUnstake: Decimal,
+        gate: BalanceReadGate,
+        outcome: ReadOutcome
+    ) -> UnstakeTransactionViewModel {
+        UnstakeTransactionViewModel(
+            coin: makeCoin(coin),
+            vault: vault,
+            isAutocompound: true,
+            availableToUnstake: availableToUnstake,
+            readAutocompoundBalance: { _, _ in
+                await gate.wait()
+                switch outcome {
+                case .succeeds(let baseUnits):
+                    return baseUnits
+                case .fails:
+                    throw ReadFailure()
+                }
+            }
+        )
+    }
+
+    /// What `AmountTextField` does when the user edits the field: the field takes
+    /// ownership of the value and the percentage control is cleared.
+    private func typeAmount(_ amount: String, into viewModel: UnstakeTransactionViewModel) {
+        viewModel.amountField.value = amount
+        viewModel.percentageSelected = nil
+    }
+
+    /// What `UnstakeTransactionScreen` does when the user moves the slider.
+    private func selectPercentage(_ percentage: Double, on viewModel: UnstakeTransactionViewModel) {
+        viewModel.percentageSelected = percentage
+        viewModel.onPercentage(percentage)
+    }
+
+    /// `AmountTextField.setupAmount()` — the rule that actually rewrites the field
+    /// whenever `availableAmount` moves: re-derive the amount from the percentage,
+    /// and do nothing at all once the user has taken the field over. Mirrored here
+    /// because the view is a SwiftUI body and a unit test cannot render it, and it
+    /// is the step that turns a re-armed percentage into an overwritten amount.
+    private func syncFieldToCeiling(_ viewModel: UnstakeTransactionViewModel) {
+        guard let percentage = viewModel.percentageSelected else { return }
+        let derived = viewModel.availableAmount * Decimal(percentage) / 100
+        viewModel.amountField.value = derived.formatToDecimal(digits: 4)
+    }
+
+    private func completeLoad(_ viewModel: UnstakeTransactionViewModel, gate: BalanceReadGate) async {
+        await gate.open()
+        _ = await viewModel.autocompoundLoadTask?.value
+        syncFieldToCeiling(viewModel)
+    }
+
+    // MARK: - A typed amount survives the load
+
+    func testATypedAmountSurvivesALateBalanceLoad() async throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let gate = BalanceReadGate()
+        let viewModel = makeViewModel(
+            coin: TokensStore.tcy,
+            vault: TestStore.makeVault(),
+            availableToUnstake: 100,
+            gate: gate,
+            outcome: .succeeds(baseUnits: 25_000_000_000)
+        )
+
+        viewModel.onLoad()
+        typeAmount("50", into: viewModel)
+        await completeLoad(viewModel, gate: gate)
+
+        XCTAssertEqual(viewModel.amountField.value, "50", "the load must not rewrite what the user typed")
+        XCTAssertEqual(viewModel.availableAmount, 250, "the network figure is still the ceiling")
+        XCTAssertNil(viewModel.percentageSelected, "the field, not the slider, still owns the value")
+        // 50 of the corrected 250, not of the 100 the card was showing.
+        XCTAssertEqual(viewModel.resolvedPercentage, 20, accuracy: 0.0001)
+    }
+
+    /// The acceptance criterion that actually moves money: the wasm execute has to
+    /// spend the amount the field is showing, sized against the corrected ceiling.
+    ///
+    /// 50 of 250 is deliberately a whole percentage. The builders still take an
+    /// `Int` percentage, so a ratio like 49/250 would lose the remainder to that
+    /// truncation — a separate, pre-existing defect being fixed by moving the
+    /// memo to basis points, and not something this test should pin either way.
+    func testTheTransactionBuiltAfterTheLoadMatchesTheField() async throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let gate = BalanceReadGate()
+        let viewModel = makeViewModel(
+            coin: TokensStore.tcy,
+            vault: TestStore.makeVault(),
+            availableToUnstake: 100,
+            gate: gate,
+            outcome: .succeeds(baseUnits: 25_000_000_000)
+        )
+
+        viewModel.onLoad()
+        typeAmount("50", into: viewModel)
+        await completeLoad(viewModel, gate: gate)
+
+        let builder = try XCTUnwrap(viewModel.transactionBuilder)
+        let payload = try XCTUnwrap(builder.wasmContractPayload)
+        let funds = try XCTUnwrap(payload.coins.first)
+        XCTAssertEqual(funds.denom, "x/staking-tcy")
+        // 20% of the 250 TCY receipt balance = the 50 TCY on screen.
+        XCTAssertEqual(funds.amount, "5000000000")
+    }
+
+    /// Every asset that reaches the async revision, not sTCY alone. sRUJI keeps the
+    /// card's RUJI-denominated ceiling by design — its receipt read only sizes the
+    /// redeemed shares — so the assertion there is that the ceiling stays put.
+    func testEveryAutoCompoundAssetKeepsATypedAmountAcrossTheLoad() async throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let vault = TestStore.makeVault()
+
+        for meta in Self.autocompoundCoins {
+            let gate = BalanceReadGate()
+            let viewModel = makeViewModel(
+                coin: meta,
+                vault: vault,
+                availableToUnstake: 100,
+                gate: gate,
+                outcome: .succeeds(baseUnits: 25_000_000_000)
+            )
+
+            viewModel.onLoad()
+            typeAmount("50", into: viewModel)
+            await completeLoad(viewModel, gate: gate)
+
+            XCTAssertEqual(viewModel.amountField.value, "50", "\(meta.ticker) overwrote the typed amount")
+            XCTAssertNil(viewModel.percentageSelected, "\(meta.ticker) re-armed the percentage control")
+            XCTAssertEqual(viewModel.autocompoundBalance, 250, "\(meta.ticker) did not record the receipt balance")
+
+            let expectedCeiling: Decimal = meta.ticker.uppercased() == "RUJI" ? 100 : 250
+            XCTAssertEqual(viewModel.availableAmount, expectedCeiling, "\(meta.ticker) ceiling")
+        }
+    }
+
+    // MARK: - A selected percentage survives too
+
+    func testASelectedPercentageSurvivesTheLoadAndRescalesToTheNewCeiling() async throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let gate = BalanceReadGate()
+        let viewModel = makeViewModel(
+            coin: TokensStore.tcy,
+            vault: TestStore.makeVault(),
+            availableToUnstake: 100,
+            gate: gate,
+            outcome: .succeeds(baseUnits: 25_000_000_000)
+        )
+
+        viewModel.onLoad()
+        selectPercentage(40, on: viewModel)
+        await completeLoad(viewModel, gate: gate)
+
+        XCTAssertEqual(viewModel.percentageSelected, 40, "the load must not snap the slider back to 100%")
+        XCTAssertFalse(viewModel.isMaxAmount, "a 40% withdrawal is not a max withdrawal")
+        XCTAssertEqual(viewModel.availableAmount, 250)
+        XCTAssertEqual(viewModel.resolvedPercentage, 40, accuracy: 0.0001)
+        // Re-derived against the corrected ceiling: 40% of 250, not the whole 250.
+        XCTAssertEqual(viewModel.amountField.value.toDecimal(), 100)
+    }
+
+    /// The untouched case has to keep behaving exactly as it did: the sheet opens on
+    /// the whole position and the corrected ceiling is adopted wholesale.
+    func testAnUntouchedFieldStillAdoptsTheLoadedCeilingAtFullPercentage() async throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let gate = BalanceReadGate()
+        let viewModel = makeViewModel(
+            coin: TokensStore.tcy,
+            vault: TestStore.makeVault(),
+            availableToUnstake: 100,
+            gate: gate,
+            outcome: .succeeds(baseUnits: 25_000_000_000)
+        )
+
+        viewModel.onLoad()
+        await completeLoad(viewModel, gate: gate)
+
+        XCTAssertEqual(viewModel.availableAmount, 250)
+        XCTAssertEqual(viewModel.percentageSelected, 100)
+        XCTAssertTrue(viewModel.isMaxAmount)
+        XCTAssertEqual(viewModel.amountField.value.toDecimal(), 250, "nothing was entered, so the sheet still offers the whole position")
+    }
+
+    // MARK: - A ceiling that moves down
+
+    /// The form pipeline only re-validates when the field's *value* changes, and a
+    /// corrected ceiling moves the validator underneath a value that does not — so
+    /// without an explicit re-validation the sheet would happily build a withdrawal
+    /// for more than the position holds.
+    func testALoweredCeilingInvalidatesATypedAmountThatNoLongerFits() async throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let gate = BalanceReadGate()
+        let viewModel = makeViewModel(
+            coin: TokensStore.tcy,
+            vault: TestStore.makeVault(),
+            availableToUnstake: 100,
+            gate: gate,
+            outcome: .succeeds(baseUnits: 5_000_000_000)
+        )
+
+        viewModel.onLoad()
+        typeAmount("90", into: viewModel)
+        await completeLoad(viewModel, gate: gate)
+
+        XCTAssertEqual(viewModel.availableAmount, 50)
+        XCTAssertEqual(viewModel.amountField.value, "90", "the amount is still the user's to correct")
+        XCTAssertFalse(viewModel.validForm, "90 no longer fits in a 50 position")
+        XCTAssertNil(viewModel.transactionBuilder)
+    }
+
+    /// A position that really is empty may lower the ceiling to zero — the existing
+    /// "amount cannot be zero" copy is the honest answer there.
+    func testAnEmptyPositionLowersTheCeilingAndInvalidatesTheForm() async throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let gate = BalanceReadGate()
+        let viewModel = makeViewModel(
+            coin: TokensStore.tcy,
+            vault: TestStore.makeVault(),
+            availableToUnstake: 100,
+            gate: gate,
+            outcome: .succeeds(baseUnits: 0)
+        )
+
+        viewModel.onLoad()
+        typeAmount("50", into: viewModel)
+        await completeLoad(viewModel, gate: gate)
+
+        XCTAssertEqual(viewModel.availableAmount, 0)
+        XCTAssertFalse(viewModel.validForm)
+        XCTAssertEqual(viewModel.resolvedPercentage, 0, "a zero ceiling has no fraction to derive")
+        XCTAssertNil(viewModel.transactionBuilder)
+    }
+
+    // MARK: - A read that failed
+
+    /// A failure reports zero exactly as an empty position does, and it must not be
+    /// mistaken for one: the card figure is a real number and the read result is
+    /// not, so the ceiling — and the typed amount standing against it — stay.
+    func testAFailedReadLeavesTheCeilingAndTheTypedAmountAlone() async throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let gate = BalanceReadGate()
+        let viewModel = makeViewModel(
+            coin: TokensStore.tcy,
+            vault: TestStore.makeVault(),
+            availableToUnstake: 100,
+            gate: gate,
+            outcome: .fails
+        )
+
+        viewModel.onLoad()
+        typeAmount("50", into: viewModel)
+        await completeLoad(viewModel, gate: gate)
+
+        XCTAssertEqual(viewModel.availableAmount, 100, "a failed read must not replace a real ceiling with zero")
+        XCTAssertEqual(viewModel.amountField.value, "50")
+        XCTAssertEqual(viewModel.resolvedPercentage, 50, accuracy: 0.0001)
+    }
+
+    /// …and the sheet still refuses to sign it. The receipt balance is what funds
+    /// every auto-compound redemption, so a zero there builds a wasm execute
+    /// carrying no funds — a fee for a transaction that moves nothing.
+    func testNoAutoCompoundRedemptionIsBuiltWithoutAReceiptBalance() async throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let vault = TestStore.makeVault()
+
+        for meta in Self.autocompoundCoins {
+            let gate = BalanceReadGate()
+            let viewModel = makeViewModel(
+                coin: meta,
+                vault: vault,
+                availableToUnstake: 100,
+                gate: gate,
+                outcome: .fails
+            )
+
+            viewModel.onLoad()
+            typeAmount("50", into: viewModel)
+            await completeLoad(viewModel, gate: gate)
+            // Isolate the receipt guard from form validity: the amount itself is
+            // perfectly valid against the ceiling that survived the failure.
+            viewModel.validForm = true
+
+            XCTAssertEqual(viewModel.autocompoundBalance, 0)
+            XCTAssertNil(viewModel.transactionBuilder, "\(meta.ticker) built a redemption with no funds")
+            XCTAssertTrue(viewModel.isContinueDisabled, "\(meta.ticker) left Continue silently doing nothing")
+        }
+    }
+
+    /// …and it has to say so rather than looking live and doing nothing when
+    /// tapped. `AmountFunctionTransactionScreen` already takes this; the sheet
+    /// just never passed it.
+    func testContinueIsDisabledUntilTheReceiptBalanceIsIn() async throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let gate = BalanceReadGate()
+        let viewModel = makeViewModel(
+            coin: TokensStore.tcy,
+            vault: TestStore.makeVault(),
+            availableToUnstake: 100,
+            gate: gate,
+            outcome: .succeeds(baseUnits: 25_000_000_000)
+        )
+
+        viewModel.onLoad()
+        typeAmount("50", into: viewModel)
+        XCTAssertTrue(viewModel.isContinueDisabled, "nothing is signable while the read is in flight")
+
+        await completeLoad(viewModel, gate: gate)
+
+        XCTAssertFalse(viewModel.isContinueDisabled)
+    }
+
+    /// A bonded position withdraws by memo against the staked balance and reads no
+    /// receipt at all, so none of this may touch it.
+    func testABondedPositionNeverWaitsOnAReceiptBalance() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let viewModel = UnstakeTransactionViewModel(
+            coin: makeCoin(TokensStore.tcy),
+            vault: TestStore.makeVault(),
+            isAutocompound: false,
+            availableToUnstake: 100
+        )
+
+        viewModel.onLoad()
+
+        XCTAssertNil(viewModel.autocompoundLoadTask, "a bonded position has no receipt to read")
+        XCTAssertFalse(viewModel.isContinueDisabled)
+        XCTAssertEqual(viewModel.availableAmount, 100)
+        XCTAssertEqual(viewModel.percentageSelected, 100)
+    }
+}

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/UnstakeAsyncBalanceLoadTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/UnstakeAsyncBalanceLoadTests.swift
@@ -69,12 +69,13 @@ final class UnstakeAsyncBalanceLoadTests: XCTestCase {
         vault: Vault,
         availableToUnstake: Decimal,
         gate: BalanceReadGate,
-        outcome: ReadOutcome
+        outcome: ReadOutcome,
+        isAutocompound: Bool = true
     ) -> UnstakeTransactionViewModel {
         UnstakeTransactionViewModel(
             coin: makeCoin(coin),
             vault: vault,
-            isAutocompound: true,
+            isAutocompound: isAutocompound,
             availableToUnstake: availableToUnstake,
             readAutocompoundBalance: { _, _ in
                 await gate.wait()
@@ -387,23 +388,47 @@ final class UnstakeAsyncBalanceLoadTests: XCTestCase {
         XCTAssertFalse(viewModel.isContinueDisabled)
     }
 
-    /// A bonded position withdraws by memo against the staked balance and reads no
-    /// receipt at all, so none of this may touch it.
-    func testABondedPositionNeverWaitsOnAReceiptBalance() throws {
+    /// A bonded position must never be left waiting on a balance the sheet never
+    /// asked for — that combination is a Continue button that can never enable and
+    /// a transaction that can never be built. Looped over every asset because it is
+    /// invisible on the one that reads nothing: TCY and RUJI bond by memo against
+    /// the staked balance, while bRUNE is only ever held as the ybRUNE receipt and
+    /// so spends receipt units whichever card opened the sheet.
+    func testABondedPositionNeverWaitsOnAReceiptBalance() async throws {
         let token = try TestStore.installInMemoryContainer()
         defer { TestStore.restore(token) }
-        let viewModel = UnstakeTransactionViewModel(
-            coin: makeCoin(TokensStore.tcy),
-            vault: TestStore.makeVault(),
-            isAutocompound: false,
-            availableToUnstake: 100
-        )
+        let vault = TestStore.makeVault()
 
-        viewModel.onLoad()
+        for meta in Self.autocompoundCoins {
+            let gate = BalanceReadGate()
+            let viewModel = makeViewModel(
+                coin: meta,
+                vault: vault,
+                availableToUnstake: 100,
+                gate: gate,
+                outcome: .succeeds(baseUnits: 25_000_000_000),
+                isAutocompound: false
+            )
 
-        XCTAssertNil(viewModel.autocompoundLoadTask, "a bonded position has no receipt to read")
-        XCTAssertFalse(viewModel.isContinueDisabled)
-        XCTAssertEqual(viewModel.availableAmount, 100)
-        XCTAssertEqual(viewModel.percentageSelected, 100)
+            viewModel.onLoad()
+
+            let spendsReceiptUnits = meta.ticker.uppercased() == "BRUNE"
+            XCTAssertEqual(
+                viewModel.autocompoundLoadTask != nil,
+                spendsReceiptUnits,
+                "\(meta.ticker) reads a receipt it does not spend, or spends one it never reads"
+            )
+
+            await completeLoad(viewModel, gate: gate)
+            // Isolate the receipt guard from form validity, as elsewhere here.
+            viewModel.validForm = true
+
+            XCTAssertFalse(viewModel.isContinueDisabled, "\(meta.ticker) left Continue disabled for good")
+            XCTAssertNotNil(viewModel.transactionBuilder, "\(meta.ticker) can never build its withdrawal")
+            XCTAssertEqual(viewModel.percentageSelected, 100, "\(meta.ticker) percentage")
+            // Only the receipt-funded one takes its ceiling from the read.
+            let expectedCeiling: Decimal = spendsReceiptUnits ? 250 : 100
+            XCTAssertEqual(viewModel.availableAmount, expectedCeiling, "\(meta.ticker) ceiling")
+        }
     }
 }


### PR DESCRIPTION
## Description

Fixes #5092

`UnstakeTransactionViewModel.onLoad()` set the ceiling synchronously, then revised it from the network for auto-compound positions — awaiting `fetchAutocompoundBalance()`, reassigning `availableAmount`, and calling `setupAmountField()` a **second** time. A user who typed before that returned had their amount overwritten, or silently reinterpreted as a different fraction of the position. Worst on a slow connection, which is exactly when there is time to type first.

## The fix is subtractive

`AmountTextField` already does the right thing when `availableAmount` changes: with a percentage selected it re-derives from the new ceiling; when the user has typed it does nothing, because typing clears `percentageSelected`. All the damage came from the view model re-running `setupAmountField()`, whose `percentageSelected = 100` re-armed that derivation over a field the user owned.

So the async path now moves **only the ceiling and its validator** — never the percentage, never `isMaxAmount`. Both cases then fall out for free: a dragged 40% stays 40% and re-scales; a typed 50 stays 50 and `percentageFromAmount` re-derives its fraction against the corrected ceiling. `percentageSelected == nil` is the "the field owns this value" signal, which is the same signal `percentageSelected ?? percentageFromAmount` already relied on.

### Two further defects on the same path

**A failed read was indistinguishable from an empty position.** `fetchAutocompoundBalance()` collapsed a throw into `.zero`, and that zero was adopted as the ceiling: the field was rewritten to 0, every amount rejected, and the sheet dead-ended on a figure that was never real. Now a failure leaves the ceiling and the typed amount alone; a *genuine* zero may still lower the ceiling.

**`Form.validForm` went stale.** `Form.setupForm()` only re-validates on a *value* change, so moving the validator under a value that does not move left `validForm` answering against the replaced ceiling — a lowered ceiling would have let an over-balance amount through, since `transactionBuilder` reads `validForm` and `validateErrors()` never writes it. The revision now re-validates when the field owns the value.

## Scope note — one deliberate addition

Fixing the above made Continue *reachable* after a failed read, where TCY/bRUNE would build a `liquid.unbond` funded from a zero receipt balance: a signable, fee-paying no-op. So this adds the `autocompoundBalance > 0` guard sRUJI already ships, and passes `isContinueDisabled` (a parameter `AmountFunctionTransactionScreen` already takes and four sibling sheets already use) so that reads as a disabled button rather than a tap that silently does nothing.

That is slightly beyond the issue's "Must Do" list. It is included because the fix creates the state it guards; happy to split it out if preferred. **No new views and no new strings.**

## Which feature is affected?
- [ ] Create vault ( Secure / Fast)
- [ ] Sending
- [ ] Swap
- [ ] New Chain / Chain related feature

Neither sends nor swaps — this is the DeFi unstake sheet's input handling. No signing, payload-building or broadcast path is touched, and **how the transaction is built is unchanged**, per the issue's "Must NOT Do".

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

`make test`: `** TEST SUCCEEDED **` — **6063 tests, 11 skipped, 0 failures**. SwiftLint 26, identical to `origin/main`.

**11 new tests** in `UnstakeAsyncBalanceLoadTests`, using a latching actor gate on an injected read — no sleeps, no wall-clock. Coverage: a typed amount survives across **all three** auto-compound assets (sTCY, ybRUNE, sRUJI), not sTCY alone; the built wasm payload matches the field; a dragged 40% survives and re-scales; an untouched field still adopts the whole position; a lowered ceiling invalidates an amount that no longer fits; a failed read changes nothing; no redemption is built without a receipt balance; a bonded position starts no read at all.

## Additional context

Cross-model review, 2 Codex rounds. One finding was **rejected with reason**: that `Int(resolvedPercentage)` truncates to whole percent. That is pre-existing on `main` (this diff only renames the expression), the issue explicitly forbids changing how the transaction is built, and #5089 replaces it with basis points — pinning it here would fight that PR.

**Deferred:** the whole-percent truncation (#5089's), and the stale `isMaxAmount` after typing (also #5089's, deliberately not asserted here so the two do not conflict). A failed read now gives a disabled Continue with no *explanation*; a "couldn't read your position — retry" state needs new copy and was out of scope.

## Agent Metadata
- **Agent**: Claude Code
- **Issue**: #5092
- **Needs human review for**: the `isContinueDisabled` / `autocompoundBalance > 0` addition described under Scope note — it is a real behaviour change and your call whether it belongs here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asynchronous loading of auto-compound balances during unstaking.
  * Unstake limits update automatically while preserving entered amounts and selections.

* **Bug Fixes**
  * Prevented receipt-based unstaking or redemption when no eligible balance is available.
  * Continue remains disabled until balances load and entered amounts are valid.
  * Improved validation when available balances decrease or cannot be loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->