### PR TITLE
fix(defi): redeem receipt shares at the amount typed, not the nearest whole percent

### DIFF
--- a/VultisigApp/VultisigApp/Components/Forms/AmountPercentageBinding.swift
+++ b/VultisigApp/VultisigApp/Components/Forms/AmountPercentageBinding.swift
@@ -25,8 +25,27 @@ import Foundation
 /// figure the user typed.
 enum AmountPercentageBinding {
 
+    /// How many decimals the function-transaction amount field renders, and
+    /// therefore the precision `AmountTextField.setupAmount()` writes when the
+    /// percentage control fills the field.
+    ///
+    /// Named rather than repeated because it is not only a display choice: a MAX
+    /// selection puts the balance TRUNCATED to this precision into the field, so
+    /// anything deciding "is this the whole position" has to know the figure it
+    /// is comparing against was rounded here. See
+    /// `ReceiptShareRedemption.isWholePosition`.
+    static let displayedDecimals = 4
+
     /// The percentage of `available` that `amount` comes to, clamped to 0…100,
     /// or `nil` when there is no balance to take a percentage of.
+    ///
+    /// ⚠️ **Lossy, and load-bearingly so.** The result is a `Double`, so a
+    /// fraction within about 1e-15 of the whole position comes back as exactly
+    /// `100`. When the field already held 100 that is not a change, SwiftUI emits
+    /// no `onChange`, and `UnstakeTransactionViewModel.onPercentage` never runs to
+    /// clear the MAX flag — leaving it stale-true over an amount the user meant to
+    /// be short of the balance. Nothing downstream may treat that flag as the sole
+    /// evidence of a full exit; see `ReceiptShareRedemption.baseUnits`.
     ///
     /// The clamp is load-bearing: the amount field accepts whatever is being
     /// typed, including a figure above the balance (rejecting that is the

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Common/Screen/AmountFunctionTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Common/Screen/AmountFunctionTransactionScreen.swift
@@ -44,7 +44,10 @@ struct AmountFunctionTransactionScreen<CustomView: View, TopView: View>: View {
         availableAmount: Decimal,
         percentageSelected: Binding<Double?>,
         percentageFieldType: PercentageFieldType,
-        amountDecimals: Int = 4,
+        // Defaults to the precision the amount/percentage binding rounds to, so
+        // a screen that does not override it cannot drift from the figure that
+        // binding derives its percentage from.
+        amountDecimals: Int = AmountPercentageBinding.displayedDecimals,
         amountField: FormField,
         isContinueDisabled: Bool = false,
         customViewPosition: AmountTextField<CustomView>.CustomViewPosition = .balance,

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
@@ -209,9 +209,22 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
             // `account.withdraw`. Both arrive here on the RUJI coin because the
             // compounded card maps sRUJI back to its bond coin.
             if isAutocompound {
+                // The redemption spends receipt shares, and unlike TCY/bRUNE the
+                // share balance is not what bounds the amount field — so nothing
+                // else stops a zero here. A zero means the read is still in flight,
+                // failed, or the position is empty; all three would build a wasm
+                // execute carrying no funds.
+                guard autocompoundBalance > 0 else { return nil }
+                // Carries the typed amount rather than a whole percentage of the
+                // position, for the reason its bRUNE sibling does — the
+                // redemption is FUNDED with an absolute share count. Here the
+                // amount is priced in RUJI and the funds are sRUJI shares, so
+                // `availableAmount` is what converts between them: it is the RUJI
+                // the shares are worth, read at the same moment as the shares.
                 return RUJILiquidUnbondTransactionBuilder(
                     coin: coin,
-                    percentage: Int(resolvedPercentage),
+                    withdrawAmount: amountField.value.toDecimal(),
+                    stakedAmount: availableAmount,
                     receiptShares: autocompoundBalance,
                     sendMaxAmount: isMaxAmount
                 )
@@ -301,7 +314,6 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
     /// them — so there is no ten-thousandth to address and no cliff at one basis
     /// point. Their floor is one receipt base unit, enforced by the builder
     /// refusing to fund a redemption with nothing (`ReceiptShareRedemption`).
-    /// RUJI-compound is still on the whole-percentage expression.
     private var withdrawsInBasisPoints: Bool {
         ["TCY", "CACAO"].contains(coin.ticker.uppercased())
     }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
@@ -190,9 +190,15 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
                 stakedAmount: availableAmount
             )
         case "BRUNE":
+            // Carries the typed amount rather than a whole percentage of the
+            // position: the unbond is FUNDED with an absolute count of
+            // `x/staking-x/brune` receipt units, so it can express the figure
+            // exactly and `Int(percentage)` was throwing that away — see
+            // `ReceiptShareRedemption`.
             return BRUNEUnstakeTransactionBuilder(
                 coin: coin,
-                percentage: Int(resolvedPercentage),
+                withdrawAmount: amountField.value.toDecimal(),
+                stakedAmount: availableAmount,
                 autoCompoundAmount: autocompoundBalance,
                 sendMaxAmount: isMaxAmount
             )
@@ -289,9 +295,13 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
     /// here gets the finer conversion with no floor under it, which is the
     /// round-to-zero hazard the validator exists to close.
     ///
-    /// bRUNE/ybRUNE and RUJI-compound are deliberately absent: they scale receipt
-    /// base units by `percentage / 100` instead of addressing the position in
-    /// ten-thousandths, which is a different mechanism and a different change.
+    /// bRUNE/ybRUNE and RUJI-compound are deliberately absent, and stay absent
+    /// now that they no longer floor to a whole percent either. They redeem
+    /// receipt shares, and a `liquid.unbond`'s FUNDS carry an absolute count of
+    /// them — so there is no ten-thousandth to address and no cliff at one basis
+    /// point. Their floor is one receipt base unit, enforced by the builder
+    /// refusing to fund a redemption with nothing (`ReceiptShareRedemption`).
+    /// RUJI-compound is still on the whole-percentage expression.
     private var withdrawsInBasisPoints: Bool {
         ["TCY", "CACAO"].contains(coin.ticker.uppercased())
     }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
@@ -220,7 +220,14 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
                 // redemption is FUNDED with an absolute share count. Here the
                 // amount is priced in RUJI and the funds are sRUJI shares, so
                 // `availableAmount` is what converts between them: it is the RUJI
-                // the shares are worth, read at the same moment as the shares.
+                // the shares are worth.
+                //
+                // ⚠️ The two come from different reads — `availableAmount` from
+                // the persisted card, `autocompoundBalance` from this sheet's own
+                // fetch — so the implied share price is only as coherent as those
+                // two are. The coupling is not new: the whole-percentage path this
+                // replaces divided by `availableAmount` and scaled
+                // `autocompoundBalance` in exactly the same way.
                 return RUJILiquidUnbondTransactionBuilder(
                     coin: coin,
                     withdrawAmount: amountField.value.toDecimal(),

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/BRUNE/BRUNEUnstakeTransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/BRUNE/BRUNEUnstakeTransactionBuilder.swift
@@ -18,7 +18,17 @@ import VultisigCommonData
 struct BRUNEUnstakeTransactionBuilder: TransactionBuilder {
     static let destinationAddress = BRUNEStakingConstants.contract
     let coin: Coin
-    let percentage: Int
+    /// What the user asked to unbond, in the units the sheet was denominated in.
+    ///
+    /// Those units are ybRUNE receipt units: the staked card renders the receipt
+    /// balance directly, so this figure and `autoCompoundAmount` are the same
+    /// kind of thing (see `UnstakeTransactionViewModel.receiptBalanceIsAvailableAmount`).
+    /// It is converted against `stakedAmount` all the same rather than assumed —
+    /// see `ReceiptShareRedemption`.
+    let withdrawAmount: Decimal
+    /// The position the sheet was showing — the balance `withdrawAmount` is a
+    /// share of, in the same units.
+    let stakedAmount: Decimal
     let autoCompoundAmount: Decimal
     let sendMaxAmount: Bool
 
@@ -34,9 +44,27 @@ struct BRUNEUnstakeTransactionBuilder: TransactionBuilder {
 
     var transactionType: VSTransactionType { .genericContract }
 
+    /// The `x/staking-x/brune` base units this unbond is funded with — the whole
+    /// of the instruction, since the execute message itself is empty.
+    ///
+    /// Converted straight from the typed amount. It used to be reached through
+    /// `Int(percentage)`, which floored a step to a whole 1% of the position and
+    /// silently unbonded ~20 ybRUNE less than was asked for on a 2002.74 position;
+    /// the funds carry an absolute count, so there was never a coarse step to
+    /// round to. `ReceiptShareRedemption` holds the arithmetic and the guards.
+    var redeemedUnits: Decimal {
+        ReceiptShareRedemption.baseUnits(
+            forAmount: withdrawAmount,
+            positionValue: stakedAmount,
+            receiptBaseUnits: coin.decimalToCrypto(value: autoCompoundAmount),
+            closingPosition: sendMaxAmount
+        )
+    }
+
     var wasmContractPayload: WasmExecuteContractPayload? {
-        let withdrawAmount = (coin.decimalToCrypto(value: autoCompoundAmount) * Decimal(percentage)) / 100
-        let units = withdrawAmount.toInt()
+        // A redemption funded with nothing pays a fee to unbond nothing. The
+        // amount field's own validators normally stop it reaching here.
+        let units = redeemedUnits.toInt()
         guard units >= 1 else { return nil }
 
         return WasmExecuteContractPayload(

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/BRUNE/BRUNEUnstakeTransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/BRUNE/BRUNEUnstakeTransactionBuilder.swift
@@ -64,7 +64,14 @@ struct BRUNEUnstakeTransactionBuilder: TransactionBuilder {
     var wasmContractPayload: WasmExecuteContractPayload? {
         // A redemption funded with nothing pays a fee to unbond nothing. The
         // amount field's own validators normally stop it reaching here.
-        let units = redeemedUnits.toInt()
+        //
+        // ⚠️ Kept in `Decimal` rather than routed through `Decimal.toInt()`. That
+        // wraps outside signed 64-bit range, and the receipt balance is parsed as
+        // `UInt64` — so a position above `Int.max` base units would render as a
+        // negative count, fail this guard, and become unwithdrawable at MAX.
+        // `wholeUnits` has already made this an integer, so its description is
+        // the digits and nothing else.
+        let units = redeemedUnits
         guard units >= 1 else { return nil }
 
         return WasmExecuteContractPayload(
@@ -74,7 +81,7 @@ struct BRUNEUnstakeTransactionBuilder: TransactionBuilder {
             { "liquid": { "unbond": {} } }
             """,
             coins: [CosmosCoin(
-                amount: String(units),
+                amount: units.description,
                 denom: TokensStore.ybrune.contractAddress
             )]
         )

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/RUJI/RUJILiquidUnbondTransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/RUJI/RUJILiquidUnbondTransactionBuilder.swift
@@ -52,16 +52,29 @@ struct RUJILiquidUnbondTransactionBuilder: TransactionBuilder {
     /// and ybRUNE are quoted to the user as receipt COUNTS: their cards render the
     /// share balance directly, so nothing on those sheets says what a share is
     /// worth and any figure derived from one would understate the payout. This
-    /// card renders the position's RUJI value instead, so the ratio between
-    /// `stakedAmount` and `receiptShares` is a live redemption price, read at the
-    /// same moment as the balances themselves.
+    /// card renders the position's RUJI value instead, so `stakedAmount` and
+    /// `receiptShares` between them imply what a share is worth.
     ///
     /// Deliberately NOT the amount that was typed: the redemption spends whole
-    /// shares, so the two differ by up to one share's worth. And it is a
-    /// projection, not a commitment — the share price moves as the pool
-    /// compounds, so what the redemption is worth on execution moves with it.
-    /// Applying the ratio the sheet was showing is the closest an absolute figure
-    /// can get. See `TCYUnstakeTransactionBuilder.withdrawDisplayAmount`.
+    /// shares, so the two differ by up to one share's worth.
+    ///
+    /// ⚠️ **A projection, not a commitment, and from TWO reads rather than one.**
+    /// `stakedAmount` reaches here from the persisted DeFi card (THORChain's
+    /// GraphQL `liquidSize`); `receiptShares` is a separate THORNode bank-balance
+    /// read the sheet makes itself. They are close together in practice, not
+    /// simultaneous. If they disagree — a stale card, or another device unbonding
+    /// in between — this figure is wrong by that same proportion, because the
+    /// redemption it describes is sized from exactly the same pair.
+    ///
+    /// That is the accepted shape of a fractional withdrawal on this screen, not
+    /// a new hazard: `TCYUnstakeTransactionBuilder.withdrawDisplayAmount` carries
+    /// the identical caveat for a position that moves between the read and the
+    /// execution. What it never does is claim MORE than was asked for — the share
+    /// count is truncated, so the quote is bounded above by the typed amount, and
+    /// `ReceiptShareRedemptionTests` pins that under a deliberately incoherent
+    /// pair. Making the two reads one coherent snapshot is the fix that would
+    /// retire the caveat, and it belongs to the sheet's balance loading rather
+    /// than here.
     var withdrawDisplayAmount: Decimal? {
         let held = heldUnits
         let redeemed = redeemedUnits
@@ -104,7 +117,11 @@ struct RUJILiquidUnbondTransactionBuilder: TransactionBuilder {
     var wasmContractPayload: WasmExecuteContractPayload? {
         // A redemption funded with nothing pays a fee to unbond nothing. The
         // amount field's own validators normally stop it reaching here.
-        let units = redeemedUnits.toInt()
+        //
+        // ⚠️ Kept in `Decimal` rather than routed through `Decimal.toInt()` —
+        // see the bRUNE sibling for why a 64-bit round trip can make a large
+        // position unwithdrawable.
+        let units = redeemedUnits
         guard units >= 1 else { return nil }
 
         return WasmExecuteContractPayload(
@@ -114,7 +131,7 @@ struct RUJILiquidUnbondTransactionBuilder: TransactionBuilder {
             { "liquid": { "unbond": {} } }
             """,
             coins: [CosmosCoin(
-                amount: String(units),
+                amount: units.description,
                 denom: TokensStore.sruji.contractAddress
             )]
         )

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/RUJI/RUJILiquidUnbondTransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/RUJI/RUJILiquidUnbondTransactionBuilder.swift
@@ -17,19 +17,57 @@ import VultisigCommonData
 /// `x/staking-x/ruji` balance. RUJI and sRUJI share 8 decimals, so scaling the
 /// redeemed fraction with the RUJI coin yields the right receipt base units.
 ///
-/// Redeeming a share of the position is driven by the percentage rather than by
-/// a RUJI amount, which sidesteps the share-price conversion entirely: at 100%
-/// the exact held share balance is redeemed, so there is no rounding dust and it
-/// can never exceed what is held even if the share price moved since the sheet
-/// opened.
+/// ⚠️ **The amount and the receipt are different units.** The compounded card
+/// renders `stakedAmount` — what the receipt is WORTH in RUJI, the pool's liquid
+/// size — so that is what the sheet's balance and the typed amount are priced in,
+/// while the funds are a count of shares worth more than 1 RUJI each. The two
+/// balances the sheet was opened with are the redemption ratio between them, and
+/// `ReceiptShareRedemption` is where the conversion and its guards live. A full
+/// exit still redeems the exact held share balance, pinned rather than derived,
+/// so it can neither leave dust behind nor exceed what is held if the share price
+/// moved since the sheet opened.
 struct RUJILiquidUnbondTransactionBuilder: TransactionBuilder {
     static let destinationAddress = RUJIStakingConstants.contract
     let coin: Coin
-    let percentage: Int
+    /// What the user asked to redeem, priced in RUJI like the card it was typed
+    /// under.
+    let withdrawAmount: Decimal
+    /// The RUJI the position is worth — the balance `withdrawAmount` is a share
+    /// of, and the figure the verify screen quotes a fraction of.
+    let stakedAmount: Decimal
     let receiptShares: Decimal
     let sendMaxAmount: Bool
 
     var amount: String { "0" }
+
+    /// The RUJI this redemption will pay out, quantised to the shares it actually
+    /// spends.
+    ///
+    /// ⚠️ **Required, not decorative.** `amount` is the literal `"0"` — the funds
+    /// are the instruction — so without this the verify screen falls through to
+    /// the generic header and names no figure at all, which is where this arm
+    /// stood before.
+    ///
+    /// ⚠️ **Why this position can name a figure when its siblings cannot.** sTCY
+    /// and ybRUNE are quoted to the user as receipt COUNTS: their cards render the
+    /// share balance directly, so nothing on those sheets says what a share is
+    /// worth and any figure derived from one would understate the payout. This
+    /// card renders the position's RUJI value instead, so the ratio between
+    /// `stakedAmount` and `receiptShares` is a live redemption price, read at the
+    /// same moment as the balances themselves.
+    ///
+    /// Deliberately NOT the amount that was typed: the redemption spends whole
+    /// shares, so the two differ by up to one share's worth. And it is a
+    /// projection, not a commitment — the share price moves as the pool
+    /// compounds, so what the redemption is worth on execution moves with it.
+    /// Applying the ratio the sheet was showing is the closest an absolute figure
+    /// can get. See `TCYUnstakeTransactionBuilder.withdrawDisplayAmount`.
+    var withdrawDisplayAmount: Decimal? {
+        let held = heldUnits
+        let redeemed = redeemedUnits
+        guard stakedAmount > 0, held >= 1, redeemed >= 1 else { return nil }
+        return (stakedAmount * redeemed) / held
+    }
 
     var memo: String { "" }
 
@@ -41,11 +79,32 @@ struct RUJILiquidUnbondTransactionBuilder: TransactionBuilder {
 
     var transactionType: VSTransactionType { .genericContract }
 
+    /// The whole `x/staking-x/ruji` base units held — the denominator the payout
+    /// projection is a share of, and the ceiling the redemption clamps to.
+    var heldUnits: Decimal {
+        ReceiptShareRedemption.wholeUnits(coin.decimalToCrypto(value: receiptShares))
+    }
+
+    /// The `x/staking-x/ruji` base units this redemption is funded with — the
+    /// whole of the instruction, since the execute message itself is empty.
+    ///
+    /// Converted straight from the typed amount. It used to be reached through
+    /// `Int(percentage)`, which floored a step to a whole 1% of the position; the
+    /// funds carry an absolute share count, so there was never a coarse step to
+    /// round to.
+    var redeemedUnits: Decimal {
+        ReceiptShareRedemption.baseUnits(
+            forAmount: withdrawAmount,
+            positionValue: stakedAmount,
+            receiptBaseUnits: coin.decimalToCrypto(value: receiptShares),
+            closingPosition: sendMaxAmount
+        )
+    }
+
     var wasmContractPayload: WasmExecuteContractPayload? {
-        let redeemed = (coin.decimalToCrypto(value: receiptShares) * Decimal(percentage)) / 100
-        // Rounds DOWN to whole base units: redeeming more shares than are held
-        // would fail on-chain, and a fractional `CosmosCoin.amount` is malformed.
-        let units = redeemed.toInt()
+        // A redemption funded with nothing pays a fee to unbond nothing. The
+        // amount field's own validators normally stop it reaching here.
+        let units = redeemedUnits.toInt()
         guard units >= 1 else { return nil }
 
         return WasmExecuteContractPayload(

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/ReceiptShareRedemption.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/ReceiptShareRedemption.swift
@@ -68,6 +68,14 @@ enum ReceiptShareRedemption {
     /// asked to close. Same reason `UnstakeTransactionViewModel.withdrawBasisPoints`
     /// pins 10000 for MAX.
     ///
+    /// ⚠️ **But the flag alone is not evidence of a full exit**, which is why the
+    /// amount has to agree with it. The flag is set from a `Double` percentage
+    /// (`AmountPercentageBinding.percentage`), and on a large position a typed
+    /// amount a hair under the balance derives exactly `100` — the same value the
+    /// field already held, so SwiftUI emits no change, `onPercentage` never runs,
+    /// and the flag stays true over an amount that was meant to leave something
+    /// staked. Trusting it by itself would close that position.
+    ///
     /// ⚠️ **A partial withdrawal can never close the position.** Truncation only
     /// moves the result down, and the result only reaches the held balance when
     /// `amount` reaches `positionValue` — which is a full exit however it was
@@ -81,9 +89,10 @@ enum ReceiptShareRedemption {
         closingPosition: Bool
     ) -> Decimal {
         let held = wholeUnits(receiptBaseUnits)
-        guard held >= 1 else { return 0 }
-        guard !closingPosition else { return held }
-        guard positionValue > 0, amount > 0 else { return 0 }
+        guard held >= 1, positionValue > 0, amount > 0 else { return 0 }
+        if closingPosition, isWholePosition(amount: amount, positionValue: positionValue) {
+            return held
+        }
 
         // Multiplied BEFORE it is divided. Taking the fraction first
         // (`amount / positionValue`) rounds it to the mantissa's 38 digits and
@@ -93,5 +102,24 @@ enum ReceiptShareRedemption {
         // exactly.
         let redeemed = wholeUnits((held * amount) / positionValue)
         return min(redeemed, held)
+    }
+
+    /// Whether `amount` is the whole position **as the amount field is able to
+    /// state it** — the balance itself, or the figure a MAX selection prefills,
+    /// which is that balance truncated to `AmountPercentageBinding.displayedDecimals`.
+    ///
+    /// The truncated form has to count, or a MAX exit on a position with more
+    /// decimals than the field renders would be read as a partial and leave a
+    /// sliver staked. Nothing BETWEEN the two counts, which is what makes this a
+    /// real check rather than a tolerance: a figure the user typed with more
+    /// precision than MAX would have written is a figure MAX did not write.
+    static func isWholePosition(amount: Decimal, positionValue: Decimal) -> Bool {
+        guard positionValue > 0 else { return false }
+        if amount >= positionValue { return true }
+
+        var raw = positionValue
+        var prefilled = Decimal()
+        NSDecimalRound(&prefilled, &raw, AmountPercentageBinding.displayedDecimals, .down)
+        return amount == prefilled
     }
 }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/ReceiptShareRedemption.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/ReceiptShareRedemption.swift
@@ -1,0 +1,97 @@
+//
+//  ReceiptShareRedemption.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Converts a withdrawal amount into the receipt base units a `liquid.unbond`
+/// redemption is FUNDED with.
+///
+/// The sibling of `WithdrawBasisPoints`, for the other kind of unstake this app
+/// builds. A fractional-withdrawal memo (`tcy-:<bps>`, `POOL-:<bps>`) names a
+/// share of the position and can express nothing finer than a ten-thousandth. A
+/// `liquid.unbond` names no figure at all — the wasm execute is empty and the
+/// funds attached to it are the instruction, an ABSOLUTE count of receipt units
+/// (`x/staking-x/brune`, `x/staking-x/ruji`). An absolute count has no coarse
+/// step to work around: the smallest thing it can express is one base unit,
+/// 0.00000001 of a share.
+///
+/// So the ten-thousandths are the wrong ceiling here, not the right one. What
+/// these two positions were actually doing was worse than either: they reached
+/// the share count through `Int(percentageSelected ?? percentageFromAmount)`,
+/// which floors the fraction to a whole percent and makes one step a whole 1% of
+/// the position — ~20 tokens on the 2002.74 position the defect was reported
+/// against. Converting the typed amount straight into base units removes the step
+/// entirely rather than making it 100× smaller.
+///
+/// ⚠️ **The amount and the receipt are not always in the same units.** The two
+/// callers differ, and the difference is why this takes a `positionValue` instead
+/// of assuming one:
+///
+/// - **bRUNE/ybRUNE** — the staked card renders the ybRUNE receipt balance
+///   directly, so the typed amount already IS a receipt figure and the conversion
+///   comes out exact.
+/// - **RUJI/sRUJI** — the compounded card renders the RUJI the receipt is worth,
+///   so the typed amount is priced in RUJI and the share count follows from the
+///   ratio between the two balances the sheet was opened with.
+///
+/// Passing both figures makes the conversion correct either way, and it stays
+/// bounded by the shares actually held rather than by an invariant asserted
+/// somewhere else.
+enum ReceiptShareRedemption {
+
+    /// `value` truncated to whole base units.
+    ///
+    /// A `CosmosCoin.amount` is an integer string, and a fractional one is
+    /// malformed. Truncating rather than rounding is the same call
+    /// `WithdrawBasisPoints` makes and for the same reason: **a redemption never
+    /// spends more of the position than was asked for**, and rounding up could
+    /// also exceed the shares actually held, which fails on-chain.
+    static func wholeUnits(_ value: Decimal) -> Decimal {
+        guard value > 0 else { return 0 }
+        var raw = value
+        var floored = Decimal()
+        NSDecimalRound(&floored, &raw, 0, .down)
+        return floored
+    }
+
+    /// The whole receipt base units to redeem for `amount` of a position worth
+    /// `positionValue`, out of the `receiptBaseUnits` held. `0` when there is
+    /// nothing to redeem, which is never a valid instruction — a `liquid.unbond`
+    /// funded with nothing pays a fee to withdraw nothing, so the callers refuse
+    /// to build one.
+    ///
+    /// ⚠️ **`closingPosition` pins the whole balance rather than deriving it.**
+    /// The amount field renders a rounded figure, so deriving a full exit from it
+    /// could leave a sliver of shares behind and keep a position open the user
+    /// asked to close. Same reason `UnstakeTransactionViewModel.withdrawBasisPoints`
+    /// pins 10000 for MAX.
+    ///
+    /// ⚠️ **A partial withdrawal can never close the position.** Truncation only
+    /// moves the result down, and the result only reaches the held balance when
+    /// `amount` reaches `positionValue` — which is a full exit however it was
+    /// typed. The clamp is what stops an over-balance figure asking for more
+    /// shares than exist; rejecting that figure is `AmountBalanceValidator`'s job,
+    /// and it has to let the value through to report it.
+    static func baseUnits(
+        forAmount amount: Decimal,
+        positionValue: Decimal,
+        receiptBaseUnits: Decimal,
+        closingPosition: Bool
+    ) -> Decimal {
+        let held = wholeUnits(receiptBaseUnits)
+        guard held >= 1 else { return 0 }
+        guard !closingPosition else { return held }
+        guard positionValue > 0, amount > 0 else { return 0 }
+
+        // Multiplied BEFORE it is divided. Taking the fraction first
+        // (`amount / positionValue`) rounds it to the mantissa's 38 digits and
+        // then scales that error up by the share count, which can land a whole
+        // base unit short of an exact figure. This order divides once, at the
+        // end, so an amount that is an exact share of the position converts
+        // exactly.
+        let redeemed = wholeUnits((held * amount) / positionValue)
+        return min(redeemed, held)
+    }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/ReceiptShareRedemption.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/ReceiptShareRedemption.swift
@@ -39,6 +39,23 @@ import Foundation
 /// Passing both figures makes the conversion correct either way, and it stays
 /// bounded by the shares actually held rather than by an invariant asserted
 /// somewhere else.
+///
+/// ⚠️ **What bounds the precision here is the INPUT, not this arithmetic.** The
+/// typed figure reaches these builders through `String.toDecimal()`, which parses
+/// with `NumberFormatter` and therefore round-trips through a `Double` — so the
+/// `Decimal` that arrives can already differ from what was typed in the 16th
+/// significant digit. `Decimal`'s own 38-digit multiply and divide below can
+/// likewise land one base unit off an exact quotient on a position large enough
+/// to need twenty digits.
+///
+/// Both are real and neither is worth exact integer arithmetic here: the second
+/// is a base unit, the first is thousands of times larger on the same position,
+/// and no amount of care downstream recovers a figure that was already perturbed
+/// upstream. Whichever way that error falls, the result is still truncated and
+/// still clamped to the shares held, so the outcome stays within one base unit of
+/// the request and can never exceed the position. Tightening the conversion while
+/// the amount arrives via `Double` would be precision theatre; the input is where
+/// it would have to start.
 enum ReceiptShareRedemption {
 
     /// `value` truncated to whole base units.
@@ -113,6 +130,15 @@ enum ReceiptShareRedemption {
     /// sliver staked. Nothing BETWEEN the two counts, which is what makes this a
     /// real check rather than a tolerance: a figure the user typed with more
     /// precision than MAX would have written is a figure MAX did not write.
+    ///
+    /// ⚠️ **The one case it cannot separate** is a user typing, by hand, exactly
+    /// what MAX would have prefilled on a position carrying more decimals than
+    /// the field shows. That closes the position, taking up to one display step
+    /// more than was asked — bounded, invisible at the precision the screen
+    /// renders, and unavoidable from the amount alone. Separating them needs the
+    /// field to report that the amount was typed rather than derived, which
+    /// `AmountPercentageSync.amountIsUserTyped` already knows and does not
+    /// currently surface to the view model.
     static func isWholePosition(amount: Decimal, positionValue: Decimal) -> Bool {
         guard positionValue > 0 else { return false }
         if amount >= positionValue { return true }

--- a/VultisigApp/VultisigAppTests/Defi/RujiDualPositionWiringTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/RujiDualPositionWiringTests.swift
@@ -88,7 +88,13 @@ final class RujiDualPositionWiringTests: XCTestCase {
             isAutocompound: true,
             availableToUnstake: Decimal(string: "140.64866515")!
         )
+        viewModel.availableAmount = Decimal(string: "140.64866515")!
         viewModel.autocompoundBalance = Decimal(string: "138.55943656")!
+        // What the sheet opens on: MAX, with the field prefilled from the
+        // balance. The redemption is driven by the amount now, so leaving the
+        // field empty would build nothing.
+        viewModel.setupAmountField()
+        viewModel.amountField.value = "140.64866515"
         viewModel.validForm = true
 
         let builder = try XCTUnwrap(viewModel.transactionBuilder)

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/BRUNEStakeTransactionBuilderTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/BRUNEStakeTransactionBuilderTests.swift
@@ -89,7 +89,8 @@ final class BRUNEStakeTransactionBuilderTests: XCTestCase {
     func testUnstakeBuilderEmitsLiquidUnbondMessage() throws {
         let builder = BRUNEUnstakeTransactionBuilder(
             coin: Self.makeBRuneCoin(),
-            percentage: 100,
+            withdrawAmount: Decimal(string: "5")!,
+            stakedAmount: Decimal(string: "5")!,
             autoCompoundAmount: Decimal(string: "5")!,
             sendMaxAmount: true
         )
@@ -100,7 +101,8 @@ final class BRUNEStakeTransactionBuilderTests: XCTestCase {
     func testUnstakeBuilderUsesLiquidBondContract() throws {
         let builder = BRUNEUnstakeTransactionBuilder(
             coin: Self.makeBRuneCoin(),
-            percentage: 100,
+            withdrawAmount: Decimal(string: "5")!,
+            stakedAmount: Decimal(string: "5")!,
             autoCompoundAmount: Decimal(string: "5")!,
             sendMaxAmount: true
         )
@@ -111,7 +113,8 @@ final class BRUNEStakeTransactionBuilderTests: XCTestCase {
     func testUnstakeBuilderFundsWithReceiptDenomFull() throws {
         let builder = BRUNEUnstakeTransactionBuilder(
             coin: Self.makeBRuneCoin(),
-            percentage: 100,
+            withdrawAmount: Decimal(string: "5")!,
+            stakedAmount: Decimal(string: "5")!,
             autoCompoundAmount: Decimal(string: "5")!,
             sendMaxAmount: true
         )
@@ -124,24 +127,29 @@ final class BRUNEStakeTransactionBuilderTests: XCTestCase {
         XCTAssertEqual(funds.amount, "500000000")
     }
 
-    func testUnstakeBuilderScalesByPercentage() throws {
+    /// ⚠️ FAILS on the parent commit, which funded this with 250000000 —
+    /// `Int(50.0346) = 50`, i.e. half the position rather than the 2.50173 that
+    /// was asked for.
+    func testUnstakeBuilderRedeemsTheAmountAskedForRatherThanAWholePercentage() throws {
         let builder = BRUNEUnstakeTransactionBuilder(
             coin: Self.makeBRuneCoin(),
-            percentage: 50,
+            withdrawAmount: Decimal(string: "2.50173")!,
+            stakedAmount: Decimal(string: "5")!,
             autoCompoundAmount: Decimal(string: "5")!,
             sendMaxAmount: false
         )
         let payload = try XCTUnwrap(builder.wasmContractPayload)
         let funds = try XCTUnwrap(payload.coins.first)
-        // 50% of 5 ybRUNE at 8 decimals → 250_000_000 receipt units.
-        XCTAssertEqual(funds.amount, "250000000")
+        // 2.50173 ybRUNE at 8 decimals → 250_173_000 receipt units.
+        XCTAssertEqual(funds.amount, "250173000")
     }
 
     func testUnstakeBuilderReturnsNilForSubUnitWithdrawal() {
         // 100% of an amount that scales below one base unit must not emit a payload.
         let builder = BRUNEUnstakeTransactionBuilder(
             coin: Self.makeBRuneCoin(),
-            percentage: 100,
+            withdrawAmount: Decimal(string: "0.000000001")!,
+            stakedAmount: Decimal(string: "0.000000001")!,
             autoCompoundAmount: Decimal(string: "0.000000001")!, // < 1e-8
             sendMaxAmount: true
         )

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/RUJIStakingTransactionBuilderTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/RUJIStakingTransactionBuilderTests.swift
@@ -104,7 +104,8 @@ final class RUJIStakingTransactionBuilderTests: XCTestCase {
     func testLiquidUnbondEmitsLiquidUnbondMessage() throws {
         let builder = RUJILiquidUnbondTransactionBuilder(
             coin: Self.makeRujiCoin(),
-            percentage: 100,
+            withdrawAmount: Decimal(string: "140.64866515")!,
+            stakedAmount: Decimal(string: "140.64866515")!,
             receiptShares: Decimal(string: "138.55943656")!,
             sendMaxAmount: true
         )
@@ -114,14 +115,15 @@ final class RUJIStakingTransactionBuilderTests: XCTestCase {
         XCTAssertEqual(builder.transactionType, .genericContract)
     }
 
-    /// At 100% the EXACT held share balance is redeemed — no rounding dust, and
+    /// A full exit redeems the EXACT held share balance — no rounding dust, and
     /// it can never exceed what is held even if the share price moved since the
-    /// sheet opened. This is what makes the percentage-driven redemption safe
-    /// without a share-price conversion.
-    func testLiquidUnbondRedeemsTheExactShareBalanceAtFullPercentage() throws {
+    /// sheet opened. Pinned rather than derived from the typed figure, which is
+    /// what keeps that true once the redemption is driven by an amount.
+    func testLiquidUnbondRedeemsTheExactShareBalanceAtAFullExit() throws {
         let builder = RUJILiquidUnbondTransactionBuilder(
             coin: Self.makeRujiCoin(),
-            percentage: 100,
+            withdrawAmount: Decimal(string: "140.64866515")!,
+            stakedAmount: Decimal(string: "140.64866515")!,
             receiptShares: Decimal(string: "138.55943656")!,
             sendMaxAmount: true
         )
@@ -132,16 +134,20 @@ final class RUJIStakingTransactionBuilderTests: XCTestCase {
         XCTAssertEqual(funds.amount, "13855943656")
     }
 
-    func testLiquidUnbondScalesSharesByPercentage() throws {
+    /// ⚠️ FAILS on the parent commit, which funded this with 6927971828 —
+    /// `Int(49.99997) = 49`, i.e. 49% of the share balance rather than the shares
+    /// 70.3243 RUJI is worth. The gap is ~1.4 RUJI on a 140 RUJI position.
+    func testLiquidUnbondRedeemsTheSharesTheTypedAmountIsWorth() throws {
         let builder = RUJILiquidUnbondTransactionBuilder(
             coin: Self.makeRujiCoin(),
-            percentage: 50,
+            withdrawAmount: Decimal(string: "70.3243")!,
+            stakedAmount: Decimal(string: "140.64866515")!,
             receiptShares: Decimal(string: "138.55943656")!,
             sendMaxAmount: false
         )
         let payload = try XCTUnwrap(builder.wasmContractPayload)
         let funds = try XCTUnwrap(payload.coins.first)
-        XCTAssertEqual(funds.amount, "6927971828")
+        XCTAssertEqual(funds.amount, "6927968618")
     }
 
     /// Redeeming zero shares is a no-op the contract would reject, so the
@@ -149,7 +155,8 @@ final class RUJIStakingTransactionBuilderTests: XCTestCase {
     func testLiquidUnbondProducesNoPayloadBelowOneBaseUnit() {
         let builder = RUJILiquidUnbondTransactionBuilder(
             coin: Self.makeRujiCoin(),
-            percentage: 1,
+            withdrawAmount: Decimal(string: "0.0000000001")!,
+            stakedAmount: 1,
             receiptShares: Decimal(string: "0.00000001")!,
             sendMaxAmount: false
         )
@@ -159,7 +166,8 @@ final class RUJIStakingTransactionBuilderTests: XCTestCase {
     func testLiquidUnbondProducesNoPayloadWithoutAShareBalance() {
         let builder = RUJILiquidUnbondTransactionBuilder(
             coin: Self.makeRujiCoin(),
-            percentage: 100,
+            withdrawAmount: Decimal(string: "140.64866515")!,
+            stakedAmount: Decimal(string: "140.64866515")!,
             receiptShares: 0,
             sendMaxAmount: true
         )

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/ReceiptShareRedemptionTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/ReceiptShareRedemptionTests.swift
@@ -238,6 +238,13 @@ final class ReceiptShareRedemptionTests: XCTestCase {
 
     /// The share balance not having loaded (or having failed to load) leaves
     /// nothing to unbond, MAX included.
+    ///
+    /// ⚠️ Asserts no BUILDER, not merely an empty payload. The refusal moved
+    /// upstream: `transactionBuilder` now declines outright for any position
+    /// funded from a receipt balance that reads zero, rather than handing back a
+    /// builder whose wasm execute happens to carry no funds. Refusing earlier is
+    /// the stronger guarantee — there is no longer an object a caller could sign
+    /// something from.
     func testABRuneUnbondBuildsNothingBeforeTheReceiptBalanceLoads() throws {
         let token = try TestStore.installInMemoryContainer()
         defer { TestStore.restore(token) }
@@ -248,7 +255,7 @@ final class ReceiptShareRedemptionTests: XCTestCase {
         viewModel.amountField.value = "2002.7400"
         viewModel.validForm = true
 
-        XCTAssertNil(try XCTUnwrap(viewModel.transactionBuilder).wasmContractPayload)
+        XCTAssertNil(viewModel.transactionBuilder)
     }
 
     // MARK: - RUJI auto-compound / sRUJI

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/ReceiptShareRedemptionTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/ReceiptShareRedemptionTests.swift
@@ -340,6 +340,86 @@ final class ReceiptShareRedemptionTests: XCTestCase {
         XCTAssertTrue(try XCTUnwrap(builder.wasmContractPayload).coins.isEmpty)
     }
 
+    /// ⚠️ The two balances behind this arm come from different reads — the RUJI
+    /// valuation from the persisted card, the share count from the sheet's own
+    /// fetch — so they can disagree. What must hold anyway: the quote never
+    /// exceeds what was asked for, and a partial redemption still leaves the
+    /// position open. Here the card is stale at twice the current share balance,
+    /// which is the worst case that path can produce.
+    func testAnIncoherentPairStillCannotOverQuoteOrCloseThePosition() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let typed = Decimal(string: "70")!
+        let builder = RUJILiquidUnbondTransactionBuilder(
+            coin: makeCoin(TokensStore.ruji),
+            withdrawAmount: typed,
+            stakedAmount: Decimal(string: "140")!,   // what the card was showing
+            receiptShares: Decimal(string: "70")!,   // what is actually held now
+            sendMaxAmount: false
+        )
+
+        XCTAssertLessThanOrEqual(try XCTUnwrap(builder.withdrawDisplayAmount), typed)
+        XCTAssertLessThan(builder.redeemedUnits, builder.heldUnits)
+        XCTAssertEqual(
+            try XCTUnwrap(try XCTUnwrap(builder.wasmContractPayload).coins.first).amount,
+            "3500000000"
+        )
+    }
+
+    // MARK: - Beyond 64 bits
+
+    /// ⚠️ A receipt balance is read as `UInt64` base units, so it can exceed
+    /// `Int.max` — and routing the redeemed count through `Decimal.toInt()` wraps
+    /// there. A wrapped count reads as negative, fails the `>= 1` guard, and
+    /// makes the position unwithdrawable at MAX rather than merely mis-sized.
+    /// 1e11 tokens at 8 decimals is 1e19 base units, comfortably past 9.22e18.
+    func testAReceiptBalanceBeyondSixtyFourBitsStillCloses() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let huge = Decimal(string: "100000000000")!
+
+        let brune = BRUNEUnstakeTransactionBuilder(
+            coin: makeCoin(TokensStore.brune),
+            withdrawAmount: huge,
+            stakedAmount: huge,
+            autoCompoundAmount: huge,
+            sendMaxAmount: true
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(try XCTUnwrap(brune.wasmContractPayload).coins.first).amount,
+            "10000000000000000000"
+        )
+
+        let ruji = RUJILiquidUnbondTransactionBuilder(
+            coin: makeCoin(TokensStore.ruji),
+            withdrawAmount: huge,
+            stakedAmount: huge,
+            receiptShares: huge,
+            sendMaxAmount: true
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(try XCTUnwrap(ruji.wasmContractPayload).coins.first).amount,
+            "10000000000000000000"
+        )
+    }
+
+    /// The funded count is an integer string on the wire — a fractional
+    /// `CosmosCoin.amount` is malformed, and dropping the 64-bit round trip means
+    /// nothing else is truncating it.
+    func testTheFundedCountIsAlwaysWholeDigits() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = makeRujiViewModel()
+        type("70.3243", into: viewModel)
+        let units = try fundedUnits(of: viewModel)
+
+        XCTAssertFalse(units.contains("."), "rendered \(units)")
+        XCTAssertFalse(units.contains("e"), "rendered \(units)")
+        XCTAssertTrue(units.allSatisfy { $0.isASCII && $0.isNumber }, "rendered \(units)")
+    }
+
     // MARK: - Fixtures
 
     private func makeCoin(_ asset: CoinMeta) -> Coin {

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/ReceiptShareRedemptionTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/ReceiptShareRedemptionTests.swift
@@ -1,0 +1,261 @@
+//
+//  ReceiptShareRedemptionTests.swift
+//  VultisigAppTests
+//
+//  The two unstake arms that redeem RECEIPT SHARES rather than asking a memo for
+//  a fraction of a position. Their `liquid.unbond` is funded with an absolute
+//  count of receipt base units, so the typed amount is expressible exactly — but
+//  it was reached through `Int(percentageSelected ?? percentageFromAmount)`,
+//  which floors the fraction to a whole percent and makes one step a whole 1% of
+//  the position. On the 2002.74 position the sibling defect was reported against
+//  that is ~20 tokens, silently.
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class ReceiptShareRedemptionTests: XCTestCase {
+
+    /// The position from the bug report, reused here so the two arms can be
+    /// compared against the same arithmetic.
+    private let staked = Decimal(string: "2002.74")!
+    /// The same position in receipt base units, at the 8 decimals bRUNE, ybRUNE,
+    /// RUJI and sRUJI all share.
+    private let stakedUnits = Decimal(string: "200274000000")!
+
+    // MARK: - The conversion
+
+    func testAnExactShareOfThePositionConvertsExactly() {
+        XCTAssertEqual(
+            ReceiptShareRedemption.baseUnits(
+                forAmount: Decimal(string: "1002.73")!,
+                positionValue: staked,
+                receiptBaseUnits: stakedUnits,
+                closingPosition: false
+            ),
+            Decimal(string: "100273000000")!
+        )
+    }
+
+    /// Truncated, never rounded up: a redemption must not spend more of the
+    /// position than was asked for, and a fractional `CosmosCoin.amount` is
+    /// malformed besides.
+    func testAFractionalUnitIsTruncatedRatherThanRounded() {
+        // 3 units of a 3-token position, asking for 1.9999 tokens' worth.
+        XCTAssertEqual(
+            ReceiptShareRedemption.baseUnits(
+                forAmount: Decimal(string: "1.9999")!,
+                positionValue: 3,
+                receiptBaseUnits: 3,
+                closingPosition: false
+            ),
+            1
+        )
+    }
+
+    /// ⚠️ A full exit pins the whole held balance instead of deriving it. The
+    /// amount field renders a rounded figure, so a derived MAX could leave a
+    /// sliver of shares behind and keep open a position the user asked to close.
+    func testClosingThePositionSpendsEveryHeldShare() {
+        XCTAssertEqual(
+            ReceiptShareRedemption.baseUnits(
+                forAmount: Decimal(string: "1.5")!,
+                positionValue: staked,
+                receiptBaseUnits: stakedUnits,
+                closingPosition: true
+            ),
+            stakedUnits
+        )
+    }
+
+    /// ⚠️ The other half of the same invariant: a PARTIAL withdrawal must never
+    /// close the position. Truncation only moves the result down, so the held
+    /// balance is reached only by an amount that reaches the whole position.
+    func testAPartialRedemptionNeverSpendsTheWholeBalance() {
+        let units = ReceiptShareRedemption.baseUnits(
+            forAmount: Decimal(string: "2002.7399")!,
+            positionValue: staked,
+            receiptBaseUnits: stakedUnits,
+            closingPosition: false
+        )
+        XCTAssertLessThan(units, stakedUnits)
+        XCTAssertEqual(units, Decimal(string: "200273990000")!)
+    }
+
+    /// Rejecting an over-balance figure is `AmountBalanceValidator`'s job, and it
+    /// has to let the value through to report it — so the conversion clamps
+    /// rather than asking the chain for shares that do not exist.
+    func testMoreThanThePositionClampsToWhatIsHeld() {
+        XCTAssertEqual(
+            ReceiptShareRedemption.baseUnits(
+                forAmount: staked * 3,
+                positionValue: staked,
+                receiptBaseUnits: stakedUnits,
+                closingPosition: false
+            ),
+            stakedUnits
+        )
+    }
+
+    /// An amount below a single receipt base unit has nothing to redeem. This is
+    /// the floor under these two arms — one base unit rather than the one basis
+    /// point a fractional-withdrawal memo floors at.
+    func testAnAmountTooSmallForOneBaseUnitIsZero() {
+        XCTAssertEqual(
+            ReceiptShareRedemption.baseUnits(
+                forAmount: Decimal(string: "0.000000001")!,
+                positionValue: staked,
+                receiptBaseUnits: stakedUnits,
+                closingPosition: false
+            ),
+            0
+        )
+    }
+
+    /// A share balance that has not loaded, failed to load, or is empty. Nothing
+    /// is redeemable, MAX included — pinning a balance of nothing would build a
+    /// redemption funded with nothing.
+    func testThereIsNothingToRedeemWithoutAShareBalance() {
+        for closing in [true, false] {
+            XCTAssertEqual(
+                ReceiptShareRedemption.baseUnits(
+                    forAmount: 10,
+                    positionValue: staked,
+                    receiptBaseUnits: 0,
+                    closingPosition: closing
+                ),
+                0
+            )
+        }
+    }
+
+    func testThereIsNothingToRedeemAgainstAnEmptyPosition() {
+        XCTAssertEqual(
+            ReceiptShareRedemption.baseUnits(
+                forAmount: 10,
+                positionValue: 0,
+                receiptBaseUnits: stakedUnits,
+                closingPosition: false
+            ),
+            0
+        )
+    }
+
+    // MARK: - bRUNE / ybRUNE
+
+    /// ⚠️ The regression test for the bRUNE arm. Verified to FAIL on the parent
+    /// commit, where the same inputs fund the unbond with **100137000000** —
+    /// `Int(50.0679) = 50`, so 50% of the receipt balance instead of the 1002.73
+    /// that was typed. The difference is 1.36 ybRUNE on this position.
+    func testABRuneUnbondRedeemsTheAmountThatWasTypedNotAFlooredPercentage() throws {
+        XCTAssertEqual(try redeemedBRuneUnits(typing: "1002.73"), "100273000000")
+    }
+
+    /// ⚠️ Also FAILS on the parent commit, at the top of the range where the
+    /// flooring is most expensive: `Int(99.995) = 99` unbonded 198271260000 —
+    /// 19.93 ybRUNE less than the 2002.64 asked for. Both figures leave the
+    /// position open, which is the point of the assertion below them; only one of
+    /// them withdraws what was requested.
+    func testABRunePartialUnbondTakesTheTypedAmountAndLeavesThePositionOpen() throws {
+        let units = try redeemedBRuneUnits(typing: "2002.64")
+        XCTAssertEqual(units, "200264000000")
+        XCTAssertLessThan(Decimal(string: units)!, stakedUnits)
+    }
+
+    /// A full exit still empties the receipt balance exactly — the property the
+    /// old `percentage == 100` path had for free and the new one has to pin.
+    func testABRuneFullExitUnbondsTheWholeReceiptBalance() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = makeBRuneViewModel()
+        viewModel.setupAmountField()          // MAX — what the sheet opens on
+        viewModel.amountField.value = "2002.7400"
+        viewModel.validForm = true
+
+        XCTAssertEqual(try fundedUnits(of: viewModel), "200274000000")
+    }
+
+    /// Nothing to redeem must mean no transaction, not a redemption funded with
+    /// nothing: the fee would be spent unbonding zero.
+    func testABRuneUnbondBelowOneReceiptUnitBuildsNothing() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = makeBRuneViewModel()
+        type("0.000000001", into: viewModel)
+
+        XCTAssertNil(try XCTUnwrap(viewModel.transactionBuilder).wasmContractPayload)
+    }
+
+    /// The share balance not having loaded (or having failed to load) leaves
+    /// nothing to unbond, MAX included.
+    func testABRuneUnbondBuildsNothingBeforeTheReceiptBalanceLoads() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = makeBRuneViewModel()
+        viewModel.autocompoundBalance = 0
+        viewModel.setupAmountField()
+        viewModel.amountField.value = "2002.7400"
+        viewModel.validForm = true
+
+        XCTAssertNil(try XCTUnwrap(viewModel.transactionBuilder).wasmContractPayload)
+    }
+
+    // MARK: - Fixtures
+
+    private func makeCoin(_ asset: CoinMeta) -> Coin {
+        Coin(
+            asset: asset,
+            address: "thor1fixturereceiptvaultaddress0000000000",
+            hexPublicKey: "02" + String(repeating: "00", count: 32)
+        )
+    }
+
+    /// Types `amount` into the sheet the way the field does, so the view model is
+    /// left in the state the real screen leaves it in.
+    ///
+    /// The two lines after the assignment are what `AmountTextField` and
+    /// `UnstakeTransactionScreen` do between them on every keystroke: derive the
+    /// percentage from the typed amount, then let the view model reconsider
+    /// whether the position is being closed. Skipping them would leave
+    /// `percentageSelected` on its initial 100 and quietly test a MAX withdrawal
+    /// instead of a custom one.
+    private func type(_ amount: String, into viewModel: UnstakeTransactionViewModel) {
+        viewModel.amountField.value = amount
+        viewModel.percentageSelected = viewModel.percentageFromAmount
+        viewModel.onPercentage(viewModel.percentageFromAmount)
+        viewModel.validForm = true
+    }
+
+    /// The bRUNE sheet as the DeFi card opens it: the ybRUNE receipt balance is
+    /// both the ceiling and the thing being spent, because the staked card
+    /// renders receipt units directly.
+    private func makeBRuneViewModel() -> UnstakeTransactionViewModel {
+        let viewModel = UnstakeTransactionViewModel(
+            coin: makeCoin(TokensStore.brune),
+            vault: TestStore.makeVault(),
+            isAutocompound: true,
+            availableToUnstake: staked
+        )
+        viewModel.availableAmount = staked
+        viewModel.autocompoundBalance = staked
+        return viewModel
+    }
+
+    private func fundedUnits(of viewModel: UnstakeTransactionViewModel) throws -> String {
+        let payload = try XCTUnwrap(try XCTUnwrap(viewModel.transactionBuilder).wasmContractPayload)
+        return try XCTUnwrap(payload.coins.first).amount
+    }
+
+    private func redeemedBRuneUnits(typing amount: String) throws -> String {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = makeBRuneViewModel()
+        type(amount, into: viewModel)
+        return try fundedUnits(of: viewModel)
+    }
+}

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/ReceiptShareRedemptionTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/ReceiptShareRedemptionTests.swift
@@ -23,6 +23,12 @@ final class ReceiptShareRedemptionTests: XCTestCase {
     /// The same position in receipt base units, at the 8 decimals bRUNE, ybRUNE,
     /// RUJI and sRUJI all share.
     private let stakedUnits = Decimal(string: "200274000000")!
+    /// A real RUJI compounded position: the card's RUJI-denominated value and the
+    /// sRUJI share balance behind it. They differ because a share is worth more
+    /// than 1 RUJI — which is exactly what makes this arm a different conversion
+    /// from bRUNE's.
+    private let rujiStaked = Decimal(string: "140.64866515")!
+    private let rujiShares = Decimal(string: "138.55943656")!
 
     // MARK: - The conversion
 
@@ -204,6 +210,136 @@ final class ReceiptShareRedemptionTests: XCTestCase {
         XCTAssertNil(try XCTUnwrap(viewModel.transactionBuilder).wasmContractPayload)
     }
 
+    // MARK: - RUJI auto-compound / sRUJI
+    //
+    // The other arm, and not the same shape: this card renders what the receipt
+    // is WORTH in RUJI, so the typed amount is priced in RUJI and the share count
+    // follows from the ratio between the two balances the sheet was opened with.
+    // The bRUNE arm's amount is already a share count.
+
+    /// ⚠️ The regression test for the RUJI arm. Verified to FAIL on the parent
+    /// commit, where the same inputs redeem **6789412391** shares —
+    /// `Int(49.99997) = 49`, so 49% of the share balance instead of the shares
+    /// 70.3243 RUJI is worth. That is ~1.4 RUJI missing from a 140 RUJI position.
+    func testTheCompoundedRujiRedemptionSpendsTheSharesTheTypedAmountIsWorth() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = makeRujiViewModel()
+        type("70.3243", into: viewModel)
+
+        XCTAssertEqual(try fundedUnits(of: viewModel), "6927968618")
+    }
+
+    /// ⚠️ Also FAILS on the parent commit, where `withdrawDisplayAmount` is `nil`
+    /// for this builder and the verify screen names no figure at all.
+    ///
+    /// The figure is a projection at the ratio the sheet was showing, quantised
+    /// to whole shares — so it tracks the typed amount to within one share's
+    /// worth and never exceeds it.
+    func testTheCompoundedRujiRedemptionQuotesTheRujiThatWillBePaidOut() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let vault = TestStore.makeVault()
+
+        let viewModel = makeRujiViewModel(vault: vault)
+        type("70.3243", into: viewModel)
+        let builder = try XCTUnwrap(viewModel.transactionBuilder)
+
+        let typed = Decimal(string: "70.3243")!
+        let quoted = try XCTUnwrap(builder.withdrawDisplayAmount)
+        XCTAssertLessThanOrEqual(quoted, typed, "a redemption must never quote more than was asked for")
+        XCTAssertEqual(
+            NSDecimalNumber(decimal: quoted).doubleValue,
+            NSDecimalNumber(decimal: typed).doubleValue,
+            accuracy: 0.0000001
+        )
+
+        // And it reaches the screen that approves it. The withdrawal provider
+        // keys on the builder-supplied figure rather than on TCY specifically,
+        // so a redemption that carries one is described by it too.
+        let hero = try XCTUnwrap(TransactionHeroResolver.hero(
+            on: .functionCallVerify,
+            for: .initiating(builder.buildSendTransaction(vault: vault))
+        ))
+        guard case .send(let title, let coin) = hero else {
+            return XCTFail("a redemption should render as a resolved single-sided amount")
+        }
+        XCTAssertEqual(coin.ticker, "RUJI")
+        XCTAssertNotEqual(coin.amount, "0")
+        XCTAssertTrue(coin.amount.contains("70.32429999"), "rendered \(coin.amount)")
+        XCTAssertEqual(title, "quotedWithdrawalVerifyTitle".localized)
+    }
+
+    /// The wire truth is untouched: the redemption still carries no amount of its
+    /// own, because the funds are the instruction.
+    func testTheCompoundedRujiRedemptionStillCarriesNoAmountOnTheWire() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = makeRujiViewModel()
+        type("70.3243", into: viewModel)
+        let builder = try XCTUnwrap(viewModel.transactionBuilder)
+
+        XCTAssertEqual(builder.amount, "0")
+        XCTAssertEqual(builder.memo, "")
+    }
+
+    /// ⚠️ Asking for all but a sliver must leave that sliver staked. On the
+    /// parent this redeemed 13717384219 shares — `Int(99.99)` — which also left
+    /// the position open, but 138556 shares further from what was asked for.
+    func testACompoundedRujiPartialRedemptionLeavesThePositionOpen() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = makeRujiViewModel()
+        type("140.6486", into: viewModel)
+        let builder = try XCTUnwrap(viewModel.transactionBuilder as? RUJILiquidUnbondTransactionBuilder)
+
+        XCTAssertEqual(try fundedUnits(of: viewModel), "13855937237")
+        XCTAssertLessThan(builder.redeemedUnits, builder.heldUnits)
+    }
+
+    /// A full exit redeems every share, pinned rather than derived — the property
+    /// the old `percentage == 100` path had for free.
+    func testACompoundedRujiFullExitRedeemsEveryShare() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = makeRujiViewModel()
+        viewModel.setupAmountField()          // MAX — what the sheet opens on
+        viewModel.amountField.value = "140.64866515"
+        viewModel.validForm = true
+
+        XCTAssertEqual(try fundedUnits(of: viewModel), "13855943656")
+    }
+
+    /// The bonded RUJI position is exact already and must stay untouched: its
+    /// `withdraw:<asset>:<raw>` memo carries an ABSOLUTE amount, so none of this
+    /// applies to it. `isAutocompound` is the only thing separating the two, and
+    /// both arrive on the RUJI coin.
+    func testTheBondedRujiWithdrawalStillTakesTheAbsoluteAmountPath() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = UnstakeTransactionViewModel(
+            coin: makeCoin(TokensStore.ruji),
+            vault: TestStore.makeVault(),
+            isAutocompound: false,
+            availableToUnstake: rujiStaked
+        )
+        viewModel.availableAmount = rujiStaked
+        // The share balance is set too, so a builder that reached for it instead
+        // of the bonded path would be caught rather than merely failing to build.
+        viewModel.autocompoundBalance = rujiShares
+        type("70.3243", into: viewModel)
+
+        let builder = try XCTUnwrap(viewModel.transactionBuilder)
+        XCTAssertTrue(builder is RUJIUnstakeTransactionBuilder)
+        XCTAssertTrue(builder.memo.hasPrefix("withdraw:x/ruji:"), "built \(builder.memo)")
+        XCTAssertTrue(try XCTUnwrap(builder.wasmContractPayload).coins.isEmpty)
+    }
+
     // MARK: - Fixtures
 
     private func makeCoin(_ asset: CoinMeta) -> Coin {
@@ -248,6 +384,21 @@ final class ReceiptShareRedemptionTests: XCTestCase {
     private func fundedUnits(of viewModel: UnstakeTransactionViewModel) throws -> String {
         let payload = try XCTUnwrap(try XCTUnwrap(viewModel.transactionBuilder).wasmContractPayload)
         return try XCTUnwrap(payload.coins.first).amount
+    }
+
+    /// The RUJI compounded sheet as the DeFi card opens it: the ceiling is the
+    /// RUJI the position is worth, and the thing being spent is the sRUJI share
+    /// balance. A share is worth more than 1 RUJI, so the two differ.
+    private func makeRujiViewModel(vault: Vault? = nil) -> UnstakeTransactionViewModel {
+        let viewModel = UnstakeTransactionViewModel(
+            coin: makeCoin(TokensStore.ruji),
+            vault: vault ?? TestStore.makeVault(),
+            isAutocompound: true,
+            availableToUnstake: rujiStaked
+        )
+        viewModel.availableAmount = rujiStaked
+        viewModel.autocompoundBalance = rujiShares
+        return viewModel
     }
 
     private func redeemedBRuneUnits(typing amount: String) throws -> String {

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/ReceiptShareRedemptionTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/ReceiptShareRedemptionTests.swift
@@ -61,18 +61,59 @@ final class ReceiptShareRedemptionTests: XCTestCase {
     }
 
     /// ⚠️ A full exit pins the whole held balance instead of deriving it. The
-    /// amount field renders a rounded figure, so a derived MAX could leave a
-    /// sliver of shares behind and keep open a position the user asked to close.
-    func testClosingThePositionSpendsEveryHeldShare() {
+    /// amount field renders 4 decimals, so a MAX on a position with more of them
+    /// arrives here already short — deriving from it would leave a sliver of
+    /// shares behind and keep open a position the user asked to close.
+    func testClosingThePositionSpendsEveryHeldShareEvenFromTheRoundedField() {
+        // What MAX prefills for a 140.64866515 position.
         XCTAssertEqual(
             ReceiptShareRedemption.baseUnits(
-                forAmount: Decimal(string: "1.5")!,
-                positionValue: staked,
-                receiptBaseUnits: stakedUnits,
+                forAmount: Decimal(string: "140.6486")!,
+                positionValue: rujiStaked,
+                receiptBaseUnits: Decimal(string: "13855943656")!,
                 closingPosition: true
             ),
-            stakedUnits
+            Decimal(string: "13855943656")!
         )
+    }
+
+    /// ⚠️ **The MAX flag alone must not close a position.** It is set from a
+    /// `Double` percentage, so an amount a hair under the balance derives exactly
+    /// 100 — the value the field already held, which means SwiftUI emits no
+    /// change and the flag is never cleared. Trusting it by itself would take a
+    /// remainder the user asked to keep.
+    func testAFlagLeftStaleByADoubleRoundedPercentageDoesNotCloseThePosition() {
+        let position = Decimal(string: "100000000000")!
+        let held = Decimal(string: "10000000000000000000")!
+        let typed = Decimal(string: "99999999999.999999")!
+
+        // The collision this guards against is real, not hypothetical: the
+        // percentage the field would derive for that amount IS exactly 100.
+        XCTAssertEqual(AmountPercentageBinding.percentage(ofAmount: typed, available: position), 100)
+
+        let units = ReceiptShareRedemption.baseUnits(
+            forAmount: typed,
+            positionValue: position,
+            receiptBaseUnits: held,
+            closingPosition: true
+        )
+        XCTAssertLessThan(units, held, "an amount short of the balance must not close the position")
+        XCTAssertGreaterThan(units, 0)
+    }
+
+    /// The other side of that guard: a figure MAX itself would never have written
+    /// is not MAX, however close to the balance it sits.
+    func testOnlyTheBalanceOrTheFigureMaxPrefillsCountsAsTheWholePosition() {
+        XCTAssertTrue(ReceiptShareRedemption.isWholePosition(amount: rujiStaked, positionValue: rujiStaked))
+        XCTAssertTrue(ReceiptShareRedemption.isWholePosition(
+            amount: Decimal(string: "140.6486")!, positionValue: rujiStaked
+        ))
+        XCTAssertFalse(ReceiptShareRedemption.isWholePosition(
+            amount: Decimal(string: "140.64865")!, positionValue: rujiStaked
+        ))
+        XCTAssertFalse(ReceiptShareRedemption.isWholePosition(
+            amount: Decimal(string: "140.6485")!, positionValue: rujiStaked
+        ))
     }
 
     /// ⚠️ The other half of the same invariant: a PARTIAL withdrawal must never
@@ -308,7 +349,9 @@ final class ReceiptShareRedemptionTests: XCTestCase {
 
         let viewModel = makeRujiViewModel()
         viewModel.setupAmountField()          // MAX — what the sheet opens on
-        viewModel.amountField.value = "140.64866515"
+        // What `AmountTextField.setupAmount()` writes: the balance truncated to
+        // the field's 4 decimals, which is already short of the position.
+        viewModel.amountField.value = "140.6486"
         viewModel.validForm = true
 
         XCTAssertEqual(try fundedUnits(of: viewModel), "13855943656")

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/WithdrawBasisPointsTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/WithdrawBasisPointsTests.swift
@@ -233,45 +233,6 @@ final class WithdrawBasisPointsTests: XCTestCase {
         XCTAssertNil(viewModel.transactionBuilder)
     }
 
-    /// ⚠️ RUJI-compound is still on the whole-percentage expression, and is the
-    /// last arm that is. If someone converts it, this is the test that should be
-    /// updated rather than silently passing.
-    ///
-    /// It is NOT a case for basis points: a `liquid.unbond` is funded with an
-    /// absolute count of receipt shares, so it can express the typed amount
-    /// exactly and has no ten-thousandth to round to. `ReceiptShareRedemption` is
-    /// the conversion it wants, and its bRUNE sibling already uses it — which is
-    /// why bRUNE has left this test.
-    ///
-    /// The redeemed units are the assertion because the unbond carries no memo —
-    /// the fraction rides in the wasm execute's funds.
-    func testTheRujiCompoundSiblingStillBuildsFromAWholePercentage() throws {
-        let token = try TestStore.installInMemoryContainer()
-        defer { TestStore.restore(token) }
-
-        // RUJI alone now: this commit moves bRUNE off the whole-percentage path,
-        // so the sibling it used to share this assertion with no longer belongs
-        // here. One fixture, so one vault key is enough.
-        let viewModel = UnstakeTransactionViewModel(
-            coin: Coin(
-                asset: TokensStore.ruji,
-                address: "thor1fixturereceiptvaultaddress0000000000",
-                hexPublicKey: "02" + String(repeating: "00", count: 32)
-            ),
-            vault: TestStore.makeVault(pubKey: "test-pub-ruji-compound"),
-            isAutocompound: true,
-            availableToUnstake: staked
-        )
-        viewModel.availableAmount = staked
-        viewModel.autocompoundBalance = staked
-        type("1002.73", into: viewModel)
-
-        let payload = try XCTUnwrap(try XCTUnwrap(viewModel.transactionBuilder).wasmContractPayload)
-        // Int(50.0679) = 50 — the flooring still in place here. Converting the
-        // typed amount straight to shares would redeem 100273000000 instead.
-        XCTAssertEqual(payload.coins.first?.amount, "100137000000")
-    }
-
     /// The bonded RUJI position is exact already and must stay untouched: its
     /// `withdraw:<asset>:<raw>` memo carries an ABSOLUTE amount, so there is no
     /// fraction to quantise and nothing here applies to it.

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/WithdrawBasisPointsTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/WithdrawBasisPointsTests.swift
@@ -233,44 +233,43 @@ final class WithdrawBasisPointsTests: XCTestCase {
         XCTAssertNil(viewModel.transactionBuilder)
     }
 
-    /// ⚠️ bRUNE/ybRUNE and RUJI-compound are still on the whole-percentage
-    /// expression, deliberately: they scale receipt base units by
-    /// `percentage / 100` rather than addressing the position in ten-thousandths,
-    /// which is a different mechanism and a different change. If someone converts
-    /// them later, this is the test that should be updated rather than silently
-    /// passing.
+    /// ⚠️ RUJI-compound is still on the whole-percentage expression, and is the
+    /// last arm that is. If someone converts it, this is the test that should be
+    /// updated rather than silently passing.
     ///
-    /// The withdrawn units are the assertion because neither unbond carries a memo
-    /// — the fraction rides in the wasm execute's funds. Both share 8 decimals with
-    /// their receipt token, so both land on the same figure for the same position.
-    func testTheReceiptScalingSiblingsStillBuildFromAWholePercentage() throws {
+    /// It is NOT a case for basis points: a `liquid.unbond` is funded with an
+    /// absolute count of receipt shares, so it can express the typed amount
+    /// exactly and has no ten-thousandth to round to. `ReceiptShareRedemption` is
+    /// the conversion it wants, and its bRUNE sibling already uses it — which is
+    /// why bRUNE has left this test.
+    ///
+    /// The redeemed units are the assertion because the unbond carries no memo —
+    /// the fraction rides in the wasm execute's funds.
+    func testTheRujiCompoundSiblingStillBuildsFromAWholePercentage() throws {
         let token = try TestStore.installInMemoryContainer()
         defer { TestStore.restore(token) }
 
-        for asset in [TokensStore.brune, TokensStore.ruji] {
-            let viewModel = UnstakeTransactionViewModel(
-                coin: Coin(
-                    asset: asset,
-                    address: "thor1fixturereceiptvaultaddress0000000000",
-                    hexPublicKey: "02" + String(repeating: "00", count: 32)
-                ),
-                // One vault per asset: both share the container, and `Vault`'s
-                // unique attributes make a second identical fixture upsert over
-                // the first rather than sit beside it.
-                vault: TestStore.makeVault(pubKey: "test-pub-\(asset.ticker.lowercased())"),
-                isAutocompound: true,
-                availableToUnstake: staked
-            )
-            viewModel.availableAmount = staked
-            viewModel.autocompoundBalance = staked
-            type("1002.73", into: viewModel)
+        // RUJI alone now: this commit moves bRUNE off the whole-percentage path,
+        // so the sibling it used to share this assertion with no longer belongs
+        // here. One fixture, so one vault key is enough.
+        let viewModel = UnstakeTransactionViewModel(
+            coin: Coin(
+                asset: TokensStore.ruji,
+                address: "thor1fixturereceiptvaultaddress0000000000",
+                hexPublicKey: "02" + String(repeating: "00", count: 32)
+            ),
+            vault: TestStore.makeVault(pubKey: "test-pub-ruji-compound"),
+            isAutocompound: true,
+            availableToUnstake: staked
+        )
+        viewModel.availableAmount = staked
+        viewModel.autocompoundBalance = staked
+        type("1002.73", into: viewModel)
 
-            let payload = try XCTUnwrap(try XCTUnwrap(viewModel.transactionBuilder).wasmContractPayload)
-            // Int(50.0679) = 50 — the flooring this issue fences off. Addressing
-            // the same position in ten-thousandths would redeem 5006 bps of
-            // 200274000000 = 100257164400 units instead.
-            XCTAssertEqual(payload.coins.first?.amount, "100137000000", "\(asset.ticker)")
-        }
+        let payload = try XCTUnwrap(try XCTUnwrap(viewModel.transactionBuilder).wasmContractPayload)
+        // Int(50.0679) = 50 — the flooring still in place here. Converting the
+        // typed amount straight to shares would redeem 100273000000 instead.
+        XCTAssertEqual(payload.coins.first?.amount, "100137000000")
     }
 
     /// The bonded RUJI position is exact already and must stay untouched: its


### PR DESCRIPTION
## Description

Fixes #5090

`UnstakeTransactionViewModel` held the withdrawal fraction as a `Double` and truncated it to `Int` at each builder call site, so a typed amount was silently quantised to **1% of the position** — a ~20 token step on a 2002.74 position. That is how #5074 arrived as a user report; this PR fixes the two arms #5089 deliberately fenced off.

### Scope: two arms, not three

The issue lists bRUNE, RUJI auto-compound **and CACAO**. **CACAO was already fixed on this branch's base** by the last commit of #5089 — it is in `withdrawsInBasisPoints`, has a `withdrawDisplayAmount`, and is covered (`POOL-:5006`). The issue text predates that commit. Real scope is **bRUNE and RUJI auto-compound**.

### Deliberate deviation: not basis points

The issue asks for basis-point resolution. That is right for the memo-carrying arms and wrong for these two.

A `tcy-:<bps>` / `POOL-:<bps>` memo names a **fraction**, and cannot express finer than a ten-thousandth — which is why `WithdrawBasisPoints` exists. A `liquid.unbond` names **nothing**: the execute message is empty and the **attached funds are the instruction**, an absolute count of receipt base units. Routing these arms through basis points would re-impose a quantisation the instruction does not have.

So they get a sibling, `ReceiptShareRedemption`, converting the typed amount straight to base units. Accuracy goes from 1% of the position to **~1e-8** of it — three orders finer than the 0.01% the acceptance criteria asked for.

The two arms are not symmetric, which is why the conversion takes a position value rather than assuming one:

- **bRUNE** — the card renders the ybRUNE receipt balance directly, so the typed amount is already a share count.
- **RUJI auto-compound** — the card renders what the receipt is *worth* in RUJI, so shares follow from the ratio of the two balances.

### What the screen says it will pay out

RUJI auto-compound gains a `withdrawDisplayAmount` (`stakedAmount × redeemed / held`): that card quotes the position's value, so the ratio is real, and the verify screen named no figure at all before. It renders through the withdrawal provider #5089 already installed in `TransactionHeroResolver` — that provider keys on a builder-supplied figure rather than on TCY, so it describes this redemption too, which `testTheCompoundedRujiRedemptionQuotesTheRujiThatWillBePaidOut` pins end to end.

**bRUNE deliberately still names none**, reusing #5089's established call: its sheet is denominated in ybRUNE while the payout is bRUNE, and the bond ratio is not held here. What changed for bRUNE is that the figure in the field is now exactly the figure redeemed.

**Guards, per arm:** a full exit *pins* the whole held balance rather than deriving it; truncation means a partial can never close the position; the count is clamped to held; and below one base unit no payload is built. That base unit is the floor for these arms, in place of the one basis point the bps arms floor at — which is why they stay out of `withdrawsInBasisPoints` and `WithdrawMinimumAmountValidator`.

## What only the whole-branch review caught

**A near-MAX typed amount could close a position meant to stay open.** `AmountPercentageBinding.percentage` returns a `Double`, so an amount within ~1e-15 of the balance derives *exactly* 100 — the value a fresh sheet already holds. SwiftUI emits no `onChange`, `onPercentage` never runs, and `isMaxAmount` stays true. A full exit now additionally requires the amount to **be** the position: the balance, or the balance truncated to the field's own precision (what MAX prefills). Exact rather than a tolerance — MAX's prefill is already up to one display step short, so any window wide enough to admit it also admits the typed amounts the check exists to catch.

**A large position could become unwithdrawable at MAX.** The redemption is kept in `Decimal` rather than routed through `Decimal.toInt()`, which wraps outside signed 64-bit range while the receipt balance is parsed as `UInt64` — so a position above `Int.max` base units would render as a negative count, fail the positive guard, and build no payload at all.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast)
- [ ] Sending
- [ ] Swap
- [x] New Chain / Chain related feature

**No tx link.** Both arms are fund paths — the funds attached to the unbond are what change — and signing one needs a real staked THORChain position, which this environment does not have.

> ⚠️ **Wants an on-device mainnet check before merge.** Every commit message says so.

## Parity

- Android: `n/a: not implemented` — no `liquid.unbond` staking path in the app source.
- Windows + extension: `n/a: not affected` — `core/ui/vault/deposit/staking/resolvers/stcy-auto.ts:25-38` converts the typed amount straight to share units and attaches it as funds. It never routes through a percentage, so the quantisation fixed here does not exist there. (Its denomination differs — it treats the typed amount as a share count — which is a UI choice, not this defect.)
- SDK: `n/a: no amount entry` — the funds arrive already built.

## Testing

Full `make test` on this exact tree: **`** TEST SUCCEEDED **`, 0 failures.** SwiftLint clean.

`ReceiptShareRedemptionTests` covers both arms: the conversion and its guards, the MAX-flag closure, the `Decimal` range behaviour, the payout quote reaching the verify screen, and the refusal below one base unit. The precision limit is documented where it actually runs out rather than claimed away.

## Stack

```
main → #5176 → #5089 → #5157 (this)
```

Rebased onto #5089 directly. It previously sat on #5136, which has been **closed as superseded** — that PR added a declared `FunctionTransactionKind` to every builder for the initiator's verify screen, and the decoder in #5176 covers the reported defect without it. Nothing in this PR depended on it: the two `functionKind` declarations it carried were dropped, and the payout figure renders through #5089's registry instead.

Review #5176 and #5089 first.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Agent Metadata

- **Agent**: Claude Code
- **Issue**: #5090
- **Confidence**: high on the conversion and guards; the residual risk is the two-read projection named below
- **Needs human review for**: the on-device mainnet check, and the RUJI payout quote — it comes from two reads taken close together but not simultaneously (the persisted DeFi card's `liquidSize` and a separate THORNode bank-balance read), so a stale card skews the quote by that same proportion. It is bounded above by the typed amount and never quotes more than was asked for.
