### PR TITLE
fix(kamino): read a withdraw built as withdraw_from_available

### DIFF
--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoInstructionSequence.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoInstructionSequence.swift
@@ -274,7 +274,22 @@ enum KaminoInstructionSequence {
             return nil
         case .kvault:
             if Array(data.prefix(8)) == KaminoInstructionDiscriminator.kvaultDeposit { return .kvaultDeposit }
-            if Array(data.prefix(8)) == KaminoInstructionDiscriminator.kvaultWithdraw { return .kvaultWithdraw }
+            // TWO discriminators, one kind. `withdraw` and
+            // `withdraw_from_available` are the same withdraw — same `u64` share
+            // argument, same authority, same share account burned, same payout
+            // account credited — and which one the builder emits says only
+            // whether the vault's liquid buffer covered the request. That is a
+            // fact about the vault's balance sheet, not about what the user is
+            // being asked to approve, so drawing the distinction here would put
+            // a difference on the verify screen that means nothing to the person
+            // reading it.
+            //
+            // They may share the map because they share the accounts: see
+            // `KaminoInstructionAccounts.KvaultWithdraw`.
+            if Array(data.prefix(8)) == KaminoInstructionDiscriminator.kvaultWithdraw
+                || Array(data.prefix(8)) == KaminoInstructionDiscriminator.kvaultWithdrawFromAvailable {
+                return .kvaultWithdraw
+            }
             return nil
         case .memo:
             // The tag is matched WHOLE, not as a prefix. A memo is free-form

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoSolanaInstructions.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoSolanaInstructions.swift
@@ -72,7 +72,7 @@ enum KaminoAttribution {
 
 /// Instruction discriminators for the programs a Kamino Earn transaction uses.
 ///
-/// The six Anchor ones are `sha256("global:<name>")[0..<8]`, and each was also
+/// The seven Anchor ones are `sha256("global:<name>")[0..<8]`, and each was also
 /// read back out of a mainnet-simulated transaction built by the Kamino API, so
 /// the constant and the observation agree.
 ///
@@ -86,7 +86,29 @@ enum KaminoInstructionDiscriminator {
     static let kvaultDeposit: [UInt8] = [0xf2, 0x23, 0xc6, 0x89, 0x52, 0xe1, 0xf2, 0xb6]
     /// `kvault::withdraw(u64 shareAmount)` — the argument is in SHARES, the
     /// inverse of deposit's unit.
+    ///
+    /// One of TWO instructions a withdraw arrives as; see
+    /// `kvaultWithdrawFromAvailable`. This is the one the builder emits when the
+    /// request does not fit the vault's liquid buffer, because only this one
+    /// carries the accounts needed to pull the shortfall out of a lending
+    /// reserve.
     static let kvaultWithdraw: [UInt8] = [0xb7, 0x12, 0x46, 0x9c, 0x94, 0x6d, 0xa1, 0x22]
+    /// `kvault::withdraw_from_available(u64 shareAmount)` — the same withdraw,
+    /// served entirely out of the vault's liquid buffer.
+    ///
+    /// Which of the two arrives is a fact about the VAULT's liquidity at build
+    /// time, not about the user's request: Kamino's builder emits this one when
+    /// the reserves need not be touched and `withdraw` when they must, and both
+    /// are in live use. So both are accepted, and both mean the same thing to
+    /// the person signing — burn this many shares from this account, pay out to
+    /// that one.
+    ///
+    /// Reading one under the other's account map is safe, and that is checked
+    /// rather than assumed: the program's IDL declares `withdraw`'s accounts as
+    /// `withdraw_from_available`'s fourteen followed by the reserve group, so the
+    /// two share a prefix by construction. Every index in
+    /// `KaminoInstructionAccounts.KvaultWithdraw` lies inside it.
+    static let kvaultWithdrawFromAvailable: [UInt8] = [0x13, 0x83, 0x70, 0x9b, 0xaa, 0xdc, 0x22, 0x39]
     /// `farms::initialize_user` — creates the user's farm state. Absent when it
     /// already exists.
     static let farmsInitializeUser: [UInt8] = [0x6f, 0x11, 0xb9, 0xfa, 0x3c, 0x7a, 0x26, 0xfe]
@@ -241,6 +263,20 @@ enum KaminoInstructionAccounts {
         static let minimumCount = 8
     }
 
+    /// `kvault::withdraw` AND `kvault::withdraw_from_available`, which share
+    /// these positions rather than merely happening to agree on them.
+    ///
+    /// The program's IDL declares `withdraw`'s account list as the
+    /// `withdraw_from_available` group — all fourteen of its accounts, in order —
+    /// followed by the reserve-exit group and the event pair. So the first
+    /// fourteen slots of the longer instruction ARE the shorter one's, and every
+    /// index below is inside that shared prefix. Confirmed on the wire too: the
+    /// same wallet's withdraw from one vault, built both ways minutes apart,
+    /// resolves to identical pubkeys through slot 13 and first differs at 14.
+    ///
+    /// This is why one index map serves both. If it did not, the verify screen
+    /// would name a vault, a mint or a payout account that the instruction being
+    /// signed does not actually put there.
     enum KvaultWithdraw {
         static let user = 0
         static let vault = 1
@@ -249,6 +285,9 @@ enum KaminoInstructionAccounts {
         static let userShareAccount = 7
         static let sharesMint = 8
         static let minimumCount = 9
+        /// The number of accounts the two withdraw instructions share, and the
+        /// bound every index above must stay under.
+        static let sharedPrefixCount = 14
     }
 
     enum FarmsInitializeUser {

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/KaminoTransactionFixtures.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/KaminoTransactionFixtures.swift
@@ -329,6 +329,120 @@ enum KaminoTransactionFixtures {
         lookupTable: "7EzosNioQ6FDNvMKLfg6om5wTVHiJo9vVx7DZNGYBKU3"
     )
 
+    // MARK: - The two shapes a kVault withdraw arrives as
+
+    /// A withdraw captured as the API builds it TODAY, with the metadata needed
+    /// to check what its kVault instruction names.
+    ///
+    /// Separate from `Vector` because these have no `injected` counterpart: they
+    /// exist to pin WHICH instruction a withdraw is and which accounts it hands
+    /// it, not to pin the compute-budget edit, and inventing an injected form
+    /// here would assert this repository's own injector against itself.
+    struct WithdrawShape {
+        let name: String
+        /// The transaction exactly as `POST /ktx/kvault/withdraw` returned it.
+        let source: String
+        let owner: String
+        let vault: KaminoVaultDescriptor
+        let lookupTable: String
+        /// The `u64` the kVault instruction carries, in share base units.
+        let shareBaseUnits: UInt64
+        /// The Anchor discriminator its kVault instruction actually carries.
+        let discriminator: [UInt8]
+        /// Where in the instruction list the kVault instruction sits.
+        let kvaultPosition: Int
+    }
+
+    /// Captured 2026-08-17 from `api.kamino.finance` by building unsigned
+    /// transactions for third-party wallets — a POST and a decode. Nothing was
+    /// signed, nothing was broadcast, no funds moved.
+    ///
+    /// The point of the three together is the pair at the bottom. `withdraw` and
+    /// `withdraw_from_available` are two different instructions, and the app
+    /// reads both through ONE index map, so what has to be shown is that they
+    /// put the same accounts in the same slots. The RWA pair is the same wallet
+    /// and the same vault built minutes apart at two amounts, which isolates the
+    /// instruction choice from every other thing that could have moved.
+
+    /// The same wallet, vault and amount as `stakedWithdraw` — which the API
+    /// built as `withdraw` on 2026-08-05 — re-requested twelve days later and
+    /// built as `withdraw_from_available` instead. Nothing about the request
+    /// changed; the builder did.
+    static let steakhouseWithdrawFromAvailable = WithdrawShape(
+        name: "Steakhouse USDC farm-staked withdraw, served from available",
+        source: """
+            AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQAGCkz4SpXM\
+            eg7DW2ZzLbkMAlm0lEy/B1TiRwZqby23/jKmEZHG3rE/6w+tbzGqcJEiaHqq1pOV6hBzDAKRU/oz2gBP0vandYbwNC1pR0Jk5hEc\
+            RCdjUbAG+77T/irHPNQhwVKV1ablytlLnalT6Uu+r5A74BZTGAutrI1EFMK1BOlSAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\
+            AAAAAAAP2mzp9mGY3YcNiphvMGdcRvg+L1KDSHlS9dUFY+PveoyXJY9OJInxuz0QKRSODYMLWhOZ2v8QhASOe9jb6fhZmXEpeigA\
+            Qkk+QnGQx3tkfob30ZlyH9FWKZZcnWtllPjYsBAXY9PlHxJuYVbehd6MYTBZuERo0No/6KKiJRzHAQTZCvHbiTnsNf+U2WQNV9zD\
+            J5S7Phu2b9OuhJqE3NuUvfB1QgHnOYKe1dm5mlLjmGmkZq7fv9CfHPFdjPzILwMFBgYAAgAKBBsBAQgEAAEMCBhaX2sqzXwy4QAA\
+            AKHtzM4bwtMAAAAAAAAIBwABDAIPFBsIJGa7MdwkhEMGBgADABEEGwEBCRYAEwcOFwMRAgobGxoFCRIQCw0YFhkVEBODcJuq3CI5\
+            QEIPAAAAAAABgunUZsNGfS6ysNnMvrR72/SV7hwbtHfQ2q+tA1+n6+QKBTUxJS8yEwIJAQgzJxUECzcHAw==
+            """,
+        owner: "6BTaMq25LcNDTVhheUe9UyvwWgayqFv77njymVnG8SNy",
+        vault: KaminoVaultRegistry.steakhouseUSDC,
+        lookupTable: "9p2oT9J6BojHigd3V5qXzrwsQf4dtgMgLxtrzLVR3rwu",
+        shareBaseUnits: 1_000_000,
+        discriminator: KaminoInstructionDiscriminator.kvaultWithdrawFromAvailable,
+        kvaultPosition: 4
+    )
+
+    /// RWA USDC, 0.1 shares — small enough to come out of the vault's liquid
+    /// buffer.
+    static let rwaWithdrawFromAvailable = WithdrawShape(
+        name: "RWA USDC withdraw within the liquid buffer",
+        source: """
+            AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQAHDNoCv8wM\
+            ibw6Lr4BmZ1YTpOeVn/4S36DtYOGzRgDXOKyYzgVo8SCHv6vMZzmhFsM/xwo9ba+8DhruJa5obQssdqLHq0uF+eOhpzTo0NOxNMw\
+            qn/FcaYEsDHWG42IIXsccJMMviJpos8IjAJXhdQDhhXDZKlLvFULPKq22Z9VXpLV7o9xyh+eqw7KWuFQ+JBjQjBsqd8l556Z6qrD\
+            KvbXgCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/abOn2YZjdhw2KmG8wZ1xG+D4vUoNIeVL11QVj4+96KB9owf4c\
+            9rZFjmv6T/xyniO69oNYjHK6VyfK9vZER9SMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WZlxKXooAEJJPkJxkMd7ZH6G\
+            99GZch/RVimWXJ1rZZT42LAQF2PT5R8SbmFW3oXejGEwWbhEaNDaP+iioiUcxwEE2Qrx24k57DX/lNlkDVfcwyeUuz4btm/TroSa\
+            hNzblP+aTZHtgWqxCflIhg+zfXpPx8nqhtR4aUXtv/qOMPSRBQgGAAIAFQUfAQEKBAAEEwoYWl9rKs18MuEAAID2SuHHAi0VAAAA\
+            AAAACgcABBMCDB0fCCRmuzHcJIRDCAYAAQAXBR8BAQscABYJDhwBFwIVHx8eBgsQDRQSEQ8DGhkYGxgYBxATg3CbqtwiOaCGAQAA\
+            AAAAAe2fwxn34IL78QI/+BXzVcvhipsyGbV9meEtiYwh+T/eDAwSDzYQPBYLFAUBAggiHRgtBA0HAw==
+            """,
+        owner: "Fg2JxF1M8HLXqZ1ZBb1SrEXHsYjfrLMovxguep3YdR6Z",
+        vault: KaminoVaultRegistry.rwaUSDC,
+        lookupTable: "GzavHphVhGp9PERAfT3NcQwFesevQD386puHtVtsbq6m",
+        shareBaseUnits: 100_000,
+        discriminator: KaminoInstructionDiscriminator.kvaultWithdrawFromAvailable,
+        kvaultPosition: 4
+    )
+
+    /// The SAME wallet and vault, for its whole 22,319-share position — far more
+    /// than the buffer holds, so the builder has to exit a lending reserve and
+    /// emits `withdraw` rather than `withdraw_from_available`.
+    ///
+    /// This is what makes keeping the older discriminator a finding rather than
+    /// a precaution: it is not legacy, it is the large-withdraw path, and it is
+    /// live.
+    static let rwaReserveExitWithdraw = WithdrawShape(
+        name: "RWA USDC withdraw that must exit a reserve",
+        source: """
+            AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQAHDNoCv8wM\
+            ibw6Lr4BmZ1YTpOeVn/4S36DtYOGzRgDXOKyYzgVo8SCHv6vMZzmhFsM/xwo9ba+8DhruJa5obQssdqLHq0uF+eOhpzTo0NOxNMw\
+            qn/FcaYEsDHWG42IIXsccJMMviJpos8IjAJXhdQDhhXDZKlLvFULPKq22Z9VXpLV7o9xyh+eqw7KWuFQ+JBjQjBsqd8l556Z6qrD\
+            KvbXgCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/abOn2YZjdhw2KmG8wZ1xG+D4vUoNIeVL11QVj4+96KB9owf4c\
+            9rZFjmv6T/xyniO69oNYjHK6VyfK9vZER9SMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WZlxKXooAEJJPkJxkMd7ZH6G\
+            99GZch/RVimWXJ1rZZT42LAQF2PT5R8SbmFW3oXejGEwWbhEaNDaP+iioiUcxwEE2Qrx24k57DX/lNlkDVfcwyeUuz4btm/TroSa\
+            hNzblCOoFarHtwhoITtdC1PA4aJ57878mgrAsZc5ZYYKGAozBQgGAAIAGAUkAQEKBAAEFQoYWl9rKs18MuEAAACPV2GcYhbYHUgA\
+            AAAACgcABBUCDCEkCCRmuzHcJIRDCAYAAQAaBSQBAQsnABkJDx8BGgIYJCQiBgsZFg0bIBIXJCMGCxEOFhQTEAMdHBseGxsHELcS\
+            RpyUbaEiwOlQMgUAAAAB7Z/DGffggvvxAj/4FfNVy+GKmzIZtX2Z4S2JjCH5P94PDBUSDzYQJTwWCxQnBQECCiIdGC0EKQ0HCAM=
+            """,
+        owner: "Fg2JxF1M8HLXqZ1ZBb1SrEXHsYjfrLMovxguep3YdR6Z",
+        vault: KaminoVaultRegistry.rwaUSDC,
+        lookupTable: "GzavHphVhGp9PERAfT3NcQwFesevQD386puHtVtsbq6m",
+        shareBaseUnits: 22_319_000_000,
+        discriminator: KaminoInstructionDiscriminator.kvaultWithdraw,
+        kvaultPosition: 4
+    )
+
+    /// The two shapes of the SAME withdraw, in the order they must agree in.
+    static let withdrawShapePair: (available: WithdrawShape, reserveExit: WithdrawShape) =
+        (rwaWithdrawFromAvailable, rwaReserveExitWithdraw)
+
     static let all: [Vector] = [
         usdcDeposit,
         solDeposit,
@@ -357,6 +471,74 @@ enum KaminoTransactionFixtures {
     /// nothing; resolving both sides through the real table shows the edit
     /// preserved the account *pubkeys* every instruction receives.
     static let lookupTables: [String: [String]] = [
+        "GzavHphVhGp9PERAfT3NcQwFesevQD386puHtVtsbq6m": [
+            "CPpw5U5iwkWYoAVPJ9NfBkDtWFehADZfmbXTFP3idtLD",
+            "DWSXb18xZApz29vnQpgR2m6MynCT7PznaXt7Ut7M7KaP",
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "D6hDbSjooxfjXrfKo7xBKVFeoaJrtnXY75uAbxeFbPgU",
+            "DgHN3q3dSYAchNX7V3D4aYiTWMx8RHTgHbfPiwiqBkE9",
+            "SysvarRent111111111111111111111111111111111",
+            "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD",
+            "Sysvar1nstructions1111111111111111111111111",
+            "9F4DocmnddboTZjcdnScq5346KDpgGa3hzx1S9a3L1YK",
+            "6UodrBjL2ZreDy7QdR4YV1oxqMBjVYSEyrFpctqqwGwL",
+            "ArwyAHmnFmbKbUxC2fnK5VUEpspHrnoFtJ22bvEyriKk",
+            "232RETZLCkPninSdSDcVPmzpX5vD541xnnC2nbNuqDsw",
+            "HJs6CeLJfy3jj7BgzieK2kqaQAuuMbkcHaAGksdQ9NDn",
+            "5WodE5oHa6Uy16zg4eTep9t6DqJKx7jFN6bomAm7bVQv",
+            "6ea6GorjfT2SmUH8HSwg4LLae5RCqVVEYzcznBJEge9e",
+            "6XdN3zXeoYKgfSeZb8h1LpiEkUXRJ3CbimE5FJ35XFBP",
+            "5BDugAB1RXHkxFhL1oye4o2zbu8j8uHb3xDrzm4Evvuv",
+            "4QKFoFDzNFnvfkzVazABbCEfMwd3y1pZqUVzmpnkCphj",
+            "4Q9daJeraPU7JCzWv6tcb9XiJpAJrTX9rTStckCdM6HA",
+            "AYL4LMc4ZCVyq3Z7XPJGWDM4H9PiWjqXAAuuHBEGVR2Z",
+            "4cjKhMGtDhQgtZqjojkwE1899h1q4X1Arx8fT6gEQGDg",
+            "9GJ9GBRwCp4pHmWrQ43L5xpc9Vykg7jnfwcFGN8FoHYu",
+            "vza1i5NBUTFKgCPGbETeBZWLRZmnKWBEGUPDkitLPBa",
+            "9Y7uwXgQ68mGqRtZfuFaP4hc4fxeJ7cE9zTtqTxVhfGU",
+            "EetQRys9azm1GsK476sr3R3W2hw79eUbBCmvGt83LoNc",
+            "4mZ3qoCZa35TYd6qc73CfDZkP6U7WnvGVeKeCaNQ5wZG",
+            "GresxT3Ditj5N9sHi6qTBoy96tctJ4HknUX2tCMiri3M",
+            "3RKnGEmHto1N6keVvLkXkSrG4KytUjuLvvhAYpbLQUh9",
+            "52FSGeeokLpgvgAMdqxyt5Hoc2TbUYj5b8yxrEdZ37Vf",
+            "2yuyM9BiAZfYaQqxiknRyzRrcLMVkW7ztVc2Fzbuqq7n",
+            "GJhiSVVBERAizvJkVcQXY35utyi4homJ8JxrnwHJGxeC",
+            "UBSsE59MB1TKtADobD8spRgMGhMFoYaLDmkN3MFQmkp",
+            "6TYhz24fBMDEmD1bDqHb9EYTCWQtYZdeekXojPiV4K3A",
+            "47tfyEG9SsdEnUm9cw5kY9BXngQGqu3LBoop9j5uTAv8",
+            "GNcywqL6AZajsyyitxGQUvbihPgAzGZUqKfjYcvTj2pi",
+            "7vNfe1qX8iDxP5p3A4fosrjLqdn1YjmmGcZZkG2b4APF",
+            "8BkQTZsT8ssKMU643De4iiV5Wf3pENdUFTsdtHPueKjB",
+            "5iLRav31Y7DJwM6bZ7s92jqvV3zd1wZMcp4mYeKXh8cj",
+            "DBieuGmP1xh36oZRwTtw722yJ8pzZ8wycYD9nY2BSxwn",
+            "6aTxdy7Hg7MHtE8NDBZWxxw9tnpj56XmdoCpkf8g2hxZ",
+            "FsvTiXTUFDc4aLbrov4PrvDTjXCWCniL1dxTUkZ1T2ss",
+            "9Q31s4yVMXXsSWJyzNNReLH76nZqzHpFmWJUTEFZxAoJ",
+            "3LehT54KD2qUiCvTS3EW49HrWzUw4YcPbkHfg1sXp6TV",
+            "B5WhxpGmV5BfJnRBpB93dMSePHtttFySJ4dcAZ9YzYYc",
+            "CqAoLuqWtavaVE8deBjMKe8ZfSt9ghR6Vb8nfsyabyHA",
+            "HqEqwkTmqCAVEQQaEBuSSGD2EAvcorFogqhZz46TYJyz",
+            "H6JUwz8c61eQnYUx8avGXydKztKPyGvgWAUjmZUPS3BC",
+            "BzSw9sWTxUumr2wHhDiezkaLy3QZQS1KT4a9Fz8GvAQ6",
+            "DKaVQFXD6Qz4USTkRWyPun3oU6r1RfYsWJ8YqLpnSnN5",
+            "CtgiQTkAQp8h1ayqdE21Cr56qekdqeQ19da3j1KLgSUn",
+            "9SLBVnPz8dRGvafST6zNBZYSSt3HtdU68XQLGR13t3uM",
+            "2vxWpj2yE6JGQdcvyVEiDRBtLXfovnqxsnjtS6AjdKWX",
+            "CzEcTo66owDYLH1ieFR64u4gV5YT3FSLEg8G61nAvuP1",
+            "6kmkjcVrp7RfyRBrfCoKbe6Wss3urVaaB1Lez5kSNHd1",
+            "4USKstZaYG9Jj5HZxib6Ttzxw1mBMs1XnvHq1Teh9zZe",
+            "DJAA9btNhDbU8bAUfxWzZ3L8Ap9FLqhxaCPRerC9WRee",
+            "C58hPXv85vAMfFrbjBwrpUV8rKfNxVdAS91W25sNdjbm",
+            "GLCsvVJu2FrjNMYH3VxwfwzuegTzmrSs4JfirKv2YGpb",
+            "9wH3XVuXzqEpgaaJBmCwZAxDKJJAFTdBriwYpGA189f2",
+            "8Lvi1DFPoAGPQ25qpRKzzRaSAnWdeVZqt9XmEapm8uLt",
+            "BQxSShgirmS8J3BTRJyNoG7tjeihqjjJziHSNbe6cm3b",
+            "CtczsMw1sw4xRkLJVvNUB5NAN5z8GFnyx5Vcwv2mYipH",
+            "Gr8af5L8JrCgaPubCQjAmG8X1ScNkmjnoZxtFBFsDqaJ",
+            "Gc5VL3SJb18t4QwssFkpXHpUvtKTsgYqgoovgyR5Qh9o",
+            "cTZhwaK4J39vYLuZZXYv74KJGLGUiBmnyyQyWkVpYq5"
+        ],
         "9p2oT9J6BojHigd3V5qXzrwsQf4dtgMgLxtrzLVR3rwu": [
             "sadmBTQm5HJsyzWHEjV4YwG9CiahZKVDVqAyS4Wx1zH",
             "HDsayqAsDWy3QvANGqh2yNraqcD8Fnjgh73Mhb3WRS5E",

--- a/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoTransactionValidatorTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoTransactionValidatorTests.swift
@@ -791,14 +791,22 @@ final class KaminoTransactionValidatorTests: XCTestCase {
 
     // MARK: - Discriminator provenance
 
-    /// The four Anchor discriminators are `sha256("global:<name>")[0..<8]`. Pinning
+    /// The five Anchor discriminators are `sha256("global:<name>")[0..<8]`. Pinning
     /// them against the hash rather than against the bytes that were observed
     /// means a typo in a constant that sizes or targets a transaction cannot
     /// survive to runtime.
+    ///
+    /// It does not, on its own, mean the app names the RIGHT instructions —
+    /// `kvaultWithdraw` was a correct hash of a name the API had stopped using.
+    /// That half is `KaminoWithdrawFromAvailableTests`, against captured bytes.
     func testAnchorDiscriminatorsMatchTheirInstructionNames() throws {
         let expectations: [(String, [UInt8])] = [
             ("global:deposit", KaminoInstructionDiscriminator.kvaultDeposit),
             ("global:withdraw", KaminoInstructionDiscriminator.kvaultWithdraw),
+            (
+                "global:withdraw_from_available",
+                KaminoInstructionDiscriminator.kvaultWithdrawFromAvailable
+            ),
             ("global:initialize_user", KaminoInstructionDiscriminator.farmsInitializeUser),
             ("global:stake", KaminoInstructionDiscriminator.farmsStake)
         ]

--- a/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoWithdrawFromAvailableTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoWithdrawFromAvailableTests.swift
@@ -259,6 +259,65 @@ final class KaminoWithdrawFromAvailableTests: XCTestCase {
         )
     }
 
+    // MARK: - Through the initiating device's validator
+
+    /// The check the initiating device makes before it signs, run over the bytes
+    /// as captured.
+    ///
+    /// It is the strongest statement available about the account map, and it is
+    /// a different statement from the decode: the validator resolves the address
+    /// lookup table and compares the authority, the vault, both mints, the payout
+    /// account and the share source against the request it is answering — so it
+    /// fails if any of those slots holds something other than what the app says
+    /// it holds. Both instructions, so the claim covers both.
+    func testEveryCapturedShapeValidatesAgainstTheRequestItAnswers() throws {
+        for shape in Self.shapes {
+            try KaminoTransactionValidator.validate(
+                transaction: try SolanaV0Transaction(base64Transaction: shape.source),
+                intent: Self.intent(for: shape),
+                lookupTables: KaminoTransactionFixtures.lookupTables
+            )
+        }
+    }
+
+    /// And it refuses one whose share source has been repointed at the payout
+    /// account — so the acceptance above is the map being checked, not the map
+    /// being ignored.
+    ///
+    /// The expected error is asserted WHOLE, role and address, rather than
+    /// "something threw". A refusal for an unrelated reason would keep a test
+    /// that only asked for a throw green while proving nothing about slot 7, and
+    /// slot 7 is the account the shares come out of. The mutation swaps two
+    /// account indices the message already carries, so nothing about its length
+    /// or structure changes and there is no parse failure to hide behind.
+    func testAWithdrawWhoseShareSourceWasRepointedIsRefusedOnThatSlot() throws {
+        let shape = KaminoTransactionFixtures.steakhouseWithdrawFromAvailable
+        var mutated = try MutableTransaction(base64: shape.source)
+        let layout = KaminoInstructionAccounts.KvaultWithdraw.self
+        let instruction = mutated.instructions[shape.kvaultPosition]
+        let payoutIndex = instruction.accounts[layout.userTokenAccount]
+        XCTAssertNotEqual(payoutIndex, instruction.accounts[layout.userShareAccount])
+        mutated.instructions[shape.kvaultPosition].accounts[layout.userShareAccount] = payoutIndex
+
+        let transaction = try SolanaV0Transaction(base64Transaction: try mutated.base64())
+        let payout = try transaction.resolvedAccountAddresses(
+            lookupTables: KaminoTransactionFixtures.lookupTables
+        )[Int(payoutIndex)]
+
+        XCTAssertThrowsError(
+            try KaminoTransactionValidator.validate(
+                transaction: transaction,
+                intent: Self.intent(for: shape),
+                lookupTables: KaminoTransactionFixtures.lookupTables
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? KaminoValidationError,
+                .accountNotOwnedByUser(role: "withdraw share source", actual: payout)
+            )
+        }
+    }
+
     // MARK: - Still fail-closed
 
     /// Widening the set of accepted discriminators is not the same as accepting
@@ -310,6 +369,50 @@ final class KaminoWithdrawFromAvailableTests: XCTestCase {
 
     private static func anchorDiscriminator(_ name: String) -> [UInt8] {
         [UInt8](SHA256.hash(data: Data("global:\(name)".utf8)).prefix(8))
+    }
+
+    /// The request each capture answers. Every one is a whole-position holder
+    /// withdrawing from a farm-staked balance, so the unstaked half is zero and
+    /// the farms pair is required — which is what the API built.
+    ///
+    /// Only the live fields are supplied; the mints, their decimals and the farm
+    /// come from the registry, which is the point of pinning them there.
+    private static func intent(
+        for shape: KaminoTransactionFixtures.WithdrawShape
+    ) -> KaminoTransactionIntent {
+        let descriptor = shape.vault
+        return KaminoTransactionIntent(
+            operation: .withdraw(
+                KaminoWithdrawRequest(
+                    shares: KaminoShareAmount(
+                        baseUnits: BigInt(shape.shareBaseUnits),
+                        decimals: descriptor.sharesDecimals
+                    ),
+                    unstakedShares: KaminoShareAmount(
+                        baseUnits: BigInt(0),
+                        decimals: descriptor.sharesDecimals
+                    )
+                )
+            ),
+            vault: KaminoVaultInfo(
+                descriptor: descriptor,
+                name: descriptor.fallbackName,
+                minDeposit: KaminoTokenAmount(
+                    baseUnits: BigInt(100_000),
+                    decimals: descriptor.tokenDecimals
+                ),
+                minWithdraw: KaminoShareAmount(
+                    baseUnits: BigInt(1_000),
+                    decimals: descriptor.sharesDecimals
+                ),
+                lookupTable: shape.lookupTable,
+                apy30d: Decimal(string: "0.0391") ?? .zero,
+                tokensPerShare: KaminoRate(apiString: "1.0536041812651029025")
+                    ?? KaminoRate(apiString: "1")!,
+                tokenPriceUsd: 1
+            ),
+            owner: shape.owner
+        )
     }
 
     private static func kvaultInstruction(

--- a/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoWithdrawFromAvailableTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoWithdrawFromAvailableTests.swift
@@ -1,0 +1,347 @@
+//
+//  KaminoWithdrawFromAvailableTests.swift
+//  VultisigAppTests
+//
+//  A withdraw does not arrive as one instruction. It arrives as EITHER
+//  `kvault::withdraw` or `kvault::withdraw_from_available`, and which one is a
+//  fact about the vault's liquid buffer at the moment the API builds it.
+//
+//  The app knew only the first, so every withdraw decoded to nothing and the
+//  verify screen refused to describe bytes it was being asked to co-sign. These
+//  tests pin both — and, because the two are genuinely different instructions
+//  read through ONE account index map, they pin the thing that makes sharing the
+//  map legitimate rather than convenient: the two put the same accounts in the
+//  same slots for every slot the app reads.
+//
+//  Three vectors, captured 2026-08-17 from `api.kamino.finance` by POSTing
+//  `/ktx/kvault/withdraw` for third-party wallets and decoding the reply. The
+//  API builds UNSIGNED transactions for any address: nothing was signed, nothing
+//  was broadcast, no funds moved.
+//
+
+import BigInt
+import CryptoKit
+@testable import VultisigApp
+import XCTest
+
+final class KaminoWithdrawFromAvailableTests: XCTestCase {
+
+    // MARK: - The discriminators are derived, not pasted
+
+    /// Both kVault withdraw discriminators, recomputed from the instruction NAME
+    /// with a hash implementation the app does not use.
+    ///
+    /// The derivation is the identification. A constant lifted out of a captured
+    /// transaction matches the bytes it was lifted from and says nothing about
+    /// what they are; one that equals `sha256("global:<name>")[0..<8]` says the
+    /// bytes are that instruction. This is the check the original constant never
+    /// had a partner for — it was right about `withdraw` and simply named the
+    /// wrong instruction.
+    func testBothWithdrawDiscriminatorsAreTheirAnchorNames() {
+        XCTAssertEqual(
+            KaminoInstructionDiscriminator.kvaultWithdraw,
+            Self.anchorDiscriminator("withdraw")
+        )
+        XCTAssertEqual(
+            KaminoInstructionDiscriminator.kvaultWithdrawFromAvailable,
+            Self.anchorDiscriminator("withdraw_from_available")
+        )
+        XCTAssertEqual(
+            KaminoInstructionDiscriminator.kvaultDeposit,
+            Self.anchorDiscriminator("deposit")
+        )
+    }
+
+    /// Three kVault instructions, three distinct eight-byte prefixes. A collision
+    /// would make one of them unreachable and the other a liar.
+    func testTheKvaultDiscriminatorsAreDistinct() {
+        let discriminators = [
+            KaminoInstructionDiscriminator.kvaultDeposit,
+            KaminoInstructionDiscriminator.kvaultWithdraw,
+            KaminoInstructionDiscriminator.kvaultWithdrawFromAvailable
+        ]
+        XCTAssertEqual(Set(discriminators.map { Data($0) }).count, discriminators.count)
+        for discriminator in discriminators {
+            XCTAssertEqual(discriminator.count, 8)
+        }
+    }
+
+    // MARK: - The captured bytes carry what the constants claim
+
+    /// Read out of the wire, not out of the enum: each captured transaction's
+    /// kVault instruction carries the discriminator its shape says it should,
+    /// and the `u64` share argument the request asked for.
+    func testEveryCapturedShapeCarriesTheDiscriminatorAndAmountItClaims() throws {
+        for shape in Self.shapes {
+            let instruction = try Self.kvaultInstruction(of: shape)
+            XCTAssertEqual(
+                Array(instruction.data.prefix(8)),
+                shape.discriminator,
+                shape.name
+            )
+            XCTAssertEqual(
+                KaminoInstructionDiscriminator.anchorArgument(instruction.data),
+                shape.shareBaseUnits,
+                shape.name
+            )
+        }
+    }
+
+    /// And the sequence walker calls every one of them a vault withdraw. This is
+    /// the step that used to return `nil`, which is where the whole failure
+    /// started.
+    func testEveryCapturedShapeIsRecognisedAsAVaultWithdraw() throws {
+        for shape in Self.shapes {
+            let kinds = try Self.kinds(of: shape.source)
+            XCTAssertEqual(
+                kinds,
+                [.createTokenAccount, .farmsUnstake, .farmsWithdrawUnstakedDeposits,
+                 .createTokenAccount, .kvaultWithdraw],
+                shape.name
+            )
+        }
+    }
+
+    /// The whole point of the fix, end to end: the offline decode a co-signer
+    /// runs now describes these transactions instead of refusing them.
+    func testTheOfflineDecodeReadsEveryCapturedShape() throws {
+        for shape in Self.shapes {
+            let decoded = try XCTUnwrap(
+                KaminoTransactionDecoder.decode(rawTransactions: [shape.source]),
+                shape.name
+            )
+            XCTAssertEqual(decoded.operation, .withdraw, shape.name)
+            XCTAssertEqual(decoded.descriptor, shape.vault, shape.name)
+            XCTAssertEqual(decoded.amountBaseUnits, BigInt(shape.shareBaseUnits), shape.name)
+            XCTAssertEqual(decoded.signer, shape.owner, shape.name)
+            XCTAssertFalse(decoded.withdrawsEntirePosition, shape.name)
+            XCTAssertNil(decoded.priorityFee, shape.name)
+        }
+    }
+
+    /// The exact pair of answers the verify screen keys `.unreadable` off.
+    ///
+    /// It reaches that state when the bytes DO invoke the kVaults program and the
+    /// decode still returns nothing — which is precisely what every one of these
+    /// used to do. Asserting both halves says the fix removed the refusal rather
+    /// than removing the recognition.
+    func testTheseAreTheBytesTheVerifyScreenUsedToCallUnreadable() throws {
+        for shape in Self.shapes {
+            let transaction = try SolanaV0Transaction(base64Transaction: shape.source)
+            XCTAssertTrue(KaminoTransactionDecoder.invokesKaminoVault(transaction), shape.name)
+            XCTAssertNotNil(KaminoTransactionDecoder.decode(transaction), shape.name)
+        }
+    }
+
+    // MARK: - Why one account map may serve two instructions
+
+    /// The load-bearing check.
+    ///
+    /// `withdraw` and `withdraw_from_available` are different instructions with
+    /// different account counts, and the app reads both through
+    /// `KaminoInstructionAccounts.KvaultWithdraw`. If their orderings differed,
+    /// the verify screen would name a vault, a mint or a payout account that the
+    /// instruction being signed does not put there — which is worse than the
+    /// refusal this change removes.
+    ///
+    /// They do not differ. The program's IDL declares `withdraw`'s accounts as
+    /// the `withdraw_from_available` group followed by the reserve-exit group, so
+    /// the first fourteen are shared by construction. Here that is checked
+    /// against the wire, by PUBKEY, on one wallet's withdraw from one vault built
+    /// both ways minutes apart — which leaves the instruction choice as the only
+    /// difference between the two.
+    func testTheTwoWithdrawInstructionsAgreeOnEverySharedSlot() throws {
+        let pair = KaminoTransactionFixtures.withdrawShapePair
+        let available = try Self.resolvedKvaultAccounts(of: pair.available)
+        let reserveExit = try Self.resolvedKvaultAccounts(of: pair.reserveExit)
+
+        let shared = KaminoInstructionAccounts.KvaultWithdraw.sharedPrefixCount
+        XCTAssertGreaterThanOrEqual(available.count, shared)
+        XCTAssertGreaterThanOrEqual(reserveExit.count, shared)
+        XCTAssertEqual(
+            Array(available.prefix(shared)),
+            Array(reserveExit.prefix(shared)),
+            "the two withdraw instructions must name the same accounts in the shared prefix"
+        )
+
+        // And they are not simply the same instruction twice: the longer one
+        // carries the reserve-exit group, which is where they part.
+        XCTAssertNotEqual(available.count, reserveExit.count)
+        XCTAssertNotEqual(available[shared], reserveExit[shared])
+    }
+
+    /// Every index the app actually reads lies inside that shared prefix. This is
+    /// what turns the agreement above into permission to share the map: a later
+    /// index added below `sharedPrefixCount` would be read out of a region the
+    /// two instructions are not known to agree on, and this fails then.
+    func testEveryIndexTheAppReadsLiesInsideTheSharedPrefix() {
+        let indexes = [
+            KaminoInstructionAccounts.KvaultWithdraw.user,
+            KaminoInstructionAccounts.KvaultWithdraw.vault,
+            KaminoInstructionAccounts.KvaultWithdraw.userTokenAccount,
+            KaminoInstructionAccounts.KvaultWithdraw.tokenMint,
+            KaminoInstructionAccounts.KvaultWithdraw.userShareAccount,
+            KaminoInstructionAccounts.KvaultWithdraw.sharesMint
+        ]
+        for index in indexes {
+            XCTAssertLessThan(index, KaminoInstructionAccounts.KvaultWithdraw.sharedPrefixCount)
+        }
+        XCTAssertLessThanOrEqual(
+            KaminoInstructionAccounts.KvaultWithdraw.minimumCount,
+            KaminoInstructionAccounts.KvaultWithdraw.sharedPrefixCount
+        )
+    }
+
+    /// The slots are not merely equal to each other — they hold what the app says
+    /// they hold, resolved through the real lookup table and compared against the
+    /// pinned registry and a locally derived associated token account.
+    ///
+    /// Both instructions, because "the map is right for `withdraw`" and "the map
+    /// is right for `withdraw_from_available`" are two claims.
+    func testBothInstructionsNameTheVaultTheMintsAndTheSignersOwnAccounts() throws {
+        let pair = KaminoTransactionFixtures.withdrawShapePair
+        for shape in [pair.available, pair.reserveExit] {
+            let accounts = try Self.resolvedKvaultAccounts(of: shape)
+            let layout = KaminoInstructionAccounts.KvaultWithdraw.self
+
+            XCTAssertEqual(accounts[layout.user], shape.owner, shape.name)
+            XCTAssertEqual(accounts[layout.vault], shape.vault.address, shape.name)
+            XCTAssertEqual(accounts[layout.tokenMint], shape.vault.tokenMint, shape.name)
+            XCTAssertEqual(accounts[layout.sharesMint], shape.vault.sharesMint, shape.name)
+            XCTAssertTrue(
+                SolanaAssociatedTokenAccount
+                    .ownedAccounts(owner: shape.owner, mint: shape.vault.sharesMint)
+                    .contains(accounts[layout.userShareAccount]),
+                shape.name
+            )
+            XCTAssertTrue(
+                SolanaAssociatedTokenAccount
+                    .ownedAccounts(owner: shape.owner, mint: shape.vault.tokenMint)
+                    .contains(accounts[layout.userTokenAccount]),
+                shape.name
+            )
+        }
+    }
+
+    /// The same request, built twelve days apart, switched instruction without
+    /// changing a single account it hands it.
+    ///
+    /// `stakedWithdraw` was captured on 2026-08-05 as `withdraw`;
+    /// `steakhouseWithdrawFromAvailable` is the same wallet, vault and one-share
+    /// amount re-requested on 2026-08-17 and built as `withdraw_from_available`.
+    /// So the drift that broke the decoder is recorded here as the API change it
+    /// was, not as a constant that had always been wrong.
+    func testTheSameRequestSwitchedInstructionButNotItsAccounts() throws {
+        let legacy = try SolanaV0Transaction(
+            base64Transaction: KaminoTransactionFixtures.stakedWithdraw.source
+        )
+        let legacyAccounts = try legacy.resolvedAccountAddresses(
+            lookupTables: KaminoTransactionFixtures.lookupTables
+        )
+        let legacyInstruction = legacy.instructions[4]
+        XCTAssertEqual(
+            Array(legacyInstruction.data.prefix(8)),
+            KaminoInstructionDiscriminator.kvaultWithdraw
+        )
+
+        let current = KaminoTransactionFixtures.steakhouseWithdrawFromAvailable
+        let currentAccounts = try Self.resolvedKvaultAccounts(of: current)
+
+        XCTAssertEqual(
+            legacyInstruction.accountIndexes
+                .prefix(KaminoInstructionAccounts.KvaultWithdraw.sharedPrefixCount)
+                .map { legacyAccounts[Int($0)] },
+            Array(currentAccounts.prefix(KaminoInstructionAccounts.KvaultWithdraw.sharedPrefixCount))
+        )
+        XCTAssertEqual(
+            KaminoInstructionDiscriminator.anchorArgument(legacyInstruction.data),
+            current.shareBaseUnits
+        )
+    }
+
+    // MARK: - Still fail-closed
+
+    /// Widening the set of accepted discriminators is not the same as accepting
+    /// whatever the kVault program is asked to do. A third one is still nothing
+    /// this decoder will describe.
+    func testAnUnrecognisedKvaultInstructionIsStillRefused() throws {
+        let shape = KaminoTransactionFixtures.steakhouseWithdrawFromAvailable
+        var mutated = try MutableTransaction(base64: shape.source)
+        // `kvault::deposit_with_min_shares_out` — a real instruction of the same
+        // program that this app never asks for.
+        mutated.instructions[shape.kvaultPosition].data.replaceSubrange(
+            0..<8,
+            with: Self.anchorDiscriminator("deposit_with_min_shares_out")
+        )
+        let refused = try mutated.base64()
+
+        XCTAssertNil(KaminoTransactionDecoder.decode(rawTransactions: [refused]))
+        XCTAssertNotNil(KaminoTransactionDecoder.decode(rawTransactions: [shape.source]))
+    }
+
+    /// A single flipped byte in the discriminator is not "close enough" either.
+    func testAOneByteDiscriminatorEditIsRefused() throws {
+        let shape = KaminoTransactionFixtures.steakhouseWithdrawFromAvailable
+        var mutated = try MutableTransaction(base64: shape.source)
+        mutated.instructions[shape.kvaultPosition].data[0] ^= 0x01
+        XCTAssertNil(KaminoTransactionDecoder.decode(rawTransactions: [try mutated.base64()]))
+    }
+
+    /// The deposit discriminator is untouched by all of this, and a deposit is
+    /// still read as a deposit rather than folded into the withdraw branch.
+    func testTheDepositPathIsUnaffected() throws {
+        let decoded = try XCTUnwrap(
+            KaminoTransactionDecoder.decode(
+                rawTransactions: [KaminoTransactionFixtures.usdcDeposit.source]
+            )
+        )
+        XCTAssertEqual(decoded.operation, .deposit)
+    }
+
+    // MARK: - Helpers
+
+    private static var shapes: [KaminoTransactionFixtures.WithdrawShape] {
+        [
+            KaminoTransactionFixtures.steakhouseWithdrawFromAvailable,
+            KaminoTransactionFixtures.rwaWithdrawFromAvailable,
+            KaminoTransactionFixtures.rwaReserveExitWithdraw
+        ]
+    }
+
+    private static func anchorDiscriminator(_ name: String) -> [UInt8] {
+        [UInt8](SHA256.hash(data: Data("global:\(name)".utf8)).prefix(8))
+    }
+
+    private static func kvaultInstruction(
+        of shape: KaminoTransactionFixtures.WithdrawShape
+    ) throws -> SolanaV0Transaction.Instruction {
+        let transaction = try SolanaV0Transaction(base64Transaction: shape.source)
+        return transaction.instructions[shape.kvaultPosition]
+    }
+
+    /// The kVault instruction's accounts as PUBKEYS, with the lookup table
+    /// resolved. An account index is only a position; comparing indices across
+    /// two different transactions would compare nothing.
+    private static func resolvedKvaultAccounts(
+        of shape: KaminoTransactionFixtures.WithdrawShape
+    ) throws -> [String] {
+        let transaction = try SolanaV0Transaction(base64Transaction: shape.source)
+        let accounts = try transaction.resolvedAccountAddresses(
+            lookupTables: KaminoTransactionFixtures.lookupTables
+        )
+        return transaction.instructions[shape.kvaultPosition].accountIndexes.map { accounts[Int($0)] }
+    }
+
+    private static func kinds(of base64: String) throws -> [KaminoInstructionSequence.Kind?] {
+        let transaction = try SolanaV0Transaction(base64Transaction: base64)
+        let accounts = transaction.staticAccountAddresses
+        return transaction.instructions.map { instruction in
+            let index = Int(instruction.programIdIndex)
+            guard accounts.indices.contains(index) else { return nil }
+            return KaminoInstructionSequence.kind(
+                program: KaminoSolanaProgram(programId: accounts[index]),
+                data: instruction.data
+            )
+        }
+    }
+}


### PR DESCRIPTION
> ⚠️ **This is a signing-path verify decoder.** It reads the raw bytes a user is
> about to co-sign and tells the verify screen what they do. It wants a human
> review and an on-device pass before merge. **Nothing was signed or broadcast in
> producing this change** — every capture below is a `POST` to
> `/ktx/kvault/withdraw`, which returns *unsigned* bytes for any address.

## Problem

`KaminoTransactionDecoder` could not read **any** Kamino Earn withdraw. The verify
screen showed

> These bytes call the Kamino vault program but could not be read as a deposit or
> a withdrawal. Do not sign them.

with Join disabled — on every device, whichever platform initiated, staked or
unstaked. Deposits were unaffected.

Nothing was ever at risk: the refusal is fail-closed and the bytes themselves are
correct. But the feature is unusable in the withdraw direction.

## Root cause

A kVault withdraw does not arrive as one instruction. It arrives as either
`kvault::withdraw` or `kvault::withdraw_from_available`, and which one depends on
whether the request fits the vault's liquid buffer.

| instruction | `sha256("global:<name>")[0..<8]` |
|---|---|
| `withdraw` | `b712469c946da122` — the only one the app knew |
| `withdraw_from_available` | `1383709baadc2239` — what the API builds today |
| `deposit` | `f223c68952e1f2b6` — unchanged, which is why deposits worked |

`KaminoInstructionSequence.kind(program:data:)` returned `nil` for the
unrecognised discriminator → `decode` found zero kVault positions → the
`vaultPositions.count == 1` guard failed → `nil` → `.unreadable`.

This is API drift, not a constant that was always wrong. The wiki's 2026-08-05
capture round recorded the kVault withdraw as `b712469c946da122` with 33
accounts; the *same* wallet, vault and amount re-requested on 2026-08-17 is
`1383709baadc2239` with 22.

## Fix

Accept **both** discriminators as the one existing `Kind.kvaultWithdraw`.

Collapsing them to a single `Kind` is deliberate. They are the same operation —
same `u64` shares argument, same authority, same share account burned, same
payout account credited — differing only in where the liquidity comes from, which
is a fact about the vault's balance sheet and not about what the user is being
asked to approve. A second `Kind` would need the step template to express
alternation (it cannot) and would fork `Layout(operation:)`, the validator's
dispatch and the paired-step machinery for a distinction the screen must not
draw.

`withdraw` is **kept**, not replaced — see below.

## What I proved about the `withdraw_from_available` account layout

This was the load-bearing risk: `KaminoInstructionAccounts.KvaultWithdraw` holds
positional indices (`user=0, vault=1, userTokenAccount=5, tokenMint=6,
userShareAccount=7, sharesMint=8`), and reusing them for a *different*
instruction would make the verify screen attest to accounts it has not proven —
worse than the refusal this removes.

**Four independent lines of evidence say the map transfers exactly.**

**1 — The program's IDL.** `src/idl/kvault.json` in `Kamino-Finance/klend-sdk`
(kamino_vault 2.2.2) declares `withdraw`'s accounts as a *nested group*:

| instruction | flattened accounts |
|---|---|
| `withdrawFromAvailable` | 14: `user, vaultState, globalConfig, tokenVault, baseVaultAuthority, userTokenAta, tokenMint, userSharesAta, sharesMint, tokenProgram, sharesTokenProgram, klendProgram, eventAuthority, program` |
| `withdraw` | 25: `withdrawFromAvailable.*` — the same 14, in the same order — then `withdrawFromReserveAccounts.*` (9), then `eventAuthority, program` |

So the shared prefix exists **by construction**, not by coincidence. The IDL's
names line up with the app's constants one for one, and every index the app reads
is ≤ 8.

**2 — A paired live capture.** Same wallet, same vault (RWA USDC), built minutes
apart at two amounts:

| amount | discriminator | instruction | accounts |
|---|---|---|---|
| `0.1` shares | `1383709baadc2239` | `withdraw_from_available` | 28 (14 + 14 remaining) |
| `22319` shares — the whole position | `b712469c946da122` | `withdraw` | 39 (25 + 14 remaining) |

Resolved through the address lookup table and compared **by pubkey**, the two
agree on slots 0–13 exactly and first diverge at slot 14 — precisely where the
IDL puts the reserve group. The trailing 14 `remaining_accounts` are identical
too. Slot 1 resolves to the RWA vault, slot 6 to the USDC mint, slot 8 to the RWA
shares mint, all matching `KaminoVaultRegistry`.

**3 — The builder's own branch.** `buildShareExitIxs` in klend-sdk picks
`withdrawFromAvailableIxs` when nothing has to come out of the reserves and
otherwise builds `withdrawIx`. That is why `withdraw` is kept: it is not legacy,
it is the exceeds-the-buffer path, and capture 2 above shows it live today.

**4 — Codex, independently.** The read-only review round corroborated the
ordering from Kamino's *program source* (`handler_withdraw.rs`) rather than from
the SDK's IDL copy, and confirmed nothing downstream branches on the raw
discriminator.

### What I did NOT prove

- **A withdraw that must exit MORE THAN ONE reserve.** `buildReserveExitIxs`
  loops over the reserves in the liquidity plan and emits one `withdraw` per
  reserve. The decoder's `vaultPositions.count == 1` guard refuses that, and the
  step template names only one `kvaultWithdraw` — so such a transaction stays
  **unreadable**, fail-closed, exactly as it is today and no worse than before
  this change. Left alone deliberately: summarising N instructions as one amount
  is a claim the screen has never made and needs its own design. Not observed in
  any capture — the 22,319-share whole-position withdraw above was still a single
  instruction.
- **Provenance of the checked-in captures.** As with any golden fixture, the
  base64 blobs and the lookup-table snapshot cannot prove *themselves*; they are
  inputs. Every assertion about them is against something else — a SHA-256
  derivation, the pinned registry, or a locally derived ATA.

## Tests

New `KaminoWithdrawFromAvailableTests` — 15 tests, all from captured bytes, none
built from the enum the production code reads:

- both withdraw discriminators recomputed from `sha256("global:<name>")` with
  **CryptoKit** (a different hash implementation from the app's), plus the
  deposit, plus distinctness;
- each capture's kVault instruction read off the wire: discriminator and `u64`
  share argument;
- `kind()` recognises all three; `decode` reads all three end-to-end (operation,
  descriptor, amount, signer);
- the pair `invokesKaminoVault == true` / `decode != nil` — the exact pair the
  screen keyed `.unreadable` off;
- **the shared-prefix proof**: both RWA captures resolved through the real lookup
  table agree on slots 0–13 by pubkey and differ at 14;
- **the guard on the map**: every index the app reads is `< sharedPrefixCount`,
  so adding one outside the proven region fails;
- both instructions name the vault, both mints and the signer's own ATAs;
- the 2026-08-05 `withdraw` and the 2026-08-17 `withdraw_from_available` for the
  same request carry the same accounts;
- all three run through `KaminoTransactionValidator` — the initiating device's
  pre-signing check, with the lookup table resolved;
- repointing the share source at the payout account is refused, asserting the
  whole `KaminoValidationError.accountNotOwnedByUser(role: "withdraw share
  source", actual:)` rather than "something threw";
- fail-closed preserved: a third real kVault discriminator and a one-byte edit
  are both still refused; the deposit path is untouched.

`KaminoTransactionValidatorTests.testAnchorDiscriminatorsMatchTheirInstructionNames`
extended to five names.

Three vectors added to `KaminoTransactionFixtures`, plus the RWA vault's lookup
table contents (read from mainnet 2026-08-17).

## Verification

| gate | result |
|---|---|
| full unit suite, iPhone 17 Pro Max sim | `** TEST SUCCEEDED **` — **6506 tests, 11 skipped, 0 failures** |
| swiftlint, 5 changed files | 0 violations |
| Codex read-only, 2 rounds | no production findings; 2 test-quality findings, both fixed |

Not yet run on device — please exercise a real Kamino withdraw on the verify
screen before merge.

Plan and full review ledger:
`wiki/pages/projects/vultisig/kamino-earn-5017/withdraw-discriminator-5182-plan.md`

Closes #5182


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for recognizing both Kamino vault withdrawal transaction variants.
  - Improved handling of withdrawals from available funds and reserve exits.
  - Enhanced transaction decoding and account resolution across both withdrawal paths.

- **Bug Fixes**
  - Improved validation for malformed or unrelated Kamino instructions.
  - Preserved existing deposit transaction handling while supporting the new withdrawal variant.

- **Tests**
  - Added comprehensive coverage for withdrawal decoding, validation, discriminator handling, and account compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->