### PR TITLE
fix(thorchain): treat a null Midgard TCY distribution list as empty

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/THORChainStakingService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/THORChainStakingService.swift
@@ -401,7 +401,7 @@ private extension THORChainStakingService {
 
         // 2. Get user-specific distributions from Midgard
         let distributionData = try await fetchTcyUserDistributions(address: address)
-        let distributions = distributionData.distributions
+        let distributions = distributionData.distributions ?? []
 
         guard !distributions.isEmpty else {
             return 0

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/TargetType/THORChainStakingAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/TargetType/THORChainStakingAPI.swift
@@ -135,7 +135,7 @@ struct TcyStakerResponse: Codable {
 
 /// Response model for TCY user distributions from Midgard
 struct TcyUserDistributionsResponse: Codable {
-    let distributions: [TcyUserDistribution]
+    let distributions: [TcyUserDistribution]?
     let total: String?
 
     struct TcyUserDistribution: Codable {

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/TargetType/THORChainStakingAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/TargetType/THORChainStakingAPI.swift
@@ -138,7 +138,7 @@ struct TcyUserDistributionsResponse: Codable {
     let distributions: [TcyUserDistribution]?
     let total: String?
 
-    struct TcyUserDistribution: Codable {
+    struct TcyUserDistribution: Codable, Equatable {
         let date: String      // Timestamp
         let amount: String    // RUNE amount in satoshis
     }

--- a/VultisigApp/VultisigAppTests/Blockchain/THORChain/TcyUserDistributionsDecodingTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/THORChain/TcyUserDistributionsDecodingTests.swift
@@ -38,6 +38,29 @@ final class TcyUserDistributionsDecodingTests: XCTestCase {
         XCTAssertEqual(distributions.first?.amount, "12345")
     }
 
+    /// Midgard omitting the key entirely, rather than sending `null`, must decode
+    /// the same way — `decodeIfPresent` treats both as absent.
+    func testAnOmittedDistributionsKeyDecodesToNil() throws {
+        let response = try decode(Self.responseWithOmittedKey)
+        XCTAssertNil(response.distributions)
+    }
+
+    /// A genuinely empty list is a third shape for the same "no history" case.
+    func testAnEmptyDistributionsListDecodes() throws {
+        let response = try decode(Self.responseWithEmptyList)
+        XCTAssertEqual(response.distributions, [])
+    }
+
+    /// All three "no history" shapes normalize to the same `[]` the call site
+    /// (`calculateTcyAPY`'s `guard !distributions.isEmpty else { return 0 }`)
+    /// keys its zero-rate branch on.
+    func testAllNoHistoryShapesNormalizeToAnEmptyArray() throws {
+        for json in [Self.responseWithNoHistory, Self.responseWithOmittedKey, Self.responseWithEmptyList] {
+            let normalized = try decode(json).distributions ?? []
+            XCTAssertEqual(normalized, [])
+        }
+    }
+
     // MARK: - Fixtures
 
     /// Verbatim from `https://.../thorchain_midgard/v2/tcy/distribution/{address}`
@@ -57,6 +80,23 @@ final class TcyUserDistributionsDecodingTests: XCTestCase {
         "apr": "1.5",
         "distributions": [{"date": "1700000000", "amount": "12345"}],
         "total": "12345"
+    }
+    """
+
+    private static let responseWithOmittedKey = """
+    {
+        "address": "thor18altpx2gwt4c4ejr5uzda4kyzsudyn9q56fnng",
+        "apr": "0",
+        "total": "0"
+    }
+    """
+
+    private static let responseWithEmptyList = """
+    {
+        "address": "thor18altpx2gwt4c4ejr5uzda4kyzsudyn9q56fnng",
+        "apr": "0",
+        "distributions": [],
+        "total": "0"
     }
     """
 }

--- a/VultisigApp/VultisigAppTests/Blockchain/THORChain/TcyUserDistributionsDecodingTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/THORChain/TcyUserDistributionsDecodingTests.swift
@@ -1,0 +1,62 @@
+//
+//  TcyUserDistributionsDecodingTests.swift
+//  VultisigAppTests
+//
+//  Midgard's `/v2/tcy/distribution/{address}` sends `"distributions": null`,
+//  verbatim, for an address with no payout history yet. Against a
+//  non-optional `[TcyUserDistribution]` that threw `DecodingError
+//  .valueNotFound`, which aborted the whole TCY staking-details fetch (APR,
+//  reward estimate, and the position itself) for any address too new or too
+//  small to have been paid out.
+//
+//  The fixture below is captured verbatim from mainnet Midgard.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class TcyUserDistributionsDecodingTests: XCTestCase {
+
+    private func decode(_ json: String) throws -> TcyUserDistributionsResponse {
+        try JSONDecoder().decode(TcyUserDistributionsResponse.self, from: Data(json.utf8))
+    }
+
+    /// ⚠️ The regression. A staked address with no payout history yet.
+    func testANullDistributionsListDecodesToNil() throws {
+        let response = try decode(Self.responseWithNoHistory)
+
+        XCTAssertNil(response.distributions)
+        XCTAssertEqual(response.total, "0")
+    }
+
+    /// The populated case keeps working the same way.
+    func testAPopulatedDistributionsListDecodes() throws {
+        let response = try decode(Self.responseWithHistory)
+
+        let distributions = try XCTUnwrap(response.distributions)
+        XCTAssertEqual(distributions.count, 1)
+        XCTAssertEqual(distributions.first?.amount, "12345")
+    }
+
+    // MARK: - Fixtures
+
+    /// Verbatim from `https://.../thorchain_midgard/v2/tcy/distribution/{address}`
+    /// for a real address with a small, fresh TCY stake.
+    private static let responseWithNoHistory = """
+    {
+        "address": "thor18altpx2gwt4c4ejr5uzda4kyzsudyn9q56fnng",
+        "apr": "0",
+        "distributions": null,
+        "total": "0"
+    }
+    """
+
+    private static let responseWithHistory = """
+    {
+        "address": "thor18altpx2gwt4c4ejr5uzda4kyzsudyn9q56fnng",
+        "apr": "1.5",
+        "distributions": [{"date": "1700000000", "amount": "12345"}],
+        "total": "12345"
+    }
+    """
+}


### PR DESCRIPTION
## Description

The TCY staking-details fetch (`THORChainStakingService.fetchTcyStakingDetails`) threw
`HTTPError.decodingFailed` — logged as "Error fetching TCY staking details: Failed to
decode response: The data couldn't be read because it is missing." — for any address
that has staked TCY but has not yet received a distribution payout.

Root cause: Midgard's `/v2/tcy/distribution/{address}` returns the `distributions` field
as literal JSON `null` (not `[]`) when there's no payout history yet, e.g.:

```json
{
	"address": "thor18altpx2gwt4c4ejr5uzda4kyzsudyn9q56fnng",
	"apr": "0",
	"distributions": null,
	"total": "0"
}
```

`TcyUserDistributionsResponse.distributions` was a non-optional `[TcyUserDistribution]`,
so decoding `null` into it threw `DecodingError.valueNotFound`. That error propagated out
of `calculateTcyAPY` and up through `THORChainStakeInteractor.positions(for:)`, which
catches it and drops the whole TCY position — so an affected address's TCY stake
disappeared from the DeFi screen entirely instead of just showing 0% APY.

Fix: make `distributions` optional and default to `[]` when reading it. The existing
`guard !distributions.isEmpty else { return 0 }` right after already treats an empty list
as "no distribution history, 0% APY" — the correct behavior for a fresh staker.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

This is a read-only display fix (TCY staking position / APR fetch) — no signing,
broadcast, or fee computation touched.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings — `swiftlint lint` clean on both changed files
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional context

Verified the Midgard response shape directly against a live address with a small, fresh
TCY stake — `distributions` was `null`. The exact payload is now pinned as a regression
fixture in `TcyUserDistributionsDecodingTests` (both the null-history and
populated-history shapes), so the field can't silently regress back to non-optional.
`make test`-equivalent run of just this suite passes.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: none filed
- **Confidence**: high — root cause confirmed against the live Midgard response for the
  reporting user's own address
- **Needs human review for**: none — root cause confirmed live, fix and regression test
  both pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staking data handling when distribution information is missing or unavailable.
  * APY calculations now safely treat missing distribution data as empty, preventing errors when the API returns no distributions.
  * Added support for responses with null or omitted distribution information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->