### PR TITLE
fix(defi): denominate the CACAO withdraw ceiling in CACAO, not pool units

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Maya/API/MayaChainAPIService+Staking.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Maya/API/MayaChainAPIService+Staking.swift
@@ -26,8 +26,8 @@ extension MayaChainAPIService {
 
         return MayaCacaoPoolPosition(
             address: address,
-            stakedAmount: currentValue,  // Use value for display (includes earnings)
-            availableUnits: userUnits,   // Units available for unstaking
+            stakedAmount: currentValue,  // Member's CACAO value (includes earnings)
+            availableUnits: userUnits,   // Pool units held — NOT a CACAO amount
             userUnits: userUnits,
             netDeposit: netDeposit,
             lastWithdrawHeight: member.lastWithdrawHeight,
@@ -93,11 +93,17 @@ extension MayaChainAPIService {
 
 // MARK: - Staking Models
 
+/// A member's position in the CACAO pool, in the API's own scales.
+///
+/// The two scales are not interchangeable: `stakedAmount` is CACAO, the pool-unit
+/// fields are pool units, and a unit is worth `stakedAmount / userUnits` CACAO —
+/// a rate at or above 1 that only rises as the pool earns. Every figure the app
+/// shows a user, and every ceiling it lets a user type against, is CACAO.
 struct MayaCacaoPoolPosition {
     let address: String
-    let stakedAmount: Decimal      // Current value in CACAO (for display)
-    let availableUnits: Decimal    // Units available for unstaking
-    let userUnits: Decimal         // User's pool units
+    let stakedAmount: Decimal      // Current value in CACAO, base units (for display and withdrawal)
+    let availableUnits: Decimal    // Pool units held — NOT a CACAO amount
+    let userUnits: Decimal         // Pool units held (duplicate of `availableUnits`)
     let netDeposit: Decimal        // Deposit - Withdrawn
     let lastWithdrawHeight: Int64
     let lastDepositHeight: Int64

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/MayaChainStakeInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/MayaChainStakeInteractor.swift
@@ -35,22 +35,56 @@ struct MayaChainStakeInteractor: StakeInteractor {
             return []
         }
 
-        let stakedAmount = position.stakedAmount / pow(10, cacao.decimals)
-        let availableToUnstake = position.availableUnits / pow(10, cacao.decimals)
         let aprData = try? await mayaChainAPIService.getCacaoPoolAPR()
-
         let unstakeMetadata = await unstakeMetadata(for: position)
 
         return [
-            StakePositionData(
+            Self.stakePositionData(
+                position: position,
                 coin: cacao.meta,
-                type: .stake,
-                amount: stakedAmount,
-                availableToUnstake: availableToUnstake,
+                decimals: cacao.decimals,
                 apr: aprData?.apr ?? 0,
                 unstakeMetadata: unstakeMetadata
             )
         ]
+    }
+
+    /// Projects a fetched CACAO pool position onto the row the DeFi tab renders
+    /// and the withdraw sheet is opened from.
+    ///
+    /// Both figures are the member's CACAO **value**, and deliberately the same
+    /// figure. The position also carries the member's pool *units*, which are a
+    /// different scale entirely — value = units × the pool's CACAO-per-unit, a
+    /// rate that only rises as the pool earns — so feeding one to the card and
+    /// the other to the sheet showed the user a quantity they never held.
+    ///
+    /// `availableToUnstake` is not merely a label. It is the ceiling the sheet
+    /// renders, validates against, and derives the signed fraction from: a CACAO
+    /// withdrawal carries no coin amount at all, only a basis-point share of the
+    /// position (`POOL-:<bps>`). A share picked off the slider is unaffected by
+    /// what the ceiling is denominated in, but a *typed* amount is read as a
+    /// fraction of it — so the ceiling has to be denominated in what the user is
+    /// typing, or the fraction asks for the wrong money.
+    ///
+    /// Pure, and separated from the fetch above, so the projection is exercised
+    /// without a network hop.
+    static func stakePositionData(
+        position: MayaCacaoPoolPosition,
+        coin: CoinMeta,
+        decimals: Int,
+        apr: Double,
+        unstakeMetadata: UnstakeMetadata
+    ) -> StakePositionData {
+        let cacaoValue = position.stakedAmount / pow(10, decimals)
+
+        return StakePositionData(
+            coin: coin,
+            type: .stake,
+            amount: cacaoValue,
+            availableToUnstake: cacaoValue,
+            apr: apr,
+            unstakeMetadata: unstakeMetadata
+        )
     }
 }
 

--- a/VultisigApp/VultisigAppTests/Defi/MayaCacaoWithdrawCeilingTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/MayaCacaoWithdrawCeilingTests.swift
@@ -1,0 +1,267 @@
+//
+//  MayaCacaoWithdrawCeilingTests.swift
+//  VultisigAppTests
+//
+//  The MayaChain CACAO staked card and its withdraw sheet must be denominated in
+//  the same thing. They were not: the card rendered the member's CACAO value and
+//  the sheet's ceiling was the member's pool units, a strictly smaller and
+//  entirely different scale.
+//
+//  Because a CACAO withdrawal signs no coin amount — only a basis-point share of
+//  the position (`POOL-:<bps>`) — the display fix has a money question attached,
+//  and these tests answer both halves of it: a share picked off the slider signs
+//  the same memo under either ceiling, and a typed amount now resolves against
+//  the CACAO figure the user was reading.
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class MayaCacaoWithdrawCeilingTests: XCTestCase {
+
+    /// CACAO's scale (`TokensStore.cacao.decimals`).
+    private let decimals = 10
+    private let oneCacao = Decimal(sign: .plus, exponent: 10, significand: 1)
+
+    private var token: TestContextToken!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        token = try TestStore.installInMemoryContainer()
+    }
+
+    override func tearDown() async throws {
+        TestStore.restore(token)
+        token = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Fixtures
+
+    /// A member whose units are worth more than one CACAO each — the ordinary
+    /// state of an earning pool, and the one that makes the two scales diverge.
+    private func makePosition(cacao: Decimal, units: Decimal) -> MayaCacaoPoolPosition {
+        MayaCacaoPoolPosition(
+            address: "maya1fixturecacaopoolmemberaddress00000000",
+            stakedAmount: cacao * oneCacao,
+            availableUnits: units * oneCacao,
+            userUnits: units * oneCacao,
+            netDeposit: cacao * oneCacao,
+            lastWithdrawHeight: 0,
+            lastDepositHeight: 1_000
+        )
+    }
+
+    private func project(_ position: MayaCacaoPoolPosition) -> StakePositionData {
+        MayaChainStakeInteractor.stakePositionData(
+            position: position,
+            coin: TokensStore.cacao,
+            decimals: decimals,
+            apr: 0.12,
+            unstakeMetadata: maturedMetadata
+        )
+    }
+
+    private var maturedMetadata: UnstakeMetadata {
+        UnstakeMetadata(
+            lastDepositHeight: 1_000,
+            maturityBlocks: 302_400,
+            snapshotHeight: 1_000 + 302_400 + 10,
+            snapshotTimestamp: Date().timeIntervalSince1970
+        )
+    }
+
+    private func makeCacaoCoin() -> Coin {
+        Coin(
+            asset: TokensStore.cacao,
+            address: "maya1fixturecacaopoolmemberaddress00000000",
+            hexPublicKey: "02" + String(repeating: "00", count: 32)
+        )
+    }
+
+    private func makeViewModel(availableToUnstake: Decimal, pubKey: String) -> UnstakeTransactionViewModel {
+        let viewModel = UnstakeTransactionViewModel(
+            coin: makeCacaoCoin(),
+            vault: TestStore.makeVault(pubKey: pubKey),
+            isAutocompound: false,
+            availableToUnstake: availableToUnstake
+        )
+        viewModel.onLoad()
+        return viewModel
+    }
+
+    /// What `UnstakeTransactionScreen` + `AmountTextField` do when the slider
+    /// moves: the percentage takes ownership and the field is re-derived from the
+    /// ceiling in force.
+    private func selectPercentage(_ percentage: Double, on viewModel: UnstakeTransactionViewModel) {
+        viewModel.percentageSelected = percentage
+        viewModel.onPercentage(percentage)
+        let derived = viewModel.availableAmount * Decimal(percentage) / 100
+        viewModel.amountField.value = derived.formatToDecimal(digits: 4)
+    }
+
+    /// What `AmountTextField` does when the user edits the field by hand: the
+    /// field takes ownership and the percentage control is cleared.
+    private func typeAmount(_ amount: String, into viewModel: UnstakeTransactionViewModel) {
+        viewModel.amountField.value = amount
+        viewModel.percentageSelected = nil
+    }
+
+    // MARK: - The projection is CACAO on both figures
+
+    /// The regression itself. 1000 pool units worth 1200 CACAO: the card said
+    /// 1200 and the withdraw sheet said 1000.
+    func testWithdrawCeilingIsTheCacaoValueNotPoolUnits() {
+        let data = project(makePosition(cacao: 1_200, units: 1_000))
+
+        XCTAssertEqual(data.amount, 1_200, "the staked card figure must stay the member's CACAO value")
+        XCTAssertEqual(
+            data.availableToUnstake,
+            1_200,
+            "the withdraw ceiling must be the same CACAO value, not the pool units the sheet used to show"
+        )
+        XCTAssertNotEqual(data.availableToUnstake, 1_000, "scaled pool units must never reach the withdraw path")
+    }
+
+    /// The card and the sheet are one number, at every unit/value ratio — including
+    /// the degenerate 1:1 that would have hidden the bug in a fixture.
+    func testCardAmountAndWithdrawCeilingAlwaysAgree() {
+        let ratios: [(cacao: Decimal, units: Decimal)] = [
+            (1_200, 1_000),      // an earning pool
+            (500, 500),          // 1:1 — the case that hides the defect
+            (Decimal(string: "0.0000000001")!, Decimal(string: "0.00000000005")!), // one base unit
+            (2_002, Decimal(string: "1734.6")!)
+        ]
+
+        for ratio in ratios {
+            let data = project(makePosition(cacao: ratio.cacao, units: ratio.units))
+            XCTAssertEqual(
+                data.availableToUnstake,
+                data.amount,
+                "card and withdraw ceiling diverged at \(ratio.cacao) CACAO / \(ratio.units) units"
+            )
+            XCTAssertEqual(data.amount, ratio.cacao)
+        }
+    }
+
+    /// The projection still divides by the coin's scale — the fix changed which
+    /// field is read, not whether it is converted out of base units.
+    func testProjectionConvertsOutOfBaseUnits() {
+        let position = makePosition(cacao: 42, units: 40)
+
+        XCTAssertEqual(project(position).amount, 42)
+        XCTAssertEqual(position.stakedAmount, 42 * oneCacao, "fixture must be in base units for the test to mean anything")
+    }
+
+    /// Everything else on the row is carried through untouched, so the ceiling fix
+    /// cannot be read as a rewrite of the card.
+    func testProjectionCarriesTheRestOfTheRowUnchanged() {
+        let metadata = maturedMetadata
+        let data = MayaChainStakeInteractor.stakePositionData(
+            position: makePosition(cacao: 1_200, units: 1_000),
+            coin: TokensStore.cacao,
+            decimals: decimals,
+            apr: 0.12,
+            unstakeMetadata: metadata
+        )
+
+        XCTAssertEqual(data.coin, TokensStore.cacao)
+        XCTAssertEqual(data.type, .stake)
+        XCTAssertEqual(data.apr, 0.12)
+        XCTAssertEqual(data.unstakeMetadata, metadata)
+    }
+
+    // MARK: - Money regression: the slider path signs the same memo either way
+
+    /// The fund-safety question. `CacaoUnstakeTransactionBuilder` carries
+    /// `amount = "0"`, so the memo is the entire instruction — and on the slider
+    /// path the memo is derived from the percentage alone. Changing the ceiling
+    /// from pool units to CACAO must therefore move nothing that gets signed.
+    func testSliderDrivenWithdrawalSignsTheSameMemoUnderEitherCeiling() {
+        let unitsCeiling: Decimal = 1_000   // what the sheet used to open on
+        let cacaoCeiling: Decimal = 1_200   // what it opens on now
+
+        for percentage in [100.0, 50.0, 25.0, 10.0] {
+            let before = makeViewModel(availableToUnstake: unitsCeiling, pubKey: "cacao-before-\(Int(percentage))")
+            let after = makeViewModel(availableToUnstake: cacaoCeiling, pubKey: "cacao-after-\(Int(percentage))")
+
+            selectPercentage(percentage, on: before)
+            selectPercentage(percentage, on: after)
+
+            let beforeMemo = before.transactionBuilder?.memo
+            let afterMemo = after.transactionBuilder?.memo
+
+            XCTAssertEqual(beforeMemo, "POOL-:\(Int(percentage) * 100)")
+            XCTAssertEqual(
+                afterMemo,
+                beforeMemo,
+                "the ceiling fix moved the signed memo at \(percentage)% — it must not"
+            )
+        }
+    }
+
+    /// A full exit is still a full exit: 100% signs the whole position, and the
+    /// builder attaches no coin amount to it.
+    func testFullExitStillSignsTheWholePositionAndCarriesNoAmount() throws {
+        let viewModel = makeViewModel(availableToUnstake: 1_200, pubKey: "cacao-full-exit")
+        selectPercentage(100, on: viewModel)
+
+        let builder = try XCTUnwrap(viewModel.transactionBuilder)
+        XCTAssertEqual(builder.memo, "POOL-:10000")
+        XCTAssertEqual(builder.amount, "0", "a CACAO withdrawal signs a share, never a coin amount")
+        XCTAssertFalse(builder.sendMaxAmount)
+    }
+
+    // MARK: - The typed path is where the user-visible fix lands
+
+    /// The sheet opens on the figure the card was showing, so a typed amount is
+    /// read against CACAO. Under the old units ceiling the same figure was over
+    /// the maximum and could not be submitted at all.
+    func testATypedCacaoAmountResolvesAgainstTheCacaoPosition() throws {
+        let underUnitsCeiling = makeViewModel(availableToUnstake: 1_000, pubKey: "cacao-typed-units")
+        let underCacaoCeiling = makeViewModel(availableToUnstake: 1_200, pubKey: "cacao-typed-cacao")
+
+        typeAmount("1100", into: underUnitsCeiling)
+        typeAmount("1100", into: underCacaoCeiling)
+
+        XCTAssertNil(
+            underUnitsCeiling.transactionBuilder,
+            "1100 of a 1200-CACAO position was unreachable while the ceiling was 1000 pool units"
+        )
+
+        let builder = try XCTUnwrap(underCacaoCeiling.transactionBuilder)
+        XCTAssertEqual(builder.memo, "POOL-:9100", "1100 of 1200 CACAO is 91% of the position")
+    }
+
+    /// The ceiling is also what the field is validated against, so the sheet now
+    /// accepts everything the card said the user holds.
+    func testTheWholeCardAmountIsEnterable() throws {
+        let viewModel = makeViewModel(availableToUnstake: 1_200, pubKey: "cacao-typed-max")
+        typeAmount("1200", into: viewModel)
+
+        let builder = try XCTUnwrap(viewModel.transactionBuilder)
+        XCTAssertEqual(builder.memo, "POOL-:10000")
+    }
+
+    /// And nothing beyond it is: the ceiling still bounds the form.
+    func testAnAmountAboveTheCardAmountIsStillRefused() {
+        let viewModel = makeViewModel(availableToUnstake: 1_200, pubKey: "cacao-typed-over")
+        typeAmount("1200.0001", into: viewModel)
+
+        XCTAssertNil(viewModel.transactionBuilder)
+    }
+
+    // MARK: - The sheet opens on the ceiling it was handed
+
+    /// Pins the seam the fix travels through: whatever the interactor projected is
+    /// what the sheet renders, validates and derives from.
+    func testTheSheetOpensOnTheProjectedCeiling() throws {
+        let data = project(makePosition(cacao: 1_200, units: 1_000))
+        let ceiling = try XCTUnwrap(data.availableToUnstake)
+        let viewModel = makeViewModel(availableToUnstake: ceiling, pubKey: "cacao-seam")
+
+        XCTAssertEqual(viewModel.availableAmount, 1_200)
+        XCTAssertEqual(viewModel.availableAmount, data.amount, "the sheet must open on the card's figure")
+    }
+}

--- a/VultisigApp/VultisigAppTests/Defi/MayaCacaoWithdrawCeilingTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/MayaCacaoWithdrawCeilingTests.swift
@@ -91,6 +91,16 @@ final class MayaCacaoWithdrawCeilingTests: XCTestCase {
         return viewModel
     }
 
+    /// The whole seam in one call: fetched position → interactor projection →
+    /// `DefiChainScreenModel` handing `availableToUnstake` to the sheet. Tests
+    /// built this way fail against the pre-fix mapping rather than merely
+    /// characterising the sheet against a hand-picked ceiling.
+    private func makeSheet(cacao: Decimal, units: Decimal, pubKey: String) throws -> UnstakeTransactionViewModel {
+        let data = project(makePosition(cacao: cacao, units: units))
+        let ceiling = try XCTUnwrap(data.availableToUnstake)
+        return makeViewModel(availableToUnstake: ceiling, pubKey: pubKey)
+    }
+
     /// What `UnstakeTransactionScreen` + `AmountTextField` do when the slider
     /// moves: the percentage takes ownership and the field is re-derived from the
     /// ceiling in force.
@@ -146,12 +156,23 @@ final class MayaCacaoWithdrawCeilingTests: XCTestCase {
     }
 
     /// The projection still divides by the coin's scale — the fix changed which
-    /// field is read, not whether it is converted out of base units.
+    /// field is read, not whether it is converted out of base units. Written with
+    /// a literal base-unit figure rather than the fixture's own multiplication, so
+    /// the assertion cannot agree with itself.
     func testProjectionConvertsOutOfBaseUnits() {
-        let position = makePosition(cacao: 42, units: 40)
+        let position = MayaCacaoPoolPosition(
+            address: "maya1fixturecacaopoolmemberaddress00000000",
+            stakedAmount: 420_000_000_000,  // 42 CACAO at 10 decimals
+            availableUnits: 400_000_000_000,
+            userUnits: 400_000_000_000,
+            netDeposit: 420_000_000_000,
+            lastWithdrawHeight: 0,
+            lastDepositHeight: 1_000
+        )
 
-        XCTAssertEqual(project(position).amount, 42)
-        XCTAssertEqual(position.stakedAmount, 42 * oneCacao, "fixture must be in base units for the test to mean anything")
+        let data = project(position)
+        XCTAssertEqual(data.amount, 42)
+        XCTAssertEqual(data.availableToUnstake, 42)
     }
 
     /// Everything else on the row is carried through untouched, so the ceiling fix
@@ -178,7 +199,16 @@ final class MayaCacaoWithdrawCeilingTests: XCTestCase {
     /// `amount = "0"`, so the memo is the entire instruction — and on the slider
     /// path the memo is derived from the percentage alone. Changing the ceiling
     /// from pool units to CACAO must therefore move nothing that gets signed.
-    func testSliderDrivenWithdrawalSignsTheSameMemoUnderEitherCeiling() {
+    /// Deliberately an invariant rather than a before/after regression: the
+    /// property under test — that the ceiling does not reach the signed bytes on
+    /// this path — must hold on both sides of the fix, so a test that only failed
+    /// beforehand would be testing the wrong thing. Both ceilings are supplied
+    /// explicitly for the same reason.
+    ///
+    /// Every field the builder contributes to the signed `SendTransaction` is
+    /// compared, not just the memo, so a future builder that starts carrying a
+    /// coin amount cannot slip past this.
+    func testSliderDrivenWithdrawalSignsTheSameTransactionUnderEitherCeiling() {
         let unitsCeiling: Decimal = 1_000   // what the sheet used to open on
         let cacaoCeiling: Decimal = 1_200   // what it opens on now
 
@@ -189,22 +219,34 @@ final class MayaCacaoWithdrawCeilingTests: XCTestCase {
             selectPercentage(percentage, on: before)
             selectPercentage(percentage, on: after)
 
-            let beforeMemo = before.transactionBuilder?.memo
-            let afterMemo = after.transactionBuilder?.memo
+            guard
+                let beforeBuilder = before.transactionBuilder,
+                let afterBuilder = after.transactionBuilder
+            else {
+                return XCTFail("both ceilings must build a transaction at \(percentage)%")
+            }
 
-            XCTAssertEqual(beforeMemo, "POOL-:\(Int(percentage) * 100)")
+            XCTAssertEqual(beforeBuilder.memo, "POOL-:\(Int(percentage) * 100)")
             XCTAssertEqual(
-                afterMemo,
-                beforeMemo,
+                afterBuilder.memo,
+                beforeBuilder.memo,
                 "the ceiling fix moved the signed memo at \(percentage)% — it must not"
+            )
+            XCTAssertEqual(afterBuilder.amount, beforeBuilder.amount)
+            XCTAssertEqual(afterBuilder.amount, "0", "a CACAO withdrawal signs a share, never a coin amount")
+            XCTAssertEqual(afterBuilder.sendMaxAmount, beforeBuilder.sendMaxAmount)
+            XCTAssertEqual(afterBuilder.toAddress, beforeBuilder.toAddress)
+            XCTAssertEqual(
+                afterBuilder.memoFunctionDictionary.allItems(),
+                beforeBuilder.memoFunctionDictionary.allItems()
             )
         }
     }
 
-    /// A full exit is still a full exit: 100% signs the whole position, and the
-    /// builder attaches no coin amount to it.
+    /// A full exit is still a full exit, driven end-to-end from the projection:
+    /// 100% signs the whole position and the builder attaches no coin amount.
     func testFullExitStillSignsTheWholePositionAndCarriesNoAmount() throws {
-        let viewModel = makeViewModel(availableToUnstake: 1_200, pubKey: "cacao-full-exit")
+        let viewModel = try makeSheet(cacao: 1_200, units: 1_000, pubKey: "cacao-full-exit")
         selectPercentage(100, on: viewModel)
 
         let builder = try XCTUnwrap(viewModel.transactionBuilder)
@@ -219,37 +261,39 @@ final class MayaCacaoWithdrawCeilingTests: XCTestCase {
     /// read against CACAO. Under the old units ceiling the same figure was over
     /// the maximum and could not be submitted at all.
     func testATypedCacaoAmountResolvesAgainstTheCacaoPosition() throws {
-        let underUnitsCeiling = makeViewModel(availableToUnstake: 1_000, pubKey: "cacao-typed-units")
-        let underCacaoCeiling = makeViewModel(availableToUnstake: 1_200, pubKey: "cacao-typed-cacao")
+        let sheet = try makeSheet(cacao: 1_200, units: 1_000, pubKey: "cacao-typed-cacao")
+        // The ceiling the pre-fix mapping produced for the same position, kept
+        // explicit so the contrast is stated rather than implied.
+        let preFixSheet = makeViewModel(availableToUnstake: 1_000, pubKey: "cacao-typed-units")
 
-        typeAmount("1100", into: underUnitsCeiling)
-        typeAmount("1100", into: underCacaoCeiling)
+        typeAmount("1100", into: sheet)
+        typeAmount("1100", into: preFixSheet)
 
         XCTAssertNil(
-            underUnitsCeiling.transactionBuilder,
+            preFixSheet.transactionBuilder,
             "1100 of a 1200-CACAO position was unreachable while the ceiling was 1000 pool units"
         )
 
-        let builder = try XCTUnwrap(underCacaoCeiling.transactionBuilder)
+        let builder = try XCTUnwrap(sheet.transactionBuilder)
         XCTAssertEqual(builder.memo, "POOL-:9100", "1100 of 1200 CACAO is 91% of the position")
     }
 
     /// The ceiling is also what the field is validated against, so the sheet now
     /// accepts everything the card said the user holds.
     func testTheWholeCardAmountIsEnterable() throws {
-        let viewModel = makeViewModel(availableToUnstake: 1_200, pubKey: "cacao-typed-max")
-        typeAmount("1200", into: viewModel)
+        let sheet = try makeSheet(cacao: 1_200, units: 1_000, pubKey: "cacao-typed-max")
+        typeAmount("1200", into: sheet)
 
-        let builder = try XCTUnwrap(viewModel.transactionBuilder)
+        let builder = try XCTUnwrap(sheet.transactionBuilder)
         XCTAssertEqual(builder.memo, "POOL-:10000")
     }
 
     /// And nothing beyond it is: the ceiling still bounds the form.
-    func testAnAmountAboveTheCardAmountIsStillRefused() {
-        let viewModel = makeViewModel(availableToUnstake: 1_200, pubKey: "cacao-typed-over")
-        typeAmount("1200.0001", into: viewModel)
+    func testAnAmountAboveTheCardAmountIsStillRefused() throws {
+        let sheet = try makeSheet(cacao: 1_200, units: 1_000, pubKey: "cacao-typed-over")
+        typeAmount("1200.0001", into: sheet)
 
-        XCTAssertNil(viewModel.transactionBuilder)
+        XCTAssertNil(sheet.transactionBuilder)
     }
 
     // MARK: - The sheet opens on the ceiling it was handed
@@ -258,10 +302,9 @@ final class MayaCacaoWithdrawCeilingTests: XCTestCase {
     /// what the sheet renders, validates and derives from.
     func testTheSheetOpensOnTheProjectedCeiling() throws {
         let data = project(makePosition(cacao: 1_200, units: 1_000))
-        let ceiling = try XCTUnwrap(data.availableToUnstake)
-        let viewModel = makeViewModel(availableToUnstake: ceiling, pubKey: "cacao-seam")
+        let sheet = try makeSheet(cacao: 1_200, units: 1_000, pubKey: "cacao-seam")
 
-        XCTAssertEqual(viewModel.availableAmount, 1_200)
-        XCTAssertEqual(viewModel.availableAmount, data.amount, "the sheet must open on the card's figure")
+        XCTAssertEqual(sheet.availableAmount, 1_200)
+        XCTAssertEqual(sheet.availableAmount, data.amount, "the sheet must open on the card's figure")
     }
 }


### PR DESCRIPTION
## Problem

The MayaChain CACAO staked card and its withdrawal sheet were denominated in two different scales. The staked-positions list showed the member's **CACAO value**; tapping **Remove** opened a slider whose maximum was the member's **pool units** — a different, and in an earning pool strictly smaller, quantity. Users saw one number on the list and another on the removal screen, with no way to tell how much CACAO they were actually withdrawing.

Reported by **SamYap** on Discord against v1.44.70 iOS.

## Root cause

`MayaChainStakeInteractor` split one position across two scales:

```swift
let stakedAmount = position.stakedAmount / pow(10, cacao.decimals)      // member.value — CACAO
let availableToUnstake = position.availableUnits / pow(10, cacao.decimals)  // member.units — POOL UNITS
```

`StakePositionData.amount` (the card) got the CACAO value; `StakePositionData.availableToUnstake` got the pool units. That second field travels `DefiChainScreenModel.unstakeTransactionType(for:)` → `FunctionTransactionType.unstake(…)` → `UnstakeTransactionViewModel.availableAmount`, which is what the slider, the Max button, the `AmountBalanceValidator` and the displayed balance all read.

A pool unit is worth `member.value / member.units` CACAO — a rate at or above 1 that only rises as the pool earns — so the two figures are never interchangeable.

Corroborating that CACAO is the intended denomination everywhere else: `BalanceService` already feeds `coin.stakedBalance` (and therefore `coin.stakedBalanceDecimal`, the sheet's *fallback* ceiling) from `position.stakedAmount`, the CACAO value. The explicit `availableToUnstake` was the only units-denominated figure in the entire path.

## Fix

Project the same CACAO value into both figures, in the interactor that produces them — not by branching on chain in the chain-agnostic screen model or view model. The mapping is extracted into a pure `static func MayaChainStakeInteractor.stakePositionData(position:coin:decimals:apr:unstakeMetadata:)` so it can be exercised without a network hop; `fetchStakePositions` keeps doing the I/O and is otherwise unchanged.

Also corrects the now-misleading comments on `MayaCacaoPoolPosition`, whose `availableUnits` field advertised itself as "units available for unstaking".

## ⚠️ Can the signed amount change?

**Answered precisely, and independently verified by a read-only cross-model review.**

`CacaoUnstakeTransactionBuilder` carries `amount = "0"` and `sendMaxAmount = false`, and `TransactionBuilder.buildSendTransaction(vault:)` copies both straight into `SendTransaction`. **A CACAO withdrawal signs no coin amount at all** — the entire instruction is the memo `POOL-:<bps>`, where

```
bps = Int(resolvedPercentage) * 100
resolvedPercentage = percentageSelected ?? (amountField.value / availableAmount * 100)
```

| path | effect of this change |
|---|---|
| **Slider / Max / percentage** (`percentageSelected != nil`) | `availableAmount` does not appear in the expression. **Byte-identical before and after.** This is the default: the sheet opens at 100%. |
| **Typed amount** (`percentageSelected == nil`) | `availableAmount` is the denominator, so the signed bps **does** change — and that *is* the defect being fixed. A typed CACAO figure was being read as a fraction of a pool-unit total, and any amount between the units total and the real CACAO total could not be entered at all. |

No user-entered absolute CACAO amount reaches `SendTransaction.amount` on either path.

## Tests

New `VultisigAppTests/Defi/MayaCacaoWithdrawCeilingTests.swift` (10 tests), pinning both halves:

- the projection puts the CACAO value — never scaled pool units — into `availableToUnstake`, at every unit/value ratio including the degenerate 1:1 that would hide the bug in a fixture;
- **money regression:** a slider-driven withdrawal signs the same transaction under the old units ceiling and the new CACAO ceiling at 100/50/25/10%, comparing every builder field that reaches `SendTransaction` (memo, `amount`, `sendMaxAmount`, `toAddress`, memo dictionary) — not just the memo;
- the typed path, driven end-to-end through the real projection: the whole card amount is now enterable, an amount between the two totals resolves to the right fraction (`POOL-:9100` for 1100 of 1200), and anything above the position is still refused.

## Verification status

- ✅ **Full unit suite green** on a dedicated simulator: `** TEST SUCCEEDED **`, 6501 tests executed, 11 skipped, 0 failures.
- ✅ `swiftlint` clean on all touched files.
- ✅ Read-only cross-model review of the branch diff; the fund-safety trace above was independently re-derived from the source rather than taken on trust.
- ❌ **Not verified on device.** Confirming the sheet now opens on the card's figure needs a real CACAOPool position — please treat this as an outstanding manual step before merge.

## Known residual (deliberately out of scope)

`DefiPositionsStorageService.upsert(stake:for:)` has no delete-stale, and a failed Maya fetch returns `[]`, so a **cached row written by a pre-fix build keeps its pool-unit `availableToUnstake` until a refresh succeeds**. In that window the reported symptom reproduces unchanged — never worse than current shipped behaviour, and self-healing on the first successful fetch (which the chain screen performs on appear). Closing it would mean a MayaChain-CACAO-specific backfill inside a chain-agnostic view model, or gating the withdraw CTA on a fresh fetch. Both are larger than this issue's stated scope ("don't alter withdrawal transaction logic") — flagging rather than doing it silently. Happy to add it here if a maintainer prefers.

## Note for reviewers

A textual conflict is plausible with the unmerged `feat/operation-coverage` / `feat/verify-hero-verbs` branches, which rework `UnstakeTransactionViewModel`'s CACAO arm and `CacaoUnstakeTransactionBuilder`. This change touches neither file. Those branches add a `withdrawDisplayAmount` derived from `availableAmount`, which would be *equally wrong* while the ceiling is pool units — so this is a prerequisite for them rather than a competitor.

Closes #5184

🤖 Generated with [Claude Code](https://claude.com/claude-code)
