### PR TITLE
fix(wallet): show the GRAM asset mark on the TON portfolio row

### DIFF
--- a/VultisigApp/VultisigApp/Features/Common/Views/GroupedChainCellView.swift
+++ b/VultisigApp/VultisigApp/Features/Common/Views/GroupedChainCellView.swift
@@ -13,6 +13,12 @@ struct GroupedChainCellView: View {
     let fiatBalance: String
     let cryptoBalance: String
     let assetCount: Int
+    /// Leading artwork override. `nil` — the default, and what every
+    /// chain-identity surface wants — renders `chain.logo`. The wallet's
+    /// balance rows pass the artwork already resolved on `ChainRowModel`, so a
+    /// rebranded native asset (GRAM on TON) shows its own mark beside the
+    /// balance it belongs to while the chain keeps its identity elsewhere.
+    var assetLogo: String?
     /// When provided, replaces the default `N assets` / `cryptoBalance` subtitle.
     /// Used by DeFi rows to render `"%d positions"` / "No positions found" instead
     /// of wallet asset counts. The override is rendered with the small caption font
@@ -25,6 +31,13 @@ struct GroupedChainCellView: View {
     private var truncatedAddress: String {
         guard address.count > 8 else { return address }
         return address.prefix(4) + "..." + address.suffix(4)
+    }
+
+    /// Passed as both the image and the chain-badge name so the two always
+    /// match, which is what keeps `AsyncImageView` from overlaying a `chain-*`
+    /// badge on a row that never had one.
+    private var leadingLogo: String {
+        assetLogo ?? chain.logo
     }
 
     private var showAssetCount: Bool {
@@ -53,10 +66,10 @@ struct GroupedChainCellView: View {
         HStack {
             HStack(spacing: 12) {
                 AsyncImageView(
-                    logo: chain.logo,
+                    logo: leadingLogo,
                     size: CGSize(width: 36, height: 36),
                     ticker: chain.ticker,
-                    tokenChainLogo: chain.logo
+                    tokenChainLogo: leadingLogo
                 )
 
                 VStack(alignment: .leading, spacing: 4) {

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Models/ChainRowModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Models/ChainRowModel.swift
@@ -19,6 +19,15 @@ struct ChainRowModel: Identifiable, Equatable {
     /// matches the asset ticker so "ETH" surfaces every ETH-based chain, the
     /// same as the pre-projection search did via the native coin's ticker.
     let nativeTicker: String
+    /// Artwork for the row's leading mark. `chain.logo` for almost every chain;
+    /// the native coin's own logo where the asset brand superseded the chain's
+    /// — `gram` on TON after the Toncoin → Gram rebrand, so the mark matches the
+    /// GRAM balance printed beside it. Resolved once in `VaultDetailLogic`
+    /// (see `assetBrandedChains`) so the cell stays a pure renderer, and never
+    /// taken from a non-native coin: a chain holding only USDT keeps the chain
+    /// mark. Chain-identity surfaces (selectors, QR/address, jetton badges)
+    /// read `chain.logo` directly and are unaffected.
+    let assetLogo: String
     /// Precomputed address for the copy affordance (native coin's, falling back
     /// to the first coin on the chain).
     let address: String

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/ChainList/VaultChainCellView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/ChainList/VaultChainCellView.swift
@@ -35,6 +35,7 @@ struct VaultChainCellView: View, Equatable {
                 fiatBalance: row.fiatBalance,
                 cryptoBalance: row.cryptoBalance,
                 assetCount: row.assetCount,
+                assetLogo: row.assetLogo,
                 onCopy: onCopy
             )
             .contentShape(Rectangle())
@@ -48,6 +49,7 @@ struct VaultChainCellView: View, Equatable {
         row: ChainRowModel(
             chain: .bitcoin,
             nativeTicker: "BTC",
+            assetLogo: "btc",
             address: "bc1qexampleaddress",
             fiatBalance: "$0.00",
             cryptoBalance: "0 BTC",

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
@@ -244,12 +244,39 @@ struct VaultDetailLogic {
             return ChainRowModel(
                 chain: chain,
                 nativeTicker: native?.ticker ?? "",
+                assetLogo: assetLogo(for: chain, native: native),
                 address: native?.address ?? coins.first?.address ?? "",
                 fiatBalance: coins.totalBalanceInFiatDecimal.formatToFiat(includeCurrencySymbol: true),
                 cryptoBalance: native?.balanceStringWithTicker ?? "",
                 assetCount: coins.count
             )
         }
+    }
+
+    /// Chains whose wallet row is drawn with the native *asset's* mark instead
+    /// of the chain's. TON is here because the Toncoin → Gram rebrand renamed
+    /// the asset while deliberately keeping the chain's TON identity for chain
+    /// selectors, addresses, jetton badges and protocol identifiers — so the
+    /// chain mark is the retired Toncoin diamond and the balance under it reads
+    /// GRAM.
+    ///
+    /// An allow-list rather than "always prefer the native coin's logo", because
+    /// eleven chains ship a native asset whose art differs from the chain's and
+    /// only TON's difference is a rebrand. Base, Arbitrum, Optimism, Blast and
+    /// Robinhood all hold plain ETH, so preferring the asset everywhere would
+    /// replace five distinct network marks with five identical ETH circles;
+    /// Maya, Polygon, Noble and the two Terras would shift too. Add a chain here
+    /// when its asset brand supersedes its chain brand, not merely when the two
+    /// differ.
+    private static let assetBrandedChains: Set<Chain> = [.ton]
+
+    /// Leading artwork for a chain's wallet row: the native coin's own logo for
+    /// the rebranded chains above, the chain mark otherwise. Falls back to the
+    /// chain mark when the chain has no native coin, or that coin was persisted
+    /// without artwork, so the row can never resolve to a missing image.
+    private func assetLogo(for chain: Chain, native: Coin?) -> String {
+        guard Self.assetBrandedChains.contains(chain) else { return chain.logo }
+        return native?.logo.nilIfEmpty ?? chain.logo
     }
 
     func updateBalance(vault: Vault) async -> [Chain] {

--- a/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
@@ -25,6 +25,9 @@
 //       subsequent same-vault, same-membership `updateBalance` still skips.
 //    6. The `chainRows` builder projects the expected rows, and two builds from
 //       equal inputs are `==` (Equatable rows).
+//    7. A row's leading artwork follows the native *asset* only where the asset
+//       brand superseded the chain's — TON shows GRAM after the rebrand — and
+//       every other chain, including the ETH L2s, keeps its chain mark.
 //
 
 import Combine
@@ -399,6 +402,124 @@ final class VaultDetailViewModelTests: XCTestCase {
         XCTAssertEqual(first, second, "Two builds from the same vault must be ==")
     }
 
+    // MARK: - Row artwork follows the native asset
+
+    /// A vault that has been through `TonGramRebrandMigration` holds a native
+    /// TON coin whose stored `logo` is "gram". The wallet row renders a balance
+    /// denominated in that asset, so it must take the asset's artwork — the row
+    /// used to render `chain.logo` and kept showing the old blue TON mark next
+    /// to a GRAM balance.
+    func testChainRows_migratedTonVault_projectsGramAssetLogo() {
+        let vault = makeVault(pubKey: "vault-ton", chains: [])
+        // Exactly what the rebrand migration writes onto an existing coin.
+        vault.coins = [makeCoin(pubKey: "vault-ton", chain: .ton, ticker: "GRAM", logo: "gram")]
+
+        let row = VaultDetailLogic().chainRows(vault: vault).first { $0.chain == .ton }
+
+        XCTAssertEqual(row?.assetLogo, "gram")
+        XCTAssertNotEqual(row?.assetLogo, Chain.ton.logo,
+                          "The row must not fall back to the TON chain mark for a GRAM balance")
+    }
+
+    /// The fresh-vault path: a newly added TON native coin is built from the
+    /// bundled catalog, so this asserts against the real `TokensStore` entry
+    /// rather than a hand-made fixture. Both paths have to land on "gram" or
+    /// migrated and fresh vaults would disagree.
+    func testChainRows_freshTonVaultFromCatalog_projectsGramAssetLogo() throws {
+        let meta = try XCTUnwrap(
+            TokensStore.TokenSelectionAssets.first { $0.chain == .ton && $0.isNativeToken },
+            "The bundled catalog must carry a native TON asset"
+        )
+        XCTAssertEqual(meta.logo, "gram", "Catalog native TON metadata must already be rebranded")
+
+        let vault = makeVault(pubKey: "vault-ton-fresh", chains: [])
+        vault.coins = [Coin(asset: meta, address: "addr-ton", hexPublicKey: "")]
+
+        let row = VaultDetailLogic().chainRows(vault: vault).first { $0.chain == .ton }
+
+        XCTAssertEqual(row?.assetLogo, "gram")
+    }
+
+    /// A chain the vault only holds a token on has no native coin to take
+    /// artwork from, so the row keeps the chain mark. It must NOT borrow the
+    /// token's logo — a TON-chain row holding only USDT is still a TON row.
+    func testChainRows_chainWithoutNativeCoin_keepsChainLogo() {
+        let vault = makeVault(pubKey: "vault-jetton", chains: [])
+        vault.coins = [
+            makeCoin(pubKey: "vault-jetton", chain: .ton, ticker: "USDT", logo: "usdt", isNativeToken: false)
+        ]
+
+        let row = VaultDetailLogic().chainRows(vault: vault).first { $0.chain == .ton }
+
+        XCTAssertEqual(row?.assetLogo, Chain.ton.logo)
+        XCTAssertNotEqual(row?.assetLogo, "usdt", "A jetton must not become the chain row's mark")
+    }
+
+    /// A native coin persisted without artwork must not blank the row — an
+    /// empty stored logo resolves to the chain mark, not to a missing image.
+    func testChainRows_nativeCoinWithoutLogo_fallsBackToChainLogo() {
+        let vault = makeVault(pubKey: "vault-nologo", chains: [])
+        vault.coins = [makeCoin(pubKey: "vault-nologo", chain: .ton, ticker: "GRAM", logo: "")]
+
+        let row = VaultDetailLogic().chainRows(vault: vault).first { $0.chain == .ton }
+
+        XCTAssertEqual(row?.assetLogo, Chain.ton.logo)
+    }
+
+    /// Every row except TON keeps the chain mark it already had. Eleven chains
+    /// ship a native asset whose art differs from the chain's, so a blanket
+    /// "prefer the native coin's logo" would silently repaint ten unrelated
+    /// rows; only TON's difference is a rebrand. Built against the real catalog
+    /// so widening the allow-list can never be an accident.
+    func testChainRows_onlyTonDivergesFromTheChainMark() {
+        let natives = TokensStore.TokenSelectionAssets.filter(\.isNativeToken)
+        let vault = makeVault(pubKey: "vault-catalog", chains: [])
+        vault.coins = natives.map { Coin(asset: $0, address: "addr-\($0.chain.name)", hexPublicKey: "") }
+
+        let rows = VaultDetailLogic().chainRows(vault: vault)
+        let diverging = rows.filter { $0.assetLogo != $0.chain.logo }.map(\.chain)
+
+        XCTAssertEqual(Set(diverging), [.ton],
+                       "TON is the only chain whose native asset was rebranded away from the chain mark")
+    }
+
+    /// The concrete regression the allow-list exists to prevent: Base, Arbitrum,
+    /// Optimism, Blast and Robinhood all hold plain ETH, so following the native
+    /// asset there would collapse five distinct network marks into five
+    /// identical ETH circles in a list whose rows are otherwise told apart by
+    /// their icon.
+    func testChainRows_ethL2s_keepTheirNetworkMarksRatherThanTheEthAsset() {
+        let l2s: [Chain] = [.base, .arbitrum, .optimism, .blast]
+        let vault = makeVault(pubKey: "vault-l2-art", chains: [])
+        vault.coins = l2s.map { makeCoin(pubKey: "vault-l2-art", chain: $0, ticker: "ETH", logo: "eth") }
+
+        let rows = VaultDetailLogic().chainRows(vault: vault)
+
+        for chain in l2s {
+            XCTAssertEqual(rows.first { $0.chain == chain }?.assetLogo, chain.logo,
+                           "\(chain.name) must keep its own network mark")
+            XCTAssertNotEqual(rows.first { $0.chain == chain }?.assetLogo, "eth")
+        }
+    }
+
+    /// Artwork is part of row equality, so the migration's logo rewrite reaches
+    /// the screen: rows are `Equatable` precisely so SwiftUI can skip unchanged
+    /// ones, and a row whose only change is its icon must still count as changed.
+    func testChainRows_assetLogoParticipatesInRowEquality() {
+        let logic = VaultDetailLogic()
+
+        let legacy = makeVault(pubKey: "vault-eq", chains: [])
+        legacy.coins = [makeCoin(pubKey: "vault-eq", chain: .ton, ticker: "GRAM", logo: "ton")]
+
+        let migrated = makeVault(pubKey: "vault-eq", chains: [])
+        migrated.coins = [makeCoin(pubKey: "vault-eq", chain: .ton, ticker: "GRAM", logo: "gram")]
+
+        XCTAssertNotEqual(logic.chainRows(vault: legacy), logic.chainRows(vault: migrated),
+                          "A logo-only change must make the row unequal so the list repaints")
+        XCTAssertEqual(logic.chainRows(vault: migrated), logic.chainRows(vault: migrated),
+                       "Equal inputs must still produce equal rows")
+    }
+
     // MARK: - filteredRows search parity
 
     /// Searching the native asset ticker must surface chains whose `chain.ticker`
@@ -707,6 +828,28 @@ final class VaultDetailViewModelTests: XCTestCase {
             priceProviderId: "",
             contractAddress: "",
             isNativeToken: true
+        )
+        return Coin(asset: meta, address: "addr-\(pubKey)-\(chain.name)", hexPublicKey: "")
+    }
+
+    /// Coin with explicit artwork, for the row-artwork tests. `logo` is a stored
+    /// value on `Coin` (never refreshed from the catalog), which is why the
+    /// rebrand needed a migration and why these tests set it directly.
+    private func makeCoin(
+        pubKey: String,
+        chain: Chain,
+        ticker: String,
+        logo: String,
+        isNativeToken: Bool = true
+    ) -> Coin {
+        let meta = CoinMeta(
+            chain: chain,
+            ticker: ticker,
+            logo: logo,
+            decimals: 8,
+            priceProviderId: "",
+            contractAddress: isNativeToken ? "" : "contract-\(ticker)",
+            isNativeToken: isNativeToken
         )
         return Coin(asset: meta, address: "addr-\(pubKey)-\(chain.name)", hexPublicKey: "")
     }


### PR DESCRIPTION
## Problem

After the Toncoin → Gram rebrand, the Wallet portfolio row for The Open Network prints a **GRAM** ticker and a GRAM balance next to the retired blue **Toncoin** diamond.

## Root cause

The row's ticker and balance come from the migrated native coin, but the artwork never did. `GroupedChainCellView` rendered `chain.logo` (`"ton"`) directly, and `ChainRowModel` — the `Equatable` value projection the wallet chain list is driven off — carried no artwork field at all, so the coin's own `"gram"` logo had no path to the screen.

Both sources of that logo were already correct, so **no new migration is needed** (verified):

- `TokensStore.swift:3004` / `:3159` — the native TON `CoinMeta` is `ticker: "GRAM", logo: "gram"` (fresh vaults).
- `TonGramRebrandMigration.swift:33` — rewrites `ticker` *and* `logo` on existing vault coins (migrated vaults).
- `git show cc40438d6` confirms both fields flipped in the same commit, so the migration's `ticker == "TON"` guard can never skip a coin that already has the new ticker but the old logo.

## Fix

- `ChainRowModel` gains `let assetLogo: String` — a **resolved** value, mirroring the shape `address` already uses (native coin's value with the fallback baked in at projection time).
- `VaultDetailLogic.chainRows` fills it via `assetLogo(for:native:)`. Fallbacks, in order: chain not allow-listed → `chain.logo`; no native coin → `chain.logo`; native coin persisted with an empty logo → `chain.logo`. Never sourced from a non-native coin, so a TON row holding only USDT keeps the chain mark rather than borrowing the jetton's.
- `GroupedChainCellView` — **shared** — takes `var assetLogo: String?` defaulting to `nil` → `chain.logo`. The DeFi call site (`DefiChainCellView.swift:26`) and every chain-identity surface are unchanged by construction; the only other reference is the file's own `#Preview`.
- `VaultChainCellView` passes `assetLogo: row.assetLogo`.

### Two details worth a reviewer's eye

**No row gains a badge.** `AsyncImageView` overlays a `chain-<x>` mark when `logo != tokenChainLogo`. Every grouped chain row has always passed the same string twice, so none has ever shown a badge. Passing `gram` as the image while leaving `tokenChainLogo: chain.logo` would have silently added a TON badge to the TON row alone. The cell therefore resolves one `leadingLogo` and passes it to both parameters, keeping that invariant true by construction. (`Coin.tokenChainLogo` returns `nil` for native tokens — asset cells don't badge natives either.)

**The issue's literal suggestion has ten rows of collateral, so this is scoped.** "Use the native coin logo, fall back to `chain.logo`" applied unconditionally changes **eleven** rows, not one. Comparing every native `CoinMeta` in `TokensStore.TokenSelectionAssets` against its `ChainConfig.logo`:

| Chain | `chain.logo` | native asset logo |
|---|---|---|
| arbitrum, base, blast, optimism, robinhood | `arbitrum` / `base` / `blast` / `optimism` / `robinhood` | `eth` (all five) |
| mayaChain | `maya` | `cacao` |
| polygon | `matic` | `pol` |
| noble | `noble` | `usdc` |
| terra | `terra` | `luna` |
| terraClassic | `terraclassic` | `lunc` |
| **ton** | `ton` | **`gram`** |

Five ETH L2 rows would collapse into five identical ETH circles in a list whose rows are otherwise told apart by their icon — which contradicts the issue's own acceptance criterion that other wallet rows are unaffected. So the resolution is gated on `VaultDetailLogic.assetBrandedChains: Set<Chain> = [.ton]`, documented in place: a chain joins when its **asset brand superseded its chain brand**, not merely when the two differ.

> **Reviewer decision point:** Polygon (MATIC → POL) is the plausible next member and Maya/Noble/Terra are arguable — but that's a product call, not this bug. If you want every row to follow its native asset, `assetBrandedChains` is the one line to change; `testChainRows_onlyTonDivergesFromTheChainMark` is the test that will fail and enumerate the consequences.

## Tests

Seven new tests in `VultisigAppTests/Wallet/VaultDetailViewModelTests.swift`:

| Test | Pins |
|---|---|
| `testChainRows_migratedTonVault_projectsGramAssetLogo` | migrated coin (exactly what the migration writes) → `gram`, and *not* the chain mark |
| `testChainRows_freshTonVaultFromCatalog_projectsGramAssetLogo` | fresh coin built from the real `TokensStore` entry → `gram` |
| `testChainRows_chainWithoutNativeCoin_keepsChainLogo` | jetton-only TON chain → chain mark, never the token's |
| `testChainRows_nativeCoinWithoutLogo_fallsBackToChainLogo` | empty stored logo → chain mark, not a missing image |
| `testChainRows_ethL2s_keepTheirNetworkMarksRatherThanTheEthAsset` | Base/Arbitrum/Optimism/Blast keep their network marks |
| `testChainRows_onlyTonDivergesFromTheChainMark` | catalog-wide: `.ton` is the only divergence, so widening the scope can't be accidental |
| `testChainRows_assetLogoParticipatesInRowEquality` | a logo-only change makes the row unequal, so the migration's rewrite actually repaints a row SwiftUI would otherwise skip |

## Verification

- **Gate:** `** TEST SUCCEEDED **` — `Executed 6498 tests, with 11 tests skipped and 0 failures (0 unexpected) in 101.271 (104.341) seconds`. Full unit suite (`xcodebuild test`, iPhone 17 Pro Max / iOS 26.5), not a subset; run twice, the second time against the exact commit being pushed. All seven new tests pass.
- **SwiftLint:** clean on all five touched files.
- **Not verified on a device or simulator visually.** Rendering the row needs a real vault with TON enabled, which I don't have. I did not run the app and I am **not** claiming a visual confirmation. What is verified is the artwork *string* end-to-end through the projection, for both the migrated and the fresh-vault path, plus the negative cases above. I also did not add a snapshot test: the suite runs at `precision: 0.99999` and a golden PNG for a 36pt icon is more fragile than it is informative.
- **Cross-model review:** one read-only `codex exec` pass over the whole branch returned **no findings** (no BLOCKER/MAJOR/MINOR/NIT). It independently enumerated the call sites, confirmed no non-Wallet surface changed, confirmed no row gains or loses a badge, and endorsed the allow-list scoping over the unconditional form.
- **Unchanged by inspection:** `Chain.logo`, the `.ton` case, chain name/ticker, `feeUnit`, addresses, decimals, signing, and every external `TON` identifier (SwapKit / Banxa / CoinGecko). Chain selectors, receive/QR/address views and jetton chain badges all still read `chain.logo`.

Closes #5178
