### PR TITLE
fix(functions): resolve Swift 6 warnings in Maya bond view models

### DIFF
--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Maya/BondMaya/BondMayaTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Maya/BondMaya/BondMayaTransactionViewModel.swift
@@ -171,32 +171,29 @@ final class BondMayaTransactionViewModel: ObservableObject, Form {
                 let positions = try await fetchUserLPPositions()
                 let assets = try await assetsDataSource.fetchAssets()
 
-                await MainActor.run {
-                    guard !Task.isCancelled else { return }
-                    isLoading = false
-                    userLPPositions = positions
+                guard !Task.isCancelled else { return }
+                isLoading = false
+                userLPPositions = positions
 
-                    if let firstAsset = assets.first {
-                        selectedAsset = firstAsset
-                    } else {
-                        assetsUnavailableReason = Self.noPositionsKey
-                    }
+                if let firstAsset = assets.first {
+                    selectedAsset = firstAsset
+                } else {
+                    assetsUnavailableReason = Self.noPositionsKey
                 }
             } catch {
                 Log.send.viewModel.error("Error loading bondable Maya assets: \(error.localizedDescription, privacy: .public)")
-                await MainActor.run {
-                    guard !Task.isCancelled else { return }
-                    isLoading = false
-                    assetsUnavailableReason = Self.loadFailedKey
-                }
+                guard !Task.isCancelled else { return }
+                isLoading = false
+                assetsUnavailableReason = Self.loadFailedKey
             }
         }
     }
 
     /// The user's unbonded LP units per pool, keyed by pool name.
     private func fetchUserLPPositions() async throws -> [String: String] {
-        async let memberDetailsTask = mayaAPIService.getMemberDetails(address: coin.address)
-        async let allBondedUnitsTask = mayaAPIService.getAllBondedLPUnitsByPool(address: coin.address)
+        let address = coin.address
+        async let memberDetailsTask = mayaAPIService.getMemberDetails(address: address)
+        async let allBondedUnitsTask = mayaAPIService.getAllBondedLPUnitsByPool(address: address)
 
         let memberDetails = try await memberDetailsTask
         let allBondedUnits = try await allBondedUnitsTask

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Maya/UnbondMaya/UnbondMayaTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Maya/UnbondMaya/UnbondMayaTransactionViewModel.swift
@@ -189,36 +189,32 @@ final class UnbondMayaTransactionViewModel: ObservableObject, Form {
             do {
                 let assets = try await assetsDataSource.fetchAssets()
 
-                await MainActor.run {
-                    guard isCurrentRequest(for: nodeAddress) else { return }
-                    isLoading = false
-                    availableBondedAssets = assets
+                guard isCurrentRequest(for: nodeAddress) else { return }
+                isLoading = false
+                availableBondedAssets = assets
 
-                    if assets.isEmpty {
-                        addressViewModel.field.error = "noBondedAssetsOnNode".localized
-                        selectedAsset = nil
-                    } else if let selectedAsset, assets.contains(selectedAsset) {
-                        // Same asset, different node: `$selectedAsset` will not
-                        // fire, so nothing else would re-read the bonded units
-                        // for the node now in the address field.
-                        fetchBondedLPUnits(for: selectedAsset)
-                    } else {
-                        // An asset only bonded on the PREVIOUS node must not
-                        // survive the switch — unbonding it here would build a
-                        // memo for a pool the user has no position in on this
-                        // node.
-                        selectedAsset = assets.first
-                    }
+                if assets.isEmpty {
+                    addressViewModel.field.error = "noBondedAssetsOnNode".localized
+                    selectedAsset = nil
+                } else if let selectedAsset, assets.contains(selectedAsset) {
+                    // Same asset, different node: `$selectedAsset` will not
+                    // fire, so nothing else would re-read the bonded units
+                    // for the node now in the address field.
+                    fetchBondedLPUnits(for: selectedAsset)
+                } else {
+                    // An asset only bonded on the PREVIOUS node must not
+                    // survive the switch — unbonding it here would build a
+                    // memo for a pool the user has no position in on this
+                    // node.
+                    selectedAsset = assets.first
                 }
             } catch {
                 Log.send.viewModel.error("Error fetching bonded LP positions: \(error.localizedDescription, privacy: .public)")
-                await MainActor.run {
-                    guard isCurrentRequest(for: nodeAddress) else { return }
-                    isLoading = false
-                    availableBondedAssets = []
-                    selectedAsset = nil
-                    assetsUnavailableReason = "bondedAssetsLoadFailed"
-                }
+                guard isCurrentRequest(for: nodeAddress) else { return }
+                isLoading = false
+                availableBondedAssets = []
+                selectedAsset = nil
+                assetsUnavailableReason = "bondedAssetsLoadFailed"
             }
         }
     }
@@ -311,35 +307,29 @@ final class UnbondMayaTransactionViewModel: ObservableObject, Form {
                 )
 
                 guard let units = bondedUnits, units > 0 else {
-                    await MainActor.run {
-                        guard isCurrentRequest(for: nodeAddress, asset: asset) else { return }
-                        clearBondedUnitsCeiling()
-                    }
+                    guard isCurrentRequest(for: nodeAddress, asset: asset) else { return }
+                    clearBondedUnitsCeiling()
                     return
                 }
 
-                await MainActor.run {
-                    // This figure is the unbond ceiling; publishing it for a
-                    // node or asset the user has since left would raise the
-                    // limit on a position that does not have it.
-                    guard isCurrentRequest(for: nodeAddress, asset: asset) else { return }
-                    bondedUnitsCeiling = BondedUnitsCeiling(
-                        nodeAddress: nodeAddress,
-                        asset: asset,
-                        units: String(units)
-                    )
+                // This figure is the unbond ceiling; publishing it for a
+                // node or asset the user has since left would raise the
+                // limit on a position that does not have it.
+                guard isCurrentRequest(for: nodeAddress, asset: asset) else { return }
+                bondedUnitsCeiling = BondedUnitsCeiling(
+                    nodeAddress: nodeAddress,
+                    asset: asset,
+                    units: String(units)
+                )
 
-                    // Update validator with bonded units
-                    lpUnitsField.validators = Self.baseLPUnitsValidators + [
-                        LPUnitsValidator(availableUnits: String(units))
-                    ]
-                }
+                // Update validator with bonded units
+                lpUnitsField.validators = Self.baseLPUnitsValidators + [
+                    LPUnitsValidator(availableUnits: String(units))
+                ]
             } catch {
                 Log.send.viewModel.error("Error fetching bonded LP units: \(error.localizedDescription, privacy: .public)")
-                await MainActor.run {
-                    guard isCurrentRequest(for: nodeAddress, asset: asset) else { return }
-                    clearBondedUnitsCeiling()
-                }
+                guard isCurrentRequest(for: nodeAddress, asset: asset) else { return }
+                clearBondedUnitsCeiling()
             }
         }
     }


### PR DESCRIPTION
## Summary
- Removed redundant `await MainActor.run { }` wrappers in `BondMayaTransactionViewModel` and `UnbondMayaTransactionViewModel` — both classes are already MainActor-isolated (via `Form`'s `@MainActor` conformance), so the enclosing `Task { [weak self] in }` bodies already run on the main actor. The wrappers only added an unnecessary `@Sendable` closure boundary, which is what triggered Swift 6's "implicit `self.`" warnings.
- Fixed the two "non-Sendable `Coin`" warnings in `BondMayaTransactionViewModel.fetchUserLPPositions()` by capturing `coin.address` (a `Sendable` `String`) once before the `async let`s, instead of letting the non-Sendable `Coin` cross into the child tasks.

## Test Plan
- [x] `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — 0 violations in the two changed files
- [x] `xcodebuild` (via XcodeBuildMCP `build_sim`) — build succeeds, all 30 warnings previously reported for these two files are gone; no new warnings introduced

Co-Authored-By: Claude <noreply@anthropic.com>