### PR TITLE
fix(keysign): unstick the joining device's signing-error screen

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
@@ -37,19 +37,6 @@ enum KeysignStatus {
     /// avoid pushing the user toward a one-tap re-broadcast (double-spend
     /// risk). Distinct from `.KeysignFailed`, which is a confirmed failure.
     case KeysignBroadcastUnconfirmed
-
-    /// True while the shared connecting/signing animation is on screen; false
-    /// for every error/retry surface. Hosts that hide their own nav bar while
-    /// this is true (so the animation has no chrome) must show it again once
-    /// this flips false, or an error surface renders with no way back.
-    var isAnimating: Bool {
-        switch self {
-        case .connectingToFastServer, .CreatingInstance, .KeysignECDSA, .KeysignEdDSA, .KeysignMLDSA, .KeysignFinished:
-            return true
-        case .connectingToFastServerFailed, .KeysignFailed, .KeysignRetryRequested, .KeysignVaultMismatch, .KeysignBroadcastUnconfirmed:
-            return false
-        }
-    }
 }
 enum TssKeysignError: Error {
     case keysignFail

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
@@ -37,6 +37,19 @@ enum KeysignStatus {
     /// avoid pushing the user toward a one-tap re-broadcast (double-spend
     /// risk). Distinct from `.KeysignFailed`, which is a confirmed failure.
     case KeysignBroadcastUnconfirmed
+
+    /// True while the shared connecting/signing animation is on screen; false
+    /// for every error/retry surface. Hosts that hide their own nav bar while
+    /// this is true (so the animation has no chrome) must show it again once
+    /// this flips false, or an error surface renders with no way back.
+    var isAnimating: Bool {
+        switch self {
+        case .connectingToFastServer, .CreatingInstance, .KeysignECDSA, .KeysignEdDSA, .KeysignMLDSA, .KeysignFinished:
+            return true
+        case .connectingToFastServerFailed, .KeysignFailed, .KeysignRetryRequested, .KeysignVaultMismatch, .KeysignBroadcastUnconfirmed:
+            return false
+        }
+    }
 }
 enum TssKeysignError: Error {
     case keysignFail

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/JoinKeysignView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/JoinKeysignView.swift
@@ -34,9 +34,18 @@ struct JoinKeysignView: View {
     }
 
     var isInAnimationState: Bool {
-        viewModel.status == .WaitingForKeysignToStart
-            || viewModel.status == .KeysignStarted
-            || viewModel.status == .QBTCClaim
+        switch viewModel.status {
+        case .WaitingForKeysignToStart, .QBTCClaim:
+            return true
+        case .KeysignStarted:
+            // The nested `KeysignView` can drop into an error/retry surface
+            // without changing this outer status — keep the nav bar (and its
+            // back button) hidden only while that inner ceremony is actually
+            // animating, so an error surface isn't left with no way out.
+            return keysignVM.status.isAnimating
+        default:
+            return false
+        }
     }
 
     var states: some View {
@@ -120,6 +129,13 @@ struct JoinKeysignView: View {
             customMessagePayload: viewModel.customMessagePayload,
             encryptionKeyHex: viewModel.encryptionKeyHex,
             isInitiateDevice: false,
+            onRetry: { _ in
+                // The cosigner has no verify screen to pop back to and retry
+                // against — that surface only exists on the initiator. Restart
+                // is the same recovery this view already uses for its other
+                // keysign error states.
+                appViewModelLegacy.restart()
+            },
             decodedFunctionName: viewModel.decodedFunctionName,
             decodedTokenAmount: viewModel.decodedTokenAmount,
             decodedTokenTicker: viewModel.decodedTokenTicker,

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/JoinKeysignView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/JoinKeysignView.swift
@@ -33,19 +33,18 @@ struct JoinKeysignView: View {
             }
     }
 
+    // Deliberately keyed on the outer `viewModel.status` only, not the nested
+    // `keysignVM.status`: this flag drives `main`'s VStack-wrap branch and
+    // `content`'s toolbar branch below, and switching either mid-ceremony
+    // (e.g. on a broadcast retry) rebuilds `states`' branch of the view tree,
+    // resetting the nested `KeysignView`'s `@State` and re-firing its
+    // `.onLoad`, which restarts signing — an infinite retry loop if the
+    // retryable condition reproduces. The nested error surfaces have their
+    // own working "Try Again" instead of a back button (see `onRetry` below).
     var isInAnimationState: Bool {
-        switch viewModel.status {
-        case .WaitingForKeysignToStart, .QBTCClaim:
-            return true
-        case .KeysignStarted:
-            // The nested `KeysignView` can drop into an error/retry surface
-            // without changing this outer status — keep the nav bar (and its
-            // back button) hidden only while that inner ceremony is actually
-            // animating, so an error surface isn't left with no way out.
-            return keysignVM.status.isAnimating
-        default:
-            return false
-        }
+        viewModel.status == .WaitingForKeysignToStart
+            || viewModel.status == .KeysignStarted
+            || viewModel.status == .QBTCClaim
     }
 
     var states: some View {


### PR DESCRIPTION
## Description

On the joining/cosigner device, `KeysignView`'s error/retry surfaces are hosted inside `JoinKeysignView`, which never wired an `onRetry` action. When the ceremony hits `.KeysignRetryRequested` (e.g. the "Transaction expired. Please try again." broadcast retry), the "Try Again" button called `onRetry?(reason)`, which was `nil` — a silent no-op, trapping the user on the screen exactly as described.

The initiator device doesn't have this problem — `SigningKeysignScreen` already wires `onRetry` to pop back to the verify screen.

Fixes #5183

## Fix

- Wired `onRetry` on the cosigner's `KeysignView` to `appViewModelLegacy.restart()` — the same recovery this view already uses for its other keysign error states, since the cosigner has no verify screen of its own to retry against (only the initiator does).

An earlier version of this PR also tried to reveal `JoinKeysignView`'s nav bar (for a back button) during the nested ceremony's error states, by making `isInAnimationState` react to `keysignVM.status`. That broke SwiftUI view identity: `isInAnimationState` also drives `main`'s VStack-wrap branch and `content`'s toolbar branch, and flipping either mid-ceremony rebuilds that branch of the tree, resetting the nested `KeysignView`'s `@State` and re-firing its `.onLoad` — which restarts the whole signing ceremony, looping forever if the retryable condition reproduces. That part was reverted; `isInAnimationState` is back to depending only on the outer `JoinKeysignViewModel` status, matching the initiator's screens (which also have no nav bar on their error surfaces and rely solely on a working retry button).

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [x] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Parity

- Android: n/a — iOS-only SwiftUI navigation/state-wiring bug (missing `onRetry` callback), not a protocol or keysign-logic difference.
- Windows + extension: n/a — same reason.
- SDK: n/a — same reason.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

N/A — this is a navigation/state-wiring fix for a multi-device keysign flow (requires two physical/paired devices to repro live); verified via full simulator build + code trace of the state machine instead.

## Additional context

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #5183
- **Confidence**: medium
- **Needs human review for**: confirming on real paired devices that the joining device's "Try Again" now recovers as expected and no longer loops (this fix was verified by build + code trace, not a live two-device repro)