### PR TITLE
fix(blockaid): net a same-mint SOL/WSOL diff pair instead of calling it a swap

### DIFF
--- a/VultisigApp/VultisigApp/Components/Hero/HeroContent.swift
+++ b/VultisigApp/VultisigApp/Components/Hero/HeroContent.swift
@@ -14,6 +14,9 @@ import Foundation
 /// - `.title` — function name only (4byte decoded), no resolved balance change.
 ///   Used when Blockaid simulation failed or returned no diff.
 /// - `.send` — resolved single-sided balance change (Blockaid `.transfer`).
+/// - `.receive` — resolved single-sided balance change in the other direction
+///   (Blockaid `.receive`). Carries an explicit label, because an unlabelled
+///   amount on a signing screen reads as money leaving.
 /// - `.swap` — resolved from → to balance change (Blockaid `.swap`).
 ///
 /// Mirrors `BlockaidTransferDisplay` / `BlockaidSwapDisplay` / `EvmCalldataFallback`
@@ -21,12 +24,14 @@ import Foundation
 enum HeroContent: Hashable {
     case title(text: String, caption: String?)
     case send(title: String?, coin: HeroCoinAmount)
+    case receive(title: String?, coin: HeroCoinAmount)
     case swap(title: String?, from: HeroCoinAmount, to: HeroCoinAmount)
 
     var title: String? {
         switch self {
         case .title(let text, _): return text
         case .send(let title, _): return title
+        case .receive(let title, _): return title
         case .swap(let title, _, _): return title
         }
     }

--- a/VultisigApp/VultisigApp/Components/Hero/HeroContentView.swift
+++ b/VultisigApp/VultisigApp/Components/Hero/HeroContentView.swift
@@ -18,6 +18,8 @@ struct HeroContentView: View {
                 titleOnly(text: text, caption: caption)
             case .send(let title, let coin):
                 send(title: title, coin: coin)
+            case .receive(let title, let coin):
+                receive(title: title, coin: coin)
             case .swap(let title, let from, let to):
                 swap(title: title, from: from, to: to)
             }
@@ -50,6 +52,26 @@ struct HeroContentView: View {
                 .frame(maxWidth: .infinity, alignment: .center)
         }
         coinRow(coin, iconSize: 36)
+    }
+
+    /// The inflow twin of `send`. Every other hero shape states money leaving,
+    /// so the amount carries an explicit "Receive" label — without it the row
+    /// is indistinguishable from a send.
+    @ViewBuilder
+    private func receive(title: String?, coin: HeroCoinAmount) -> some View {
+        if let title {
+            Text(title)
+                .font(Theme.fonts.bodyMMedium)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .frame(maxWidth: .infinity, alignment: .center)
+        }
+        VStack(spacing: 8) {
+            Text("receive".localized)
+                .font(Theme.fonts.caption10)
+                .foregroundStyle(Theme.colors.textTertiary)
+                .frame(maxWidth: .infinity, alignment: .center)
+            coinRow(coin, iconSize: 36)
+        }
     }
 
     @ViewBuilder

--- a/VultisigApp/VultisigApp/Components/Hero/HeroContentView.swift
+++ b/VultisigApp/VultisigApp/Components/Hero/HeroContentView.swift
@@ -17,9 +17,9 @@ struct HeroContentView: View {
             case .title(let text, let caption):
                 titleOnly(text: text, caption: caption)
             case .send(let title, let coin):
-                send(title: title, coin: coin)
+                amountRow(title: title, coin: coin, label: nil)
             case .receive(let title, let coin):
-                receive(title: title, coin: coin)
+                amountRow(title: title, coin: coin, label: "receive".localized)
             case .swap(let title, let from, let to):
                 swap(title: title, from: from, to: to)
             }
@@ -43,33 +43,27 @@ struct HeroContentView: View {
         .frame(maxWidth: .infinity, alignment: .center)
     }
 
+    /// The single-row heroes: send and receive render the same row and differ
+    /// only by `label`. Every hero shape but the receive states money leaving,
+    /// so the inflow carries an explicit label — without it the row is
+    /// indistinguishable from a send.
     @ViewBuilder
-    private func send(title: String?, coin: HeroCoinAmount) -> some View {
+    private func amountRow(title: String?, coin: HeroCoinAmount, label: String?) -> some View {
         if let title {
             Text(title)
                 .font(Theme.fonts.bodyMMedium)
                 .foregroundStyle(Theme.colors.textSecondary)
                 .frame(maxWidth: .infinity, alignment: .center)
         }
-        coinRow(coin, iconSize: 36)
-    }
-
-    /// The inflow twin of `send`. Every other hero shape states money leaving,
-    /// so the amount carries an explicit "Receive" label — without it the row
-    /// is indistinguishable from a send.
-    @ViewBuilder
-    private func receive(title: String?, coin: HeroCoinAmount) -> some View {
-        if let title {
-            Text(title)
-                .font(Theme.fonts.bodyMMedium)
-                .foregroundStyle(Theme.colors.textSecondary)
-                .frame(maxWidth: .infinity, alignment: .center)
-        }
-        VStack(spacing: 8) {
-            Text("receive".localized)
-                .font(Theme.fonts.caption10)
-                .foregroundStyle(Theme.colors.textTertiary)
-                .frame(maxWidth: .infinity, alignment: .center)
+        if let label {
+            VStack(spacing: 8) {
+                Text(label)
+                    .font(Theme.fonts.caption10)
+                    .foregroundStyle(Theme.colors.textTertiary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                coinRow(coin, iconSize: 36)
+            }
+        } else {
             coinRow(coin, iconSize: 36)
         }
     }

--- a/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidSimulationModels.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidSimulationModels.swift
@@ -41,8 +41,15 @@ struct EthereumSimulateTransactionRequestJson: Codable {
 /// The parsed form intentionally mirrors the vultisig-windows model so the dApp
 /// hero can promote a `send` / `swap.fromCoin` / `transfer.fromCoin` branch to
 /// the primary display instead of the front-runnable 4byte title.
+///
+/// `receive` is the one shape the extension has no counterpart for. It exists
+/// because a Solana transaction can unwrap wrapped SOL back into native SOL,
+/// which Blockaid reports as an out leg and an in leg of the *same* mint: the
+/// pair nets to an inflow, and rendering that as `transfer` would state the
+/// opposite of what the transaction does.
 enum BlockaidSimulationInfo: Equatable {
     case transfer(fromCoin: BlockaidSimulationCoin, fromAmount: BigInt)
+    case receive(coin: BlockaidSimulationCoin, amount: BigInt)
     case swap(
         fromCoin: BlockaidSimulationCoin,
         toCoin: BlockaidSimulationCoin,
@@ -50,35 +57,43 @@ enum BlockaidSimulationInfo: Equatable {
         toAmount: BigInt
     )
 
-    var fromCoin: BlockaidSimulationCoin {
+    /// The coin the hero leads with: the asset leaving for `transfer` and
+    /// `swap`, the asset arriving for `receive`. Deliberately not named
+    /// `fromCoin` — a `receive` has no from side, and a name implying one is
+    /// how an inflow ends up displayed as an outflow.
+    var primaryCoin: BlockaidSimulationCoin {
         switch self {
         case .transfer(let coin, _):
+            return coin
+        case .receive(let coin, _):
             return coin
         case .swap(let coin, _, _, _):
             return coin
         }
     }
 
-    var fromAmount: BigInt {
+    var primaryAmount: BigInt {
         switch self {
         case .transfer(_, let amount):
+            return amount
+        case .receive(_, let amount):
             return amount
         case .swap(_, _, let amount, _):
             return amount
         }
     }
 
-    var fromAmountDecimal: Decimal {
-        fromAmount.description.toDecimal() / pow(Decimal(10), fromCoin.decimals)
+    var primaryAmountDecimal: Decimal {
+        primaryAmount.description.toDecimal() / pow(Decimal(10), primaryCoin.decimals)
     }
 
-    /// Human-readable from-side amount (e.g. "1.25"). For both transfer and
-    /// swap simulations.
+    /// Human-readable leading amount (e.g. "1.25"). For all three shapes.
     var heroAmountText: String {
-        fromAmountDecimal.formatForDisplay()
+        primaryAmountDecimal.formatForDisplay()
     }
 
-    /// The "to" side of a swap simulation. Nil for transfer.
+    /// The "to" side of a swap simulation. Nil for transfer and receive —
+    /// a receive's single coin is its `primaryCoin`.
     var toCoin: BlockaidSimulationCoin? {
         if case .swap(_, let coin, _, _) = self { return coin }
         return nil

--- a/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidSimulationParser.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidSimulationParser.swift
@@ -107,6 +107,10 @@ enum BlockaidSimulationParser {
     /// filtered out as "likely the transaction fee". One remaining diff maps to
     /// `.transfer`, two remaining diffs map to `.swap` (or `.transfer` if only
     /// the out side has a value).
+    ///
+    /// Diverges from the extension in one place: a two-diff pair that resolves
+    /// to the same mint is netted rather than reported as a swap — see
+    /// `netSameMint(outCoin:outAmount:inCoin:inAmount:)`.
     static func parseSolana(
         response: BlockaidSolanaSimulationResponseJson
     ) -> BlockaidSimulationInfo? {
@@ -161,6 +165,16 @@ enum BlockaidSimulationParser {
            let inAmount = parseRawAmount(inRaw),
            let fromCoin = buildSolanaCoin(from: outSource.asset),
            let toCoin = buildSolanaCoin(from: inSource.asset) {
+            if let outMint = fromCoin.address,
+               let inMint = toCoin.address,
+               outMint == inMint {
+                return netSameMint(
+                    outCoin: fromCoin,
+                    outAmount: outAmount,
+                    inCoin: toCoin,
+                    inAmount: inAmount
+                )
+            }
             return .swap(fromCoin: fromCoin, toCoin: toCoin, fromAmount: outAmount, toAmount: inAmount)
         }
 
@@ -170,6 +184,46 @@ enum BlockaidSimulationParser {
             return .transfer(fromCoin: fromCoin, fromAmount: outAmount)
         }
 
+        return nil
+    }
+
+    /// Collapses an out/in pair that resolves to a single mint into the net
+    /// movement of that mint.
+    ///
+    /// Nothing was exchanged, so a swap hero would name a destination asset the
+    /// user is not receiving. Wrapping SOL and spending it in the same
+    /// transaction is the common source: the wrap-in and the spend-out cancel
+    /// and never surface as diffs of their own, leaving only the wSOL account's
+    /// rent-exempt residual as a small incoming diff beside the real native-SOL
+    /// out leg. `buildSolanaCoin` maps native SOL onto the wrapped-SOL mint, so
+    /// both legs arrive here carrying the same mint and are directly netted.
+    ///
+    /// The direction is decided by the net, not by which leg is which: the same
+    /// pair arrives reversed when a transaction unwraps wSOL back into native
+    /// SOL (a Kamino wrapped-SOL withdraw closes its payout account, which is
+    /// what unwraps it), where the out leg is only the residual being returned
+    /// and the in leg is the amount the user actually receives. The coin comes
+    /// from whichever leg the net follows, so the ticker stays truthful —
+    /// native SOL reads "SOL" even though it shares WSOL's mint here.
+    ///
+    /// An exact cancellation nets to zero. There is no honest hero for "your
+    /// balance does not change", so it returns nil and the caller falls back to
+    /// the generic title.
+    ///
+    /// Mints are compared exactly. Solana addresses are base58 and
+    /// case-sensitive, unlike the EVM path's checksummed hex.
+    private static func netSameMint(
+        outCoin: BlockaidSimulationCoin,
+        outAmount: BigInt,
+        inCoin: BlockaidSimulationCoin,
+        inAmount: BigInt
+    ) -> BlockaidSimulationInfo? {
+        if outAmount > inAmount {
+            return .transfer(fromCoin: outCoin, fromAmount: outAmount - inAmount)
+        }
+        if inAmount > outAmount {
+            return .receive(coin: inCoin, amount: inAmount - outAmount)
+        }
         return nil
     }
 

--- a/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidSimulationParser.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidSimulationParser.swift
@@ -167,14 +167,14 @@ enum BlockaidSimulationParser {
             if let outMint = fromCoin.address,
                let inMint = toCoin.address,
                outMint == inMint {
-                // Both sides can collapse onto one diff when the other carries
-                // neither leg. Netting a diff against itself is still the net
-                // movement of that asset — but only while the diff that was
-                // skipped holds nothing of its own. Otherwise the hero would
-                // state an authoritative net having never looked at a balance
-                // change the transaction makes, so decline and let the caller
-                // fall back to the generic title.
-                if outIndex == inIndex, carriesBalance(diffs[outIndex == 0 ? 1 : 0]) {
+                // The netting reads exactly two legs: one diff's out side and
+                // one diff's in side, which can collapse onto the same diff.
+                // Every other leg the response states goes unread, so netting
+                // past one would have the hero state an authoritative net
+                // having never looked at a balance change the transaction
+                // makes. Decline and let the caller fall back to the generic
+                // title.
+                guard readsEveryLeg(diffs, outIndex: outIndex, inIndex: inIndex) else {
                     return nil
                 }
                 return netSameMint(
@@ -243,11 +243,31 @@ enum BlockaidSimulationParser {
         return nil
     }
 
-    /// Whether a diff states a balance change at all, in either direction.
-    private static func carriesBalance(
-        _ diff: BlockaidSolanaSimulationJson.AccountAssetDiff
+    /// Whether the netting's two legs are the only balance changes the
+    /// response states.
+    ///
+    /// The netting subtracts `diffs[inIndex].in` from `diffs[outIndex].out`
+    /// and reads nothing else — not the out leg of any other diff, nor the in
+    /// leg of any other diff, and not the opposite leg of either source when
+    /// the two indices differ. Any of those carrying a balance means the net
+    /// on screen would be missing an amount the transaction moves, which is
+    /// worse than no net at all.
+    private static func readsEveryLeg(
+        _ diffs: [BlockaidSolanaSimulationJson.AccountAssetDiff],
+        outIndex: Int,
+        inIndex: Int
     ) -> Bool {
-        diff.out?.rawValue != nil || diff.`in`?.rawValue != nil
+        diffs.indices.allSatisfy { index in
+            (index == outIndex || !carriesBalance(diffs[index].out))
+                && (index == inIndex || !carriesBalance(diffs[index].`in`))
+        }
+    }
+
+    /// Whether a single leg states a balance change.
+    private static func carriesBalance(
+        _ leg: BlockaidSolanaSimulationJson.BalanceChange?
+    ) -> Bool {
+        leg?.rawValue != nil
     }
 
     /// Builds a `BlockaidSimulationCoin` from a Solana asset, substituting the

--- a/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidSimulationParser.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidSimulationParser.swift
@@ -153,11 +153,10 @@ enum BlockaidSimulationParser {
         // Mirror the extension's positional destructuring: first diff is the
         // out side, second is the in side. Fall back to .transfer when only
         // one side carries a value (matches the extension's `else if` branch).
-        let outCandidate = diffs[0]
-        let inCandidate = diffs[1]
-
-        let inSource = inCandidate.`in` != nil ? inCandidate : outCandidate
-        let outSource = outCandidate.out != nil ? outCandidate : inCandidate
+        let outIndex = diffs[0].out != nil ? 0 : 1
+        let inIndex = diffs[1].`in` != nil ? 1 : 0
+        let outSource = diffs[outIndex]
+        let inSource = diffs[inIndex]
 
         if let outRaw = outSource.out?.rawValue,
            let inRaw = inSource.`in`?.rawValue,
@@ -168,6 +167,16 @@ enum BlockaidSimulationParser {
             if let outMint = fromCoin.address,
                let inMint = toCoin.address,
                outMint == inMint {
+                // Both sides can collapse onto one diff when the other carries
+                // neither leg. Netting a diff against itself is still the net
+                // movement of that asset — but only while the diff that was
+                // skipped holds nothing of its own. Otherwise the hero would
+                // state an authoritative net having never looked at a balance
+                // change the transaction makes, so decline and let the caller
+                // fall back to the generic title.
+                if outIndex == inIndex, carriesBalance(diffs[outIndex == 0 ? 1 : 0]) {
+                    return nil
+                }
                 return netSameMint(
                     outCoin: fromCoin,
                     outAmount: outAmount,
@@ -212,12 +221,19 @@ enum BlockaidSimulationParser {
     ///
     /// Mints are compared exactly. Solana addresses are base58 and
     /// case-sensitive, unlike the EVM path's checksummed hex.
+    ///
+    /// Both legs must be non-negative. Blockaid states each side's magnitude
+    /// and puts the direction in the field name, but `raw_value` decodes a
+    /// signed integer, and a negative reaching the subtraction would flip the
+    /// direction of an approval headline. Fail closed instead.
     private static func netSameMint(
         outCoin: BlockaidSimulationCoin,
         outAmount: BigInt,
         inCoin: BlockaidSimulationCoin,
         inAmount: BigInt
     ) -> BlockaidSimulationInfo? {
+        guard outAmount >= 0, inAmount >= 0 else { return nil }
+
         if outAmount > inAmount {
             return .transfer(fromCoin: outCoin, fromAmount: outAmount - inAmount)
         }
@@ -225,6 +241,13 @@ enum BlockaidSimulationParser {
             return .receive(coin: inCoin, amount: inAmount - outAmount)
         }
         return nil
+    }
+
+    /// Whether a diff states a balance change at all, in either direction.
+    private static func carriesBalance(
+        _ diff: BlockaidSolanaSimulationJson.AccountAssetDiff
+    ) -> Bool {
+        diff.out?.rawValue != nil || diff.`in`?.rawValue != nil
     }
 
     /// Builds a `BlockaidSimulationCoin` from a Solana asset, substituting the

--- a/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidSimulationParser.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidSimulationParser.swift
@@ -264,10 +264,19 @@ enum BlockaidSimulationParser {
     }
 
     /// Whether a single leg states a balance change.
+    ///
+    /// A leg that decodes to zero moves nothing, so it is not a change the
+    /// netting has to account for — declining over one would drop a net the
+    /// hero could state honestly. A leg that is present but whose magnitude
+    /// does not decode is not provably zero (`BalanceChange` keeps a
+    /// `raw_value` it cannot read as nil), so it counts as a change and the
+    /// netting fails closed.
     private static func carriesBalance(
         _ leg: BlockaidSolanaSimulationJson.BalanceChange?
     ) -> Bool {
-        leg?.rawValue != nil
+        guard let leg else { return false }
+        guard let raw = leg.rawValue, let amount = parseRawAmount(raw) else { return true }
+        return amount != 0
     }
 
     /// Builds a `BlockaidSimulationCoin` from a Solana asset, substituting the

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/BlockaidSimulationInfo+HeroContent.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/BlockaidSimulationInfo+HeroContent.swift
@@ -11,9 +11,13 @@ import Foundation
 /// hero and can't drift.
 extension BlockaidSimulationInfo {
 
-    /// Hero for this simulation: a single coin row for transfers, from/to
-    /// rows for swaps. Fiat sub-lines are resolved best-effort against
+    /// Hero for this simulation: a single coin row for transfers and receives,
+    /// from/to rows for swaps. Fiat sub-lines are resolved best-effort against
     /// `vaultCoins` (see `heroFiat(for:amount:vaultCoins:)`).
+    ///
+    /// A `receive` maps to its own hero shape rather than reusing `.send`: the
+    /// two render the same row, and only the label separates money arriving
+    /// from money leaving.
     func heroContent(title: String?, vaultCoins: [Coin]) -> HeroContent {
         switch self {
         case .transfer(let coin, _):
@@ -23,7 +27,17 @@ extension BlockaidSimulationInfo {
                     amount: heroAmountText,
                     ticker: coin.ticker,
                     logo: coin.logo,
-                    fiat: Self.heroFiat(for: coin, amount: fromAmountDecimal, vaultCoins: vaultCoins)
+                    fiat: Self.heroFiat(for: coin, amount: primaryAmountDecimal, vaultCoins: vaultCoins)
+                )
+            )
+        case .receive(let coin, _):
+            return .receive(
+                title: title,
+                coin: HeroCoinAmount(
+                    amount: heroAmountText,
+                    ticker: coin.ticker,
+                    logo: coin.logo,
+                    fiat: Self.heroFiat(for: coin, amount: primaryAmountDecimal, vaultCoins: vaultCoins)
                 )
             )
         case .swap(let from, let to, _, _):
@@ -33,7 +47,7 @@ extension BlockaidSimulationInfo {
                     amount: heroAmountText,
                     ticker: from.ticker,
                     logo: from.logo,
-                    fiat: Self.heroFiat(for: from, amount: fromAmountDecimal, vaultCoins: vaultCoins)
+                    fiat: Self.heroFiat(for: from, amount: primaryAmountDecimal, vaultCoins: vaultCoins)
                 ),
                 to: HeroCoinAmount(
                     amount: heroToAmountText ?? "",

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/BlockaidSimulationInfo+HeroContent.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/BlockaidSimulationInfo+HeroContent.swift
@@ -21,42 +21,54 @@ extension BlockaidSimulationInfo {
     func heroContent(title: String?, vaultCoins: [Coin]) -> HeroContent {
         switch self {
         case .transfer(let coin, _):
-            return .send(
-                title: title,
-                coin: HeroCoinAmount(
-                    amount: heroAmountText,
-                    ticker: coin.ticker,
-                    logo: coin.logo,
-                    fiat: Self.heroFiat(for: coin, amount: primaryAmountDecimal, vaultCoins: vaultCoins)
-                )
-            )
+            return .send(title: title, coin: primaryRow(for: coin, vaultCoins: vaultCoins))
         case .receive(let coin, _):
-            return .receive(
-                title: title,
-                coin: HeroCoinAmount(
-                    amount: heroAmountText,
-                    ticker: coin.ticker,
-                    logo: coin.logo,
-                    fiat: Self.heroFiat(for: coin, amount: primaryAmountDecimal, vaultCoins: vaultCoins)
-                )
-            )
+            return .receive(title: title, coin: primaryRow(for: coin, vaultCoins: vaultCoins))
         case .swap(let from, let to, _, _):
             return .swap(
                 title: title,
-                from: HeroCoinAmount(
-                    amount: heroAmountText,
-                    ticker: from.ticker,
-                    logo: from.logo,
-                    fiat: Self.heroFiat(for: from, amount: primaryAmountDecimal, vaultCoins: vaultCoins)
-                ),
-                to: HeroCoinAmount(
-                    amount: heroToAmountText ?? "",
-                    ticker: to.ticker,
-                    logo: to.logo,
-                    fiat: Self.heroFiat(for: to, amount: toAmountDecimal ?? .zero, vaultCoins: vaultCoins)
+                from: primaryRow(for: from, vaultCoins: vaultCoins),
+                to: Self.coinAmount(
+                    for: to,
+                    text: heroToAmountText ?? "",
+                    amount: toAmountDecimal ?? .zero,
+                    vaultCoins: vaultCoins
                 )
             )
         }
+    }
+
+    /// The row for the amount this simulation leads with — the transferred,
+    /// received, or swapped-from coin. Only the swap's destination row reads a
+    /// different amount.
+    private func primaryRow(
+        for coin: BlockaidSimulationCoin,
+        vaultCoins: [Coin]
+    ) -> HeroCoinAmount {
+        Self.coinAmount(
+            for: coin,
+            text: heroAmountText,
+            amount: primaryAmountDecimal,
+            vaultCoins: vaultCoins
+        )
+    }
+
+    /// One coin row of the hero. Every row resolves its ticker, logo and fiat
+    /// the same way, so they are built here rather than at each call site —
+    /// `text` is the pre-formatted amount shown, `amount` the same value as a
+    /// Decimal for pricing.
+    private static func coinAmount(
+        for coin: BlockaidSimulationCoin,
+        text: String,
+        amount: Decimal,
+        vaultCoins: [Coin]
+    ) -> HeroCoinAmount {
+        HeroCoinAmount(
+            amount: text,
+            ticker: coin.ticker,
+            logo: coin.logo,
+            fiat: heroFiat(for: coin, amount: amount, vaultCoins: vaultCoins)
+        )
     }
 
     /// Best-effort fiat for a hero coin row, resolved against the active

--- a/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummaryView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummaryView.swift
@@ -498,7 +498,7 @@ struct SendCryptoVerifySummaryView<ContentFooter: View>: View {
         switch input.hero {
         case nil, .title:
             return true
-        case .send, .swap:
+        case .send, .receive, .swap:
             return false
         }
     }

--- a/VultisigApp/VultisigAppTests/Keysign/InitiatorAmountFiatTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/InitiatorAmountFiatTests.swift
@@ -151,6 +151,32 @@ final class InitiatorAmountFiatTests: XCTestCase {
         XCTAssertTrue(coin.fiat?.contains("6") == true, "2 SOL at $3 should render as 6, got \(coin.fiat ?? "nil")")
     }
 
+    /// An inflow must reach its own hero shape. A `receive` rendered through
+    /// `.send` would be indistinguishable from money leaving — the amount row
+    /// is identical and only the label separates them.
+    func testInitiatorHeroReceiveMapsToReceiveHero() {
+        let sol = makeCoin(.solana, ticker: "SOL", decimals: 9, isNative: true)
+        setPrice(3.0, for: sol)
+        let vm = makeKeysignViewModel(vaultCoins: [sol])
+        // A wrapped-SOL withdraw nets to an inflow of 2 SOL. At $3 = $6.
+        vm.blockaidSimulation = .receive(
+            coin: simCoin(
+                chain: .solana,
+                address: BlockaidSimulationParser.wrappedSolMint,
+                ticker: "SOL",
+                decimals: 9
+            ),
+            amount: BigInt("2000000000")
+        )
+
+        guard case .receive(_, let coin) = vm.heroContent else {
+            return XCTFail("A receive simulation must produce a receive hero, never a send")
+        }
+        XCTAssertEqual(coin.ticker, "SOL")
+        XCTAssertEqual(coin.amount, Decimal(2).formatForDisplay())
+        XCTAssertTrue(coin.fiat?.contains("6") == true, "2 SOL at $3 should render as 6, got \(coin.fiat ?? "nil")")
+    }
+
     func testInitiatorHeroFiatNilForZeroAmount() {
         let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
         setPrice(2.0, for: eth)

--- a/VultisigApp/VultisigAppTests/Keysign/JoinKeysignAmountFiatTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/JoinKeysignAmountFiatTests.swift
@@ -75,7 +75,44 @@ final class JoinKeysignAmountFiatTests: XCTestCase {
         XCTAssertEqual(vm.getAmountFiat(), "", "Swaps show fiat on the hero from/to rows, not the amount field")
     }
 
+    // MARK: - Co-signer keysign hero (JoinKeysignViewModel.heroContent)
+
+    /// The co-signer builds its hero through the same
+    /// `BlockaidSimulationInfo.heroContent(title:vaultCoins:)` the initiator
+    /// uses, but reaches it past an extra TON fallback branch. Pinned on both
+    /// devices because a hero that named the wrong direction on one of them
+    /// would still be the screen the approval decision rests on.
+    func testCoSignerHeroReceiveMapsToReceiveHero() {
+        let sol = makeCoin(.solana, ticker: "SOL", decimals: 9, isNative: true)
+        setPrice(3.0, for: sol)
+        let vm = makeViewModel(payload: makePayload(coin: sol, toAmount: .zero))
+        vm.vault = makeVault(coins: [sol])
+        // A wrapped-SOL withdraw nets to an inflow of 2 SOL. At $3 = $6.
+        vm.blockaidSimulation = .receive(
+            coin: BlockaidSimulationCoin(
+                chain: .solana,
+                address: BlockaidSimulationParser.wrappedSolMint,
+                ticker: "SOL",
+                logo: "logo",
+                decimals: 9
+            ),
+            amount: BigInt("2000000000")
+        )
+
+        guard case .receive(_, let coin) = vm.heroContent else {
+            return XCTFail("A receive simulation must produce a receive hero, never a send")
+        }
+        XCTAssertEqual(coin.ticker, "SOL")
+        XCTAssertTrue(coin.fiat?.contains("6") == true, "2 SOL at $3 should render as 6, got \(coin.fiat ?? "nil")")
+    }
+
     // MARK: - Helpers
+
+    private func makeVault(coins: [Coin]) -> Vault {
+        let vault = Vault(name: "cosign-hero-test-vault")
+        vault.coins = coins
+        return vault
+    }
 
     private func makeViewModel(payload: KeysignPayload) -> JoinKeysignViewModel {
         let vm = JoinKeysignViewModel()

--- a/VultisigApp/VultisigAppTests/Services/BlockaidSimulationParserTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/BlockaidSimulationParserTests.swift
@@ -137,18 +137,18 @@ final class BlockaidSimulationParserTests: XCTestCase {
 
     // MARK: - Decimal + formatting
 
-    func test_fromAmountDecimal_usesCoinDecimals() {
+    func test_primaryAmountDecimal_usesCoinDecimals() {
         let usdc = BlockaidSimulationInfo.transfer(
             fromCoin: BlockaidSimulationCoin(chain: .ethereum, address: nil, ticker: "USDC", logo: "", decimals: 6),
             fromAmount: BigInt("1500000")
         )
-        XCTAssertEqual(usdc.fromAmountDecimal, Decimal(string: "1.5"))
+        XCTAssertEqual(usdc.primaryAmountDecimal, Decimal(string: "1.5"))
 
         let weth = BlockaidSimulationInfo.transfer(
             fromCoin: BlockaidSimulationCoin(chain: .ethereum, address: nil, ticker: "WETH", logo: "", decimals: 18),
             fromAmount: BigInt("2500000000000000000")
         )
-        XCTAssertEqual(weth.fromAmountDecimal, Decimal(string: "2.5"))
+        XCTAssertEqual(weth.primaryAmountDecimal, Decimal(string: "2.5"))
     }
 
     func test_heroAmountText_matchesFormatForDisplay() {

--- a/VultisigApp/VultisigAppTests/Services/BlockaidSolanaSimulationParserTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/BlockaidSolanaSimulationParserTests.swift
@@ -243,6 +243,140 @@ final class BlockaidSolanaSimulationParserTests: XCTestCase {
         XCTAssertEqual(toCoin.ticker, "BONK")
     }
 
+    /// A genuine swap out of native SOL must survive the same-mint netting:
+    /// native SOL carries the wrapped-SOL mint sentinel, so the guard has to
+    /// compare against the *other* leg's mint rather than treat every native
+    /// SOL leg as wrap noise.
+    func test_parseSolana_swap_nativeSolToUsdc_staysSwap() {
+        let sol = native(symbol: "SOL", decimals: 9)
+        let usdc = token(symbol: "USDC", address: "Usdc1111", decimals: 6)
+        let diffs = [
+            diff(asset: sol, out: balance("1000000000")),
+            diff(asset: usdc, in: balance("150000000"))
+        ]
+
+        let info = BlockaidSimulationParser.parseSolana(response: response(with: diffs))
+
+        guard case let .swap(fromCoin, toCoin, fromAmount, toAmount) = info else {
+            return XCTFail("expected .swap, got \(String(describing: info))")
+        }
+        XCTAssertEqual(fromCoin.ticker, "SOL")
+        XCTAssertEqual(toCoin.ticker, "USDC")
+        XCTAssertEqual(fromAmount, BigInt("1000000000"))
+        XCTAssertEqual(toAmount, BigInt("150000000"))
+    }
+
+    // MARK: - Same-mint netting
+
+    /// A Kamino wrapped-SOL vault deposit wraps SOL and spends it in the same
+    /// transaction, so the wSOL account is left holding only its rent-exempt
+    /// residual — 2,039,280 lamports, the rent of a 165-byte token account.
+    /// Blockaid reports that residual as a small incoming WSOL diff beside the
+    /// real native-SOL out leg. Both legs resolve to the wrapped-SOL mint, so
+    /// there is no swap here: the hero must state the net outflow, and name it
+    /// SOL rather than the WSOL the user is not receiving.
+    ///
+    /// Raw values captured from a real Blockaid response for an Allez SOL
+    /// deposit.
+    func test_parseSolana_solOutWsolIn_netsToTransfer() {
+        let diffs = [
+            diff(asset: native(symbol: "SOL", decimals: 9), out: balance("59435000")),
+            diff(
+                asset: token(symbol: "WSOL", address: BlockaidSimulationParser.wrappedSolMint, decimals: 9),
+                in: balance("2039280")
+            )
+        ]
+
+        let info = BlockaidSimulationParser.parseSolana(response: response(with: diffs))
+
+        guard case let .transfer(coin, amount) = info else {
+            return XCTFail("expected netted .transfer, got \(String(describing: info))")
+        }
+        XCTAssertEqual(coin.ticker, "SOL", "the net follows the native leg, so the ticker must not read WSOL")
+        XCTAssertEqual(coin.logo, Chain.solana.logo)
+        XCTAssertEqual(amount, BigInt("57395720"), "59435000 out - 2039280 in")
+    }
+
+    /// The mirror image, and the reason the pair is netted rather than reduced
+    /// to its out leg: a wrapped-SOL withdraw closes the payout account, which
+    /// unwraps wSOL into native SOL. The out leg is only the residual going
+    /// back; the in leg is what the user actually receives. Keeping the out leg
+    /// would headline 0.00203928 and drop the 0.059435 arriving — and reporting
+    /// it as a transfer would state an outflow for an inflow.
+    func test_parseSolana_wsolOutSolIn_netsToReceive() {
+        let diffs = [
+            diff(
+                asset: token(symbol: "WSOL", address: BlockaidSimulationParser.wrappedSolMint, decimals: 9),
+                out: balance("2039280")
+            ),
+            diff(asset: native(symbol: "SOL", decimals: 9), in: balance("61474280"))
+        ]
+
+        let info = BlockaidSimulationParser.parseSolana(response: response(with: diffs))
+
+        guard case let .receive(coin, amount) = info else {
+            return XCTFail("expected netted .receive, got \(String(describing: info))")
+        }
+        XCTAssertEqual(coin.ticker, "SOL")
+        XCTAssertEqual(coin.logo, Chain.solana.logo)
+        XCTAssertEqual(amount, BigInt("59435000"), "61474280 in - 2039280 out")
+    }
+
+    /// Diff order is not contractual. The same withdraw with its legs the other
+    /// way round must still net to the same inflow.
+    func test_parseSolana_wsolOutSolIn_netsToReceive_regardlessOfDiffOrder() {
+        let diffs = [
+            diff(asset: native(symbol: "SOL", decimals: 9), in: balance("61474280")),
+            diff(
+                asset: token(symbol: "WSOL", address: BlockaidSimulationParser.wrappedSolMint, decimals: 9),
+                out: balance("2039280")
+            )
+        ]
+
+        let info = BlockaidSimulationParser.parseSolana(response: response(with: diffs))
+
+        guard case let .receive(coin, amount) = info else {
+            return XCTFail("expected netted .receive, got \(String(describing: info))")
+        }
+        XCTAssertEqual(coin.ticker, "SOL")
+        XCTAssertEqual(amount, BigInt("59435000"))
+    }
+
+    /// An exact wrap/unwrap round trip nets to zero. "Your balance does not
+    /// change" has no honest hero, so the parser returns nil and the caller
+    /// falls back to the generic title rather than headlining a zero amount.
+    func test_parseSolana_sameMintExactCancellation_returnsNil() {
+        let diffs = [
+            diff(asset: native(symbol: "SOL", decimals: 9), out: balance("2039280")),
+            diff(
+                asset: token(symbol: "WSOL", address: BlockaidSimulationParser.wrappedSolMint, decimals: 9),
+                in: balance("2039280")
+            )
+        ]
+
+        XCTAssertNil(BlockaidSimulationParser.parseSolana(response: response(with: diffs)))
+    }
+
+    /// The three-diff native-SOL fee filter runs first, so a same-mint pair can
+    /// still be what is left afterwards — here two wSOL accounts either side of
+    /// a separate native-SOL fee leg. The netting must apply to the survivors.
+    func test_parseSolana_threeDiffs_afterSolFeeFilter_netsSameMintPair() {
+        let wsol = token(symbol: "WSOL", address: BlockaidSimulationParser.wrappedSolMint, decimals: 9)
+        let diffs = [
+            diff(asset: wsol, out: balance("5000000")),
+            diff(asset: native(symbol: "SOL", decimals: 9), out: balance("5000")), // fee leg
+            diff(asset: wsol, in: balance("1000000"))
+        ]
+
+        let info = BlockaidSimulationParser.parseSolana(response: response(with: diffs))
+
+        guard case let .transfer(coin, amount) = info else {
+            return XCTFail("expected netted .transfer, got \(String(describing: info))")
+        }
+        XCTAssertEqual(coin.ticker, "WSOL")
+        XCTAssertEqual(amount, BigInt("4000000"), "5000000 out - 1000000 in")
+    }
+
     /// If only one side of a two-diff swap has a value, fall back to .transfer
     /// — matches the extension's `else if (outAsset && outValue)` branch.
     func test_parseSolana_swap_fallsBackToTransfer_whenInMissing() {

--- a/VultisigApp/VultisigAppTests/Services/BlockaidSolanaSimulationParserTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/BlockaidSolanaSimulationParserTests.swift
@@ -427,6 +427,78 @@ final class BlockaidSolanaSimulationParserTests: XCTestCase {
         XCTAssertNil(BlockaidSimulationParser.parseSolana(response: response(with: diffs)))
     }
 
+    /// An explicit zero leg moves nothing, so it is not a balance change the
+    /// netting has to account for: the wSOL net is still the whole story and
+    /// declining over the untouched USDC account would drop a net the hero can
+    /// state honestly.
+    func testParseSolanaSameMintNetsWhenTheUnreadLegIsExplicitlyZero() {
+        let wsol = token(symbol: "WSOL", address: BlockaidSimulationParser.wrappedSolMint, decimals: 9)
+        let diffs = [
+            diff(asset: wsol, in: balance("2000000"), out: balance("5000000")),
+            diff(asset: token(symbol: "USDC", address: "Usdc1111", decimals: 6), out: balance("0"))
+        ]
+
+        let info = BlockaidSimulationParser.parseSolana(response: response(with: diffs))
+
+        guard case let .transfer(coin, amount) = info else {
+            return XCTFail("expected netted .transfer, got \(String(describing: info))")
+        }
+        XCTAssertEqual(coin.ticker, "WSOL")
+        XCTAssertEqual(amount, BigInt("3000000"), "5000000 out - 2000000 in")
+    }
+
+    /// The same for a zero leg on the diff supplying the opposite side: the
+    /// SOL/WSOL net stands, since nothing was left unaccounted for.
+    func testParseSolanaSameMintDistinctSourcesNetsWhenTheHiddenLegIsZero() {
+        let diffs = [
+            diff(asset: native(symbol: "SOL", decimals: 9), out: balance("59435000")),
+            diff(
+                asset: token(symbol: "WSOL", address: BlockaidSimulationParser.wrappedSolMint, decimals: 9),
+                in: balance("2039280"),
+                out: balance("0")
+            )
+        ]
+
+        let info = BlockaidSimulationParser.parseSolana(response: response(with: diffs))
+
+        guard case let .transfer(coin, amount) = info else {
+            return XCTFail("expected netted .transfer, got \(String(describing: info))")
+        }
+        XCTAssertEqual(coin.ticker, "SOL")
+        XCTAssertEqual(amount, BigInt("57395720"), "59435000 out - 2039280 in")
+    }
+
+    /// A leg whose magnitude does not decode is not provably zero —
+    /// `BalanceChange` keeps a `raw_value` it cannot read as nil — so it is
+    /// still an unaccounted balance change and the netting fails closed.
+    func testParseSolanaSameMintReturnsNilWhenAnUnreadLegHasNoReadableMagnitude() {
+        let wsol = token(symbol: "WSOL", address: BlockaidSimulationParser.wrappedSolMint, decimals: 9)
+        let diffs = [
+            diff(asset: wsol, in: balance("2000000"), out: balance("5000000")),
+            diff(
+                asset: token(symbol: "USDC", address: "Usdc1111", decimals: 6),
+                out: BlockaidSolanaSimulationJson.BalanceChange(rawValue: nil)
+            )
+        ]
+
+        XCTAssertNil(BlockaidSimulationParser.parseSolana(response: response(with: diffs)))
+    }
+
+    /// The same fail-closed posture for a magnitude that is stated but is not
+    /// a number: unreadable is not zero.
+    func testParseSolanaSameMintReturnsNilWhenAnUnreadLegHasAnUndecodableMagnitude() {
+        let wsol = token(symbol: "WSOL", address: BlockaidSimulationParser.wrappedSolMint, decimals: 9)
+        let diffs = [
+            diff(asset: wsol, in: balance("2000000"), out: balance("5000000")),
+            diff(
+                asset: token(symbol: "USDC", address: "Usdc1111", decimals: 6),
+                out: balance("not-a-number")
+            )
+        ]
+
+        XCTAssertNil(BlockaidSimulationParser.parseSolana(response: response(with: diffs)))
+    }
+
     /// The legs need not collapse onto one diff for a leg to go unread. Here
     /// the netting takes its out side from the SOL diff and its in side from
     /// the WSOL diff, so the WSOL diff's own out leg is never looked at: the

--- a/VultisigApp/VultisigAppTests/Services/BlockaidSolanaSimulationParserTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/BlockaidSolanaSimulationParserTests.swift
@@ -427,6 +427,41 @@ final class BlockaidSolanaSimulationParserTests: XCTestCase {
         XCTAssertNil(BlockaidSimulationParser.parseSolana(response: response(with: diffs)))
     }
 
+    /// The legs need not collapse onto one diff for a leg to go unread. Here
+    /// the netting takes its out side from the SOL diff and its in side from
+    /// the WSOL diff, so the WSOL diff's own out leg is never looked at: the
+    /// hero would headline 57395720 (59435000 - 2039280) when the true net is
+    /// 57895720, understating what leaves the vault by the ignored 500000.
+    /// Decline instead.
+    func testParseSolanaSameMintDistinctSourcesReturnsNilWhenInSourceAlsoSpends() {
+        let diffs = [
+            diff(asset: native(symbol: "SOL", decimals: 9), out: balance("59435000")),
+            diff(
+                asset: token(symbol: "WSOL", address: BlockaidSimulationParser.wrappedSolMint, decimals: 9),
+                in: balance("2039280"),
+                out: balance("500000")
+            )
+        ]
+
+        XCTAssertNil(BlockaidSimulationParser.parseSolana(response: response(with: diffs)))
+    }
+
+    /// The mirror: the out-side diff carries an in leg of its own, which the
+    /// netting drops because the in side is taken from the other diff. The
+    /// same understatement, in the receive direction.
+    func testParseSolanaSameMintDistinctSourcesReturnsNilWhenOutSourceAlsoReceives() {
+        let diffs = [
+            diff(
+                asset: token(symbol: "WSOL", address: BlockaidSimulationParser.wrappedSolMint, decimals: 9),
+                in: balance("500000"),
+                out: balance("2039280")
+            ),
+            diff(asset: native(symbol: "SOL", decimals: 9), in: balance("61474280"))
+        ]
+
+        XCTAssertNil(BlockaidSimulationParser.parseSolana(response: response(with: diffs)))
+    }
+
     /// If only one side of a two-diff swap has a value, fall back to .transfer
     /// — matches the extension's `else if (outAsset && outValue)` branch.
     func test_parseSolana_swap_fallsBackToTransfer_whenInMissing() {

--- a/VultisigApp/VultisigAppTests/Services/BlockaidSolanaSimulationParserTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/BlockaidSolanaSimulationParserTests.swift
@@ -377,6 +377,56 @@ final class BlockaidSolanaSimulationParserTests: XCTestCase {
         XCTAssertEqual(amount, BigInt("4000000"), "5000000 out - 1000000 in")
     }
 
+    /// `raw_value` decodes a signed integer even though Blockaid states each
+    /// side's magnitude and puts the direction in the field name. A negative
+    /// reaching the subtraction would flip the direction of an approval
+    /// headline — here it would turn a net outflow into a "Receive" — so the
+    /// netting fails closed instead.
+    func test_parseSolana_sameMint_negativeRawValue_returnsNil() {
+        let diffs = [
+            diff(asset: native(symbol: "SOL", decimals: 9), out: balance("-10")),
+            diff(
+                asset: token(symbol: "WSOL", address: BlockaidSimulationParser.wrappedSolMint, decimals: 9),
+                in: balance("-5")
+            )
+        ]
+
+        XCTAssertNil(BlockaidSimulationParser.parseSolana(response: response(with: diffs)))
+    }
+
+    /// Both sides collapse onto the first diff when the second carries no in
+    /// leg. Netting a diff against itself is still that asset's net movement,
+    /// so it is allowed while the skipped diff holds nothing.
+    func test_parseSolana_sameMint_collapsedSources_netsWhenOtherDiffIsEmpty() {
+        let wsol = token(symbol: "WSOL", address: BlockaidSimulationParser.wrappedSolMint, decimals: 9)
+        let diffs = [
+            diff(asset: wsol, in: balance("2000000"), out: balance("5000000")),
+            diff(asset: token(symbol: "USDC", address: "Usdc1111", decimals: 6), in: nil, out: nil)
+        ]
+
+        let info = BlockaidSimulationParser.parseSolana(response: response(with: diffs))
+
+        guard case let .transfer(coin, amount) = info else {
+            return XCTFail("expected netted .transfer, got \(String(describing: info))")
+        }
+        XCTAssertEqual(coin.ticker, "WSOL")
+        XCTAssertEqual(amount, BigInt("3000000"), "5000000 out - 2000000 in")
+    }
+
+    /// The same collapse, but the skipped diff spends a second asset. Netting
+    /// here would headline an authoritative inflow while never looking at the
+    /// USDC leaving, so the parser declines and the caller falls back to the
+    /// generic title.
+    func test_parseSolana_sameMint_collapsedSources_returnsNil_whenOtherDiffCarriesBalance() {
+        let wsol = token(symbol: "WSOL", address: BlockaidSimulationParser.wrappedSolMint, decimals: 9)
+        let diffs = [
+            diff(asset: wsol, in: balance("61474280"), out: balance("2039280")),
+            diff(asset: token(symbol: "USDC", address: "Usdc1111", decimals: 6), out: balance("100000000"))
+        ]
+
+        XCTAssertNil(BlockaidSimulationParser.parseSolana(response: response(with: diffs)))
+    }
+
     /// If only one side of a two-diff swap has a value, fall back to .transfer
     /// — matches the extension's `else if (outAsset && outValue)` branch.
     func test_parseSolana_swap_fallsBackToTransfer_whenInMissing() {


### PR DESCRIPTION
## Problem

A Kamino Allez SOL deposit renders on the keysign hero as a **swap into `0.00203928 WSOL`** — a destination asset the user is not receiving, at an amount 29× smaller than the one leaving. The hero is the screen the approval decision rests on, and `BlockaidSimulationInfo+HeroContent.swift` is shared by the initiator (`KeysignViewModel`) and the co-signer (`JoinKeysignViewModel`), so **both devices show it**.

Blockaid's response for the deposit:

```json
{"account_assets_diff": [
  {"asset": {"type": "SOL", "decimals": 9, "symbol": "SOL", "address": null},
   "out": {"raw_value": "59435000"}},
  {"asset": {"type": "TOKEN", "address": "So11111111111111111111111111111111111111112",
             "symbol": "WSOL", "decimals": 9},
   "in": {"raw_value": "2039280"}}
]}
```

`2039280` lamports is the rent-exempt minimum of a 165-byte SPL token account. The deposit opens the wSOL ATA and never closes it (already disclosed by `KaminoDepositViewModel.showsWrappedSolNotice`), so once the vault has taken the deposit that residual is all that is left of the wrapped balance. The wrap-in and the spend-out cancel and never surface as diffs of their own.

## Root cause

`BlockaidSimulationParser.parseSolanaSwap` destructures the two diffs positionally and returns `.swap` whenever both sides carry a value — it never compares the two sides' mints. Meanwhile `buildSolanaCoin` maps native SOL onto the wrapped-SOL mint on purpose (so `TokensStore` lookups and the hero's fiat resolution work uniformly). Native SOL and a real WSOL SPL diff therefore carry the **identical** mint: a SOL-out/WSOL-in pair is the same asset on both sides and can never be a genuine swap.

Only two diffs, so the `diffs.count == 3` native-SOL fee filter does not apply.

Not Kamino-specific — any transaction that wraps SOL and spends it in one shot produces the same pair.

## Fix

When both legs of a two-diff Solana pair resolve to the same mint, collapse them into the **net** movement of that mint (`out - in`) instead of emitting a swap:

- net outflow → `.transfer` of the net, using the out leg's coin
- net inflow → `.receive` of the net, using the in leg's coin
- exact cancellation → `nil`, and the caller falls back to the generic title (there is no honest hero for "your balance does not change")

Mints are compared **exactly**: Solana addresses are base58 and case-sensitive, unlike the EVM path's checksummed hex. Comparing the *built* coins is what makes the check right — `buildSolanaCoin` already collapses native SOL onto the wrapped-SOL mint, which is precisely the "same asset" test wanted. The displayed coin comes from whichever leg the net follows, so the ticker stays truthful: both directions read **SOL**, not WSOL.

## The netting decision, and its reverse-direction consequence

Netting rather than simply keeping the out leg is a deliberate choice, and it is what the reverse direction needs.

A wrapped-SOL **withdraw** closes the payout account, and closing it is what unwraps wSOL into the native SOL the screen promises (`KaminoInstructionSequence` marks `closeTokenAccount` `required: isWrappedSolVault`). That yields the same pair reversed: a small **WSOL out** beside a large **native SOL in** — a net *inflow*. Keeping the out leg there would headline the `0.00203928` residual and drop the amount actually received, and reporting it as a `.transfer` would state an outflow for an inflow — a worse defect than the one being fixed.

`HeroContent` had no inflow shape, so this adds one:

- `BlockaidSimulationInfo.receive(coin:amount:)` → `HeroContent.receive(title:coin:)`, rendered by `HeroContentView` as the send row plus an explicit **"Receive"** label. Every other hero shape states money leaving, so an unlabelled row reads as a send. The label reuses the existing `"receive"` key, which already ships in **all 8 locales** — no new strings.
- Both keysign view models reach it through the same shared `heroContent(title:vaultCoins:)`, so initiator and co-signer cannot drift; each is pinned by its own fixture.
- `BlockaidSimulationInfo.fromCoin` / `fromAmount` / `fromAmountDecimal` are renamed `primaryCoin` / `primaryAmount` / `primaryAmountDecimal`. A `receive` has no from-side, and a name implying one is exactly how an inflow ends up displayed as an outflow. They are used only inside the model and the hero extension.

### Divergence from Android

[vultisig-android#5620](https://github.com/vultisig/vultisig-android/pull/5620) (open, not landed) fixes the same bug by keeping the **out leg** for the outflow direction and returning null for the inflow. This PR nets instead. The visible consequence: for the deposit above, iOS will read `0.05739572 SOL` (what leaves and does not come back) where Android reads `0.059435 SOL` (gross native outflow, rent included). The two platforms will disagree on that figure until one of them moves — flagged for a maintainer call.

## Tests

`BlockaidSolanaSimulationParserTests` (raw values from the captured response above):

- `test_parseSolana_solOutWsolIn_netsToTransfer` — deposit direction: `59435000` out / `2039280` in → `.transfer` of `57395720`, ticker **SOL** (not WSOL), native Solana logo.
- `test_parseSolana_wsolOutSolIn_netsToReceive` — withdraw direction: `2039280` out / `61474280` in → `.receive` of `59435000`, ticker **SOL**.
- `test_parseSolana_wsolOutSolIn_netsToReceive_regardlessOfDiffOrder` — diff order is not contractual.
- `test_parseSolana_sameMintExactCancellation_returnsNil` — exact cancellation nets to zero → no hero.
- `test_parseSolana_threeDiffs_afterSolFeeFilter_netsSameMintPair` — the fee filter runs first, so a same-mint pair can still be the survivor; the netting must apply to it.
- `test_parseSolana_sameMint_negativeRawValue_returnsNil` — `raw_value` decodes a *signed* integer; a negative reaching the subtraction would flip an approval headline's direction, so the netting fails closed.
- `test_parseSolana_sameMint_collapsedSources_netsWhenOtherDiffIsEmpty` / `..._returnsNil_whenOtherDiffCarriesBalance` — the in/out fallback can resolve both sides onto one diff. Netting a diff against itself is still that asset's net movement, so it stays allowed while the skipped diff holds nothing; with a second asset spending beside it the parser declines rather than headline a net it never looked at in full.
- `test_parseSolana_swap_nativeSolToUsdc_staysSwap` — **regression guard**: a genuine native SOL → USDC swap must still parse as `.swap`, because native SOL carries the wrapped-SOL sentinel and the guard must compare against the *other* leg's mint rather than treat every native leg as wrap noise. The pre-existing USDC → BONK swap fixture still passes unchanged.

Hero mapping, on both devices:

- `InitiatorAmountFiatTests.testInitiatorHeroReceiveMapsToReceiveHero`
- `JoinKeysignAmountFiatTests.testCoSignerHeroReceiveMapsToReceiveHero`

Both assert a `.receive` simulation produces a `.receive` hero — never a `.send` — with the ticker and fiat resolved.

## Verification

- Full unit suite on a dedicated simulator (iPhone 17 Pro Max, iOS 26.5): `** TEST SUCCEEDED **` — 6502 executed, 11 skipped, **0 failures**. All 11 new fixtures ran and passed.
- `swiftlint --config VultisigApp/.swiftlint.yml` clean on every touched file (0 violations).
- Codex read-only review of the branch, one round, five findings: two P1s **fixed** in the second commit (negative `raw_value`, collapsed sources dropping a leg — both with fixtures); one P2 **rejected with reason** (a deliberate 1:1 SOL↔WSOL wrap no longer renders as a swap — that is the accepted trade, and an exact cancellation only fires on *equal* legs, which a real wrap never has once rent and fee are in the native out); two P2s **deferred** as pre-existing and out of scope (the three-diff fee heuristic; the initiator Done screen has never carried the Blockaid hero for any shape). Codex separately confirmed every `HeroContent` switch is exhaustive, `shouldShowAmountRow` suppresses the duplicate amount row, no rename call site was missed, and the new fixtures would fail against the old parser.

## Risks / what needs a human

- **Display-only** — the signed bytes are untouched. But this is the transaction-approval hero on a signing path, and it renders on **both the initiator and the co-signer devices**: please review on device.
- The netted deposit figure (`0.05739572`) is smaller than the amount the deposit form said (`0.059435`); the difference is the rent residual the wSOL ATA keeps. That is the honest "what leaves and does not come back" number, but it will not match the deposit screen, and it disagrees with Android. Worth a maintainer call before this is un-drafted.
- **Not reproduced on device.** The outflow direction is proven against the captured raw values from the issue. The **inflow direction is derived** from the withdraw's instruction sequence, not from a captured Blockaid body for a withdraw — no such body exists anywhere in our records. The reverse fixture's raw values are constructed to match that shape.
- The `.receive` hero's label placement is new UI on the verify → sign → done screens and wants a design eye.
- The `diffs.count == 3` fee heuristic remains a separate pre-existing hazard (it would remove a real out leg as "likely the fee" if Blockaid ever returned the deposit as three diffs). Shared with the extension and Android; untouched here.

Plan: `wiki/pages/projects/vultisig/kamino-earn-5017/blockaid-sol-wsol-hero-5187-plan.md`

Closes #5187


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clear receive transaction summaries showing the asset, amount, label, and optional title.
  - Added support for inbound assets, including wrapped-SOL withdrawals.
  - Improved transaction amount and fiat-value displays across transfer, receive, and swap simulations.

- **Bug Fixes**
  - Improved Solana transaction parsing for same-asset transfers, cancellations, fees, and mixed-asset scenarios.
  - Prevented redundant amount rows for receive transactions.

- **Tests**
  - Added coverage for receive simulations, wrapped-SOL handling, and Solana parsing edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->