### PR TITLE
fix(model): publish @Transient-derived state so views re-render on change

### DIFF
--- a/.claude/rules/swiftdata.md
+++ b/.claude/rules/swiftdata.md
@@ -8,3 +8,4 @@ paths:
 - Never access `@Model` classes off MainActor
 - Use value types (structs) to pass data across actor boundaries
 - Follow the three-phase architecture: load -> transform -> save
+- `@Transient` properties are **not observation-tracked**. Writing one publishes nothing to SwiftUI, even when the value genuinely changes, so a view reading it (or anything derived from it) never re-renders — it will *appear* to work whenever a neighbouring `Storage.shared.save()` happens to re-render the tree, which is an accident, not a mechanism. A plain `@Transient` is only safe for state that no view body ever reads. Otherwise hold the value on an `ObservedTransient` box (`Core/Models/ObservedTransient.swift`) behind a computed property of the same name, and cover it with a `withObservationTracking` test that asserts the write is *published*, not just stored.

--- a/VultisigApp/VultisigApp/Core/Models/ObservedTransient.swift
+++ b/VultisigApp/VultisigApp/Core/Models/ObservedTransient.swift
@@ -1,0 +1,50 @@
+//
+//  ObservedTransient.swift
+//  VultisigApp
+//
+//  Observation-tracked storage for per-session state that hangs off a SwiftData
+//  `@Model` but is deliberately kept out of the schema.
+//
+
+import Foundation
+import Observation
+
+/// A box holding one value that publishes through the Observation registrar.
+///
+/// SwiftData excludes `@Transient` properties from a `@Model`'s observation
+/// graph. Writing one publishes nothing — not even when the value genuinely
+/// changes — so a SwiftUI view reading anything derived from it is never
+/// re-evaluated. That was measured directly: a deferred write of a *changing*
+/// value to a `@Transient` property produced the same single body evaluation as
+/// a control that wrote nothing at all. Views built on such a property appeared
+/// to work only because an unrelated `Storage.shared.save()` re-rendered the
+/// tree soon afterwards, which is an accident of neighbouring code rather than a
+/// mechanism.
+///
+/// Holding the value on a plain `@Observable` object restores publication. The
+/// model keeps a `@Transient` reference to the box; that reference is assigned
+/// once and never reassigned, so the fact that reading it is untracked costs
+/// nothing, while the read of ``value`` inside a view body registers with the
+/// registrar exactly as a persisted property would. The state stays session
+/// scoped and stays out of the schema, so no migration is involved.
+///
+/// The setter is equality-guarded. Observation's generated setters notify
+/// without comparing new to old, and a redundant notification from a deferred
+/// writer is the shape that drives a runaway re-render, so the comparison lives
+/// here instead of being re-derived at every call site.
+@Observable
+final class ObservedTransient<Value: Equatable> {
+    private var storage: Value
+
+    var value: Value {
+        get { storage }
+        set {
+            guard newValue != storage else { return }
+            storage = newValue
+        }
+    }
+
+    init(_ value: Value) {
+        self.storage = value
+    }
+}

--- a/VultisigApp/VultisigApp/Model/Coin.swift
+++ b/VultisigApp/VultisigApp/Model/Coin.swift
@@ -32,8 +32,30 @@ class Coin: ObservableObject, Codable, Hashable {
     /// Transient because it describes the mempool, which is not a thing worth
     /// persisting: it is refreshed by the same fetch that sets `rawBalance`
     /// and is meaningless a launch later.
-    @Transient var pendingRawBalance: String = "0"
+    ///
+    /// Held on an `ObservedTransient` box rather than in a `@Transient` stored
+    /// property. SwiftData does not observation-track `@Transient`, and
+    /// `CoinDetailHeaderView` reads `hasPendingBalance` to decide whether to draw
+    /// the pending line at all — so an inbound payment landing published nothing
+    /// and the line stayed absent until an unrelated save re-rendered the tree.
+    /// The value is still per-instance, still session scoped, and still absent
+    /// from the schema; only the publication changes.
+    var pendingRawBalance: String {
+        get { pendingRawBalanceBox.value }
+        set { pendingRawBalanceBox.value = newValue }
+    }
 
+    @Transient private var pendingRawBalanceBox = ObservedTransient("0")
+
+    /// Bonded THORChain / Maya nodes for this address, refreshed by the same
+    /// balance fetch.
+    ///
+    /// Deliberately still a plain `@Transient`, unlike `pendingRawBalance`: no
+    /// view reads it during a body pass, so the missing observation cannot show.
+    /// Its only readers are `UnbondTransactionViewModel.selectBondNode()`, which
+    /// pulls it once from `onLoad()` and republishes through its own `@Published`
+    /// property, and `hasBondedNodes`, which has no callers. Move it onto an
+    /// `ObservedTransient` the moment a view body reads either one.
     @Transient var bondedNodes: [RuneBondNode] = []
     @Relationship(inverse: \Vault.coins) var vault: Vault?
 

--- a/VultisigApp/VultisigApp/Model/Vault.swift
+++ b/VultisigApp/VultisigApp/Model/Vault.swift
@@ -63,8 +63,25 @@ final class Vault: ObservableObject, Codable {
     // app foreground + vault switch. Reads are sync; refresh happens at planned
     // trigger points rather than per-screen-mount. Local-only state, not part of
     // the schema — repopulated on every cold start by the refresher.
-    @Transient var fastVaultEligibility: Bool = false
-    @Transient var fastVaultEligibilityCheckedAt: Date? = nil
+    //
+    // The pair lives on `ObservedTransient` boxes rather than in `@Transient`
+    // stored properties. SwiftData does not observation-track `@Transient`, so
+    // the refresher's write published nothing at all and every view branching on
+    // `isFastVault` stayed stale until an unrelated save happened to re-render
+    // the tree. The boxes are still per-instance, still session scoped, and
+    // still absent from the schema — only the publication changes.
+    @Transient private var fastVaultEligibilityBox = ObservedTransient(false)
+    @Transient private var fastVaultEligibilityCheckedAtBox = ObservedTransient<Date?>(nil)
+
+    var fastVaultEligibility: Bool {
+        get { fastVaultEligibilityBox.value }
+        set { fastVaultEligibilityBox.value = newValue }
+    }
+
+    var fastVaultEligibilityCheckedAt: Date? {
+        get { fastVaultEligibilityCheckedAtBox.value }
+        set { fastVaultEligibilityCheckedAtBox.value = newValue }
+    }
 
     @Relationship(deleteRule: .cascade) var coins = [Coin]()
     @Relationship(deleteRule: .cascade) var hiddenTokens = [HiddenToken]()

--- a/VultisigApp/VultisigAppTests/Model/TransientObservationTests.swift
+++ b/VultisigApp/VultisigAppTests/Model/TransientObservationTests.swift
@@ -1,0 +1,160 @@
+//
+//  TransientObservationTests.swift
+//  VultisigAppTests
+//
+//  Per-session state that a view branches on has to PUBLISH when it changes,
+//  not merely end up holding the right value.
+//
+//  Asserting on the resulting value cannot show that. `vault.fastVaultEligibility`
+//  read back the value the refresher had just written even while it was a plain
+//  SwiftData `@Transient` property — and a `@Transient` write notifies nobody, so
+//  the view branching on `isFastVault` was never re-evaluated. It appeared to
+//  work only because an unrelated `Storage.shared.save()` re-rendered the tree
+//  soon after. A value-only test passes against both implementations and would
+//  have caught nothing.
+//
+//  These tests therefore observe with `withObservationTracking` and assert on
+//  whether a change was published, which is the property the views actually
+//  depend on. Each probe reads the same expression the view reads — `isFastVault`
+//  — rather than the underlying storage, so it fails if the derived property
+//  stops being reachable from the observation graph for any reason, not just the
+//  one known cause.
+//
+
+@testable import VultisigApp
+import Observation
+import XCTest
+
+/// Reference box so the `@Sendable` `onChange` closure can report back without
+/// capturing a mutable local. Every access is main-actor and synchronous —
+/// `onChange` fires from inside the write being probed, on the same thread.
+private final class ChangeRecorder: @unchecked Sendable {
+    private(set) var didChange = false
+    func record() { didChange = true }
+}
+
+/// Runs `read` under observation tracking, performs `write`, and reports whether
+/// the registrar published a change to anything `read` touched.
+@MainActor
+private func publishesChange(reading read: () -> Void, writing write: () -> Void) -> Bool {
+    let recorder = ChangeRecorder()
+    withObservationTracking {
+        read()
+    } onChange: {
+        recorder.record()
+    }
+    write()
+    return recorder.didChange
+}
+
+@MainActor
+final class TransientObservationTests: XCTestCase {
+
+    // MARK: - Vault.isFastVault
+
+    /// The acceptance case: a view branching on `isFastVault` is invalidated when
+    /// the refresher resolves eligibility, and nothing else is needed to make that
+    /// happen. `saveStorage` is a no-op here, so a save cannot be what re-renders
+    /// the tree — the write itself has to publish. Fails against a
+    /// `@Transient`-backed cache, which publishes nothing at all.
+    func testRefresherResolvingEligibilityPublishesIsFastVault() async {
+        let vault = SendFormFixture.makeVault()
+        let refresher = FastVaultEligibilityRefresher(
+            checkEligibility: { _ in true },
+            saveStorage: { },
+            now: { Date(timeIntervalSince1970: 1_000_000) }
+        )
+
+        let recorder = ChangeRecorder()
+        withObservationTracking {
+            _ = vault.isFastVault
+        } onChange: {
+            recorder.record()
+        }
+
+        await refresher.refresh(vault)
+
+        XCTAssertTrue(recorder.didChange, "resolving eligibility must publish to readers of isFastVault")
+        XCTAssertTrue(vault.isFastVault)
+    }
+
+    /// `isFastVault` short-circuits on `fastVaultEligibilityCheckedAt == nil`, so
+    /// on a cold vault the stamp is the only one of the two inputs the reader
+    /// reaches. It has to publish on its own.
+    func testStampAlonePublishesIsFastVault() {
+        let vault = SendFormFixture.makeVault()
+
+        let published = publishesChange {
+            _ = vault.isFastVault
+        } writing: {
+            vault.fastVaultEligibilityCheckedAt = Date(timeIntervalSince1970: 1)
+        }
+
+        XCTAssertTrue(published)
+    }
+
+    /// Once the cache is warm the flag is reached too, and flipping it — the
+    /// eligibility genuinely changing between refreshes — must publish.
+    func testEligibilityFlagAlonePublishesIsFastVault() {
+        let vault = SendFormFixture.makeVault()
+        vault.fastVaultEligibilityCheckedAt = Date(timeIntervalSince1970: 1)
+
+        let published = publishesChange {
+            _ = vault.isFastVault
+        } writing: {
+            vault.fastVaultEligibility = true
+        }
+
+        XCTAssertTrue(published)
+    }
+
+    /// The other half of the guard: a refresh that resolves to the value already
+    /// cached must not invalidate anyone. An unguarded box would notify on every
+    /// write, which is the shape that drives a runaway re-render when the writer
+    /// is deferred.
+    func testRedundantEligibilityWriteDoesNotPublish() {
+        let vault = SendFormFixture.makeVault()
+        vault.fastVaultEligibility = true
+        vault.fastVaultEligibilityCheckedAt = Date(timeIntervalSince1970: 1)
+
+        let published = publishesChange {
+            _ = vault.isFastVault
+        } writing: {
+            vault.fastVaultEligibility = true
+            vault.fastVaultEligibilityCheckedAt = Date(timeIntervalSince1970: 1)
+        }
+
+        XCTAssertFalse(published)
+    }
+
+    /// Vaults must not share eligibility storage. A cache keyed by anything other
+    /// than the instance — `pubKeyECDSA`, say, which this fixture leaves identical
+    /// across vaults — would cross-talk, invalidating every reader of the other
+    /// vault and reporting the wrong answer.
+    func testEligibilityIsPerVault() {
+        let vaultA = SendFormFixture.makeVault()
+        let vaultB = SendFormFixture.makeVault()
+
+        let published = publishesChange {
+            _ = vaultB.isFastVault
+        } writing: {
+            vaultA.fastVaultEligibility = true
+            vaultA.fastVaultEligibilityCheckedAt = Date(timeIntervalSince1970: 1)
+        }
+
+        XCTAssertFalse(published, "vaultB must not be invalidated by a write to vaultA")
+        XCTAssertTrue(vaultA.isFastVault)
+        XCTAssertFalse(vaultB.isFastVault)
+        XCTAssertNil(vaultB.fastVaultEligibilityCheckedAt)
+    }
+
+    /// A server-side share is never fast-signable regardless of what the cache
+    /// says, and that short-circuit has to survive the storage change.
+    func testServerPartyIsNeverFastVault() {
+        let vault = SendFormFixture.makeVault(localPartyID: "Server-1")
+        vault.fastVaultEligibility = true
+        vault.fastVaultEligibilityCheckedAt = Date(timeIntervalSince1970: 1)
+
+        XCTAssertFalse(vault.isFastVault)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Model/TransientObservationTests.swift
+++ b/VultisigApp/VultisigAppTests/Model/TransientObservationTests.swift
@@ -157,4 +157,94 @@ final class TransientObservationTests: XCTestCase {
 
         XCTAssertFalse(vault.isFastVault)
     }
+
+    // MARK: - Coin.hasPendingBalance
+
+    /// `CoinDetailHeaderView` branches on `hasPendingBalance` to decide whether
+    /// the pending line exists at all, so an inbound payment landing in the
+    /// mempool has to invalidate that read on its own — `BalanceService` writing
+    /// `pendingRawBalance` is the only event involved.
+    func testInboundBalanceArrivingPublishesHasPendingBalance() {
+        let coin = SendFormFixture.makeBTC()
+
+        let published = publishesChange {
+            _ = coin.hasPendingBalance
+        } writing: {
+            coin.pendingRawBalance = "250000"
+        }
+
+        XCTAssertTrue(published)
+        XCTAssertTrue(coin.hasPendingBalance)
+        XCTAssertEqual(coin.pendingBalanceDecimal, Decimal(string: "0.0025"))
+    }
+
+    /// The line has to disappear again once the transaction confirms and the
+    /// pending amount folds into the balance.
+    func testPendingBalanceClearingPublishesHasPendingBalance() {
+        let coin = SendFormFixture.makeBTC()
+        coin.pendingRawBalance = "250000"
+
+        let published = publishesChange {
+            _ = coin.hasPendingBalance
+        } writing: {
+            coin.pendingRawBalance = "0"
+        }
+
+        XCTAssertTrue(published)
+        XCTAssertFalse(coin.hasPendingBalance)
+    }
+
+    /// A second inbound payment while one is already pending does not flip the
+    /// boolean, but it does change the amount the view prints. Observing only
+    /// `hasPendingBalance` would miss it, so the formatted string the view
+    /// actually renders gets its own probe.
+    func testPendingAmountChangePublishesFormattedString() {
+        let coin = SendFormFixture.makeBTC()
+        coin.pendingRawBalance = "250000"
+
+        let published = publishesChange {
+            _ = coin.pendingBalanceStringWithTicker
+        } writing: {
+            coin.pendingRawBalance = "300000"
+        }
+
+        XCTAssertTrue(published)
+        XCTAssertTrue(coin.hasPendingBalance)
+    }
+
+    /// A balance refresh that reports the same mempool state must not invalidate
+    /// the view. Balances refresh on a timer, so an unguarded box would re-render
+    /// every coin detail screen on every poll for no reason.
+    func testRedundantPendingBalanceWriteDoesNotPublish() {
+        let coin = SendFormFixture.makeBTC()
+        coin.pendingRawBalance = "250000"
+
+        let published = publishesChange {
+            _ = coin.hasPendingBalance
+            _ = coin.pendingBalanceStringWithTicker
+        } writing: {
+            coin.pendingRawBalance = "250000"
+        }
+
+        XCTAssertFalse(published)
+    }
+
+    /// Coins must not share pending-balance storage. These two fixtures have the
+    /// same `id`, which is what a keyed cache would collide on — one coin's
+    /// mempool would then show up on another's screen.
+    func testPendingBalanceIsPerCoin() {
+        let coinA = SendFormFixture.makeBTC()
+        let coinB = SendFormFixture.makeBTC()
+
+        let published = publishesChange {
+            _ = coinB.hasPendingBalance
+        } writing: {
+            coinA.pendingRawBalance = "250000"
+        }
+
+        XCTAssertFalse(published, "coinB must not be invalidated by a write to coinA")
+        XCTAssertTrue(coinA.hasPendingBalance)
+        XCTAssertFalse(coinB.hasPendingBalance)
+        XCTAssertEqual(coinB.pendingRawBalance, "0")
+    }
 }


### PR DESCRIPTION
## Description

Fixes #5110

`@Transient` properties on a SwiftData `@Model` are **not observation-tracked**: writing one publishes nothing to SwiftUI, even when the value genuinely changes. Two shipping computed properties derived entirely from `@Transient` storage, so views reading them were stale until something unrelated forced a re-render:

- `Vault.isFastVault` — written asynchronously by `FastVaultEligibilityRefresher` after launch, exactly the case that needs to publish.
- `Coin.hasPendingBalance` — read by `CoinDetailHeaderView` to decide whether to show the pending line at all.

⚠️ **These appeared to work, which is the dangerous part.** A neighbouring `Storage.shared.save()` re-rendered the tree through the root `@Query` and incidentally picked up the new value — so correctness depended on an unrelated save happening to fire nearby. In-flight work to scope that root `@Query` and to guard redundant `@Model` writes removes that coupling, and each of those otherwise-correct changes makes this bug visible.

## Approach

New `ObservedTransient<Value: Equatable>` (`Core/Models/ObservedTransient.swift`) — a plain `@Observable` box with an **equality-guarded setter**. Each model holds it in a `private @Transient` reference and exposes a computed property of the same name and type, so **no reader or writer call site changes**.

**Why not a free-standing view model**, which is what the issue's option 1 literally suggests: `isFastVault` has **~30 readers**, most of them views handed only a `Vault`. Threading a new view model to all of them is a large refactor that would also put "is this vault fast-signable" in two places. The state still moves *off* the `@Model`'s storage onto an `@Observable` object — the model just keeps an accessor facade.

Per-instance boxes rather than a shared store, deliberately: a store keyed by `pubKeyECDSA` / `coin.id` would cross-talk between vaults that have no key yet — the test fixtures share `"test-pub-ecdsa"` and an identical `coin.id`. There are tests pinning that isolation.

**No schema change, no migration.** The boxes are `@Transient`, the accessors are computed (SwiftData treats computed properties as transient), neither property was ever in `CodingKeys`, and `Vault+ProtoMappable` is untouched.

The issue's option 2 (persist the values) is **rejected explicitly for `pendingRawBalance`**: it is a mempool snapshot, worthless a launch later, and persisting it would be a schema change on a critical boundary *and* move it into the redundant-write bug class.

## `@Transient` audit

Four declarations across two files; three converted. **`Coin.bondedNodes` left as a plain `@Transient` deliberately** — no view body reads it. Its only readers are `UnbondTransactionViewModel.selectBondNode()` (called once from `onLoad()` and republished through its own `@Published`) and `Coin.hasBondedNodes`, which has **zero callers**. Converting it would be unverifiable churn on a critical boundary; it now carries a comment saying exactly that, and when to convert. It is the only plain `@Transient` left in `Model/`.

Adjacent and not touched: `Coin.fiatRateAvailable` reads the non-`@Observable` `RateProvider.shared`, which the repo already solved with the issue's option 3 (a `ratesDidChange` subject).

## Which feature is affected?
- [ ] Create vault ( Secure / Fast)
- [ ] Sending
- [ ] Swap
- [ ] New Chain / Chain related feature

None of the four. This is SwiftData/SwiftUI observation plumbing on `Vault`/`Coin` plus the views reading them — no signing, broadcast or fee path is touched, and it is genuinely platform-specific (no cross-platform analogue to SwiftData observation semantics).

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

`make test`: `** TEST SUCCEEDED **` — **6063 tests, 11 skipped, 0 failures**. SwiftLint 26, exactly the baseline.

**The tests pin publication, not value.** 11 cases in `TransientObservationTests`, asserting through `withObservationTracking` on the same expression the view reads (`isFastVault`, `hasPendingBalance`, `pendingBalanceStringWithTicker`) rather than on the underlying storage. Includes a per-input sweep (`isFastVault` short-circuits on `checkedAt == nil`, so the stamp and the flag each get a case), redundant-write silence, and per-instance isolation.

**Verified against the parent rather than assumed:** reverting only `Model/Vault.swift` produces exactly 3 failures — the fast-vault publication cases. Reverting only `Model/Coin.swift` produces exactly 3 — the pending-balance ones. The value-asserting cases pass in both, which is the point: a value test cannot see this bug.

## Additional context

Cross-model review: three read-only Codex passes, 0 findings on both per-commit passes. The whole-branch pass raised one minor — *"a future view-facing plain `@Transient` still compiles and silently recreates the defect; the doc comments are good but not enforceable."* Accepted, and became the third commit.

⚠️ **That third commit edits `.claude/rules/swiftdata.md`**, a tracked repo rules file, adding the `@Transient`-publishes-nothing rule. It is markdown only — not compiled or tested — but it changes guidance for everyone working in this repo, so call it out in review. Happy to split it into its own PR if preferred.

## Agent Metadata
- **Agent**: Claude Code
- **Issue**: #5110
- **Needs human review for**: the `ObservedTransient` facade shape (accessor on the model vs. a separate view model), and whether the `.claude/rules/swiftdata.md` addition belongs in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SwiftUI updates for session-only vault eligibility and pending-balance values.
  - Prevented unnecessary updates when transient values are written with unchanged data.
  - Preserved per-instance isolation and derived-value refresh behavior.

- **Tests**
  - Added coverage for transient state updates, redundant writes, instance isolation, derived values, and server-party scenarios.

- **Documentation**
  - Documented recommended handling for transient state that must trigger SwiftUI observation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->