### PR TITLE
fix(function-call): disclose the real network fee on Verify for EVM/UTXO/Cardano

### DIFF
--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainScreenModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainScreenModel.swift
@@ -209,18 +209,11 @@ final class DefiChainScreenModel: ObservableObject {
         try await CoinService.addToChain(assets: type.coins, to: vault)
     }
 
-    /// Builds the unsigned tx and pre-fetches the chain-specific gas so Verify
-    /// shows the fee immediately. Mirrors `FunctionTransactionScreen.onVerify`:
-    /// the gas is re-fetched during Verify anyway, so a fetch failure here is
-    /// non-fatal and the un-gassed tx is returned unchanged.
+    /// Builds the unsigned tx and prices it, so Verify discloses the fee the
+    /// user is agreeing to pay. Mirrors `FunctionTransactionScreen.onVerify` —
+    /// both go through the one shared pricing step, because nothing downstream
+    /// of Verify re-resolves these figures for display.
     func buildVerifyTransaction(for builder: TransactionBuilder) async -> SendTransaction {
-        var sendTx = builder.buildSendTransaction(vault: vault)
-        do {
-            let chainSpecific = try await BlockChainService.shared.fetchSpecific(tx: sendTx)
-            sendTx = sendTx.copy(gas: chainSpecific.gas)
-        } catch {
-            // Non-fatal: gas is re-fetched during Verify.
-        }
-        return sendTx
+        await builder.buildPricedSendTransaction(vault: vault)
     }
 }

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Services/FunctionCallFeePricer.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Services/FunctionCallFeePricer.swift
@@ -24,23 +24,45 @@ private let logger = Log.send.service
 /// step instead of a `chainSpecific.gas` copy repeated at each navigation seam —
 /// there were three of them, and every one of them was wrong the same way.
 ///
-/// The figures come from `SendCryptoVerifyLogic.calculateFee`, the resolver the
-/// Send flow's own Verify screen uses, so a function call is priced the way a
-/// send is: an EVM fee is `maxFeePerGas × the limit estimated for THIS call`, a
-/// UTXO/Cardano fee is `rate × the planned size` (the sat/vB rate on its own is
-/// a rate, not a fee), and every other chain quotes a flat per-unit gas that IS
-/// the whole cost. Mirroring it is what makes "what Verify says" and "what
-/// signing charges" the same number.
+/// Off EVM the figures come from `SendCryptoVerifyLogic.calculateFee`, the
+/// resolver the Send flow's own Verify screen uses: a UTXO/Cardano fee is
+/// `rate × the planned size` (the sat/vB rate on `chainSpecific` is a rate, not
+/// a fee), and every other chain quotes a flat per-unit gas that IS the whole
+/// cost.
+///
+/// ⚠️ **EVM is priced off the chain-specific fetch the SIGNING path makes**, not
+/// off that resolver, and the difference is not cosmetic. A function call is
+/// signed from `FunctionCallVerifyViewModel.createKeysignPayload` →
+/// `BlockChainService.fetchSpecific(tx:)`, whose EVM branch floors every
+/// transaction at the 120,000 ERC-20 gas limit. The Send resolver instead
+/// floors a native transfer at `Coin.feeDefault` (23,000 on Ethereum). Pricing
+/// a native ETH call through the Send resolver therefore discloses as little as
+/// `maxFeePerGas × 23,000` for a transaction the vault signs with a limit of
+/// 120,000 — understating the fee the user approves, on the screen where they
+/// approve it. Reading the same fetch also makes this device agree with the
+/// CO-SIGNER, whose `JoinKeysignGasViewModel` prices EVM straight off
+/// `payload.chainSpecific.fee` (`maxFeePerGas × gasLimit`).
 ///
 /// It prices the REAL transaction — memo, amount and recipient included — not a
 /// bare probe. On EVM that is the difference between the gas limit of the
 /// contract call and the 21,000 of a plain transfer.
 @MainActor
 struct FunctionCallFeePricer {
-    private let logic: SendCryptoVerifyLogic
+    /// The chain-specific fetch the function-call signing path performs.
+    /// Injectable so the disclosure can be tested without a network.
+    typealias SigningChainSpecificFetch = (SendTransaction) async throws -> BlockChainSpecific
 
-    init(interactor: SendInteractor = DefaultSendInteractor.live) {
+    private let logic: SendCryptoVerifyLogic
+    private let fetchSigningChainSpecific: SigningChainSpecificFetch
+
+    init(
+        interactor: SendInteractor = DefaultSendInteractor.live,
+        fetchSigningChainSpecific: @escaping SigningChainSpecificFetch = {
+            try await BlockChainService.shared.fetchSpecific(tx: $0)
+        }
+    ) {
         self.logic = SendCryptoVerifyLogic(interactor: interactor)
+        self.fetchSigningChainSpecific = fetchSigningChainSpecific
     }
 
     /// `tx` with both fee figures resolved from the transaction itself.
@@ -49,11 +71,16 @@ struct FunctionCallFeePricer {
     /// the flow already stamped. A fee endpoint that is briefly down is not a
     /// reason to strand the user on a form with no way forward, and the failure
     /// is not silent: it is logged here, and Verify still refuses to sign a
-    /// payload it cannot build. The residual is that such a flow discloses the
-    /// figure it already had — which is what every one of these seams did
+    /// payload it cannot build — on EVM, UTXO and Cardano it is the same fetch
+    /// that failed here. The residual is that such a flow discloses the figure
+    /// it already had, which is what every one of these seams did
     /// unconditionally before.
     func priced(_ tx: SendTransaction) async -> SendTransaction {
         do {
+            if tx.coin.chainType == .EVM {
+                let chainSpecific = try await fetchSigningChainSpecific(tx)
+                return tx.copy(gas: chainSpecific.gas, fee: chainSpecific.fee)
+            }
             let result = try await logic.calculateFee(tx: tx)
             return tx.copy(gas: result.gas, fee: result.fee)
         } catch {

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Services/FunctionCallFeePricer.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Services/FunctionCallFeePricer.swift
@@ -1,0 +1,66 @@
+//
+//  FunctionCallFeePricer.swift
+//  VultisigApp
+//
+//  The one place a function-call transaction gets its network fee, between the
+//  form and the Verify screen that discloses it.
+//
+
+import Foundation
+import OSLog
+
+private let logger = Log.send.service
+
+/// Prices the transaction a function-call flow is about to put on Verify, and
+/// stamps BOTH fee figures onto it.
+///
+/// ⚠️ **Both figures, always — the fee row and the fiat figure beside it read
+/// different ones.** `SendCryptoLogic.displayFee` reads `fee` on EVM, UTXO and
+/// Cardano and `gas` everywhere else, and `CryptoAmountFormatter.feesInReadable`
+/// reads `fee` on every chain. A hand-off that fetches the chain-specific data
+/// and stamps only `gas` therefore discloses `0` on exactly the chains whose fee
+/// is largest: the user approves a fee they were never shown, and signing then
+/// re-fetches a real one and charges it. That is why this exists as a shared
+/// step instead of a `chainSpecific.gas` copy repeated at each navigation seam —
+/// there were three of them, and every one of them was wrong the same way.
+///
+/// The figures come from `SendCryptoVerifyLogic.calculateFee`, the resolver the
+/// Send flow's own Verify screen uses, so a function call is priced the way a
+/// send is: an EVM fee is `maxFeePerGas × the limit estimated for THIS call`, a
+/// UTXO/Cardano fee is `rate × the planned size` (the sat/vB rate on its own is
+/// a rate, not a fee), and every other chain quotes a flat per-unit gas that IS
+/// the whole cost. Mirroring it is what makes "what Verify says" and "what
+/// signing charges" the same number.
+///
+/// It prices the REAL transaction — memo, amount and recipient included — not a
+/// bare probe. On EVM that is the difference between the gas limit of the
+/// contract call and the 21,000 of a plain transfer.
+@MainActor
+struct FunctionCallFeePricer {
+    private let logic: SendCryptoVerifyLogic
+
+    init(interactor: SendInteractor = DefaultSendInteractor.live) {
+        self.logic = SendCryptoVerifyLogic(interactor: interactor)
+    }
+
+    /// `tx` with both fee figures resolved from the transaction itself.
+    ///
+    /// Returns `tx` unchanged when the fee cannot be resolved, keeping whatever
+    /// the flow already stamped. A fee endpoint that is briefly down is not a
+    /// reason to strand the user on a form with no way forward, and the failure
+    /// is not silent: it is logged here, and Verify still refuses to sign a
+    /// payload it cannot build. The residual is that such a flow discloses the
+    /// figure it already had — which is what every one of these seams did
+    /// unconditionally before.
+    func priced(_ tx: SendTransaction) async -> SendTransaction {
+        do {
+            let result = try await logic.calculateFee(tx: tx)
+            return tx.copy(gas: result.gas, fee: result.fee)
+        } catch {
+            logger.error(
+                "failed to price a function-call transaction: \(error.localizedDescription, privacy: .public)"
+            )
+            return tx
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionCall/ViewModels/FunctionCallViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/ViewModels/FunctionCallViewModel.swift
@@ -28,8 +28,28 @@ class FunctionCallViewModel: ObservableObject {
     private let fastVaultService = FastVaultService.shared
 
     private let mediator = Mediator.shared
+    private let feePricer = FunctionCallFeePricer()
 
     let logger = Log.send.other
+
+    /// The transaction to hand to Verify: the one the form built, with both of
+    /// its fee figures resolved.
+    ///
+    /// ⚠️ The legacy Functions screen used to navigate with only `gas`, copied
+    /// off a chain-specific fetch made against an EMPTY probe transaction. On
+    /// EVM, UTXO and Cardano the fee row reads `fee`, so Verify disclosed `0`;
+    /// and even the `gas` it did carry was priced for a bare transfer rather
+    /// than for the call being signed. Both are resolved here, from the real
+    /// transaction, on the way to the screen that discloses them.
+    ///
+    /// Drives `isLoading` because it is a network round-trip on the Continue
+    /// tap. Returns the transaction unpriced (see `FunctionCallFeePricer`) when
+    /// the fee cannot be resolved, rather than blocking the flow.
+    func pricedForVerify(_ tx: SendTransaction) async -> SendTransaction {
+        isLoading = true
+        defer { isLoading = false }
+        return await feePricer.priced(tx)
+    }
 
     /// The fiat figure printed beside the crypto fee row.
     ///

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallDetailsScreen.swift
@@ -51,6 +51,7 @@ struct FunctionCallDetailsScreen: View {
             }
         }
         .screenTitle("function".localized)
+        .withLoading(isLoading: $functionCallViewModel.isLoading)
         .alert(isPresented: $functionCallViewModel.showAlert) {
             alert
         }
@@ -220,7 +221,11 @@ struct FunctionCallDetailsScreen: View {
                     vault: vault,
                     gas: gas
                 )
-                router.navigate(to: FunctionCallRoute.verify(tx: immutableTx, vault: vault))
+                // Priced from the built transaction, not from the probe: this
+                // is the figure the user approves, and nothing downstream of
+                // Verify re-resolves it for display.
+                let pricedTx = await functionCallViewModel.pricedForVerify(immutableTx)
+                router.navigate(to: FunctionCallRoute.verify(tx: pricedTx, vault: vault))
             }
         }
     }
@@ -241,6 +246,15 @@ private extension FunctionCallDetailsScreen {
         }
     }
 
+    /// A per-unit gas figure for the coin, fetched as the form is filled.
+    ///
+    /// This is a PROBE — an empty transaction with no memo, amount or recipient
+    /// — so on EVM it prices a bare transfer, not the call being built. It is
+    /// carried into the built transaction only as the value a chain that quotes
+    /// a flat gas already has; the figure Verify discloses is resolved from the
+    /// real transaction on Continue, by `FunctionCallViewModel.pricedForVerify`.
+    /// Keeping it means a failed pricing call falls back to what the screen
+    /// showed before rather than to zero.
     func loadGasInfo() async {
         let probeTx = SendTransaction.empty(coin: selectedCoin, vault: vault)
         do {

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
@@ -17,8 +17,6 @@ struct FunctionTransactionScreen: View {
 
     @State private var isLoading: Bool = false
 
-    private let blockchainService = BlockChainService.shared
-
     @Environment(\.dismiss) var dismiss
 
     var body: some View {
@@ -269,7 +267,12 @@ struct FunctionTransactionScreen: View {
                         for: transactionBuilder.coin.chain,
                         msgCount: stakingPayload.msgCount
                     )
-                    immutableTx = immutableTx.copy(gas: scaledGas)
+                    // Both figures: `displayFee` reads `gas` on Cosmos, every
+                    // fiat fee string reads `fee`, and for a Cosmos SignDoc the
+                    // per-unit gas IS the whole cost — so they are the same
+                    // number and disagreeing about it only prints `$0.00` under
+                    // a real crypto amount.
+                    immutableTx = immutableTx.copy(gas: scaledGas, fee: scaledGas)
                 } catch {
                     // Unreachable for the staking-supported chains that ever
                     // populate `cosmosStakingPayload`; log rather than swallow
@@ -287,15 +290,9 @@ struct FunctionTransactionScreen: View {
             isLoading = true
             defer { isLoading = false }
 
-            var sendTx = transactionBuilder.buildSendTransaction(vault: vault)
-            do {
-                let chainSpecific = try await blockchainService.fetchSpecific(tx: sendTx)
-                sendTx = sendTx.copy(gas: chainSpecific.gas)
-            } catch {
-                // Non-fatal: gas will be re-fetched during Verify. Keep
-                // navigating so the user sees the verify screen even when
-                // the upstream chain-specific endpoint is briefly down.
-            }
+            // Priced before it is disclosed. Nothing downstream re-resolves the
+            // fee for display, so this figure is the one the user approves.
+            let sendTx = await transactionBuilder.buildPricedSendTransaction(vault: vault)
             router.navigate(to: FunctionCallRoute.verify(tx: sendTx, vault: vault))
         }
     }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/TransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/TransactionBuilder.swift
@@ -45,10 +45,16 @@ extension TransactionBuilder {
     /// Default — only the limit-order cancel builder overrides this.
     var limitCancelContext: LimitOrderCancelRequest? { nil }
 
-    /// Builds the immutable `SendTransaction` struct directly. `gas` /
-    /// `fee` and runtime-only fields default to the construction-time
-    /// zero state and are filled in downstream by `SendCryptoVerifyViewModel`
-    /// (via the interactor).
+    /// Builds the immutable `SendTransaction` struct directly, with `gas` /
+    /// `fee` and runtime-only fields left at the construction-time zero state.
+    ///
+    /// ⚠️ **Unpriced.** Nothing downstream of `FunctionCallRoute.verify`
+    /// re-resolves the two fee figures for display — `FunctionCallVerifyScreen`
+    /// renders whatever the hand-off carried — so a transaction navigated
+    /// straight from here discloses a zero fee. Use
+    /// `buildPricedSendTransaction(vault:)` at any seam that hands the result to
+    /// Verify; this stays for the flows that stamp their own fee (the Cosmos
+    /// staking constant, a THORChain deposit's fixed gas) and for tests.
     func buildSendTransaction(vault: Vault) -> SendTransaction {
         SendTransaction(
             coin: coin,
@@ -75,5 +81,26 @@ extension TransactionBuilder {
             solanaStakingPayload: solanaStakingPayload,
             limitCancelContext: limitCancelContext
         )
+    }
+
+    /// The transaction Verify is handed: built, then priced.
+    ///
+    /// One step for every builder, present and future, so a DeFi operation
+    /// migrated onto this pipeline discloses a real fee the day it lands rather
+    /// than inheriting a `chainSpecific.gas` copy that reads zero on EVM, UTXO
+    /// and Cardano. See `FunctionCallFeePricer` for why the two figures must
+    /// travel together.
+    @MainActor
+    func buildPricedSendTransaction(
+        vault: Vault,
+        pricer: FunctionCallFeePricer
+    ) async -> SendTransaction {
+        await pricer.priced(buildSendTransaction(vault: vault))
+    }
+
+    /// `buildPricedSendTransaction(vault:pricer:)` against the live interactor.
+    @MainActor
+    func buildPricedSendTransaction(vault: Vault) async -> SendTransaction {
+        await buildPricedSendTransaction(vault: vault, pricer: FunctionCallFeePricer())
     }
 }

--- a/VultisigApp/VultisigAppTests/FunctionCall/FunctionCallFeePricerTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionCall/FunctionCallFeePricerTests.swift
@@ -53,6 +53,19 @@ final class FunctionCallFeePricerTests: XCTestCase {
         return Coin(asset: asset, address: "bc1sender", hexPublicKey: "HexPublicKeyExample")
     }()
 
+    private static let cardano: Coin = {
+        let asset = CoinMeta(
+            chain: .cardano,
+            ticker: "ADA",
+            logo: "ada",
+            decimals: 6,
+            priceProviderId: "cardano",
+            contractAddress: "",
+            isNativeToken: true
+        )
+        return Coin(asset: asset, address: "addr1sender", hexPublicKey: "HexPublicKeyExample")
+    }()
+
     private static let rune: Coin = {
         let asset = CoinMeta(
             chain: .thorChain,
@@ -90,18 +103,27 @@ final class FunctionCallFeePricerTests: XCTestCase {
 
     // MARK: - EVM
 
+    /// The EVM chain-specific the SIGNING path resolves: 120,000 gas at
+    /// 1.32 gwei, so `fee` = 0.0001584 ETH and `gas` = the gwei price.
+    private static let signedEvmChainSpecific = BlockChainSpecific.Ethereum(
+        maxFeePerGasWei: BigInt(1_320_000_000),
+        priorityFeeWei: BigInt(100_000_000),
+        nonce: 0,
+        gasLimit: BigInt(120_000)
+    )
+
     /// ⚠️ 120,000 gas at 1.32 gwei is 0.0001584 ETH, and that TOTAL is what an
     /// EVM fee row reads. The gas PRICE alone — the figure the old hand-off
     /// copied — is 1.32 gwei, which valued as a whole fee rounds to `$0.00`.
     func testAnEvmFunctionCallDisclosesTheTotalFee() async {
         let gasPrice = BigInt(1_320_000_000)
         let totalFee = BigInt(158_400_000_000_000)
-        let mock = MockSendInteractor()
-        mock.calculateEVMFeeStub = { _ in
-            SendInteractorFeeResult(fee: totalFee, gas: gasPrice, gasLimit: BigInt(120_000))
-        }
+        let pricer = FunctionCallFeePricer(
+            interactor: MockSendInteractor(),
+            fetchSigningChainSpecific: { _ in Self.signedEvmChainSpecific }
+        )
 
-        let priced = await FunctionCallFeePricer(interactor: mock).priced(
+        let priced = await pricer.priced(
             makeFunctionCallTransaction(coin: Self.ether, toAddress: "0xinbound", amount: "0.5")
         )
 
@@ -115,22 +137,59 @@ final class FunctionCallFeePricerTests: XCTestCase {
         XCTAssertTrue(priced.gasInReadable.hasPrefix("0.0001584"), "got \(priced.gasInReadable)")
     }
 
+    /// ⚠️ The EVM figure must come from the chain-specific the SIGNING path
+    /// fetches, not from the Send flow's fee resolver.
+    ///
+    /// `BlockChainService.fetchSpecificForEVM` floors every transaction at the
+    /// 120,000 ERC-20 gas limit; `DefaultSendInteractor.calculateEVMFee` floors
+    /// a native transfer at `Coin.feeDefault` — 23,000 on Ethereum. Pricing a
+    /// native ETH call through the Send resolver understates the fee by up to
+    /// 5x against the limit the vault actually signs, and disagrees with the
+    /// co-signer, whose `JoinKeysignGasViewModel` reads `chainSpecific.fee`
+    /// straight off the payload.
+    func testAnEvmFunctionCallIsPricedOffTheChainSpecificSigningUses() async {
+        let mock = MockSendInteractor()
+        mock.calculateEVMFeeStub = { _ in
+            // The Send resolver's answer at the 23,000 native floor. If it is
+            // ever consulted for an EVM function call, this is what leaks onto
+            // Verify instead of the signed figure.
+            SendInteractorFeeResult(fee: BigInt(30_360_000_000_000), gas: BigInt(1_320_000_000))
+        }
+        let pricer = FunctionCallFeePricer(
+            interactor: mock,
+            fetchSigningChainSpecific: { _ in Self.signedEvmChainSpecific }
+        )
+
+        let priced = await pricer.priced(
+            makeFunctionCallTransaction(coin: Self.ether, toAddress: "0xinbound", amount: "0.5")
+        )
+
+        XCTAssertEqual(priced.fee, BigInt(158_400_000_000_000))
+        XCTAssertTrue(
+            mock.calculateEVMFeeCalls.isEmpty,
+            "the Send resolver's 23,000-floored figure must not reach an EVM function call"
+        )
+    }
+
     /// The fee has to be priced for THIS call, not for a bare transfer: the EVM
     /// gas limit is estimated against the calldata, and the legacy screen's
     /// probe fetch carried no memo at all.
     func testAnEvmFunctionCallIsPricedAgainstItsOwnMemoAndRecipient() async {
-        let mock = MockSendInteractor()
-        mock.calculateEVMFeeStub = { _ in
-            SendInteractorFeeResult(fee: BigInt(158_400_000_000_000), gas: BigInt(1_320_000_000))
-        }
+        var fetched: [SendTransaction] = []
+        let pricer = FunctionCallFeePricer(
+            interactor: MockSendInteractor(),
+            fetchSigningChainSpecific: { tx in
+                fetched.append(tx)
+                return Self.signedEvmChainSpecific
+            }
+        )
 
-        _ = await FunctionCallFeePricer(interactor: mock).priced(
+        _ = await pricer.priced(
             makeFunctionCallTransaction(coin: Self.ether, toAddress: "0xinbound", amount: "0.5")
         )
 
-        let request = mock.calculateEVMFeeCalls.first?.request.chainSpecific
-        XCTAssertEqual(request?.memo, Self.addLPMemo)
-        XCTAssertEqual(request?.toAddress, "0xinbound")
+        XCTAssertEqual(fetched.first?.memo, Self.addLPMemo)
+        XCTAssertEqual(fetched.first?.toAddress, "0xinbound")
     }
 
     // MARK: - UTXO
@@ -173,6 +232,30 @@ final class FunctionCallFeePricerTests: XCTestCase {
         XCTAssertEqual(mock.calculatePlanFeeCalls.first?.tx.toAddress, "bc1inbound")
     }
 
+    // MARK: - Cardano
+
+    /// The third family whose fee row reads `fee`. Cardano's `chainSpecific`
+    /// also carries a rate rather than a total, and its real fee is the one the
+    /// payload build derives from the signed size.
+    func testACardanoFunctionCallDisclosesThePlannedFee() async {
+        let plannedFee = BigInt(174_301)
+        let mock = MockSendInteractor()
+        mock.fetchChainSpecificStub = { _ in
+            .Cardano(byteFee: BigInt(44), sendMaxAmount: false, ttl: 1_000)
+        }
+        mock.calculatePlanFeeStub = { _, _ in plannedFee }
+
+        let priced = await FunctionCallFeePricer(interactor: mock).priced(
+            makeFunctionCallTransaction(coin: Self.cardano, toAddress: "addr1inbound", amount: "5")
+        )
+
+        XCTAssertEqual(
+            SendCryptoLogic.displayFee(coin: priced.coin, gas: priced.gas, fee: priced.fee),
+            plannedFee
+        )
+        XCTAssertNotEqual(priced.fee, .zero)
+    }
+
     // MARK: - The chains that already worked
 
     /// Regression guard for every DeFi builder shipping today. THORChain quotes
@@ -206,17 +289,23 @@ final class FunctionCallFeePricerTests: XCTestCase {
     func testAFailedPricingLeavesTheHandOffUntouched() async {
         struct Boom: Error {}
         let probeGas = BigInt(7)
-        let mock = MockSendInteractor()
-        mock.calculateEVMFeeStub = { _ in throw Boom() }
+        let pricer = FunctionCallFeePricer(
+            interactor: MockSendInteractor(),
+            fetchSigningChainSpecific: { _ in throw Boom() }
+        )
 
-        let priced = await FunctionCallFeePricer(interactor: mock).priced(
+        let priced = await pricer.priced(
             makeFunctionCallTransaction(
                 coin: Self.ether, toAddress: "0xinbound", amount: "0.5", gas: probeGas
             )
         )
 
         XCTAssertEqual(priced.gas, probeGas)
-        XCTAssertEqual(priced.fee, .zero)
+        XCTAssertEqual(
+            priced.fee,
+            .zero,
+            "known residual: a fetch that fails leaves the disclosure where it was, and on EVM that is zero"
+        )
     }
 
     // MARK: - The builder pipeline
@@ -225,17 +314,15 @@ final class FunctionCallFeePricerTests: XCTestCase {
     /// hand Verify a priced transaction without doing anything per-builder.
     func testAnEvmBuilderHandsVerifyAPricedTransaction() async {
         let totalFee = BigInt(158_400_000_000_000)
-        let mock = MockSendInteractor()
-        mock.calculateEVMFeeStub = { _ in
-            SendInteractorFeeResult(fee: totalFee, gas: BigInt(1_320_000_000), gasLimit: BigInt(120_000))
-        }
+        let pricer = FunctionCallFeePricer(
+            interactor: MockSendInteractor(),
+            fetchSigningChainSpecific: { _ in Self.signedEvmChainSpecific }
+        )
         let builder = StubFunctionTransactionBuilder(
             coin: Self.ether, toAddress: "0xinbound", amount: "0.5", memo: Self.addLPMemo
         )
 
-        let tx = await builder.buildPricedSendTransaction(
-            vault: .example, pricer: FunctionCallFeePricer(interactor: mock)
-        )
+        let tx = await builder.buildPricedSendTransaction(vault: .example, pricer: pricer)
 
         XCTAssertEqual(
             SendCryptoLogic.displayFee(coin: tx.coin, gas: tx.gas, fee: tx.fee),

--- a/VultisigApp/VultisigAppTests/FunctionCall/FunctionCallFeePricerTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionCall/FunctionCallFeePricerTests.swift
@@ -1,0 +1,284 @@
+//
+//  FunctionCallFeePricerTests.swift
+//  VultisigAppTests
+//
+//  What the Verify screen says a function call costs, on the chains where it
+//  used to say nothing.
+//
+
+import BigInt
+import VultisigCommonData
+import XCTest
+@testable import VultisigApp
+
+/// ⚠️ These pin the DISCLOSED figure — `SendCryptoLogic.displayFee`, the exact
+/// value the fee row and the fiat figure beside it are derived from — not just
+/// "something non-zero". A wrong fee passes a `> 0` assertion and is still a
+/// wrong fee on the screen where the user agrees to pay it.
+///
+/// The defect these cover: every seam between a function-call form and Verify
+/// fetched the chain-specific data and copied `chainSpecific.gas` alone.
+/// `displayFee` reads `fee` on EVM, UTXO and Cardano, so those three disclosed
+/// `0` — and signing re-fetched a real fee and charged it. Nothing downstream of
+/// `FunctionCallRoute.verify` re-resolves the figures for display, so the
+/// hand-off is the only chance to get them right.
+@MainActor
+final class FunctionCallFeePricerTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private static let ether: Coin = {
+        let asset = CoinMeta(
+            chain: .ethereum,
+            ticker: "ETH",
+            logo: "eth",
+            decimals: 18,
+            priceProviderId: "ethereum",
+            contractAddress: "",
+            isNativeToken: true
+        )
+        return Coin(asset: asset, address: "0xsender", hexPublicKey: "HexPublicKeyExample")
+    }()
+
+    private static let bitcoin: Coin = {
+        let asset = CoinMeta(
+            chain: .bitcoin,
+            ticker: "BTC",
+            logo: "btc",
+            decimals: 8,
+            priceProviderId: "bitcoin",
+            contractAddress: "",
+            isNativeToken: true
+        )
+        return Coin(asset: asset, address: "bc1sender", hexPublicKey: "HexPublicKeyExample")
+    }()
+
+    private static let rune: Coin = {
+        let asset = CoinMeta(
+            chain: .thorChain,
+            ticker: "RUNE",
+            logo: "rune",
+            decimals: 8,
+            priceProviderId: "thorchain",
+            contractAddress: "",
+            isNativeToken: true
+        )
+        return Coin(asset: asset, address: "thor1sender", hexPublicKey: "HexPublicKeyExample")
+    }()
+
+    /// A THORChain LP-add memo — the operation the migration is about to move
+    /// onto this pipeline from Ethereum and Bitcoin.
+    private static let addLPMemo = "+:BTC.BTC:thor1owner"
+
+    /// The shape every legacy `toSendTransaction(coin:vault:gas:)` produces:
+    /// `SendTransaction.empty` plus recipient, amount and memo — and, before
+    /// this fix, only `gas`.
+    private func makeFunctionCallTransaction(
+        coin: Coin,
+        toAddress: String,
+        amount: String,
+        gas: BigInt = .zero
+    ) -> SendTransaction {
+        SendTransaction.empty(coin: coin, vault: .example).copy(
+            toAddress: toAddress,
+            amount: amount,
+            memo: Self.addLPMemo,
+            gas: gas,
+            transactionType: .unspecified
+        )
+    }
+
+    // MARK: - EVM
+
+    /// ⚠️ 120,000 gas at 1.32 gwei is 0.0001584 ETH, and that TOTAL is what an
+    /// EVM fee row reads. The gas PRICE alone — the figure the old hand-off
+    /// copied — is 1.32 gwei, which valued as a whole fee rounds to `$0.00`.
+    func testAnEvmFunctionCallDisclosesTheTotalFee() async {
+        let gasPrice = BigInt(1_320_000_000)
+        let totalFee = BigInt(158_400_000_000_000)
+        let mock = MockSendInteractor()
+        mock.calculateEVMFeeStub = { _ in
+            SendInteractorFeeResult(fee: totalFee, gas: gasPrice, gasLimit: BigInt(120_000))
+        }
+
+        let priced = await FunctionCallFeePricer(interactor: mock).priced(
+            makeFunctionCallTransaction(coin: Self.ether, toAddress: "0xinbound", amount: "0.5")
+        )
+
+        XCTAssertEqual(
+            SendCryptoLogic.displayFee(coin: priced.coin, gas: priced.gas, fee: priced.fee),
+            totalFee,
+            "an EVM fee row reads the total, and it must be the total that was priced"
+        )
+        XCTAssertEqual(priced.fee, totalFee)
+        XCTAssertEqual(priced.gas, gasPrice, "the per-unit price still travels, for the balance guards")
+        XCTAssertTrue(priced.gasInReadable.hasPrefix("0.0001584"), "got \(priced.gasInReadable)")
+    }
+
+    /// The fee has to be priced for THIS call, not for a bare transfer: the EVM
+    /// gas limit is estimated against the calldata, and the legacy screen's
+    /// probe fetch carried no memo at all.
+    func testAnEvmFunctionCallIsPricedAgainstItsOwnMemoAndRecipient() async {
+        let mock = MockSendInteractor()
+        mock.calculateEVMFeeStub = { _ in
+            SendInteractorFeeResult(fee: BigInt(158_400_000_000_000), gas: BigInt(1_320_000_000))
+        }
+
+        _ = await FunctionCallFeePricer(interactor: mock).priced(
+            makeFunctionCallTransaction(coin: Self.ether, toAddress: "0xinbound", amount: "0.5")
+        )
+
+        let request = mock.calculateEVMFeeCalls.first?.request.chainSpecific
+        XCTAssertEqual(request?.memo, Self.addLPMemo)
+        XCTAssertEqual(request?.toAddress, "0xinbound")
+    }
+
+    // MARK: - UTXO
+
+    /// ⚠️ A UTXO fee is `rate × size`, and the size only exists once inputs are
+    /// selected — so `chainSpecific` carries a sat/vB RATE, not a fee. The old
+    /// hand-off copied that rate into `gas` and left `fee` at zero, which on a
+    /// chain whose fee row reads `fee` disclosed nothing at all.
+    func testAUtxoFunctionCallDisclosesThePlannedFeeNotTheByteRate() async {
+        let byteRate = BigInt(12)
+        let plannedFee = BigInt(3_000)
+        let mock = MockSendInteractor()
+        mock.fetchChainSpecificStub = { _ in .UTXO(byteFee: byteRate, sendMaxAmount: false) }
+        mock.calculatePlanFeeStub = { _, _ in plannedFee }
+
+        let priced = await FunctionCallFeePricer(interactor: mock).priced(
+            makeFunctionCallTransaction(coin: Self.bitcoin, toAddress: "bc1inbound", amount: "0.01")
+        )
+
+        XCTAssertEqual(
+            SendCryptoLogic.displayFee(coin: priced.coin, gas: priced.gas, fee: priced.fee),
+            plannedFee,
+            "12 sat/vB is a rate; the disclosed fee is what the planned transaction pays"
+        )
+        XCTAssertNotEqual(priced.fee, byteRate)
+        XCTAssertTrue(priced.gasInReadable.hasPrefix("0.00003"), "got \(priced.gasInReadable)")
+    }
+
+    /// The plan the fee comes from has to be the plan for this transaction.
+    func testAUtxoFunctionCallIsPlannedWithItsOwnMemoAndRecipient() async {
+        let mock = MockSendInteractor()
+        mock.fetchChainSpecificStub = { _ in .UTXO(byteFee: BigInt(12), sendMaxAmount: false) }
+        mock.calculatePlanFeeStub = { _, _ in BigInt(3_000) }
+
+        _ = await FunctionCallFeePricer(interactor: mock).priced(
+            makeFunctionCallTransaction(coin: Self.bitcoin, toAddress: "bc1inbound", amount: "0.01")
+        )
+
+        XCTAssertEqual(mock.calculatePlanFeeCalls.first?.tx.memo, Self.addLPMemo)
+        XCTAssertEqual(mock.calculatePlanFeeCalls.first?.tx.toAddress, "bc1inbound")
+    }
+
+    // MARK: - The chains that already worked
+
+    /// Regression guard for every DeFi builder shipping today. THORChain quotes
+    /// a flat per-unit gas that IS the whole cost, its fee row reads `gas`, and
+    /// pricing must not move that figure — it only fills in the `fee` the fiat
+    /// strings read.
+    func testAThorchainFunctionCallKeepsTheFigureItAlreadyDisclosed() async {
+        let depositGas = BigInt(2_000_000)
+        let mock = MockSendInteractor()
+        mock.fetchChainSpecificStub = { _ in
+            .THORChain(accountNumber: 0, sequence: 0, fee: 2_000_000, isDeposit: true)
+        }
+
+        let priced = await FunctionCallFeePricer(interactor: mock).priced(
+            makeFunctionCallTransaction(coin: Self.rune, toAddress: "", amount: "1")
+        )
+
+        XCTAssertEqual(
+            SendCryptoLogic.displayFee(coin: priced.coin, gas: priced.gas, fee: priced.fee),
+            depositGas
+        )
+        XCTAssertEqual(priced.gas, depositGas)
+        XCTAssertEqual(priced.fee, depositGas, "the fiat fee string reads `fee` on every chain")
+    }
+
+    // MARK: - Failure
+
+    /// A fee endpoint that is briefly down must not strand the user, and must
+    /// not invent a number either. The hand-off keeps whatever it already had —
+    /// the pre-existing behaviour — and the failure is logged.
+    func testAFailedPricingLeavesTheHandOffUntouched() async {
+        struct Boom: Error {}
+        let probeGas = BigInt(7)
+        let mock = MockSendInteractor()
+        mock.calculateEVMFeeStub = { _ in throw Boom() }
+
+        let priced = await FunctionCallFeePricer(interactor: mock).priced(
+            makeFunctionCallTransaction(
+                coin: Self.ether, toAddress: "0xinbound", amount: "0.5", gas: probeGas
+            )
+        )
+
+        XCTAssertEqual(priced.gas, probeGas)
+        XCTAssertEqual(priced.fee, .zero)
+    }
+
+    // MARK: - The builder pipeline
+
+    /// The seam the Add-LP and SECURE+ migrations will land on: a builder must
+    /// hand Verify a priced transaction without doing anything per-builder.
+    func testAnEvmBuilderHandsVerifyAPricedTransaction() async {
+        let totalFee = BigInt(158_400_000_000_000)
+        let mock = MockSendInteractor()
+        mock.calculateEVMFeeStub = { _ in
+            SendInteractorFeeResult(fee: totalFee, gas: BigInt(1_320_000_000), gasLimit: BigInt(120_000))
+        }
+        let builder = StubFunctionTransactionBuilder(
+            coin: Self.ether, toAddress: "0xinbound", amount: "0.5", memo: Self.addLPMemo
+        )
+
+        let tx = await builder.buildPricedSendTransaction(
+            vault: .example, pricer: FunctionCallFeePricer(interactor: mock)
+        )
+
+        XCTAssertEqual(
+            SendCryptoLogic.displayFee(coin: tx.coin, gas: tx.gas, fee: tx.fee),
+            totalFee,
+            "buildSendTransaction alone hardcodes fee: .zero — the pricing step is what fills it"
+        )
+    }
+
+    func testAUtxoBuilderHandsVerifyAPricedTransaction() async {
+        let plannedFee = BigInt(3_000)
+        let mock = MockSendInteractor()
+        mock.fetchChainSpecificStub = { _ in .UTXO(byteFee: BigInt(12), sendMaxAmount: false) }
+        mock.calculatePlanFeeStub = { _, _ in plannedFee }
+        let builder = StubFunctionTransactionBuilder(
+            coin: Self.bitcoin, toAddress: "bc1inbound", amount: "0.01", memo: Self.addLPMemo
+        )
+
+        let tx = await builder.buildPricedSendTransaction(
+            vault: .example, pricer: FunctionCallFeePricer(interactor: mock)
+        )
+
+        XCTAssertEqual(
+            SendCryptoLogic.displayFee(coin: tx.coin, gas: tx.gas, fee: tx.fee),
+            plannedFee
+        )
+    }
+}
+
+/// A minimal `TransactionBuilder` standing in for the EVM / UTXO DeFi builders
+/// the migration will add. `memoFunctionDictionary` is deliberately EMPTY:
+/// `SendCryptoLogic.isDeposit` is "dictionary non-empty AND not UTXO/Ripple/
+/// Solana", so populating it would build an Ethereum transaction as a THORChain
+/// deposit — the same trap `CancelLimitOrderTransactionBuilder` documents.
+private struct StubFunctionTransactionBuilder: TransactionBuilder {
+    let coin: Coin
+    let toAddress: String
+    let amount: String
+    let memo: String
+
+    var sendMaxAmount: Bool { false }
+    var transactionType: VSTransactionType { .unspecified }
+    var wasmContractPayload: WasmExecuteContractPayload? { nil }
+    var memoFunctionDictionary: ThreadSafeDictionary<String, String> {
+        ThreadSafeDictionary<String, String>()
+    }
+}


### PR DESCRIPTION
## ⚠️ Needs human + on-device review

This changes **what a user is shown before they approve a signature**. Please check on device: a THORChain LP add from **ETH** and from **BTC** must both show a fee on Verify that matches what signing charges.

## Problem

A function-call transaction on **EVM, UTXO or Cardano** reached the Verify screen with a network fee of **zero**. The user approved a fee they were never shown, and signing then re-fetched a real one and charged it.

## Mechanism

`SendCryptoLogic.displayFee` reads **`fee`** for `chainType == .EVM | .UTXO | .Cardano` and **`gas`** for everything else; `FunctionCallViewModel.feesInReadable` derives the fiat figure from the same call, and `CryptoAmountFormatter.feesInReadable` reads `fee` on *every* chain.

Nothing downstream of `FunctionCallRoute.verify` re-resolves either figure for display — `FunctionCallVerifyScreen` renders `transaction.gasInReadable` off the `let transaction` it was handed, and `FunctionCallVerifyViewModel` only re-fetches chain-specific data inside `createKeysignPayload`, i.e. at signing. **The hand-off is the only chance to get the disclosure right.**

Three seams built that hand-off, and each copied `chainSpecific.gas` alone, leaving `fee` at the `.zero` it was constructed with:

| Seam | What it did |
|---|---|
| `FunctionCallDetailsScreen.loadGasInfo()` (legacy Functions screen) | fetched against an **empty probe** `SendTransaction.empty`, copied `.gas` into `toSendTransaction(coin:vault:gas:)` |
| `FunctionTransactionScreen.onVerify` (DeFi pipeline) | `TransactionBuilder.buildSendTransaction(vault:)` hardcodes `fee: .zero`; the screen then copied `chainSpecific.gas` |
| `DefiChainScreenModel.buildVerifyTransaction(for:)` | the same block again, with a comment claiming "gas is re-fetched during Verify". It is not. |

Two consequences, not one:

1. **EVM / UTXO / Cardano disclosed `0`** — `displayFee` reads `fee`, which nobody set.
2. **Even the `gas` that was set was priced wrong on EVM**, because the legacy probe carried no memo, amount or recipient, so the estimate sized a bare transfer rather than the contract call being signed.

The new pipeline is currently **masked**: every shipping DeFi builder is THORChain / Cosmos / Solana / TON, where `displayFee` returns `gas` and `BlockChainSpecific.fee == gas`. That masking is exactly why this must land **before** Add-LP or SECURE+ moves an EVM or UTXO operation onto `FunctionTransaction`.

## Fix, and why there

New `FunctionCallFeePricer` (`Features/FunctionCall/Services/`) resolves both figures for a built transaction and stamps them together. It is reached through **one** new `TransactionBuilder.buildPricedSendTransaction(vault:)` — a default protocol-extension method, so every builder present and future is covered without a per-builder change — and through `FunctionCallViewModel.pricedForVerify` for the legacy screen, which now prices the **real built transaction** on Continue (behind its existing loading overlay) instead of navigating with the probe's `gas`.

- **Off EVM**: `SendCryptoVerifyLogic.calculateFee`, the resolver the Send flow's own Verify screen uses. A UTXO/Cardano fee is `rate × the planned size` — the sat/vB rate on `chainSpecific` is a rate, not a fee — and every other chain quotes a flat per-unit gas that is the whole cost.
- **On EVM**: the same `BlockChainService.fetchSpecific(tx:)` the **signing** path makes. `fetchSpecificForEVM` floors every transaction at the 120,000 ERC-20 gas limit, while the Send resolver floors a *native* transfer at `Coin.feeDefault` (23,000 on Ethereum) — so pricing a native ETH call through the Send resolver understates by up to 5x against the limit the vault signs, and disagrees with the co-signer, whose `JoinKeysignGasViewModel` prices EVM straight off `payload.chainSpecific.fee`. This was caught by the review pass and fixed in the second commit.

**Why the hand-off and not the Verify screen.** Re-pricing on Verify (the way `SendVerifyScreen` calls `loadGasInfoForSending`) would be one place for every entry point — and wrong here. Several flows deliberately stamp a fee a fresh fetch does not produce: the Cosmos staking flow stamps `CosmosStakingConfig.scaledFeeAmountBigInt`, which the SignDoc resolver actually signs, and a THORChain limit-order cancel stamps `THORChainConstants.depositGasBaseUnits` because `thorchain.swift` hardcodes it at signing regardless of what was fetched. A blanket re-fetch would clobber both and re-break disclosures that were deliberately fixed.

Also: the Cosmos staking branch now stamps `fee` alongside `gas` (the same number — a Cosmos SignDoc's per-unit gas is its whole cost), so the fiat string beside that row stops reading `$0.00`.

## Residual gaps

- **A failed fee fetch still discloses whatever the flow already had**, which on EVM/UTXO/Cardano is still zero. This is unchanged pre-existing behaviour and is now logged rather than silently swallowed, but it is not *fixed*. Mitigating fact: after the EVM change, a pricing failure on those three families is the same fetch signing needs, so the signature cannot complete either. An honest "fee unavailable" state on the Verify row (with Sign gated on it) is a separate change across three screens — happy to do it in a follow-up if you'd rather have it here.
- **Adjacent, deliberately not touched** (both found by the review pass, both worth their own issue): the two QBTC governance-vote routes in `DefiChainScreenModel` build from `SendTransaction.empty` and navigate to this same Verify screen with both figures at zero; and `EditReferralDetailsViewModel` never fetches gas at all, so a referral **edit** discloses `0 RUNE` (referral **create** does fetch it). Both are a different mechanism — a fixed signer constant, not a fetch — in another feature.

## Tests

`VultisigAppTests/FunctionCall/FunctionCallFeePricerTests.swift`, 10 cases. They pin the **disclosed** figure (`SendCryptoLogic.displayFee`, the exact value the fee row and the fiat figure are derived from) to exact values, not `> 0`:

- EVM: `120,000 × 1.32 gwei = 0.0001584 ETH`, plus a case asserting the Send resolver is **never** consulted for an EVM function call.
- UTXO: the planned `3,000` sats, explicitly *not* the `12` sat/vB rate.
- Cardano: the planned `174,301` lovelace.
- THORChain: regression guard that the figure every shipping DeFi builder discloses today does not move.
- Memo/recipient forwarding on both EVM and UTXO — the fee is priced for *this* call, not a probe.
- The builder seam (`buildPricedSendTransaction`) for a stub EVM and a stub UTXO builder — the shape the Add-LP / SECURE+ migration will land on.
- The failure path, which documents the residual gap above.

## Verification

- Full scheme: `** TEST SUCCEEDED **` (`xcodebuild test -scheme VultisigApp`, iPhone 16 sim, worktree-local `-derivedDataPath`). No failures anywhere in the suite.
- Disk before the gate: `38Gi` avail → after: `36Gi` avail (`/System/Volumes/Data`). Nowhere near exhaustion, so the marker is trustworthy.
- SwiftLint clean on every changed file.
- `make generate` run after adding the two new files.

## Cross-model review ledger (Codex, read-only)

| Finding | Verdict |
|---|---|
| EVM disclosure ≠ the signed gas limit (23,000 vs 120,000 floor) | **Fixed** (commit 2) — priced off the signing fetch; test pins that the Send resolver is never consulted |
| No Cardano test | **Fixed** — `testACardanoFunctionCallDisclosesThePlannedFee` |
| Fail-open on a pricing failure still discloses zero | **Deferred**, documented above and in the wiki plan |
| Referral edit + QBTC governance routes unpriced | **Rejected for this PR** — real, but a different mechanism in another feature; listed as adjacent |
| Does UTXO `gas` becoming the planned total break a consumer? | **Confirmed none**: `SendTransaction.byteFee` has no production call site, `isAmountExceeded` reads `fee` for UTXO/Cardano, `canBeReaped` is effectively Polkadot-only, and the keysign payload carries a freshly fetched rate |
| Actor isolation / SwiftData / conventions | No violations found |

## Merge order

Branched off plain `main`. Draft #5155 (`refactor/fn-contract-type-5137`) also edits `FunctionCallDetailsScreen.swift`, in the contract-selector region rather than in `loadGasInfo()` / the Continue button, so a conflict is possible but should be trivial — **this may need a small rebase after #5155 lands**.

Plan and rationale: `wiki/pages/projects/vultisig/functions-to-defi-migration/fee-disclosure-5140-plan.md`.

Closes #5140
