### PR TITLE
fix(defi): withdraw the amount that was actually asked for, on every staked position

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/THORChainStakingService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/THORChainStakingService.swift
@@ -194,32 +194,6 @@ private extension THORChainStakingService {
         )
     }
 
-    /// ⚠️ **An address that holds no TCY stake is an ANSWER, not a failure.**
-    ///
-    /// THORNode answers `/thorchain/tcy_staker/<addr>` for a non-staker with a
-    /// **500** — `fail to tcy staker: TCYStaker doesn't exist: thor1…` — so
-    /// "you have no position" and "the node broke" arrive with the same status
-    /// code, and the body is the only thing separating them. Left to throw, the
-    /// interactor returns no positions, storage upserts nothing, and the card
-    /// keeps the balance the user just withdrew — the position reads as still
-    /// staked until something else happens to refresh it.
-    ///
-    /// Only the absence is swallowed. Every other failure still throws, because
-    /// the persisted row keeping its last good value is the right answer to a
-    /// read that did not happen, and zeroing a funded position on a transient
-    /// fault is the more expensive mistake — the same reasoning
-    /// `makeRujiStakingDetails` records for its own empty-versus-partial split.
-    func fetchTcyStakedAmount(address: String) async throws -> TcyStakerResponse {
-        let target = THORChainStakingAPI.getTcyStakedAmount(address: address)
-        do {
-            let response = try await httpClient.request(target, responseType: TcyStakerResponse.self)
-            return response.data
-        } catch {
-            guard Self.isTcyStakerAbsent(error) else { throw error }
-            return TcyStakerResponse(amount: "0")
-        }
-    }
-
     func fetchTcyUserDistributions(address: String) async throws -> TcyUserDistributionsResponse {
         let target = THORChainStakingAPI.getTcyUserDistributions(address: address)
         let response = try await httpClient.request(target, responseType: TcyUserDistributionsResponse.self)
@@ -474,6 +448,32 @@ enum StakingError: Error, LocalizedError {
 // MARK: - Reading THORNode's "no such staker"
 
 extension THORChainStakingService {
+
+    /// ⚠️ **An address that holds no TCY stake is an ANSWER, not a failure.**
+    ///
+    /// THORNode answers `/thorchain/tcy_staker/<addr>` for a non-staker with a
+    /// **500** — `fail to tcy staker: TCYStaker doesn't exist: thor1…` — so
+    /// "you have no position" and "the node broke" arrive with the same status
+    /// code, and the body is the only thing separating them. Left to throw, the
+    /// interactor returns no positions, storage upserts nothing, and the card
+    /// keeps the balance the user just withdrew — the position reads as still
+    /// staked until something else happens to refresh it.
+    ///
+    /// Only the absence is swallowed. Every other failure still throws, because
+    /// the persisted row keeping its last good value is the right answer to a
+    /// read that did not happen, and zeroing a funded position on a transient
+    /// fault is the more expensive mistake — the same reasoning
+    /// `makeRujiStakingDetails` records for its own empty-versus-partial split.
+    func fetchTcyStakedAmount(address: String) async throws -> TcyStakerResponse {
+        let target = THORChainStakingAPI.getTcyStakedAmount(address: address)
+        do {
+            let response = try await httpClient.request(target, responseType: TcyStakerResponse.self)
+            return response.data
+        } catch {
+            guard Self.isTcyStakerAbsent(error) else { throw error }
+            return TcyStakerResponse(amount: "0")
+        }
+    }
 
     /// Whether an error is THORNode saying the address holds no TCY stake.
     ///

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/THORChainStakingService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/THORChainStakingService.swift
@@ -194,10 +194,30 @@ private extension THORChainStakingService {
         )
     }
 
+    /// ⚠️ **An address that holds no TCY stake is an ANSWER, not a failure.**
+    ///
+    /// THORNode answers `/thorchain/tcy_staker/<addr>` for a non-staker with a
+    /// **500** — `fail to tcy staker: TCYStaker doesn't exist: thor1…` — so
+    /// "you have no position" and "the node broke" arrive with the same status
+    /// code, and the body is the only thing separating them. Left to throw, the
+    /// interactor returns no positions, storage upserts nothing, and the card
+    /// keeps the balance the user just withdrew — the position reads as still
+    /// staked until something else happens to refresh it.
+    ///
+    /// Only the absence is swallowed. Every other failure still throws, because
+    /// the persisted row keeping its last good value is the right answer to a
+    /// read that did not happen, and zeroing a funded position on a transient
+    /// fault is the more expensive mistake — the same reasoning
+    /// `makeRujiStakingDetails` records for its own empty-versus-partial split.
     func fetchTcyStakedAmount(address: String) async throws -> TcyStakerResponse {
         let target = THORChainStakingAPI.getTcyStakedAmount(address: address)
-        let response = try await httpClient.request(target, responseType: TcyStakerResponse.self)
-        return response.data
+        do {
+            let response = try await httpClient.request(target, responseType: TcyStakerResponse.self)
+            return response.data
+        } catch {
+            guard Self.isTcyStakerAbsent(error) else { throw error }
+            return TcyStakerResponse(amount: "0")
+        }
     }
 
     func fetchTcyUserDistributions(address: String) async throws -> TcyUserDistributionsResponse {
@@ -448,5 +468,31 @@ enum StakingError: Error, LocalizedError {
         case .missingData:
             return "Missing required staking data"
         }
+    }
+}
+
+// MARK: - Reading THORNode's "no such staker"
+
+extension THORChainStakingService {
+
+    /// Whether an error is THORNode saying the address holds no TCY stake.
+    ///
+    /// ⚠️ **Matched on the body's marker rather than on the status code**, and
+    /// deliberately not on the code alone: every server fault on this route is
+    /// also a 500, so keying on the status would turn an outage into a zeroed
+    /// position. The status is left out of the match entirely — the marker is
+    /// the signal, and requiring 500 beside it only adds a second thing that
+    /// can drift if THORNode ever answers this with a 404.
+    ///
+    /// It is a server-authored English string, so this is a narrow contract with
+    /// an upstream that has not promised to keep it. A spelling change costs the
+    /// stale card back, not a wrong balance.
+    static func isTcyStakerAbsent(_ error: Error) -> Bool {
+        guard case HTTPError.statusCode(_, let body) = error,
+              let body,
+              let text = String(data: body, encoding: .utf8) else {
+            return false
+        }
+        return text.contains("TCYStaker doesn't exist")
     }
 }

--- a/VultisigApp/VultisigApp/Components/Forms/AmountPercentageBinding.swift
+++ b/VultisigApp/VultisigApp/Components/Forms/AmountPercentageBinding.swift
@@ -1,0 +1,131 @@
+//
+//  AmountPercentageBinding.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// The conversion, both ways, between a token amount and the 0–100 percentage of
+/// a balance that a slider or percentage button shows for it.
+///
+/// It lives outside the view on purpose. `AmountTextField` owns this binding, but
+/// it is a SwiftUI view and this repo carries no view-inspection harness — so the
+/// arithmetic deciding what a withdrawal slider claims about the user's money
+/// would otherwise be unreachable from a test. It is also the formula the unstake
+/// view model falls back to when no percentage was chosen, and one shared
+/// definition is what keeps the figure the slider shows and the figure the
+/// transaction is built from from drifting apart.
+///
+/// ⚠️ **Not `PercentageAmountLogic`**, despite the similar name. That one serves
+/// the Send / Swap / Limit Swap "25 / 50 / 75 / 100%" presets: it works from
+/// `BigInt` base units, truncates to the asset's own precision, and only goes
+/// percentage → amount. This one serves the function-transaction amount field,
+/// works in `Decimal` against a human-readable balance, and is needed in both
+/// directions because the field has to answer "what percentage is this?" for a
+/// figure the user typed.
+enum AmountPercentageBinding {
+
+    /// How many decimals the function-transaction amount field renders, and
+    /// therefore the precision `AmountTextField.setupAmount()` writes when the
+    /// percentage control fills the field.
+    ///
+    /// Named rather than repeated because it is not only a display choice: a MAX
+    /// selection puts the balance TRUNCATED to this precision into the field, so
+    /// anything deciding "is this the whole position" has to know the figure it
+    /// is comparing against was rounded here. See
+    /// `ReceiptShareRedemption.isWholePosition`.
+    static let displayedDecimals = 4
+
+    /// The percentage of `available` that `amount` comes to, clamped to 0…100,
+    /// or `nil` when there is no balance to take a percentage of.
+    ///
+    /// ⚠️ **Lossy, and load-bearingly so.** The result is a `Double`, so a
+    /// fraction within about 1e-15 of the whole position comes back as exactly
+    /// `100`. When the field already held 100 that is not a change, SwiftUI emits
+    /// no `onChange`, and `UnstakeTransactionViewModel.onPercentage` never runs to
+    /// clear the MAX flag — leaving it stale-true over an amount the user meant to
+    /// be short of the balance. Nothing downstream may treat that flag as the sole
+    /// evidence of a full exit; see `ReceiptShareRedemption.baseUnits`.
+    ///
+    /// The clamp is load-bearing: the amount field accepts whatever is being
+    /// typed, including a figure above the balance (rejecting that is the
+    /// balance validator's job, and it has to let the value through to report
+    /// it). An unclamped result would drive the slider outside its own
+    /// `0...100` range.
+    static func percentage(ofAmount amount: Decimal, available: Decimal) -> Double? {
+        guard available > 0 else { return nil }
+        let ratio = (amount / available) * 100
+        let clamped = min(max(ratio, 0), 100)
+        return (clamped as NSDecimalNumber).doubleValue
+    }
+
+    /// The amount that `percentage` of `available` comes to.
+    static func amount(forPercentage percentage: Double, available: Decimal) -> Decimal {
+        available * (Decimal(percentage) / 100)
+    }
+}
+
+/// What the amount field should do in response to a change.
+enum AmountPercentageSyncAction: Equatable {
+    /// Recompute the amount from the percentage — the percentage is in charge.
+    case setAmountFromPercentage
+    /// Re-derive the percentage from the amount, leaving the amount untouched —
+    /// the typed amount is in charge.
+    case derivePercentageFromAmount
+    /// The change was this field's own echo. Do nothing.
+    case ignore
+}
+
+/// Which of the amount and the percentage is currently the source of truth in an
+/// amount field, and therefore which one a change is allowed to overwrite.
+///
+/// This exists as a separate value type so it can be tested. It is the part of
+/// `AmountTextField` most able to move money incorrectly — it decides whether a
+/// slider may overwrite a figure the user typed — and SwiftUI `@State` and
+/// `onChange` are not reachable from a unit test in this repo.
+///
+/// The field writes the percentage itself whenever the user types, which means it
+/// then sees its own write come back through the same `onChange` that a real
+/// slider interaction arrives on. Telling the two apart is the whole job:
+///
+/// - remembering only the derived VALUE is not enough. Once a real interaction
+///   has moved away from it, a later move *back* to that same value would be
+///   mistaken for the original echo — type the full balance, drag to 99%, drag
+///   back to 100%, and the amount would be left at 99% while the screen reported
+///   a MAX withdrawal. So a real interaction *spends* the remembered value.
+/// - remembering only "was it typed" is not enough either, because a derived
+///   percentage is `nil` when the balance has not loaded yet. Both facts are
+///   tracked, so an amount typed against an empty balance is still recognised as
+///   the user's when the balance arrives.
+struct AmountPercentageSync {
+    /// The percentage this field last derived from a typed amount. `nil` when
+    /// nothing has been derived, or when the balance was unavailable at the time.
+    private(set) var lastDerivedPercentage: Double?
+    /// Whether the amount currently in the field was typed rather than produced
+    /// by the percentage control.
+    private(set) var amountIsUserTyped = false
+
+    /// The user typed, and `percentage` is what that amount works out to.
+    mutating func amountWasTyped(derivingPercentage percentage: Double?) {
+        amountIsUserTyped = true
+        lastDerivedPercentage = percentage
+    }
+
+    /// The bound percentage changed. Returns whether that was a real interaction
+    /// with the slider or the buttons — and therefore whether it may rewrite the
+    /// amount — or this field's own derived write echoing back.
+    mutating func percentageChanged(to newValue: Double?) -> AmountPercentageSyncAction {
+        if amountIsUserTyped, newValue == lastDerivedPercentage {
+            return .ignore
+        }
+        amountIsUserTyped = false
+        lastDerivedPercentage = nil
+        return .setAmountFromPercentage
+    }
+
+    /// The available balance changed — typically an async read landing after the
+    /// screen opened. Whichever side the user owns is the side that survives.
+    func balanceChanged() -> AmountPercentageSyncAction {
+        amountIsUserTyped ? .derivePercentageFromAmount : .setAmountFromPercentage
+    }
+}

--- a/VultisigApp/VultisigApp/Components/Forms/AmountTextField.swift
+++ b/VultisigApp/VultisigApp/Components/Forms/AmountTextField.swift
@@ -28,6 +28,18 @@ struct AmountTextField<CustomView: View>: View {
     let customViewPosition: CustomViewPosition
     @State var amountInternal: String = ""
     @State var size: CGSize?
+    /// Which of the amount and the percentage the user currently owns.
+    ///
+    /// Typing used to blank the percentage outright. That left the slider reading
+    /// its `percentage ?? 100` fallback — a confident 100% sitting under an amount
+    /// the user had just typed as something else — and hid the percentage caption
+    /// entirely. Deriving the percentage instead re-opens the feedback loop the
+    /// blanking existed to prevent: a `percentage` change calls `setupAmount()`,
+    /// which would overwrite the half-typed amount with a rounded one on every
+    /// keystroke. `AmountPercentageSync` is what tells this field's own derived
+    /// write apart from a real slider interaction; the reasoning lives there, with
+    /// the tests.
+    @State private var sync = AmountPercentageSync()
 
     init(
         amount: Binding<String>,
@@ -127,17 +139,21 @@ struct AmountTextField<CustomView: View>: View {
         .onChange(of: amountInternal) { _, newValue in
             guard amount != newValue else { return }
             amount = newValue
-            percentage = nil
+            syncPercentage(toTypedAmount: newValue)
         }
         .onChange(of: amount) { _, newValue in
             amountInternal = newValue
         }
-        .onChange(of: percentage) { _, _ in
-            setupAmount()
+        .onChange(of: percentage) { _, newValue in
+            apply(sync.percentageChanged(to: newValue))
         }
         .onLoad { setupAmount() }
         .onChange(of: availableAmount) { _, _ in
-            setupAmount()
+            // A balance landing late must not overwrite a figure the user typed
+            // while waiting for it — re-derive the percentage against the new
+            // balance instead. Blanking the percentage used to give this for
+            // free, by making `setupAmount()` return early.
+            apply(sync.balanceChanged())
         }
         .readSize(onChange: { size = $0 })
     }
@@ -165,9 +181,28 @@ struct AmountTextField<CustomView: View>: View {
 
     func setupAmount() {
         guard let percentage else { return }
-        let multiplier = (Decimal(percentage) / 100)
-        let amountDecimal = availableAmount * multiplier
+        let amountDecimal = AmountPercentageBinding.amount(forPercentage: percentage, available: availableAmount)
         amount = amountDecimal.formatToDecimal(digits: decimals)
+    }
+
+    /// Points the percentage control at the amount that was just typed, so the
+    /// slider and the caption report the share of the balance actually being
+    /// acted on.
+    func syncPercentage(toTypedAmount typed: String) {
+        let derived = AmountPercentageBinding.percentage(ofAmount: typed.toDecimal(), available: availableAmount)
+        sync.amountWasTyped(derivingPercentage: derived)
+        percentage = derived
+    }
+
+    func apply(_ action: AmountPercentageSyncAction) {
+        switch action {
+        case .setAmountFromPercentage:
+            setupAmount()
+        case .derivePercentageFromAmount:
+            syncPercentage(toTypedAmount: amountInternal)
+        case .ignore:
+            break
+        }
     }
 
     @ViewBuilder

--- a/VultisigApp/VultisigApp/Components/Validators/WithdrawMinimumAmountValidator.swift
+++ b/VultisigApp/VultisigApp/Components/Validators/WithdrawMinimumAmountValidator.swift
@@ -1,0 +1,70 @@
+//
+//  WithdrawMinimumAmountValidator.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Rejects a withdrawal too small for a fractional-withdrawal memo to express.
+///
+/// `AmountBalanceValidator` already refuses zero, negative and over-balance
+/// amounts, but it has no idea the memo addresses the position in ten-thousandths
+/// (see `WithdrawBasisPoints`). A small *positive* amount clears it and then rounds
+/// away to a `:0` memo — a transaction that pays a fee to withdraw nothing. On the
+/// 2002.74 TCY position this was reported against, anything under about 0.20 TCY
+/// does that.
+///
+/// Paired with `AmountBalanceValidator` on the amount field, so the existing form
+/// machinery surfaces the message and blocks Continue rather than the builder
+/// silently returning `nil` and leaving a dead button.
+struct WithdrawMinimumAmountValidator: FormFieldValidator {
+    static let formatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.locale = Locale.current
+        return formatter
+    }()
+
+    /// Enough digits that the quoted minimum is a figure the user can actually
+    /// type, however small the position.
+    static let quotedDigits = 8
+
+    let available: Decimal
+    let ticker: String
+
+    enum ValidationError: LocalizedError {
+        case belowMinimum(minimum: String, ticker: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .belowMinimum(let minimum, let ticker):
+                return String(format: "withdrawBelowMinimum".localized, minimum, ticker)
+            }
+        }
+    }
+
+    func validate(value: String) throws {
+        // A value this validator cannot read is not its call to make —
+        // `AmountBalanceValidator` reports malformed input, and reporting it
+        // twice would put two different errors on one field.
+        guard
+            let number = Self.formatter.number(from: value),
+            let amount = Decimal(string: number.stringValue),
+            amount > 0,
+            available > 0
+        else {
+            return
+        }
+
+        // Compared against the EXACT threshold, quoted at display precision.
+        // Comparing against the rounded-up figure instead would make a position
+        // smaller than that figure impossible to close at all.
+        guard amount >= WithdrawBasisPoints.minimumAmount(forAvailable: available) else {
+            let quoted = WithdrawBasisPoints.quotedMinimum(forAvailable: available, digits: Self.quotedDigits)
+            throw ValidationError.belowMinimum(
+                minimum: quoted.formatToDecimal(digits: Self.quotedDigits),
+                ticker: ticker
+            )
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1779,6 +1779,7 @@
 "whitespaceNotAllowed" = "Leerzeichen sind nicht erlaubt.";
 "withdraw" = "Abheben";
 "withdrawAmount" = "%@ abheben";
+"withdrawBelowMinimum" = "Betrag zu klein — mindestens %@ %@ abheben";
 "withdrawBelowOutboundFee" = "Betrag unter Ausgangsgebühr — mindestens %@ %@ abheben, um Netzwerkkosten zu decken";
 "withdrawPercentage" = "Abhebungsprozentsatz";
 "withdrawRewards" = "%@-Belohnungen abheben";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1779,6 +1779,7 @@
 "whitespaceNotAllowed" = "Whitespace character is not allowed";
 "withdraw" = "Withdraw";
 "withdrawAmount" = "Withdraw %@";
+"withdrawBelowMinimum" = "Amount too small — withdraw at least %@ %@";
 "withdrawBelowOutboundFee" = "Amount below outbound fee — withdraw at least %@ %@ to cover network costs";
 "withdrawPercentage" = "Withdraw Percentage";
 "withdrawRewards" = "Withdraw %@ Rewards";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1779,6 +1779,7 @@
 "whitespaceNotAllowed" = "No se permiten espacios en blanco.";
 "withdraw" = "Retirar";
 "withdrawAmount" = "Retirar %@";
+"withdrawBelowMinimum" = "Monto demasiado pequeño — retira al menos %@ %@";
 "withdrawBelowOutboundFee" = "Monto por debajo de la tarifa de salida — retira al menos %@ %@ para cubrir los costos de red";
 "withdrawPercentage" = "Porcentaje de retiro";
 "withdrawRewards" = "Retirar recompensas de %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1779,6 +1779,7 @@
 "whitespaceNotAllowed" = "Karakter bijelog prostora nije dopušten";
 "withdraw" = "Povuci";
 "withdrawAmount" = "Podignite %@";
+"withdrawBelowMinimum" = "Iznos je premalen — podignite barem %@ %@";
 "withdrawBelowOutboundFee" = "Iznos ispod izlazne naknade — podignite barem %@ %@ za pokriće mrežnih troškova";
 "withdrawPercentage" = "Postotak povlačenja";
 "withdrawRewards" = "Povuci nagrade za %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1779,6 +1779,7 @@
 "whitespaceNotAllowed" = "I caratteri di spazio non sono consentiti.";
 "withdraw" = "Preleva";
 "withdrawAmount" = "Preleva %@";
+"withdrawBelowMinimum" = "Importo troppo piccolo — preleva almeno %@ %@";
 "withdrawBelowOutboundFee" = "Importo inferiore alla commissione in uscita — preleva almeno %@ %@ per coprire i costi di rete";
 "withdrawPercentage" = "Percentuale di prelievo";
 "withdrawRewards" = "Preleva ricompense di %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1779,6 +1779,7 @@
 "whitespaceNotAllowed" = "공백 문자는 허용되지 않습니다";
 "withdraw" = "출금";
 "withdrawAmount" = "%@ 출금";
+"withdrawBelowMinimum" = "금액이 너무 적음 — 최소 %@ %@을(를) 출금하세요";
 "withdrawBelowOutboundFee" = "출금 금액이 출금 수수료보다 낮음 — 네트워크 비용을 충당하려면 최소 %@ %@을(를) 출금하세요";
 "withdrawPercentage" = "출금 비율";
 "withdrawRewards" = "%@ 보상 출금";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1779,6 +1779,7 @@
 "whitespaceNotAllowed" = "Caracteres de espaço não são permitidos.";
 "withdraw" = "Sacar";
 "withdrawAmount" = "Retirar %@";
+"withdrawBelowMinimum" = "Valor muito pequeno — retire pelo menos %@ %@";
 "withdrawBelowOutboundFee" = "Valor abaixo da taxa de saída — retire pelo menos %@ %@ para cobrir os custos da rede";
 "withdrawPercentage" = "Porcentagem de saque";
 "withdrawRewards" = "Sacar recompensas de %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1779,6 +1779,7 @@
 "whitespaceNotAllowed" = "不允许空格字符";
 "withdraw" = "提取";
 "withdrawAmount" = "提取 %@";
+"withdrawBelowMinimum" = "金额过小 — 请至少提取 %@ %@";
 "withdrawBelowOutboundFee" = "金额低于出站费用 — 请至少提取 %@ %@ 以支付网络费用";
 "withdrawPercentage" = "提取百分比";
 "withdrawRewards" = "提取 %@ 奖励";

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Common/Screen/AmountFunctionTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Common/Screen/AmountFunctionTransactionScreen.swift
@@ -44,7 +44,10 @@ struct AmountFunctionTransactionScreen<CustomView: View, TopView: View>: View {
         availableAmount: Decimal,
         percentageSelected: Binding<Double?>,
         percentageFieldType: PercentageFieldType,
-        amountDecimals: Int = 4,
+        // Defaults to the precision the amount/percentage binding rounds to, so
+        // a screen that does not override it cannot drift from the figure that
+        // binding derives its percentage from.
+        amountDecimals: Int = AmountPercentageBinding.displayedDecimals,
         amountField: FormField,
         isContinueDisabled: Bool = false,
         customViewPosition: AmountTextField<CustomView>.CustomViewPosition = .balance,

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
@@ -335,19 +335,26 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
     /// full exit can never leave a rounding remainder staked.
     var withdrawBasisPoints: Int {
         guard availableAmount > 0 else { return 0 }
+        let typed = amountField.value.toDecimal()
+
         // Pinned rather than derived: the amount field renders 4 decimals, so on
         // a small position MAX can round to 9999 and leave a sliver staked.
         //
-        // Only while the percentage still owns the value. Typing clears
-        // `percentageSelected` without ever reaching `onPercentage`, so the flag
-        // raised when the form opened at 100% outlives the selection it
-        // describes — and pinning on it alone would withdraw the whole position
-        // for an amount the user typed to be smaller.
-        guard !isMaxAmount || percentageSelected == nil else { return WithdrawBasisPoints.max }
-        return WithdrawBasisPoints.value(
-            forAmount: amountField.value.toDecimal(),
-            available: availableAmount
-        )
+        // ⚠️ **Corroborated against the amount, never against the flag alone.**
+        // Typing normally clears `percentageSelected` — but the percentage it
+        // derives is a `Double`, so an amount a hair under the balance
+        // (99999999999.999999 of 100000000000) derives *exactly* 100, which is
+        // the value the sheet already holds. No change is emitted, nothing
+        // clears, and the flag raised when the form opened at 100% survives to
+        // close a position the user typed to keep open. The receipt-share arms
+        // already refuse to trust the flag for this reason; the memo arms now
+        // ask the same question, of the same amount.
+        if isMaxAmount, percentageSelected != nil,
+           ReceiptShareRedemption.isWholePosition(amount: typed, positionValue: availableAmount) {
+            return WithdrawBasisPoints.max
+        }
+
+        return WithdrawBasisPoints.value(forAmount: typed, available: availableAmount)
     }
 
     func onPercentage(_ percentage: Double) {

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
@@ -131,7 +131,7 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
         // because then the position really is that small.
         guard receiptBalanceIsAvailableAmount, autocompoundBalanceDidLoad else { return }
         availableAmount = autocompoundBalance
-        amountField.validators = [AmountBalanceValidator(balance: availableAmount)]
+        amountField.validators = amountValidators()
 
         // The form pipeline only re-validates when a field's *value* changes.
         // With a percentage selected the view is about to rewrite the field from
@@ -174,17 +174,30 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
 
         switch coin.ticker.uppercased() {
         case "TCY":
+            // Converts the amount straight to basis points instead of through a
+            // whole percentage — see `WithdrawBasisPoints`. A zero means the
+            // amount is too small for the memo to express;
+            // `WithdrawMinimumAmountValidator` normally stops it reaching here,
+            // and refusing to build is the backstop.
+            let basisPoints = withdrawBasisPoints
+            guard basisPoints >= WithdrawBasisPoints.min else { return nil }
             return TCYUnstakeTransactionBuilder(
                 coin: coin,
-                percentage: Int(resolvedPercentage),
+                basisPoints: basisPoints,
                 autoCompoundAmount: autocompoundBalance,
                 sendMaxAmount: isMaxAmount,
                 isAutoCompound: isAutocompound
             )
         case "BRUNE":
+            // Carries the typed amount rather than a whole percentage of the
+            // position: the unbond is FUNDED with an absolute count of
+            // `x/staking-x/brune` receipt units, so it can express the figure
+            // exactly and `Int(percentage)` was throwing that away — see
+            // `ReceiptShareRedemption`.
             return BRUNEUnstakeTransactionBuilder(
                 coin: coin,
-                percentage: Int(resolvedPercentage),
+                withdrawAmount: amountField.value.toDecimal(),
+                stakedAmount: availableAmount,
                 autoCompoundAmount: autocompoundBalance,
                 sendMaxAmount: isMaxAmount
             )
@@ -195,9 +208,29 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
             // `account.withdraw`. Both arrive here on the RUJI coin because the
             // compounded card maps sRUJI back to its bond coin.
             if isAutocompound {
+                // The redemption spends receipt shares, and unlike TCY/bRUNE the
+                // share balance is not what bounds the amount field — so nothing
+                // else stops a zero here. A zero means the read is still in flight,
+                // failed, or the position is empty; all three would build a wasm
+                // execute carrying no funds.
+                guard autocompoundBalance > 0 else { return nil }
+                // Carries the typed amount rather than a whole percentage of the
+                // position, for the reason its bRUNE sibling does — the
+                // redemption is FUNDED with an absolute share count. Here the
+                // amount is priced in RUJI and the funds are sRUJI shares, so
+                // `availableAmount` is what converts between them: it is the RUJI
+                // the shares are worth.
+                //
+                // ⚠️ The two come from different reads — `availableAmount` from
+                // the persisted card, `autocompoundBalance` from this sheet's own
+                // fetch — so the implied share price is only as coherent as those
+                // two are. The coupling is not new: the whole-percentage path this
+                // replaces divided by `availableAmount` and scaled
+                // `autocompoundBalance` in exactly the same way.
                 return RUJILiquidUnbondTransactionBuilder(
                     coin: coin,
-                    percentage: Int(resolvedPercentage),
+                    withdrawAmount: amountField.value.toDecimal(),
+                    stakedAmount: availableAmount,
                     receiptShares: autocompoundBalance,
                     sendMaxAmount: isMaxAmount
                 )
@@ -209,10 +242,14 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
             )
 
         case "CACAO":
-            return CacaoUnstakeTransactionBuilder(
-                coin: coin,
-                bps: Int(resolvedPercentage) * 100,
-            )
+            // `POOL-:<bps>` is the same 0…10000 fractional withdrawal TCY's memo
+            // is, on MAYAChain rather than THORChain, and it was reached the same
+            // wrong way: `Int(percentage) * 100` spends 100 of the memo's 10 000
+            // steps, so a step is a whole 1% of the position and everything
+            // between two steps is floored away.
+            let basisPoints = withdrawBasisPoints
+            guard basisPoints >= WithdrawBasisPoints.min else { return nil }
+            return CacaoUnstakeTransactionBuilder(coin: coin, bps: basisPoints)
         default:
             return nil
         }
@@ -258,19 +295,88 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
     }
 
     var percentageFromAmount: Double {
-        guard availableAmount != .zero else { return 0 }
-        let decimal = (amountField.value.toDecimal() / availableAmount) * 100.0
-        return (decimal as NSDecimalNumber).doubleValue
+        AmountPercentageBinding.percentage(ofAmount: amountField.value.toDecimal(), available: availableAmount) ?? 0
+    }
+
+    /// Whether this position is addressed in ten-thousandths of itself — the unit
+    /// THORChain's `tcy-:<bps>` and MAYAChain's `POOL-:<bps>` carry, and the unit
+    /// the TCY auto-compound redemption scales its receipt shares by.
+    ///
+    /// What it decides is the FIELD: these positions carry
+    /// `WithdrawMinimumAmountValidator`, so an amount too small for the memo to
+    /// express is refused instead of quietly becoming a fee paid to withdraw
+    /// nothing.
+    ///
+    /// ⚠️ It does not dispatch the conversion — `transactionBuilder`'s switch does
+    /// that, because each ticker also selects a different builder. So this list and
+    /// the branches that call `withdrawBasisPoints` are two statements of the same
+    /// fact and have to be changed together. A branch converted without being added
+    /// here gets the finer conversion with no floor under it, which is the
+    /// round-to-zero hazard the validator exists to close.
+    ///
+    /// bRUNE/ybRUNE and RUJI-compound are deliberately absent, and stay absent
+    /// now that they no longer floor to a whole percent either. They redeem
+    /// receipt shares, and a `liquid.unbond`'s FUNDS carry an absolute count of
+    /// them — so there is no ten-thousandth to address and no cliff at one basis
+    /// point. Their floor is one receipt base unit, enforced by the builder
+    /// refusing to fund a redemption with nothing (`ReceiptShareRedemption`).
+    private var withdrawsInBasisPoints: Bool {
+        ["TCY", "CACAO"].contains(coin.ticker.uppercased())
+    }
+
+    /// The share of the position the memo will ask for, in basis points.
+    ///
+    /// Derived from the amount rather than from `percentageSelected`, because the
+    /// amount is the finer of the two: the slider moves in whole percent, so
+    /// reading the percentage would re-impose the very truncation this replaces.
+    /// The two agree whenever the slider is what set the amount.
+    ///
+    /// Closing the position pins the ceiling exactly instead of deriving it, so a
+    /// full exit can never leave a rounding remainder staked.
+    var withdrawBasisPoints: Int {
+        guard availableAmount > 0 else { return 0 }
+        // Pinned rather than derived: the amount field renders 4 decimals, so on
+        // a small position MAX can round to 9999 and leave a sliver staked.
+        //
+        // Only while the percentage still owns the value. Typing clears
+        // `percentageSelected` without ever reaching `onPercentage`, so the flag
+        // raised when the form opened at 100% outlives the selection it
+        // describes — and pinning on it alone would withdraw the whole position
+        // for an amount the user typed to be smaller.
+        guard !isMaxAmount || percentageSelected == nil else { return WithdrawBasisPoints.max }
+        return WithdrawBasisPoints.value(
+            forAmount: amountField.value.toDecimal(),
+            available: availableAmount
+        )
     }
 
     func onPercentage(_ percentage: Double) {
         isMaxAmount = percentage == 100
     }
 
-    func setupAmountField() {
-        self.amountField.validators = [
+    /// The validators the amount field carries for the ceiling in force now.
+    ///
+    /// Built in one place because a ceiling that arrives late has to reinstall
+    /// the same chain against the new balance: rebuilding only the balance rule
+    /// there would drop the basis-point minimum and let an amount too small to
+    /// express pass validation.
+    private func amountValidators() -> [FormFieldValidator] {
+        var validators: [FormFieldValidator] = [
             AmountBalanceValidator(balance: self.availableAmount)
         ]
+        if withdrawsInBasisPoints {
+            // These memos ask for a fraction of the position in ten-thousandths,
+            // so an amount can be positive, inside the balance, and still round
+            // away to "withdraw nothing".
+            validators.append(
+                WithdrawMinimumAmountValidator(available: self.availableAmount, ticker: coin.ticker)
+            )
+        }
+        return validators
+    }
+
+    func setupAmountField() {
+        self.amountField.validators = amountValidators()
         self.percentageSelected = 100
         self.isMaxAmount = true
     }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/BRUNE/BRUNEUnstakeTransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/BRUNE/BRUNEUnstakeTransactionBuilder.swift
@@ -18,7 +18,17 @@ import VultisigCommonData
 struct BRUNEUnstakeTransactionBuilder: TransactionBuilder {
     static let destinationAddress = BRUNEStakingConstants.contract
     let coin: Coin
-    let percentage: Int
+    /// What the user asked to unbond, in the units the sheet was denominated in.
+    ///
+    /// Those units are ybRUNE receipt units: the staked card renders the receipt
+    /// balance directly, so this figure and `autoCompoundAmount` are the same
+    /// kind of thing (see `UnstakeTransactionViewModel.receiptBalanceIsAvailableAmount`).
+    /// It is converted against `stakedAmount` all the same rather than assumed —
+    /// see `ReceiptShareRedemption`.
+    let withdrawAmount: Decimal
+    /// The position the sheet was showing — the balance `withdrawAmount` is a
+    /// share of, in the same units.
+    let stakedAmount: Decimal
     let autoCompoundAmount: Decimal
     let sendMaxAmount: Bool
 
@@ -34,9 +44,34 @@ struct BRUNEUnstakeTransactionBuilder: TransactionBuilder {
 
     var transactionType: VSTransactionType { .genericContract }
 
+    /// The `x/staking-x/brune` base units this unbond is funded with — the whole
+    /// of the instruction, since the execute message itself is empty.
+    ///
+    /// Converted straight from the typed amount. It used to be reached through
+    /// `Int(percentage)`, which floored a step to a whole 1% of the position and
+    /// silently unbonded ~20 ybRUNE less than was asked for on a 2002.74 position;
+    /// the funds carry an absolute count, so there was never a coarse step to
+    /// round to. `ReceiptShareRedemption` holds the arithmetic and the guards.
+    var redeemedUnits: Decimal {
+        ReceiptShareRedemption.baseUnits(
+            forAmount: withdrawAmount,
+            positionValue: stakedAmount,
+            receiptBaseUnits: coin.decimalToCrypto(value: autoCompoundAmount),
+            closingPosition: sendMaxAmount
+        )
+    }
+
     var wasmContractPayload: WasmExecuteContractPayload? {
-        let withdrawAmount = (coin.decimalToCrypto(value: autoCompoundAmount) * Decimal(percentage)) / 100
-        let units = withdrawAmount.toInt()
+        // A redemption funded with nothing pays a fee to unbond nothing. The
+        // amount field's own validators normally stop it reaching here.
+        //
+        // ⚠️ Kept in `Decimal` rather than routed through `Decimal.toInt()`. That
+        // wraps outside signed 64-bit range, and the receipt balance is parsed as
+        // `UInt64` — so a position above `Int.max` base units would render as a
+        // negative count, fail this guard, and become unwithdrawable at MAX.
+        // `wholeUnits` has already made this an integer, so its description is
+        // the digits and nothing else.
+        let units = redeemedUnits
         guard units >= 1 else { return nil }
 
         return WasmExecuteContractPayload(
@@ -46,7 +81,7 @@ struct BRUNEUnstakeTransactionBuilder: TransactionBuilder {
             { "liquid": { "unbond": {} } }
             """,
             coins: [CosmosCoin(
-                amount: String(units),
+                amount: units.description,
                 denom: TokensStore.ybrune.contractAddress
             )]
         )

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/RUJI/RUJILiquidUnbondTransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/RUJI/RUJILiquidUnbondTransactionBuilder.swift
@@ -17,15 +17,24 @@ import VultisigCommonData
 /// `x/staking-x/ruji` balance. RUJI and sRUJI share 8 decimals, so scaling the
 /// redeemed fraction with the RUJI coin yields the right receipt base units.
 ///
-/// Redeeming a share of the position is driven by the percentage rather than by
-/// a RUJI amount, which sidesteps the share-price conversion entirely: at 100%
-/// the exact held share balance is redeemed, so there is no rounding dust and it
-/// can never exceed what is held even if the share price moved since the sheet
-/// opened.
+/// ⚠️ **The amount and the receipt are different units.** The compounded card
+/// renders `stakedAmount` — what the receipt is WORTH in RUJI, the pool's liquid
+/// size — so that is what the sheet's balance and the typed amount are priced in,
+/// while the funds are a count of shares worth more than 1 RUJI each. The two
+/// balances the sheet was opened with are the redemption ratio between them, and
+/// `ReceiptShareRedemption` is where the conversion and its guards live. A full
+/// exit still redeems the exact held share balance, pinned rather than derived,
+/// so it can neither leave dust behind nor exceed what is held if the share price
+/// moved since the sheet opened.
 struct RUJILiquidUnbondTransactionBuilder: TransactionBuilder {
     static let destinationAddress = RUJIStakingConstants.contract
     let coin: Coin
-    let percentage: Int
+    /// What the user asked to redeem, priced in RUJI like the card it was typed
+    /// under.
+    let withdrawAmount: Decimal
+    /// The RUJI the position is worth — the balance `withdrawAmount` is a share
+    /// of, and the figure the verify screen quotes a fraction of.
+    let stakedAmount: Decimal
     let receiptShares: Decimal
     let sendMaxAmount: Bool
 
@@ -41,11 +50,36 @@ struct RUJILiquidUnbondTransactionBuilder: TransactionBuilder {
 
     var transactionType: VSTransactionType { .genericContract }
 
+    /// The whole `x/staking-x/ruji` base units held — the denominator the payout
+    /// projection is a share of, and the ceiling the redemption clamps to.
+    var heldUnits: Decimal {
+        ReceiptShareRedemption.wholeUnits(coin.decimalToCrypto(value: receiptShares))
+    }
+
+    /// The `x/staking-x/ruji` base units this redemption is funded with — the
+    /// whole of the instruction, since the execute message itself is empty.
+    ///
+    /// Converted straight from the typed amount. It used to be reached through
+    /// `Int(percentage)`, which floored a step to a whole 1% of the position; the
+    /// funds carry an absolute share count, so there was never a coarse step to
+    /// round to.
+    var redeemedUnits: Decimal {
+        ReceiptShareRedemption.baseUnits(
+            forAmount: withdrawAmount,
+            positionValue: stakedAmount,
+            receiptBaseUnits: coin.decimalToCrypto(value: receiptShares),
+            closingPosition: sendMaxAmount
+        )
+    }
+
     var wasmContractPayload: WasmExecuteContractPayload? {
-        let redeemed = (coin.decimalToCrypto(value: receiptShares) * Decimal(percentage)) / 100
-        // Rounds DOWN to whole base units: redeeming more shares than are held
-        // would fail on-chain, and a fractional `CosmosCoin.amount` is malformed.
-        let units = redeemed.toInt()
+        // A redemption funded with nothing pays a fee to unbond nothing. The
+        // amount field's own validators normally stop it reaching here.
+        //
+        // ⚠️ Kept in `Decimal` rather than routed through `Decimal.toInt()` —
+        // see the bRUNE sibling for why a 64-bit round trip can make a large
+        // position unwithdrawable.
+        let units = redeemedUnits
         guard units >= 1 else { return nil }
 
         return WasmExecuteContractPayload(
@@ -55,7 +89,7 @@ struct RUJILiquidUnbondTransactionBuilder: TransactionBuilder {
             { "liquid": { "unbond": {} } }
             """,
             coins: [CosmosCoin(
-                amount: String(units),
+                amount: units.description,
                 denom: TokensStore.sruji.contractAddress
             )]
         )

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/ReceiptShareRedemption.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/ReceiptShareRedemption.swift
@@ -1,0 +1,151 @@
+//
+//  ReceiptShareRedemption.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Converts a withdrawal amount into the receipt base units a `liquid.unbond`
+/// redemption is FUNDED with.
+///
+/// The sibling of `WithdrawBasisPoints`, for the other kind of unstake this app
+/// builds. A fractional-withdrawal memo (`tcy-:<bps>`, `POOL-:<bps>`) names a
+/// share of the position and can express nothing finer than a ten-thousandth. A
+/// `liquid.unbond` names no figure at all — the wasm execute is empty and the
+/// funds attached to it are the instruction, an ABSOLUTE count of receipt units
+/// (`x/staking-x/brune`, `x/staking-x/ruji`). An absolute count has no coarse
+/// step to work around: the smallest thing it can express is one base unit,
+/// 0.00000001 of a share.
+///
+/// So the ten-thousandths are the wrong ceiling here, not the right one. What
+/// these two positions were actually doing was worse than either: they reached
+/// the share count through `Int(percentageSelected ?? percentageFromAmount)`,
+/// which floors the fraction to a whole percent and makes one step a whole 1% of
+/// the position — ~20 tokens on the 2002.74 position the defect was reported
+/// against. Converting the typed amount straight into base units removes the step
+/// entirely rather than making it 100× smaller.
+///
+/// ⚠️ **The amount and the receipt are not always in the same units.** The two
+/// callers differ, and the difference is why this takes a `positionValue` instead
+/// of assuming one:
+///
+/// - **bRUNE/ybRUNE** — the staked card renders the ybRUNE receipt balance
+///   directly, so the typed amount already IS a receipt figure and the conversion
+///   comes out exact.
+/// - **RUJI/sRUJI** — the compounded card renders the RUJI the receipt is worth,
+///   so the typed amount is priced in RUJI and the share count follows from the
+///   ratio between the two balances the sheet was opened with.
+///
+/// Passing both figures makes the conversion correct either way, and it stays
+/// bounded by the shares actually held rather than by an invariant asserted
+/// somewhere else.
+///
+/// ⚠️ **What bounds the precision here is the INPUT, not this arithmetic.** The
+/// typed figure reaches these builders through `String.toDecimal()`, which parses
+/// with `NumberFormatter` and therefore round-trips through a `Double` — so the
+/// `Decimal` that arrives can already differ from what was typed in the 16th
+/// significant digit. `Decimal`'s own 38-digit multiply and divide below can
+/// likewise land one base unit off an exact quotient on a position large enough
+/// to need twenty digits.
+///
+/// Both are real and neither is worth exact integer arithmetic here: the second
+/// is a base unit, the first is thousands of times larger on the same position,
+/// and no amount of care downstream recovers a figure that was already perturbed
+/// upstream. Whichever way that error falls, the result is still truncated and
+/// still clamped to the shares held, so the outcome stays within one base unit of
+/// the request and can never exceed the position. Tightening the conversion while
+/// the amount arrives via `Double` would be precision theatre; the input is where
+/// it would have to start.
+enum ReceiptShareRedemption {
+
+    /// `value` truncated to whole base units.
+    ///
+    /// A `CosmosCoin.amount` is an integer string, and a fractional one is
+    /// malformed. Truncating rather than rounding is the same call
+    /// `WithdrawBasisPoints` makes and for the same reason: **a redemption never
+    /// spends more of the position than was asked for**, and rounding up could
+    /// also exceed the shares actually held, which fails on-chain.
+    static func wholeUnits(_ value: Decimal) -> Decimal {
+        guard value > 0 else { return 0 }
+        var raw = value
+        var floored = Decimal()
+        NSDecimalRound(&floored, &raw, 0, .down)
+        return floored
+    }
+
+    /// The whole receipt base units to redeem for `amount` of a position worth
+    /// `positionValue`, out of the `receiptBaseUnits` held. `0` when there is
+    /// nothing to redeem, which is never a valid instruction — a `liquid.unbond`
+    /// funded with nothing pays a fee to withdraw nothing, so the callers refuse
+    /// to build one.
+    ///
+    /// ⚠️ **`closingPosition` pins the whole balance rather than deriving it.**
+    /// The amount field renders a rounded figure, so deriving a full exit from it
+    /// could leave a sliver of shares behind and keep a position open the user
+    /// asked to close. Same reason `UnstakeTransactionViewModel.withdrawBasisPoints`
+    /// pins 10000 for MAX.
+    ///
+    /// ⚠️ **But the flag alone is not evidence of a full exit**, which is why the
+    /// amount has to agree with it. The flag is set from a `Double` percentage
+    /// (`AmountPercentageBinding.percentage`), and on a large position a typed
+    /// amount a hair under the balance derives exactly `100` — the same value the
+    /// field already held, so SwiftUI emits no change, `onPercentage` never runs,
+    /// and the flag stays true over an amount that was meant to leave something
+    /// staked. Trusting it by itself would close that position.
+    ///
+    /// ⚠️ **A partial withdrawal can never close the position.** Truncation only
+    /// moves the result down, and the result only reaches the held balance when
+    /// `amount` reaches `positionValue` — which is a full exit however it was
+    /// typed. The clamp is what stops an over-balance figure asking for more
+    /// shares than exist; rejecting that figure is `AmountBalanceValidator`'s job,
+    /// and it has to let the value through to report it.
+    static func baseUnits(
+        forAmount amount: Decimal,
+        positionValue: Decimal,
+        receiptBaseUnits: Decimal,
+        closingPosition: Bool
+    ) -> Decimal {
+        let held = wholeUnits(receiptBaseUnits)
+        guard held >= 1, positionValue > 0, amount > 0 else { return 0 }
+        if closingPosition, isWholePosition(amount: amount, positionValue: positionValue) {
+            return held
+        }
+
+        // Multiplied BEFORE it is divided. Taking the fraction first
+        // (`amount / positionValue`) rounds it to the mantissa's 38 digits and
+        // then scales that error up by the share count, which can land a whole
+        // base unit short of an exact figure. This order divides once, at the
+        // end, so an amount that is an exact share of the position converts
+        // exactly.
+        let redeemed = wholeUnits((held * amount) / positionValue)
+        return min(redeemed, held)
+    }
+
+    /// Whether `amount` is the whole position **as the amount field is able to
+    /// state it** — the balance itself, or the figure a MAX selection prefills,
+    /// which is that balance truncated to `AmountPercentageBinding.displayedDecimals`.
+    ///
+    /// The truncated form has to count, or a MAX exit on a position with more
+    /// decimals than the field renders would be read as a partial and leave a
+    /// sliver staked. Nothing BETWEEN the two counts, which is what makes this a
+    /// real check rather than a tolerance: a figure the user typed with more
+    /// precision than MAX would have written is a figure MAX did not write.
+    ///
+    /// ⚠️ **The one case it cannot separate** is a user typing, by hand, exactly
+    /// what MAX would have prefilled on a position carrying more decimals than
+    /// the field shows. That closes the position, taking up to one display step
+    /// more than was asked — bounded, invisible at the precision the screen
+    /// renders, and unavoidable from the amount alone. Separating them needs the
+    /// field to report that the amount was typed rather than derived, which
+    /// `AmountPercentageSync.amountIsUserTyped` already knows and does not
+    /// currently surface to the view model.
+    static func isWholePosition(amount: Decimal, positionValue: Decimal) -> Bool {
+        guard positionValue > 0 else { return false }
+        if amount >= positionValue { return true }
+
+        var raw = positionValue
+        var prefilled = Decimal()
+        NSDecimalRound(&prefilled, &raw, AmountPercentageBinding.displayedDecimals, .down)
+        return amount == prefilled
+    }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/TCY/TCYUnstakeTransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/TCY/TCYUnstakeTransactionBuilder.swift
@@ -11,7 +11,11 @@ import VultisigCommonData
 struct TCYUnstakeTransactionBuilder: TransactionBuilder {
     static let destinationAddress = TCYAutoCompoundConstants.contract
     let coin: Coin
-    let percentage: Int
+    /// The share of the position to withdraw, in ten-thousandths — the unit the
+    /// `tcy-:<bps>` memo carries. See `WithdrawBasisPoints` for why it is not a
+    /// percentage: routing it through one spent 100 of the memo's 10 000 steps
+    /// and floored a request for 1002.73 TCY down to 1001.37.
+    let basisPoints: Int
     let autoCompoundAmount: Decimal
     let sendMaxAmount: Bool
     let isAutoCompound: Bool
@@ -20,7 +24,6 @@ struct TCYUnstakeTransactionBuilder: TransactionBuilder {
 
     var memo: String {
         if !isAutoCompound {
-            let basisPoints = percentage * 100
             return "tcy-:\(basisPoints)"
         }
         return ""
@@ -39,7 +42,8 @@ struct TCYUnstakeTransactionBuilder: TransactionBuilder {
     var wasmContractPayload: WasmExecuteContractPayload? {
         guard isAutoCompound else { return nil }
 
-        let withdrawAmount = (coin.decimalToCrypto(value: autoCompoundAmount) * Decimal(percentage)) / 100
+        let withdrawAmount = (coin.decimalToCrypto(value: autoCompoundAmount) * Decimal(basisPoints))
+            / Decimal(WithdrawBasisPoints.max)
         let units = withdrawAmount.toInt()
         guard units >= 1 else { return nil }
 

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/WithdrawBasisPoints.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/WithdrawBasisPoints.swift
@@ -1,0 +1,97 @@
+//
+//  WithdrawBasisPoints.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Converts a withdrawal amount into the basis points a *fractional* withdrawal
+/// memo carries.
+///
+/// ⚠️ **Such a memo names a fraction of the position, never an amount.** THORChain's
+/// `tcy-:<bps>` handler and MAYAChain's `POOL-:<bps>` one both read ten-thousandths
+/// of whatever is staked at execution time, so an arbitrary decimal amount is not
+/// representable and no amount of app-side care can make one withdraw exactly.
+/// (Contrast `RUJIUnstakeTransactionBuilder`, whose `withdraw:<asset>:<raw>` memo
+/// *does* carry an absolute amount and is therefore exact — the difference is the
+/// protocol, not this code.)
+///
+/// What was representable and was being thrown away is the resolution. The amount
+/// used to reach the memo through a whole percentage — `Int(50.0679) * 100` — which
+/// spends 100 of the 10 000 steps the memo can address. Worked through on the
+/// staked-TCY position the defect was reported against: 2002.74 TCY, where one of
+/// those coarse steps is 20.03 TCY, so a request for 1002.73 floored to 50% and
+/// paid out 1001.37. The same arithmetic applies to any position and any of these
+/// memos — the ten-thousandths are a property of the convention, not of TCY.
+///
+/// Converting straight to basis points and rounding DOWN (see `value(forAmount:available:)`
+/// for why down) leaves at most one basis point behind — 0.01% of the position,
+/// about 0.20 TCY on that same position — and never takes more than was asked for.
+///
+/// ⚠️ The consequence for the screens is that the quantised figure and the typed
+/// one can differ, so nothing around signing should quote the typed string as
+/// though the chain had agreed to it.
+enum WithdrawBasisPoints {
+
+    /// A full exit. Also the clamp ceiling — a memo can never ask for more of the
+    /// position than all of it.
+    static let max = 10_000
+
+    /// The smallest fraction the memo can express. Anything under one basis point
+    /// of the position rounds to a `:0` memo, which asks for nothing.
+    static let min = 1
+
+    /// Basis points of `available` that `amount` comes to, rounded DOWN and
+    /// clamped to `1...10000`, or `0` when the amount is smaller than a single
+    /// basis point (or there is nothing staked). A `0` is never a valid memo — it
+    /// is the signal for `WithdrawMinimumAmountValidator` to reject the amount.
+    ///
+    /// ⚠️ **Down, not to nearest.** Rounding to nearest tracks the typed figure
+    /// more closely on average, but it can round *up*, and up has a cliff at the
+    /// top: anything from 99.995% of the position upwards reaches 10000 and
+    /// closes the position outright. Someone asking to withdraw 2002.64 of 2002.74
+    /// is asking to keep 0.10 TCY, and taking the last of it is not a rounding
+    /// difference — it is a different outcome. Rounding down makes the invariant
+    /// simple and checkable: **a withdrawal never takes more of the position than
+    /// was asked for, and only an explicit full exit reaches 10000.**
+    ///
+    /// The cost is up to one whole basis point left behind (0.01% of the
+    /// position, ~0.20 TCY on that same position) instead of half of one. Still
+    /// 100× finer than the whole-percent truncation this replaces, and the
+    /// remainder stays staked rather than being taken. `RUJILiquidUnbondTransactionBuilder`
+    /// rounds down for the same reason.
+    static func value(forAmount amount: Decimal, available: Decimal) -> Int {
+        guard available > 0, amount > 0 else { return 0 }
+
+        var raw = (amount / available) * Decimal(max)
+        var rounded = Decimal()
+        NSDecimalRound(&rounded, &raw, 0, .down)
+
+        let bps = NSDecimalNumber(decimal: rounded).intValue
+        guard bps >= min else { return 0 }
+        return Swift.min(bps, max)
+    }
+
+    /// Exactly one basis point of `available` — the threshold below which
+    /// `value(forAmount:available:)` returns 0 and there is nothing to ask the
+    /// chain for.
+    ///
+    /// ⚠️ Deliberately NOT rounded. Rounding the threshold up to a display
+    /// precision makes small positions unwithdrawable: a 0.00005 position would
+    /// be compared against a 0.0001 minimum and could never be closed, not even
+    /// at MAX.
+    static func minimumAmount(forAvailable available: Decimal) -> Decimal {
+        guard available > 0 else { return 0 }
+        return available / Decimal(max)
+    }
+
+    /// The same threshold rounded UP to `digits`, for the figure the error
+    /// message quotes. Up, so that retyping exactly what the message says
+    /// passes the comparison against the exact threshold above.
+    static func quotedMinimum(forAvailable available: Decimal, digits: Int) -> Decimal {
+        var raw = minimumAmount(forAvailable: available)
+        var rounded = Decimal()
+        NSDecimalRound(&rounded, &raw, digits, .up)
+        return rounded
+    }
+}

--- a/VultisigApp/VultisigAppTests/Defi/MayaCacaoWithdrawCeilingTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/MayaCacaoWithdrawCeilingTests.swift
@@ -275,7 +275,12 @@ final class MayaCacaoWithdrawCeilingTests: XCTestCase {
         )
 
         let builder = try XCTUnwrap(sheet.transactionBuilder)
-        XCTAssertEqual(builder.memo, "POOL-:9100", "1100 of 1200 CACAO is 91% of the position")
+        XCTAssertEqual(
+            builder.memo,
+            "POOL-:9166",
+            "1100 of 1200 CACAO is 91.67% of the position, which is 9166 basis points once "
+                + "`WithdrawBasisPoints` rounds down — not the 9100 a whole-percent truncation produced"
+        )
     }
 
     /// The ceiling is also what the field is validated against, so the sheet now

--- a/VultisigApp/VultisigAppTests/Defi/RujiDualPositionWiringTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/RujiDualPositionWiringTests.swift
@@ -88,7 +88,13 @@ final class RujiDualPositionWiringTests: XCTestCase {
             isAutocompound: true,
             availableToUnstake: Decimal(string: "140.64866515")!
         )
+        viewModel.availableAmount = Decimal(string: "140.64866515")!
         viewModel.autocompoundBalance = Decimal(string: "138.55943656")!
+        // What the sheet opens on: MAX, with the field prefilled from the
+        // balance. The redemption is driven by the amount now, so leaving the
+        // field empty would build nothing.
+        viewModel.setupAmountField()
+        viewModel.amountField.value = "140.64866515"
         viewModel.validForm = true
 
         let builder = try XCTUnwrap(viewModel.transactionBuilder)

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/AmountPercentageBindingTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/AmountPercentageBindingTests.swift
@@ -1,0 +1,138 @@
+//
+//  AmountPercentageBindingTests.swift
+//  VultisigAppTests
+//
+//  The amount ↔ percentage binding behind every stake / unstake / LP amount
+//  field. Typing an amount used to blank the percentage, which left the slider
+//  showing its `percentage ?? 100` fallback: a confident 100% under an amount
+//  the user had typed as something else entirely.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class AmountPercentageBindingTests: XCTestCase {
+
+    private func percentage(_ amount: String, of available: String) -> Double? {
+        AmountPercentageBinding.percentage(
+            ofAmount: Decimal(string: amount)!,
+            available: Decimal(string: available)!
+        )
+    }
+
+    /// The reported position: 1002.73 typed against 2002.74 staked is a hair
+    /// over half, and the slider has to say so rather than claiming 100%.
+    func testATypedAmountDerivesItsShareOfTheBalance() throws {
+        let derived = try XCTUnwrap(percentage("1002.73", of: "2002.74"))
+        XCTAssertEqual(derived, 50.0679, accuracy: 0.0001)
+    }
+
+    func testTheWholeBalanceIsAHundredPercent() {
+        XCTAssertEqual(percentage("2002.74", of: "2002.74"), 100)
+    }
+
+    func testNothingTypedIsZeroPercent() {
+        XCTAssertEqual(percentage("0", of: "2002.74"), 0)
+    }
+
+    /// The field has to accept an over-balance figure so the balance validator
+    /// can report it, but the slider's range is `0...100` — an unclamped
+    /// percentage would drive it off its own track.
+    func testAnAmountOverTheBalanceClampsToAHundred() {
+        XCTAssertEqual(percentage("5000", of: "2002.74"), 100)
+    }
+
+    /// No balance is not 0% of something, it is a percentage that does not
+    /// exist — and dividing by it would trap.
+    func testThereIsNoPercentageOfAnEmptyBalance() {
+        XCTAssertNil(percentage("10", of: "0"))
+    }
+
+    // MARK: - Which side the user owns
+    //
+    // The part of the amount field most able to move money incorrectly: it decides
+    // whether the slider may overwrite a figure the user typed. Reverting any of
+    // these behaviours in `AmountPercentageSync` fails a test here.
+
+    /// Typing writes the percentage, so the field then sees its own write arrive
+    /// on the same channel a real slider interaction uses. It must not treat that
+    /// as a reason to rewrite the amount — that is the feedback loop blanking the
+    /// percentage used to prevent.
+    func testTheFieldsOwnDerivedWriteIsIgnored() {
+        var sync = AmountPercentageSync()
+        sync.amountWasTyped(derivingPercentage: 50.0679)
+
+        XCTAssertEqual(sync.percentageChanged(to: 50.0679), .ignore)
+    }
+
+    func testARealSliderMoveMayRewriteTheAmount() {
+        var sync = AmountPercentageSync()
+        sync.amountWasTyped(derivingPercentage: 50.0679)
+
+        XCTAssertEqual(sync.percentageChanged(to: 75), .setAmountFromPercentage)
+    }
+
+    /// ⚠️ The derived value is SPENT by a real interaction. Remembering it
+    /// forever would suppress a later move back to the same percentage: type the
+    /// full balance (derives 100), drag to 99%, drag back to 100% — that last
+    /// move would be read as the original echo, leaving the amount at 99% while
+    /// the screen reported a MAX withdrawal.
+    func testMovingBackToADerivedPercentageIsStillARealInteraction() {
+        var sync = AmountPercentageSync()
+        sync.amountWasTyped(derivingPercentage: 100)
+
+        XCTAssertEqual(sync.percentageChanged(to: 99), .setAmountFromPercentage)
+        XCTAssertEqual(sync.percentageChanged(to: 100), .setAmountFromPercentage)
+    }
+
+    /// A balance landing after the user has typed must not overwrite what they
+    /// typed — the percentage is re-derived against the new balance instead.
+    func testALateBalanceKeepsATypedAmountAndRederivesThePercentage() {
+        var sync = AmountPercentageSync()
+        sync.amountWasTyped(derivingPercentage: 50)
+
+        XCTAssertEqual(sync.balanceChanged(), .derivePercentageFromAmount)
+    }
+
+    /// ⚠️ A percentage derived against an empty balance is `nil`, so the value
+    /// alone cannot say the amount was typed. Tracking only the value left this
+    /// case stuck: the amount stayed, the slider kept rendering its 100%
+    /// fallback, and a stale `isMaxAmount` survived.
+    func testAnAmountTypedBeforeTheBalanceArrivedIsStillTheUsers() {
+        var sync = AmountPercentageSync()
+        sync.amountWasTyped(derivingPercentage: nil)
+
+        XCTAssertEqual(sync.balanceChanged(), .derivePercentageFromAmount)
+    }
+
+    /// Nothing typed: the percentage is in charge, which is what makes a screen
+    /// that opens on MAX fill its amount in.
+    func testWithNothingTypedThePercentageDrivesTheAmount() {
+        let sync = AmountPercentageSync()
+        XCTAssertEqual(sync.balanceChanged(), .setAmountFromPercentage)
+    }
+
+    /// After the slider takes over, a later balance change belongs to it again.
+    func testASliderMoveHandsOwnershipBackToThePercentage() {
+        var sync = AmountPercentageSync()
+        sync.amountWasTyped(derivingPercentage: 50)
+        _ = sync.percentageChanged(to: 75)
+
+        XCTAssertEqual(sync.balanceChanged(), .setAmountFromPercentage)
+    }
+
+    /// A screen whose percentage starts `nil` and whose field starts empty must
+    /// not be told the (absent) amount is the user's.
+    func testAFreshFieldIsNotConsideredUserTyped() {
+        let sync = AmountPercentageSync()
+        XCTAssertFalse(sync.amountIsUserTyped)
+        XCTAssertNil(sync.lastDerivedPercentage)
+    }
+
+    func testPercentageAndAmountRoundTrip() throws {
+        let available = Decimal(string: "2002.74")!
+        let derived = try XCTUnwrap(AmountPercentageBinding.percentage(ofAmount: Decimal(string: "500.685")!, available: available))
+        let back = AmountPercentageBinding.amount(forPercentage: derived, available: available)
+        XCTAssertEqual(NSDecimalNumber(decimal: back).doubleValue, 500.685, accuracy: 0.0001)
+    }
+}

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/BRUNEStakeTransactionBuilderTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/BRUNEStakeTransactionBuilderTests.swift
@@ -89,7 +89,8 @@ final class BRUNEStakeTransactionBuilderTests: XCTestCase {
     func testUnstakeBuilderEmitsLiquidUnbondMessage() throws {
         let builder = BRUNEUnstakeTransactionBuilder(
             coin: Self.makeBRuneCoin(),
-            percentage: 100,
+            withdrawAmount: Decimal(string: "5")!,
+            stakedAmount: Decimal(string: "5")!,
             autoCompoundAmount: Decimal(string: "5")!,
             sendMaxAmount: true
         )
@@ -100,7 +101,8 @@ final class BRUNEStakeTransactionBuilderTests: XCTestCase {
     func testUnstakeBuilderUsesLiquidBondContract() throws {
         let builder = BRUNEUnstakeTransactionBuilder(
             coin: Self.makeBRuneCoin(),
-            percentage: 100,
+            withdrawAmount: Decimal(string: "5")!,
+            stakedAmount: Decimal(string: "5")!,
             autoCompoundAmount: Decimal(string: "5")!,
             sendMaxAmount: true
         )
@@ -111,7 +113,8 @@ final class BRUNEStakeTransactionBuilderTests: XCTestCase {
     func testUnstakeBuilderFundsWithReceiptDenomFull() throws {
         let builder = BRUNEUnstakeTransactionBuilder(
             coin: Self.makeBRuneCoin(),
-            percentage: 100,
+            withdrawAmount: Decimal(string: "5")!,
+            stakedAmount: Decimal(string: "5")!,
             autoCompoundAmount: Decimal(string: "5")!,
             sendMaxAmount: true
         )
@@ -124,24 +127,29 @@ final class BRUNEStakeTransactionBuilderTests: XCTestCase {
         XCTAssertEqual(funds.amount, "500000000")
     }
 
-    func testUnstakeBuilderScalesByPercentage() throws {
+    /// ⚠️ FAILS on the parent commit, which funded this with 250000000 —
+    /// `Int(50.0346) = 50`, i.e. half the position rather than the 2.50173 that
+    /// was asked for.
+    func testUnstakeBuilderRedeemsTheAmountAskedForRatherThanAWholePercentage() throws {
         let builder = BRUNEUnstakeTransactionBuilder(
             coin: Self.makeBRuneCoin(),
-            percentage: 50,
+            withdrawAmount: Decimal(string: "2.50173")!,
+            stakedAmount: Decimal(string: "5")!,
             autoCompoundAmount: Decimal(string: "5")!,
             sendMaxAmount: false
         )
         let payload = try XCTUnwrap(builder.wasmContractPayload)
         let funds = try XCTUnwrap(payload.coins.first)
-        // 50% of 5 ybRUNE at 8 decimals → 250_000_000 receipt units.
-        XCTAssertEqual(funds.amount, "250000000")
+        // 2.50173 ybRUNE at 8 decimals → 250_173_000 receipt units.
+        XCTAssertEqual(funds.amount, "250173000")
     }
 
     func testUnstakeBuilderReturnsNilForSubUnitWithdrawal() {
         // 100% of an amount that scales below one base unit must not emit a payload.
         let builder = BRUNEUnstakeTransactionBuilder(
             coin: Self.makeBRuneCoin(),
-            percentage: 100,
+            withdrawAmount: Decimal(string: "0.000000001")!,
+            stakedAmount: Decimal(string: "0.000000001")!,
             autoCompoundAmount: Decimal(string: "0.000000001")!, // < 1e-8
             sendMaxAmount: true
         )

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/RUJIStakingTransactionBuilderTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/RUJIStakingTransactionBuilderTests.swift
@@ -104,7 +104,8 @@ final class RUJIStakingTransactionBuilderTests: XCTestCase {
     func testLiquidUnbondEmitsLiquidUnbondMessage() throws {
         let builder = RUJILiquidUnbondTransactionBuilder(
             coin: Self.makeRujiCoin(),
-            percentage: 100,
+            withdrawAmount: Decimal(string: "140.64866515")!,
+            stakedAmount: Decimal(string: "140.64866515")!,
             receiptShares: Decimal(string: "138.55943656")!,
             sendMaxAmount: true
         )
@@ -114,14 +115,15 @@ final class RUJIStakingTransactionBuilderTests: XCTestCase {
         XCTAssertEqual(builder.transactionType, .genericContract)
     }
 
-    /// At 100% the EXACT held share balance is redeemed — no rounding dust, and
+    /// A full exit redeems the EXACT held share balance — no rounding dust, and
     /// it can never exceed what is held even if the share price moved since the
-    /// sheet opened. This is what makes the percentage-driven redemption safe
-    /// without a share-price conversion.
-    func testLiquidUnbondRedeemsTheExactShareBalanceAtFullPercentage() throws {
+    /// sheet opened. Pinned rather than derived from the typed figure, which is
+    /// what keeps that true once the redemption is driven by an amount.
+    func testLiquidUnbondRedeemsTheExactShareBalanceAtAFullExit() throws {
         let builder = RUJILiquidUnbondTransactionBuilder(
             coin: Self.makeRujiCoin(),
-            percentage: 100,
+            withdrawAmount: Decimal(string: "140.64866515")!,
+            stakedAmount: Decimal(string: "140.64866515")!,
             receiptShares: Decimal(string: "138.55943656")!,
             sendMaxAmount: true
         )
@@ -132,16 +134,20 @@ final class RUJIStakingTransactionBuilderTests: XCTestCase {
         XCTAssertEqual(funds.amount, "13855943656")
     }
 
-    func testLiquidUnbondScalesSharesByPercentage() throws {
+    /// ⚠️ FAILS on the parent commit, which funded this with 6927971828 —
+    /// `Int(49.99997) = 49`, i.e. 49% of the share balance rather than the shares
+    /// 70.3243 RUJI is worth. The gap is ~1.4 RUJI on a 140 RUJI position.
+    func testLiquidUnbondRedeemsTheSharesTheTypedAmountIsWorth() throws {
         let builder = RUJILiquidUnbondTransactionBuilder(
             coin: Self.makeRujiCoin(),
-            percentage: 50,
+            withdrawAmount: Decimal(string: "70.3243")!,
+            stakedAmount: Decimal(string: "140.64866515")!,
             receiptShares: Decimal(string: "138.55943656")!,
             sendMaxAmount: false
         )
         let payload = try XCTUnwrap(builder.wasmContractPayload)
         let funds = try XCTUnwrap(payload.coins.first)
-        XCTAssertEqual(funds.amount, "6927971828")
+        XCTAssertEqual(funds.amount, "6927968618")
     }
 
     /// Redeeming zero shares is a no-op the contract would reject, so the
@@ -149,7 +155,8 @@ final class RUJIStakingTransactionBuilderTests: XCTestCase {
     func testLiquidUnbondProducesNoPayloadBelowOneBaseUnit() {
         let builder = RUJILiquidUnbondTransactionBuilder(
             coin: Self.makeRujiCoin(),
-            percentage: 1,
+            withdrawAmount: Decimal(string: "0.0000000001")!,
+            stakedAmount: 1,
             receiptShares: Decimal(string: "0.00000001")!,
             sendMaxAmount: false
         )
@@ -159,7 +166,8 @@ final class RUJIStakingTransactionBuilderTests: XCTestCase {
     func testLiquidUnbondProducesNoPayloadWithoutAShareBalance() {
         let builder = RUJILiquidUnbondTransactionBuilder(
             coin: Self.makeRujiCoin(),
-            percentage: 100,
+            withdrawAmount: Decimal(string: "140.64866515")!,
+            stakedAmount: Decimal(string: "140.64866515")!,
             receiptShares: 0,
             sendMaxAmount: true
         )

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/ReceiptShareRedemptionTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/ReceiptShareRedemptionTests.swift
@@ -1,0 +1,505 @@
+//
+//  ReceiptShareRedemptionTests.swift
+//  VultisigAppTests
+//
+//  The two unstake arms that redeem RECEIPT SHARES rather than asking a memo for
+//  a fraction of a position. Their `liquid.unbond` is funded with an absolute
+//  count of receipt base units, so the typed amount is expressible exactly — but
+//  it was reached through `Int(percentageSelected ?? percentageFromAmount)`,
+//  which floors the fraction to a whole percent and makes one step a whole 1% of
+//  the position. On the 2002.74 position the sibling defect was reported against
+//  that is ~20 tokens, silently.
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class ReceiptShareRedemptionTests: XCTestCase {
+
+    /// The position from the bug report, reused here so the two arms can be
+    /// compared against the same arithmetic.
+    private let staked = Decimal(string: "2002.74")!
+    /// The same position in receipt base units, at the 8 decimals bRUNE, ybRUNE,
+    /// RUJI and sRUJI all share.
+    private let stakedUnits = Decimal(string: "200274000000")!
+    /// A real RUJI compounded position: the card's RUJI-denominated value and the
+    /// sRUJI share balance behind it. They differ because a share is worth more
+    /// than 1 RUJI — which is exactly what makes this arm a different conversion
+    /// from bRUNE's.
+    private let rujiStaked = Decimal(string: "140.64866515")!
+    private let rujiShares = Decimal(string: "138.55943656")!
+
+    // MARK: - The conversion
+
+    func testAnExactShareOfThePositionConvertsExactly() {
+        XCTAssertEqual(
+            ReceiptShareRedemption.baseUnits(
+                forAmount: Decimal(string: "1002.73")!,
+                positionValue: staked,
+                receiptBaseUnits: stakedUnits,
+                closingPosition: false
+            ),
+            Decimal(string: "100273000000")!
+        )
+    }
+
+    /// Truncated, never rounded up: a redemption must not spend more of the
+    /// position than was asked for, and a fractional `CosmosCoin.amount` is
+    /// malformed besides.
+    func testAFractionalUnitIsTruncatedRatherThanRounded() {
+        // 3 units of a 3-token position, asking for 1.9999 tokens' worth.
+        XCTAssertEqual(
+            ReceiptShareRedemption.baseUnits(
+                forAmount: Decimal(string: "1.9999")!,
+                positionValue: 3,
+                receiptBaseUnits: 3,
+                closingPosition: false
+            ),
+            1
+        )
+    }
+
+    /// ⚠️ A full exit pins the whole held balance instead of deriving it. The
+    /// amount field renders 4 decimals, so a MAX on a position with more of them
+    /// arrives here already short — deriving from it would leave a sliver of
+    /// shares behind and keep open a position the user asked to close.
+    func testClosingThePositionSpendsEveryHeldShareEvenFromTheRoundedField() {
+        // What MAX prefills for a 140.64866515 position.
+        XCTAssertEqual(
+            ReceiptShareRedemption.baseUnits(
+                forAmount: Decimal(string: "140.6486")!,
+                positionValue: rujiStaked,
+                receiptBaseUnits: Decimal(string: "13855943656")!,
+                closingPosition: true
+            ),
+            Decimal(string: "13855943656")!
+        )
+    }
+
+    /// ⚠️ **The MAX flag alone must not close a position.** It is set from a
+    /// `Double` percentage, so an amount a hair under the balance derives exactly
+    /// 100 — the value the field already held, which means SwiftUI emits no
+    /// change and the flag is never cleared. Trusting it by itself would take a
+    /// remainder the user asked to keep.
+    func testAFlagLeftStaleByADoubleRoundedPercentageDoesNotCloseThePosition() {
+        let position = Decimal(string: "100000000000")!
+        let held = Decimal(string: "10000000000000000000")!
+        let typed = Decimal(string: "99999999999.999999")!
+
+        // The collision this guards against is real, not hypothetical: the
+        // percentage the field would derive for that amount IS exactly 100.
+        XCTAssertEqual(AmountPercentageBinding.percentage(ofAmount: typed, available: position), 100)
+
+        let units = ReceiptShareRedemption.baseUnits(
+            forAmount: typed,
+            positionValue: position,
+            receiptBaseUnits: held,
+            closingPosition: true
+        )
+        XCTAssertLessThan(units, held, "an amount short of the balance must not close the position")
+        XCTAssertGreaterThan(units, 0)
+    }
+
+    /// The other side of that guard: a figure MAX itself would never have written
+    /// is not MAX, however close to the balance it sits.
+    func testOnlyTheBalanceOrTheFigureMaxPrefillsCountsAsTheWholePosition() {
+        XCTAssertTrue(ReceiptShareRedemption.isWholePosition(amount: rujiStaked, positionValue: rujiStaked))
+        XCTAssertTrue(ReceiptShareRedemption.isWholePosition(
+            amount: Decimal(string: "140.6486")!, positionValue: rujiStaked
+        ))
+        XCTAssertFalse(ReceiptShareRedemption.isWholePosition(
+            amount: Decimal(string: "140.64865")!, positionValue: rujiStaked
+        ))
+        XCTAssertFalse(ReceiptShareRedemption.isWholePosition(
+            amount: Decimal(string: "140.6485")!, positionValue: rujiStaked
+        ))
+    }
+
+    /// ⚠️ The other half of the same invariant: a PARTIAL withdrawal must never
+    /// close the position. Truncation only moves the result down, so the held
+    /// balance is reached only by an amount that reaches the whole position.
+    func testAPartialRedemptionNeverSpendsTheWholeBalance() {
+        let units = ReceiptShareRedemption.baseUnits(
+            forAmount: Decimal(string: "2002.7399")!,
+            positionValue: staked,
+            receiptBaseUnits: stakedUnits,
+            closingPosition: false
+        )
+        XCTAssertLessThan(units, stakedUnits)
+        XCTAssertEqual(units, Decimal(string: "200273990000")!)
+    }
+
+    /// Rejecting an over-balance figure is `AmountBalanceValidator`'s job, and it
+    /// has to let the value through to report it — so the conversion clamps
+    /// rather than asking the chain for shares that do not exist.
+    func testMoreThanThePositionClampsToWhatIsHeld() {
+        XCTAssertEqual(
+            ReceiptShareRedemption.baseUnits(
+                forAmount: staked * 3,
+                positionValue: staked,
+                receiptBaseUnits: stakedUnits,
+                closingPosition: false
+            ),
+            stakedUnits
+        )
+    }
+
+    /// An amount below a single receipt base unit has nothing to redeem. This is
+    /// the floor under these two arms — one base unit rather than the one basis
+    /// point a fractional-withdrawal memo floors at.
+    func testAnAmountTooSmallForOneBaseUnitIsZero() {
+        XCTAssertEqual(
+            ReceiptShareRedemption.baseUnits(
+                forAmount: Decimal(string: "0.000000001")!,
+                positionValue: staked,
+                receiptBaseUnits: stakedUnits,
+                closingPosition: false
+            ),
+            0
+        )
+    }
+
+    /// A share balance that has not loaded, failed to load, or is empty. Nothing
+    /// is redeemable, MAX included — pinning a balance of nothing would build a
+    /// redemption funded with nothing.
+    func testThereIsNothingToRedeemWithoutAShareBalance() {
+        for closing in [true, false] {
+            XCTAssertEqual(
+                ReceiptShareRedemption.baseUnits(
+                    forAmount: 10,
+                    positionValue: staked,
+                    receiptBaseUnits: 0,
+                    closingPosition: closing
+                ),
+                0
+            )
+        }
+    }
+
+    func testThereIsNothingToRedeemAgainstAnEmptyPosition() {
+        XCTAssertEqual(
+            ReceiptShareRedemption.baseUnits(
+                forAmount: 10,
+                positionValue: 0,
+                receiptBaseUnits: stakedUnits,
+                closingPosition: false
+            ),
+            0
+        )
+    }
+
+    // MARK: - bRUNE / ybRUNE
+
+    /// ⚠️ The regression test for the bRUNE arm. Verified to FAIL on the parent
+    /// commit, where the same inputs fund the unbond with **100137000000** —
+    /// `Int(50.0679) = 50`, so 50% of the receipt balance instead of the 1002.73
+    /// that was typed. The difference is 1.36 ybRUNE on this position.
+    func testABRuneUnbondRedeemsTheAmountThatWasTypedNotAFlooredPercentage() throws {
+        XCTAssertEqual(try redeemedBRuneUnits(typing: "1002.73"), "100273000000")
+    }
+
+    /// ⚠️ Also FAILS on the parent commit, at the top of the range where the
+    /// flooring is most expensive: `Int(99.995) = 99` unbonded 198271260000 —
+    /// 19.93 ybRUNE less than the 2002.64 asked for. Both figures leave the
+    /// position open, which is the point of the assertion below them; only one of
+    /// them withdraws what was requested.
+    func testABRunePartialUnbondTakesTheTypedAmountAndLeavesThePositionOpen() throws {
+        let units = try redeemedBRuneUnits(typing: "2002.64")
+        XCTAssertEqual(units, "200264000000")
+        XCTAssertLessThan(Decimal(string: units)!, stakedUnits)
+    }
+
+    /// A full exit still empties the receipt balance exactly — the property the
+    /// old `percentage == 100` path had for free and the new one has to pin.
+    func testABRuneFullExitUnbondsTheWholeReceiptBalance() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = makeBRuneViewModel()
+        viewModel.setupAmountField()          // MAX — what the sheet opens on
+        viewModel.amountField.value = "2002.7400"
+        viewModel.validForm = true
+
+        XCTAssertEqual(try fundedUnits(of: viewModel), "200274000000")
+    }
+
+    /// Nothing to redeem must mean no transaction, not a redemption funded with
+    /// nothing: the fee would be spent unbonding zero.
+    func testABRuneUnbondBelowOneReceiptUnitBuildsNothing() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = makeBRuneViewModel()
+        type("0.000000001", into: viewModel)
+
+        XCTAssertNil(try XCTUnwrap(viewModel.transactionBuilder).wasmContractPayload)
+    }
+
+    /// The share balance not having loaded (or having failed to load) leaves
+    /// nothing to unbond, MAX included.
+    ///
+    /// ⚠️ Asserts no BUILDER, not merely an empty payload. The refusal moved
+    /// upstream: `transactionBuilder` now declines outright for any position
+    /// funded from a receipt balance that reads zero, rather than handing back a
+    /// builder whose wasm execute happens to carry no funds. Refusing earlier is
+    /// the stronger guarantee — there is no longer an object a caller could sign
+    /// something from.
+    func testABRuneUnbondBuildsNothingBeforeTheReceiptBalanceLoads() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = makeBRuneViewModel()
+        viewModel.autocompoundBalance = 0
+        viewModel.setupAmountField()
+        viewModel.amountField.value = "2002.7400"
+        viewModel.validForm = true
+
+        XCTAssertNil(viewModel.transactionBuilder)
+    }
+
+    // MARK: - RUJI auto-compound / sRUJI
+    //
+    // The other arm, and not the same shape: this card renders what the receipt
+    // is WORTH in RUJI, so the typed amount is priced in RUJI and the share count
+    // follows from the ratio between the two balances the sheet was opened with.
+    // The bRUNE arm's amount is already a share count.
+
+    /// ⚠️ The regression test for the RUJI arm. Verified to FAIL on the parent
+    /// commit, where the same inputs redeem **6789412391** shares —
+    /// `Int(49.99997) = 49`, so 49% of the share balance instead of the shares
+    /// 70.3243 RUJI is worth. That is ~1.4 RUJI missing from a 140 RUJI position.
+    func testTheCompoundedRujiRedemptionSpendsTheSharesTheTypedAmountIsWorth() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = makeRujiViewModel()
+        type("70.3243", into: viewModel)
+
+        XCTAssertEqual(try fundedUnits(of: viewModel), "6927968618")
+    }
+
+    /// The wire truth is untouched: the redemption still carries no amount of its
+    /// own, because the funds are the instruction.
+    func testTheCompoundedRujiRedemptionStillCarriesNoAmountOnTheWire() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = makeRujiViewModel()
+        type("70.3243", into: viewModel)
+        let builder = try XCTUnwrap(viewModel.transactionBuilder)
+
+        XCTAssertEqual(builder.amount, "0")
+        XCTAssertEqual(builder.memo, "")
+    }
+
+    /// ⚠️ Asking for all but a sliver must leave that sliver staked. On the
+    /// parent this redeemed 13717384219 shares — `Int(99.99)` — which also left
+    /// the position open, but 138556 shares further from what was asked for.
+    func testACompoundedRujiPartialRedemptionLeavesThePositionOpen() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = makeRujiViewModel()
+        type("140.6486", into: viewModel)
+        let builder = try XCTUnwrap(viewModel.transactionBuilder as? RUJILiquidUnbondTransactionBuilder)
+
+        XCTAssertEqual(try fundedUnits(of: viewModel), "13855937237")
+        XCTAssertLessThan(builder.redeemedUnits, builder.heldUnits)
+    }
+
+    /// A full exit redeems every share, pinned rather than derived — the property
+    /// the old `percentage == 100` path had for free.
+    func testACompoundedRujiFullExitRedeemsEveryShare() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = makeRujiViewModel()
+        viewModel.setupAmountField()          // MAX — what the sheet opens on
+        // What `AmountTextField.setupAmount()` writes: the balance truncated to
+        // the field's 4 decimals, which is already short of the position.
+        viewModel.amountField.value = "140.6486"
+        viewModel.validForm = true
+
+        XCTAssertEqual(try fundedUnits(of: viewModel), "13855943656")
+    }
+
+    /// The bonded RUJI position is exact already and must stay untouched: its
+    /// `withdraw:<asset>:<raw>` memo carries an ABSOLUTE amount, so none of this
+    /// applies to it. `isAutocompound` is the only thing separating the two, and
+    /// both arrive on the RUJI coin.
+    func testTheBondedRujiWithdrawalStillTakesTheAbsoluteAmountPath() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = UnstakeTransactionViewModel(
+            coin: makeCoin(TokensStore.ruji),
+            vault: TestStore.makeVault(),
+            isAutocompound: false,
+            availableToUnstake: rujiStaked
+        )
+        viewModel.availableAmount = rujiStaked
+        // The share balance is set too, so a builder that reached for it instead
+        // of the bonded path would be caught rather than merely failing to build.
+        viewModel.autocompoundBalance = rujiShares
+        type("70.3243", into: viewModel)
+
+        let builder = try XCTUnwrap(viewModel.transactionBuilder)
+        XCTAssertTrue(builder is RUJIUnstakeTransactionBuilder)
+        XCTAssertTrue(builder.memo.hasPrefix("withdraw:x/ruji:"), "built \(builder.memo)")
+        XCTAssertTrue(try XCTUnwrap(builder.wasmContractPayload).coins.isEmpty)
+    }
+
+    /// ⚠️ The two balances behind this arm come from different reads — the RUJI
+    /// valuation from the persisted card, the share count from the sheet's own
+    /// fetch — so they can disagree. What must hold anyway: the redemption never
+    /// spends more than was asked for, and a partial one still leaves the
+    /// position open. Here the card is stale at twice the current share balance,
+    /// which is the worst case that path can produce.
+    ///
+    /// The share count is the assertion that carries it: 3 500 000 000 of the
+    /// 7 000 000 000 held is exactly half, which at the stale ratio is the 70
+    /// that was typed — never more, however far apart the two reads have drifted.
+    func testAnIncoherentPairStillCannotOverSpendOrCloseThePosition() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let typed = Decimal(string: "70")!
+        let builder = RUJILiquidUnbondTransactionBuilder(
+            coin: makeCoin(TokensStore.ruji),
+            withdrawAmount: typed,
+            stakedAmount: Decimal(string: "140")!,   // what the card was showing
+            receiptShares: Decimal(string: "70")!,   // what is actually held now
+            sendMaxAmount: false
+        )
+
+        XCTAssertLessThan(builder.redeemedUnits, builder.heldUnits)
+        XCTAssertEqual(
+            try XCTUnwrap(try XCTUnwrap(builder.wasmContractPayload).coins.first).amount,
+            "3500000000"
+        )
+    }
+
+    // MARK: - Beyond 64 bits
+
+    /// ⚠️ A receipt balance is read as `UInt64` base units, so it can exceed
+    /// `Int.max` — and routing the redeemed count through `Decimal.toInt()` wraps
+    /// there. A wrapped count reads as negative, fails the `>= 1` guard, and
+    /// makes the position unwithdrawable at MAX rather than merely mis-sized.
+    /// 1e11 tokens at 8 decimals is 1e19 base units, comfortably past 9.22e18.
+    func testAReceiptBalanceBeyondSixtyFourBitsStillCloses() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let huge = Decimal(string: "100000000000")!
+
+        let brune = BRUNEUnstakeTransactionBuilder(
+            coin: makeCoin(TokensStore.brune),
+            withdrawAmount: huge,
+            stakedAmount: huge,
+            autoCompoundAmount: huge,
+            sendMaxAmount: true
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(try XCTUnwrap(brune.wasmContractPayload).coins.first).amount,
+            "10000000000000000000"
+        )
+
+        let ruji = RUJILiquidUnbondTransactionBuilder(
+            coin: makeCoin(TokensStore.ruji),
+            withdrawAmount: huge,
+            stakedAmount: huge,
+            receiptShares: huge,
+            sendMaxAmount: true
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(try XCTUnwrap(ruji.wasmContractPayload).coins.first).amount,
+            "10000000000000000000"
+        )
+    }
+
+    /// The funded count is an integer string on the wire — a fractional
+    /// `CosmosCoin.amount` is malformed, and dropping the 64-bit round trip means
+    /// nothing else is truncating it.
+    func testTheFundedCountIsAlwaysWholeDigits() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = makeRujiViewModel()
+        type("70.3243", into: viewModel)
+        let units = try fundedUnits(of: viewModel)
+
+        XCTAssertFalse(units.contains("."), "rendered \(units)")
+        XCTAssertFalse(units.contains("e"), "rendered \(units)")
+        XCTAssertTrue(units.allSatisfy { $0.isASCII && $0.isNumber }, "rendered \(units)")
+    }
+
+    // MARK: - Fixtures
+
+    private func makeCoin(_ asset: CoinMeta) -> Coin {
+        Coin(
+            asset: asset,
+            address: "thor1fixturereceiptvaultaddress0000000000",
+            hexPublicKey: "02" + String(repeating: "00", count: 32)
+        )
+    }
+
+    /// Types `amount` into the sheet the way the field does, so the view model is
+    /// left in the state the real screen leaves it in.
+    ///
+    /// The two lines after the assignment are what `AmountTextField` and
+    /// `UnstakeTransactionScreen` do between them on every keystroke: derive the
+    /// percentage from the typed amount, then let the view model reconsider
+    /// whether the position is being closed. Skipping them would leave
+    /// `percentageSelected` on its initial 100 and quietly test a MAX withdrawal
+    /// instead of a custom one.
+    private func type(_ amount: String, into viewModel: UnstakeTransactionViewModel) {
+        viewModel.amountField.value = amount
+        viewModel.percentageSelected = viewModel.percentageFromAmount
+        viewModel.onPercentage(viewModel.percentageFromAmount)
+        viewModel.validForm = true
+    }
+
+    /// The bRUNE sheet as the DeFi card opens it: the ybRUNE receipt balance is
+    /// both the ceiling and the thing being spent, because the staked card
+    /// renders receipt units directly.
+    private func makeBRuneViewModel() -> UnstakeTransactionViewModel {
+        let viewModel = UnstakeTransactionViewModel(
+            coin: makeCoin(TokensStore.brune),
+            vault: TestStore.makeVault(),
+            isAutocompound: true,
+            availableToUnstake: staked
+        )
+        viewModel.availableAmount = staked
+        viewModel.autocompoundBalance = staked
+        return viewModel
+    }
+
+    private func fundedUnits(of viewModel: UnstakeTransactionViewModel) throws -> String {
+        let payload = try XCTUnwrap(try XCTUnwrap(viewModel.transactionBuilder).wasmContractPayload)
+        return try XCTUnwrap(payload.coins.first).amount
+    }
+
+    /// The RUJI compounded sheet as the DeFi card opens it: the ceiling is the
+    /// RUJI the position is worth, and the thing being spent is the sRUJI share
+    /// balance. A share is worth more than 1 RUJI, so the two differ.
+    private func makeRujiViewModel(vault: Vault? = nil) -> UnstakeTransactionViewModel {
+        let viewModel = UnstakeTransactionViewModel(
+            coin: makeCoin(TokensStore.ruji),
+            vault: vault ?? TestStore.makeVault(),
+            isAutocompound: true,
+            availableToUnstake: rujiStaked
+        )
+        viewModel.availableAmount = rujiStaked
+        viewModel.autocompoundBalance = rujiShares
+        return viewModel
+    }
+
+    private func redeemedBRuneUnits(typing amount: String) throws -> String {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = makeBRuneViewModel()
+        type(amount, into: viewModel)
+        return try fundedUnits(of: viewModel)
+    }
+}

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/WithdrawBasisPointsTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/WithdrawBasisPointsTests.swift
@@ -1,0 +1,280 @@
+//
+//  WithdrawBasisPointsTests.swift
+//  VultisigAppTests
+//
+//  A fractional-withdrawal memo asks for a share of the staked position in
+//  ten-thousandths. The amount used to reach it through a whole percentage —
+//  `Int(50.0679) * 100` — which spends 100 of the memo's 10 000 steps and made a
+//  request for 1002.73 TCY pay out 1001.37. TCY is the flow that reported it and
+//  the one exercised here; the conversion itself is the memo convention's, not
+//  TCY's.
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class WithdrawBasisPointsTests: XCTestCase {
+
+    /// The position from the bug report. 1001.37 × 2 recovers the staked balance
+    /// the issue rounds to "2002".
+    private let staked = Decimal(string: "2002.74")!
+
+    private func makeTCYCoin() -> Coin {
+        Coin(
+            asset: TokensStore.tcy,
+            address: "thor1fixturetcyvaultaddress00000000000000000",
+            hexPublicKey: "02" + String(repeating: "00", count: 32)
+        )
+    }
+
+    /// Types `amount` into the sheet the way the field does, so the view model is
+    /// left in the state the real screen leaves it in.
+    ///
+    /// The two lines after the assignment are what `AmountTextField` and
+    /// `UnstakeTransactionScreen` do between them on every keystroke: derive the
+    /// percentage from the typed amount, then let the view model reconsider
+    /// whether the position is being closed. Skipping them would leave
+    /// `percentageSelected` on its initial 100 and quietly test a MAX withdrawal
+    /// instead of a custom one.
+    private func type(_ amount: String, into viewModel: UnstakeTransactionViewModel) {
+        viewModel.amountField.value = amount
+        viewModel.percentageSelected = viewModel.percentageFromAmount
+        viewModel.onPercentage(viewModel.percentageFromAmount)
+        viewModel.validForm = true
+    }
+
+    private func makeViewModel(typing amount: String) throws -> UnstakeTransactionViewModel {
+        let viewModel = UnstakeTransactionViewModel(
+            coin: makeTCYCoin(),
+            vault: TestStore.makeVault(),
+            isAutocompound: false,
+            availableToUnstake: staked
+        )
+        viewModel.availableAmount = staked
+        type(amount, into: viewModel)
+        return viewModel
+    }
+
+    private func memo(typing amount: String) throws -> String {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let viewModel = try makeViewModel(typing: amount)
+        return try XCTUnwrap(viewModel.transactionBuilder).memo
+    }
+
+    // MARK: - The reported bug
+
+    /// ⚠️ The regression test for the reported third symptom. Verified to FAIL on
+    /// the parent commit, where the same inputs build `tcy-:5000` — 50% of
+    /// 2002.74 = **1001.37**, exactly the figure the user reported receiving
+    /// after asking for 1002.73.
+    func testAWithdrawalAsksForTheAmountThatWasTypedNotAFlooredPercentage() throws {
+        XCTAssertEqual(try memo(typing: "1002.73"), "tcy-:5006")
+    }
+
+    /// What the truncation cost, stated as money. 5006 bps of 2002.74 is
+    /// 1002.5717; 5000 bps is 1001.37. The old path was off by 1.36 TCY, the new
+    /// one by 0.16 — and never in the direction of taking more.
+    func testBasisPointPrecisionLandsWithinOneBasisPointOfTheRequest() {
+        let requested = Decimal(string: "1002.73")!
+        let bps = WithdrawBasisPoints.value(forAmount: requested, available: staked)
+        let delivered = (staked * Decimal(bps)) / Decimal(WithdrawBasisPoints.max)
+
+        XCTAssertLessThanOrEqual(delivered, requested, "a withdrawal must never take more than was asked for")
+        let error = NSDecimalNumber(decimal: requested - delivered).doubleValue
+        XCTAssertLessThan(error, 0.21, "one basis point of this position is 0.20 TCY")
+    }
+
+    /// ⚠️ Rounding must never close a position the user asked to keep something
+    /// in. Asking to withdraw 2002.64 of 2002.74 is asking to keep 0.10 TCY;
+    /// rounding to nearest would reach 10000 and take the last of it, which is a
+    /// different outcome rather than a rounding difference.
+    func testRoundingNeverClosesAPositionTheUserAskedToKeep() {
+        let bps = WithdrawBasisPoints.value(forAmount: Decimal(string: "2002.64")!, available: staked)
+        XCTAssertLessThan(bps, WithdrawBasisPoints.max)
+        XCTAssertEqual(bps, 9999)
+    }
+
+    // MARK: - Conversion
+
+    func testHalfThePositionIsFiveThousandBasisPoints() {
+        XCTAssertEqual(WithdrawBasisPoints.value(forAmount: staked / 2, available: staked), 5000)
+    }
+
+    func testTheWholePositionIsTenThousandBasisPoints() {
+        XCTAssertEqual(WithdrawBasisPoints.value(forAmount: staked, available: staked), 10_000)
+    }
+
+    /// A memo can never ask for more of the position than all of it, whatever the
+    /// field says.
+    func testMoreThanThePositionClampsToTenThousand() {
+        XCTAssertEqual(WithdrawBasisPoints.value(forAmount: staked * 3, available: staked), 10_000)
+    }
+
+    func testAnAmountTooSmallForOneBasisPointIsZero() {
+        // A basis point of this position is 0.200274 TCY.
+        XCTAssertEqual(WithdrawBasisPoints.value(forAmount: Decimal(string: "0.05")!, available: staked), 0)
+    }
+
+    func testThereAreNoBasisPointsOfAnEmptyPosition() {
+        XCTAssertEqual(WithdrawBasisPoints.value(forAmount: 10, available: 0), 0)
+    }
+
+    // MARK: - Closing the position
+
+    /// A full exit has to pin the ceiling rather than derive it: the amount field
+    /// renders 4 decimals, so on a small position MAX can round short and leave a
+    /// sliver staked.
+    func testClosingThePositionAsksForExactlyTenThousandBasisPoints() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let viewModel = UnstakeTransactionViewModel(
+            coin: makeTCYCoin(),
+            vault: TestStore.makeVault(),
+            isAutocompound: false,
+            availableToUnstake: staked
+        )
+        viewModel.availableAmount = staked
+        viewModel.setupAmountField()          // MAX — what the sheet opens on
+        viewModel.amountField.value = "2002.7400"
+        viewModel.validForm = true
+
+        XCTAssertEqual(try XCTUnwrap(viewModel.transactionBuilder).memo, "tcy-:10000")
+    }
+
+    // MARK: - Validation
+
+    func testAnAmountBelowOneBasisPointIsRejected() {
+        let validator = WithdrawMinimumAmountValidator(available: staked, ticker: "TCY")
+        XCTAssertThrowsError(try validator.validate(value: "0.05"))
+    }
+
+    /// The message has to name a figure that actually passes, or it sends the
+    /// user in a circle.
+    func testTheQuotedMinimumIsItselfAcceptable() throws {
+        let validator = WithdrawMinimumAmountValidator(available: staked, ticker: "TCY")
+        let quoted = WithdrawBasisPoints.quotedMinimum(
+            forAvailable: staked,
+            digits: WithdrawMinimumAmountValidator.quotedDigits
+        )
+        XCTAssertNoThrow(
+            try validator.validate(value: quoted.formatToDecimal(digits: WithdrawMinimumAmountValidator.quotedDigits))
+        )
+        XCTAssertGreaterThanOrEqual(
+            WithdrawBasisPoints.value(forAmount: quoted, available: staked),
+            WithdrawBasisPoints.min
+        )
+    }
+
+    /// ⚠️ Neither the sub-basis-point guard nor this validator may be what stops
+    /// a dust position being emptied. Comparing against a minimum rounded up to
+    /// display precision made any position smaller than that rounding
+    /// unwithdrawable — not even at MAX, because the validator blocks the form
+    /// before the builder is ever asked.
+    ///
+    /// Scope: this covers the guard and the validator, which is the whole of the
+    /// boundary this change owns. What still bounds a dust withdrawal end to end
+    /// is the shared amount field, which renders 4 decimals, so a position under
+    /// 0.0001 TCY reaches `AmountBalanceValidator` as "0". That is pre-existing
+    /// and shared by every flow using the field.
+    func testADustPositionIsNotBlockedByTheBasisPointGuard() throws {
+        let dust = Decimal(string: "0.00005")!
+        let validator = WithdrawMinimumAmountValidator(available: dust, ticker: "TCY")
+
+        XCTAssertNoThrow(try validator.validate(value: "0.00005"))
+        XCTAssertEqual(WithdrawBasisPoints.value(forAmount: dust, available: dust), WithdrawBasisPoints.max)
+    }
+
+    /// Reporting a malformed or over-balance amount is `AmountBalanceValidator`'s
+    /// job; two validators reporting the same field would fight over the message.
+    func testItLeavesMalformedAndOverBalanceAmountsToTheBalanceValidator() {
+        let validator = WithdrawMinimumAmountValidator(available: staked, ticker: "TCY")
+        XCTAssertNoThrow(try validator.validate(value: "not a number"))
+        XCTAssertNoThrow(try validator.validate(value: "0"))
+        XCTAssertNoThrow(try validator.validate(value: "999999"))
+    }
+
+    /// A withdrawal too small to express must not reach the chain even if the
+    /// validator is bypassed.
+    func testTheBuilderRefusesAnAmountThatRoundsToNothing() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let viewModel = try makeViewModel(typing: "0.05")
+
+        XCTAssertNil(viewModel.transactionBuilder)
+    }
+
+    // MARK: - Scope
+
+    /// MAYAChain's `POOL-:<bps>` addresses the position in the same
+    /// ten-thousandths THORChain's `tcy-:` does, so it gets the same conversion —
+    /// `POOL-:5000` here would be the 1%-granularity defect, on a different chain.
+    func testTheCacaoWithdrawalAsksForTheAmountThatWasTypedToo() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let viewModel = try makeCacaoViewModel(typing: "1002.73")
+
+        XCTAssertEqual(try XCTUnwrap(viewModel.transactionBuilder).memo, "POOL-:5006")
+    }
+
+    /// The floor applies on MAYAChain for the same reason it does on THORChain:
+    /// under one basis point of the position, `POOL-:0` is a fee paid to withdraw
+    /// nothing.
+    func testACacaoAmountBelowOneBasisPointIsRefused() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let viewModel = try makeCacaoViewModel(typing: "0.05")
+
+        // ⚠️ The REAL validator chain, not a hand-set `validForm`: the minimum has
+        // to be installed on the CACAO field, not just computed correctly.
+        XCTAssertThrowsError(try viewModel.amountField.validate())
+        XCTAssertNil(viewModel.transactionBuilder)
+    }
+
+    /// The bonded RUJI position is exact already and must stay untouched: its
+    /// `withdraw:<asset>:<raw>` memo carries an ABSOLUTE amount, so there is no
+    /// fraction to quantise and nothing here applies to it.
+    func testTheBondedRujiWithdrawalStillCarriesTheTypedAmount() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = UnstakeTransactionViewModel(
+            coin: Coin(
+                asset: TokensStore.ruji,
+                address: "thor1fixturerujivaultaddress00000000000000",
+                hexPublicKey: "02" + String(repeating: "00", count: 32)
+            ),
+            vault: TestStore.makeVault(),
+            isAutocompound: false,
+            availableToUnstake: staked
+        )
+        viewModel.availableAmount = staked
+        type("1002.73", into: viewModel)
+
+        XCTAssertEqual(
+            try XCTUnwrap(viewModel.transactionBuilder).memo,
+            "withdraw:x/ruji:100273000000"
+        )
+    }
+
+    private func makeCacaoViewModel(typing amount: String) throws -> UnstakeTransactionViewModel {
+        let cacao = Coin(
+            asset: TokensStore.cacao,
+            address: "maya1fixturecacaovaultaddress000000000000",
+            hexPublicKey: "02" + String(repeating: "00", count: 32)
+        )
+        let viewModel = UnstakeTransactionViewModel(
+            coin: cacao,
+            vault: TestStore.makeVault(),
+            isAutocompound: false,
+            availableToUnstake: staked
+        )
+        viewModel.availableAmount = staked
+        // What `onLoad()` does before the user touches anything — it is what
+        // installs the field's validators.
+        viewModel.setupAmountField()
+        type(amount, into: viewModel)
+        return viewModel
+    }
+}

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/WithdrawBasisPointsTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/WithdrawBasisPointsTests.swift
@@ -143,6 +143,44 @@ final class WithdrawBasisPointsTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(viewModel.transactionBuilder).memo, "tcy-:10000")
     }
 
+    /// ⚠️ **The MAX flag alone may never decide a full exit** — the invariant
+    /// `AmountPercentageBinding` states outright, because the percentage it
+    /// derives is a `Double` and a fraction within ~1e-15 of the whole position
+    /// comes back as exactly `100`. When the field already held 100 that is not a
+    /// change, so nothing clears the flag raised when the sheet opened at MAX.
+    ///
+    /// The receipt-share arms already corroborate against the amount. This pins
+    /// that the memo arms do too: with the flag and the selection both stale from
+    /// the opening MAX, an amount that says half must withdraw half.
+    ///
+    /// Reaching this state through the field needs a position the parse cannot
+    /// round-trip — `toDecimal()` goes through `NumberFormatter`, so the amount
+    /// and the percentage are derived from the same lossy value and normally
+    /// agree. The guard does not depend on that holding.
+    func testAStaleMaxFlagCannotCloseAPositionTheAmountSaysIsPartial() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let viewModel = UnstakeTransactionViewModel(
+            coin: makeTCYCoin(),
+            vault: TestStore.makeVault(),
+            isAutocompound: false,
+            availableToUnstake: staked
+        )
+        viewModel.availableAmount = staked
+        viewModel.setupAmountField()
+
+        // Both survive from the sheet opening at MAX; only the amount moved.
+        viewModel.onPercentage(100)
+        viewModel.percentageSelected = 100
+        viewModel.amountField.value = "1001.37"
+        viewModel.validForm = true
+
+        XCTAssertTrue(viewModel.isMaxAmount, "the flag the guard must not trust on its own")
+        XCTAssertEqual(viewModel.withdrawBasisPoints, 5000)
+        XCTAssertEqual(try XCTUnwrap(viewModel.transactionBuilder).memo, "tcy-:5000")
+    }
+
     // MARK: - Validation
 
     func testAnAmountBelowOneBasisPointIsRejected() {

--- a/VultisigApp/VultisigAppTests/Services/THORChainStakeInteractorTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/THORChainStakeInteractorTests.swift
@@ -458,4 +458,32 @@ final class THORChainStakeInteractorTests: XCTestCase {
     func testAccountPayloadWithoutStakingEntriesFailsClosed() {
         XCTAssertThrowsError(try makeDetails(from: #"{"data":{"node":{"stakingV2":null}}}"#))
     }
+
+    // MARK: - "no longer a staker" is an answer, not a failure
+
+    /// ⚠️ **The exact body THORNode returns after a full TCY unstake.** It is a
+    /// 500, so absence and a server fault share a status code, and swallowing
+    /// the wrong one either strands a stale balance on the card or zeroes a
+    /// funded position on an outage.
+    func test_isTcyStakerAbsent_recognisesTheNonStakerBody() {
+        let body = Data(#"{"code":2, "message":"fail to tcy staker: TCYStaker doesn't exist: thor1pe0pspu4ep85gxr5h9l6k49g024vemtr80hg4c", "details":[]}"#.utf8)
+        XCTAssertTrue(THORChainStakingService.isTcyStakerAbsent(HTTPError.statusCode(500, body)))
+    }
+
+    /// A 500 that is not this answer must keep throwing, so the persisted row
+    /// keeps its last good value rather than being zeroed by an outage.
+    func test_isTcyStakerAbsent_refusesEveryOtherFailure() {
+        let genuine = Data(#"{"code":13,"message":"internal server error","details":[]}"#.utf8)
+        XCTAssertFalse(THORChainStakingService.isTcyStakerAbsent(HTTPError.statusCode(500, genuine)))
+        XCTAssertFalse(THORChainStakingService.isTcyStakerAbsent(HTTPError.statusCode(500, nil)))
+        XCTAssertFalse(THORChainStakingService.isTcyStakerAbsent(HTTPError.timeout))
+        XCTAssertFalse(THORChainStakingService.isTcyStakerAbsent(HTTPError.invalidResponse))
+    }
+
+    /// Not keyed on the status code: THORNode uses 500 today, and the reading
+    /// should survive it being corrected to a 404 without a code change.
+    func test_isTcyStakerAbsent_isNotKeyedOnTheStatusCode() {
+        let body = Data(#"{"code":2, "message":"fail to tcy staker: TCYStaker doesn't exist: thor1abc", "details":[]}"#.utf8)
+        XCTAssertTrue(THORChainStakingService.isTcyStakerAbsent(HTTPError.statusCode(404, body)))
+    }
 }

--- a/VultisigApp/VultisigAppTests/Services/THORChainStakeInteractorTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/THORChainStakeInteractorTests.swift
@@ -487,3 +487,164 @@ final class THORChainStakeInteractorTests: XCTestCase {
         XCTAssertTrue(THORChainStakingService.isTcyStakerAbsent(HTTPError.statusCode(404, body)))
     }
 }
+
+// MARK: - The conversion the predicate guards
+
+/// `isTcyStakerAbsent` is only the predicate. The substitution it authorises —
+/// a recognised absence becoming `TcyStakerResponse(amount: "0")` instead of a
+/// throw — lives in `fetchTcyStakedAmount`, which is what the DeFi tab actually
+/// calls. These drive that method over a stubbed transport so both halves are
+/// pinned end to end: the absence reads as a zero, and everything else still
+/// throws rather than being quietly zeroed.
+///
+/// `THORChainStakingService` builds its `HTTPClient` on `URLSession.shared`, so
+/// the seam is a globally registered `URLProtocol` scoped to the `tcy_staker`
+/// route — the same interception the join-keysign and Sui service tests use.
+@MainActor
+final class THORChainStakingServiceTcyStakerTests: XCTestCase {
+
+    private let address = "thor1pe0pspu4ep85gxr5h9l6k49g024vemtr80hg4c"
+
+    /// ⚠️ **The exact body THORNode returns after a full TCY unstake.**
+    private var nonStakerBody: Data {
+        Data(#"{"code":2, "message":"fail to tcy staker: TCYStaker doesn't exist: \#(address)", "details":[]}"#.utf8)
+    }
+
+    override func setUp() {
+        super.setUp()
+        TcyStakerStubProtocol.reset()
+        URLProtocol.registerClass(TcyStakerStubProtocol.self)
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(TcyStakerStubProtocol.self)
+        TcyStakerStubProtocol.reset()
+        super.tearDown()
+    }
+
+    /// The live shape: absence arrives as a 500, and must come back as a zero
+    /// position rather than a throw that leaves the withdrawn balance on screen.
+    func testFetchTcyStakedAmountReadsA500NonStakerAsZero() async throws {
+        TcyStakerStubProtocol.configure(statusCode: 500, body: nonStakerBody)
+
+        let response = try await THORChainStakingService.shared.fetchTcyStakedAmount(address: address)
+
+        XCTAssertEqual(response.amount, "0")
+        XCTAssertEqual(TcyStakerStubProtocol.requestCount, 1)
+        XCTAssertTrue(
+            TcyStakerStubProtocol.lastPath?.hasSuffix("/thorchain/tcy_staker/\(address)") == true,
+            "The stub must have answered the tcy_staker route, got \(TcyStakerStubProtocol.lastPath ?? "nil")"
+        )
+    }
+
+    /// Not keyed on the status code: the same body behind a 404 must read the
+    /// same way, so THORNode correcting the status doesn't need a code change.
+    func testFetchTcyStakedAmountReadsA404NonStakerAsZero() async throws {
+        TcyStakerStubProtocol.configure(statusCode: 404, body: nonStakerBody)
+
+        let response = try await THORChainStakingService.shared.fetchTcyStakedAmount(address: address)
+
+        XCTAssertEqual(response.amount, "0")
+    }
+
+    /// A genuine server fault shares the 500 with the absence, and must still
+    /// throw — the persisted row keeping its last good value is the right answer
+    /// to a read that did not happen.
+    func testFetchTcyStakedAmountPropagatesAnUnrelatedFailure() async {
+        let fault = Data(#"{"code":13,"message":"internal server error","details":[]}"#.utf8)
+        TcyStakerStubProtocol.configure(statusCode: 500, body: fault)
+
+        do {
+            let response = try await THORChainStakingService.shared.fetchTcyStakedAmount(address: address)
+            XCTFail("An outage must not be converted to a zero position, got amount \(response.amount)")
+        } catch HTTPError.statusCode(let code, _) {
+            XCTAssertEqual(code, 500)
+        } catch {
+            XCTFail("Expected the status-code error to propagate, got \(error)")
+        }
+    }
+
+    /// The zero substitution must not swallow a real balance on the way past.
+    func testFetchTcyStakedAmountReturnsTheStakedAmountOnSuccess() async throws {
+        TcyStakerStubProtocol.configure(statusCode: 200, body: Data(#"{"amount":"1638238990000"}"#.utf8))
+
+        let response = try await THORChainStakingService.shared.fetchTcyStakedAmount(address: address)
+
+        XCTAssertEqual(response.amount, "1638238990000")
+    }
+}
+
+/// Answers only the `tcy_staker` route, so registering it globally leaves every
+/// other request in the suite untouched.
+private final class TcyStakerStubProtocol: URLProtocol {
+
+    private static let lock = NSLock()
+    private static var statusCode = 200
+    private static var body = Data("{}".utf8)
+    private static var count = 0
+    private static var path: String?
+
+    static var requestCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    /// The path that actually went on the wire, so a passing test cannot be one
+    /// where the stub answered some other request.
+    static var lastPath: String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return path
+    }
+
+    static func configure(statusCode: Int, body: Data) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.statusCode = statusCode
+        self.body = body
+    }
+
+    static func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        statusCode = 200
+        body = Data("{}".utf8)
+        count = 0
+        path = nil
+    }
+
+    // These are required `URLProtocol` class-method overrides; they cannot be `static`.
+    // swiftlint:disable static_over_final_class
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.path.contains("/thorchain/tcy_staker/") == true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    // swiftlint:enable static_over_final_class
+
+    override func startLoading() {
+        // Counted here rather than in `canInit`, which URLSession may consult
+        // more than once for a single load.
+        Self.lock.lock()
+        let code = Self.statusCode
+        let payload = Self.body
+        Self.count += 1
+        Self.path = request.url?.path
+        Self.lock.unlock()
+
+        // Force-unwrap is safe: the URL came from the intercepted request and
+        // every status code used here initializes a response.
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: code,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: payload)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}


### PR DESCRIPTION
## Description

Fixes #5074
Fixes #5090

A user withdrawing from a **2002.74 TCY** staked position typed **1002.73** and received **1001.37**. The same defect reached every staked position in the app, in two different shapes.

> **Replaces #5089**, which fixed the same defects but was stacked on the transaction-decoder branch and also carried a presentation layer. This is the same logic re-applied directly on `main`, with the verb/hero half deliberately left out — naming what a transaction *is* belongs to the decoder, which owns that question on both devices.

## 1. Memo-carrying positions — TCY, sTCY, CACAO

`tcy-:<bps>` and `POOL-:<bps>` ask for a fraction in **basis points** (0…10000), but the amount reached them through a *whole percentage*:

```swift
percentage: Int(percentageSelected ?? percentageFromAmount)   // 50.0679 -> 50
let basisPoints = percentage * 100                            // -> tcy-:5000
```

That spends 100 of the memo's 10 000 steps. One step is **20.03 TCY** on that position, and 50% of 2002.74 is **1001.37** — the reported figure exactly.

`WithdrawBasisPoints` now converts straight to basis points and rounds **down**, so the worst-case error falls from ~1% of the position to one ten-thousandth of it, and a withdrawal never takes more than was asked for.

## 2. Receipt-share positions — bRUNE, RUJI auto-compound

⚠️ **Basis points are the wrong instrument here, and the instruction says so.** A `tcy-:<bps>` memo names a *fraction*; `liquid.unbond` names **nothing** — the execute message is empty and the **attached funds are the instruction**, an absolute count of receipt base units.

`ReceiptShareRedemption` converts the typed amount straight to base units: **1% → ~1e-8 of the position**, three orders finer than the 0.01% the issue asked for. It takes a position *value* rather than assuming one, because the two arms are asymmetric — bRUNE's card renders the receipt balance (already a share count), while RUJI's renders what the receipt is *worth* in RUJI.

## 3. A `Double` could promote a near-MAX amount into a full exit

`AmountPercentageBinding.percentage` returns `Double`, so an amount within ~1e-15 of the balance derives **exactly 100** — the value a fresh sheet already holds. No `onChange` fires, `onPercentage` never runs, `isMaxAmount` stays true, and a position meant to stay open is closed. Fixed with an exact check, never a tolerance.

The receipt arms corroborate the flag against the amount; the memo arms now do the same, through the same rule, which still accepts the four-decimal figure MAX prefills so a genuine full exit keeps asking for 10000.

## 4. A full unstake left the card showing the old balance

Reported from a device: after fully unstaking TCY, the position kept displaying the withdrawn amount and the log showed

```
❌ HTTP Error: 500 - 276ms
{"code":2, "message":"fail to tcy staker: TCYStaker doesn't exist: thor1pe0…", "details":[]}
```

THORNode answers `/thorchain/tcy_staker/<addr>` for an address with no position with a **500**, so the read throws, `THORChainStakeInteractor` returns no positions, and storage upserts nothing. Keeping the last good value is the right answer to a read that *did not happen*; it is the wrong answer to a read that happened and said zero.

⚠️ **Absence and a genuine server fault share a status code on this route**, so only the body separates them. The check matches the body's marker and deliberately ignores the status — keying on 500 would turn an outage into a zeroed position. Every other failure still throws.

**Verified against the live endpoints. TCY is the only affected family:**

| Position | Read | Non-staker response |
|---|---|---|
| TCY staked | `/thorchain/tcy_staker` | **500 + marker — fixed here** |
| sTCY, ybRUNE, sRUJI receipt | bank balances | 200, denom absent → zero |
| RUJI / sRUJI card | Rujira GraphQL | no RUJI entry → `.empty`, already handled |
| CACAO | `/mayachain/cacao_provider` | 200 with all-zero fields |
| TON | tonapi nominator pools | empty list → explicit zero position |

## What is deliberately not here

`TransactionHeroResolver`, `QuotedWithdrawalPresentation`, the four screen hookups and their locale keys stay behind with the decoder work. `withdrawDisplayAmount` went with them — its only consumer was that presentation, so carrying it would be a field nothing reads — and `stakedAmount` left the TCY builder for the same reason. `SendTransaction` and `TransactionBuilder` are byte-identical to `main` as a result.

**26 files, +1797 / −59** against `main`.

## Testing

- Full gate green: `** TEST SUCCEEDED **`, **6549 tests, 11 skipped, 0 failures**.
- SwiftLint clean on every touched file.
- Regression coverage verified non-vacuous — reverting the fix yields `5000` instead of `5006`, `100137000000` instead of `100273000000`, and `6789412391` instead of `6927968618`, failing the TCY, bRUNE and RUJI tests respectively.

## Known and out of scope

Found while reviewing this port, all pre-existing:

- `String.toDecimal()` parses through `NumberFormatter` → `NSNumber` → double, so `"70.3243"` becomes `70.32429999999999`. A MAX receipt redemption can leave one base unit behind.
- Sub-base-unit receipt withdrawals pass the balance validator and navigate toward Verify with a nil contract payload; the minimum validator is installed only for TCY/CACAO.
- TCY auto-compound still narrows its redeemed count through `Int`, unlike the corrected bRUNE/RUJI builders — reachable only on an implausibly large position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Amount fields now keep typed values synchronized with percentage controls and account balances.
  * Staking withdrawals support more precise fractional amounts and full-position exits.
  * Added clear minimum-withdrawal validation with localized messages.
* **Bug Fixes**
  * Improved handling of unavailable or missing staking balances.
  * Prevented invalid, oversized, or below-minimum redemption amounts from generating transactions.
  * Preserved user-entered amounts when balances update later.
* **Localization**
  * Added minimum-withdrawal messages in supported languages.
* **Tests**
  * Expanded coverage for amount conversion, staking withdrawals, redemptions, and missing balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->