### PR TITLE
feat(defi): switch the Kamino attribution memo to 8k2mz

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Solana/Signing/SolanaV0Transaction.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Signing/SolanaV0Transaction.swift
@@ -123,8 +123,8 @@ struct SolanaV0Transaction: Equatable {
     static let memoProgramId = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
 
     /// Bound on an injected memo. Nothing here needs a long one — the tag this
-    /// app writes is two bytes — and the ceiling keeps a caller from spending
-    /// the transaction's remaining size budget on a note.
+    /// app writes is a handful of bytes — and the ceiling keeps a caller from
+    /// spending the transaction's remaining size budget on a note.
     static let maxMemoByteCount = 64
 
     /// The 32 raw bytes of `computeBudgetProgramId`, decoded once. The input is

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoInstructionSequence.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoInstructionSequence.swift
@@ -278,7 +278,7 @@ enum KaminoInstructionSequence {
             return nil
         case .memo:
             // The tag is matched WHOLE, not as a prefix. A memo is free-form
-            // bytes, so "vs" followed by anything else is a different memo —
+            // bytes, so the tag followed by anything else is a different memo —
             // and the one thing this app is willing to sign under the Memo
             // program is its own attribution tag, exactly.
             return data == KaminoAttribution.memoTagBytes ? .attributionMemo : nil

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoSolanaInstructions.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoSolanaInstructions.swift
@@ -66,7 +66,7 @@ enum KaminoSolanaProgram: String, CaseIterable {
 /// the injector, the validator and the verify-screen decoder all read it from
 /// here rather than each spelling it out.
 enum KaminoAttribution {
-    static let memoTag = "vs"
+    static let memoTag = "8k2mz"
     static let memoTagBytes = [UInt8](Data(memoTag.utf8))
 }
 

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/SolanaV0TransactionTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/SolanaV0TransactionTests.swift
@@ -417,11 +417,11 @@ final class SolanaV0TransactionTests: XCTestCase {
     func testMemoInjectionAppendsOneAccountlessInstructionCarryingTheText() throws {
         let transaction = try SolanaV0Transaction(wireBytes: try Builder().bytes())
 
-        let tagged = try transaction.injectingMemo("vs")
+        let tagged = try transaction.injectingMemo("8k2mz")
 
         XCTAssertEqual(tagged.instructions.count, transaction.instructions.count + 1)
         let memo = try XCTUnwrap(tagged.instructions.last)
-        XCTAssertEqual(memo.data, [UInt8]("vs".utf8))
+        XCTAssertEqual(memo.data, [UInt8]("8k2mz".utf8))
         XCTAssertTrue(memo.accountIndexes.isEmpty)
         XCTAssertEqual(tagged.staticAccountKeys[Int(memo.programIdIndex)], SolanaV0Transaction.memoProgramKey)
         // Appended to the read-only unsigned block, exactly like the budget key.
@@ -436,7 +436,7 @@ final class SolanaV0TransactionTests: XCTestCase {
     /// one slot later, and their indexes have to move with them.
     func testMemoInjectionPreservesResolvedAccountsAcrossMultipleLookupTables() throws {
         let source = try SolanaV0Transaction(wireBytes: try Self.twoTableBuilder().bytes())
-        let tagged = try source.injectingMemo("vs")
+        let tagged = try source.injectingMemo("8k2mz")
 
         let before = try source.resolvedAccountAddresses(forInstructionAt: 0, lookupTables: Self.twoTables)
         let after = try tagged.resolvedAccountAddresses(forInstructionAt: 0, lookupTables: Self.twoTables)
@@ -452,10 +452,10 @@ final class SolanaV0TransactionTests: XCTestCase {
 
         let both = try source
             .injectingComputeBudget(price: 20_000, limit: 200_000)
-            .injectingMemo("vs")
+            .injectingMemo("8k2mz")
 
         XCTAssertEqual(both.instructions.count, source.instructions.count + 3)
-        XCTAssertEqual(both.instructions.last?.data, [UInt8]("vs".utf8))
+        XCTAssertEqual(both.instructions.last?.data, [UInt8]("8k2mz".utf8))
         XCTAssertEqual(
             try source.resolvedAccountAddresses(forInstructionAt: 0, lookupTables: Self.twoTables),
             try both.resolvedAccountAddresses(forInstructionAt: 2, lookupTables: Self.twoTables)
@@ -463,9 +463,9 @@ final class SolanaV0TransactionTests: XCTestCase {
     }
 
     func testASecondMemoIsRefused() throws {
-        let tagged = try SolanaV0Transaction(wireBytes: try Builder().bytes()).injectingMemo("vs")
+        let tagged = try SolanaV0Transaction(wireBytes: try Builder().bytes()).injectingMemo("8k2mz")
 
-        XCTAssertThrowsError(try tagged.injectingMemo("vs")) { error in
+        XCTAssertThrowsError(try tagged.injectingMemo("8k2mz")) { error in
             XCTAssertEqual(error as? SolanaV0TransactionError, .memoAlreadyPresent)
         }
     }

--- a/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoTransactionValidatorTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoTransactionValidatorTests.swift
@@ -441,12 +441,15 @@ final class KaminoTransactionValidatorTests: XCTestCase {
     /// exact bytes, and iOS, Android and Windows all have to write the same
     /// ones. Pinned as literals because everything else in the suite — the
     /// fixtures, the injector, the validator, the decoder — derives from the
-    /// constants. If `memoTag` drifted to another valid two-byte string, every
-    /// one of those would still agree with itself, the live simulation would
-    /// still pass, and the attribution would silently stop matching anything.
+    /// constants. If `memoTag` drifted to another valid string, every one of
+    /// those would still agree with itself, the live simulation would still
+    /// pass, and the attribution would silently stop matching anything.
+    ///
+    /// The tag is case-sensitive: it is compared as bytes, so `8K2MZ` is a
+    /// different memo that no downstream filter would count.
     func testTheAttributionTagAndProgramArePinnedToTheirLiterals() {
-        XCTAssertEqual(KaminoAttribution.memoTag, "vs")
-        XCTAssertEqual(KaminoAttribution.memoTagBytes, [0x76, 0x73])
+        XCTAssertEqual(KaminoAttribution.memoTag, "8k2mz")
+        XCTAssertEqual(KaminoAttribution.memoTagBytes, [0x38, 0x6b, 0x32, 0x6d, 0x7a])
         XCTAssertEqual(SolanaV0Transaction.memoProgramId, "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr")
     }
 
@@ -487,7 +490,7 @@ final class KaminoTransactionValidatorTests: XCTestCase {
     /// matched whole. A memo that merely STARTS with the tag is a different
     /// memo — and the attribution filter downstream keys on the exact bytes.
     func testRejectsAMemoCarryingAnythingButTheTag() throws {
-        for text in ["v", "vsx", "VS", "vs "] {
+        for text in ["8k2m", "8k2mz1", "8K2MZ", "8k2mz "] {
             var mutable = try MutableTransaction(base64: try KaminoTransactionFixtures.usdcDeposit.tagged)
             mutable.instructions[mutable.instructions.count - 1].data = [UInt8](Data(text.utf8))
 


### PR DESCRIPTION
## Description

Kamino specified the memo their attribution keys on: **`8k2mz`**, replacing the placeholder `vs` this app has been writing since #5117.

`KaminoAttribution.memoTag` is the single source of the literal, so the injector, the validator and the offline verify-screen decoder all move with it, and the derived `tagged` test fixtures follow automatically. The rest of the diff is the tests that deliberately do *not* derive it.

No issue — the change came from Kamino directly. Context: #5017, tag introduced in #5117.

### The tag is case-sensitive

It is compared as raw bytes and matched **whole**, so `8K2MZ` is a different memo that no downstream filter would count. The pinned-literal test asserts both the string and its exact bytes (`[0x38, 0x6b, 0x32, 0x6d, 0x7a]`) precisely because everything else in the suite derives from the constant — a drift would leave the whole suite agreeing with itself and green while the attribution silently matched nothing.

The near-miss rejection cases were re-derived from the new tag (`8k2m`, `8k2mz1`, `8K2MZ`, `8k2mz `), so prefix, suffix, case and trailing-whitespace variants are all still refused.

### Two things a tag change could have broken

**Packet size.** The tag grows by three bytes. Decoding all nine fixture vectors, the largest tagged transaction goes 799 → **802 bytes** against the 1,232-byte Solana cap — 430 bytes of headroom. `injectingMemo` also enforces the limit at runtime, so an outlier vault throws rather than producing an oversized transaction.

**Compute.** The pinned `KaminoComputeBudget` limits were measured on untagged transactions and carry >62k CU of margin; three more bytes of memo data is far inside it. Production also simulates the *final tagged* transaction before signing, so this fails loudly rather than silently.

### No migration, no dual-accept window

The old tag never shipped. `a6ba7f2b5` is not an ancestor of `v1.44.70` and nothing tagged has been broadcast, so there is no on-chain history keyed on the old bytes.

The one consequence worth naming: a device on an older `main` build that builds a `vs`-tagged transaction will have it rejected as unreadable by a co-signer on this build, and blocked from co-signing. That is the guard working — the app signs exactly one memo literal under the Memo program, and teaching the decoder a legacy tag would weaken it for a window that only exists between unreleased builds. Called deliberately; say the word if a dual-accept window is wanted instead.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast)
- [ ] Sending
- [ ] Swap
- [ ] New Chain / Chain related feature

Kamino Earn deposit/withdraw on Solana. No tx link: the tagged form has not been broadcast yet, and the opt-in live test (`KAMINO_LIVE=1 testTheTaggedDepositStillFitsAndStillExecutes`) is still the thing that would measure size and compute against mainnet rather than argue them.

## Parity

- Android: `n/a` — no Kamino integration exists (grepped `*.kt`: no hits)
- Windows + extension: `n/a` — no Kamino integration exists (grepped `*.ts`/`*.tsx`/`*.go`: no hits)
- SDK: `n/a` — no Kamino integration exists
- `first:` Kamino Earn attribution memo. iOS is the only platform with a Kamino integration, so there is nothing to keep in sync today — but whoever implements Kamino on Android or Windows must write this same literal, byte for byte.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional context

**Gate:** `** TEST SUCCEEDED **` — 6052 tests, 0 failures, 11 skipped (the opt-in live suite). SwiftLint clean on every touched file.

**Codex review** (read-only, whole-commit) raised two points:
1. `SolanaV0Transaction.maxMemoByteCount`'s doc comment still described the tag as "two bytes" — **fixed** in this commit.
2. The mixed-version co-sign behaviour described above — **rejected deliberately**, reasoning in this description.

Everything else it checked came back clean: no remaining `"vs"` / `[0x76, 0x73]` / `[118, 115]` hardcodes anywhere; the byte literals are correct ASCII for `8k2mz`; and there is no persisted raw-transaction or memo path, so nothing stored keys on the old tag.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: none — request came from Kamino directly; context #5017, #5117
- **Confidence**: high
- **Needs human review for**: confirming the exact literal and its casing with Kamino (`8k2mz`, lowercase, five bytes) — it is compared byte-for-byte, so a casing mismatch would silently match nothing downstream


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified supported memo text length and attribution matching behavior.

* **Bug Fixes**
  * Updated Kamino transaction attribution to use the new `8k2mz` memo tag.
  * Improved validation to reject incomplete, modified, uppercase, or whitespace-padded variants.

* **Tests**
  * Updated memo injection and attribution coverage for the new tag, including composition, preservation, and duplicate scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->