### PR TITLE
fix(wallet): stop the portfolio search bar scrolling itself off-screen

### DIFF
--- a/VultisigApp/VultisigApp/Components/TextField/SearchTextField.swift
+++ b/VultisigApp/VultisigApp/Components/TextField/SearchTextField.swift
@@ -12,18 +12,21 @@ struct SearchTextField: View {
     @Binding var isFocused: Bool
     let showPasteButton: Bool
     let placeholder: String
+    let accessibilityIdentifier: String?
     @FocusState var focusedState: Bool
 
     init(
         value: Binding<String>,
         isFocused: Binding<Bool> = .constant(false),
         showPasteButton: Bool = false,
-        placeholder: String = "search".localized
+        placeholder: String = "search".localized,
+        accessibilityIdentifier: String? = nil
     ) {
         self._value = value
         self._isFocused = isFocused
         self.showPasteButton = showPasteButton
         self.placeholder = placeholder
+        self.accessibilityIdentifier = accessibilityIdentifier
     }
 
     var showClearButton: Bool {
@@ -45,6 +48,9 @@ struct SearchTextField: View {
                 .colorScheme(.dark)
                 .padding(.horizontal, 8)
                 .focused($focusedState)
+                .unwrap(accessibilityIdentifier) { view, id in
+                    view.accessibilityIdentifier(id)
+                }
 
             HStack(spacing: 8) {
                 clearButton

--- a/VultisigApp/VultisigApp/Core/Utils/AccessibilityID.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/AccessibilityID.swift
@@ -17,6 +17,18 @@ enum AccessibilityID {
         static let balanceLabel = "home.balanceLabel"
     }
 
+    enum VaultMain {
+        static let searchButton = "vaultMain.searchButton"
+        static let searchField = "vaultMain.searchField"
+        static let searchCancelButton = "vaultMain.searchCancelButton"
+    }
+
+    enum DefiMain {
+        static let searchButton = "defiMain.searchButton"
+        static let searchField = "defiMain.searchField"
+        static let searchCancelButton = "defiMain.searchCancelButton"
+    }
+
     enum Settings {
         static let container = "settings.container"
         static let languageCell = "settings.languageCell"

--- a/VultisigApp/VultisigApp/Features/Defi/DefiMain/DefiMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiMain/DefiMainScreen.swift
@@ -23,11 +23,11 @@ struct DefiMainScreen: View {
     @State var showSearchHeader: Bool = false
     @State var focusSearch: Bool = false
     @State var showChainSelection: Bool = false
-    @State private var searchScrollTask: Task<Void, Never>?
     @State private var clearSearchTask: Task<Void, Never>?
     @State private var refreshTask: Task<Void, Never>?
 
-    private let scrollReferenceId = "DefiMainScreenBottomContentId"
+    private let searchAnchorId = "defiMainSearchHeaderAnchor"
+    private let sectionHeaderHeight: CGFloat = 42
     private let contentInset: CGFloat = 78
     private let horizontalPadding: CGFloat = 16
 
@@ -58,16 +58,10 @@ struct DefiMainScreen: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             .background(MainBackgroundWithNotification())
             .onChange(of: showSearchHeader) { _, showSearchHeader in
-                if showSearchHeader {
-                    focusSearch = true
-                    searchScrollTask?.cancel()
-                    searchScrollTask = delayedTask(after: .milliseconds(700)) {
-                        withAnimation {
-                            scrollProxy?.scrollTo(scrollReferenceId, anchor: .center)
-                        }
-                    }
-                } else {
-                    searchScrollTask?.cancel()
+                guard showSearchHeader else { return }
+                focusSearch = true
+                withAnimation {
+                    scrollProxy?.scrollTo(searchAnchorId, anchor: .top)
                 }
             }
             .crossPlatformSheet(isPresented: $showChainSelection) {
@@ -86,7 +80,6 @@ struct DefiMainScreen: View {
             refresh()
         }
         .onDisappear {
-            searchScrollTask?.cancel()
             clearSearchTask?.cancel()
             refreshTask?.cancel()
         }
@@ -102,7 +95,8 @@ struct DefiMainScreen: View {
                 }
             }
             .transition(.opacity)
-            .frame(height: 42)
+            .frame(height: sectionHeaderHeight)
+            .background(searchScrollAnchor)
             .padding(.bottom, 16)
 
             DefiChainListView(
@@ -110,15 +104,24 @@ struct DefiMainScreen: View {
                 viewModel: viewModel,
                 onCustomizeChains: onCustomizeChains
             )
-            VStack {}
-                .background(
-                    // Reference to scroll when search gets presented
-                    VStack {}
-                        .frame(height: 300)
-                        .id(scrollReferenceId)
-                )
         }
         .id(vault.id)
+    }
+
+    /// Where the section header is parked when search opens.
+    ///
+    /// A background is centred on its host and does not affect layout, so a box
+    /// `2 * contentInset` taller than the header has its top edge exactly
+    /// `contentInset` above the header's. Scrolling *that* edge to the top of
+    /// the viewport leaves the header one floating-home-header height down —
+    /// the same clearance `VaultMainScreenScrollView`'s `topInset` gives the
+    /// rest of the content — so the field lands below that header rather than
+    /// behind it, with the results underneath it and above the keyboard.
+    var searchScrollAnchor: some View {
+        Color.clear
+            .frame(height: sectionHeaderHeight + 2 * contentInset)
+            .id(searchAnchorId)
+            .allowsHitTesting(false)
     }
 
     var defaultBottomSectionHeader: some View {
@@ -136,6 +139,7 @@ struct DefiMainScreen: View {
             CircularAccessoryIconButton(icon: .magnifier) {
                 toggleSearch()
             }
+            .accessibilityIdentifier(AccessibilityID.DefiMain.searchButton)
             CircularAccessoryIconButton(icon: .housePen, type: .secondary) {
                 showChainSelection.toggle()
             }
@@ -144,7 +148,11 @@ struct DefiMainScreen: View {
 
     var searchBottomSectionHeader: some View {
         HStack(spacing: 12) {
-            SearchTextField(value: $viewModel.searchText, isFocused: $focusSearch)
+            SearchTextField(
+                value: $viewModel.searchText,
+                isFocused: $focusSearch,
+                accessibilityIdentifier: AccessibilityID.DefiMain.searchField
+            )
             Button(action: clearSearch) {
                 Text("cancel".localized)
                     .foregroundStyle(Theme.colors.textPrimary)
@@ -152,6 +160,7 @@ struct DefiMainScreen: View {
             }
             .buttonStyle(.plain)
             .transition(.opacity)
+            .accessibilityIdentifier(AccessibilityID.DefiMain.searchCancelButton)
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
@@ -34,7 +34,6 @@ struct VaultMainScreen: View {
     @State var showReceiveList: Bool = false
     @State var focusSearch: Bool = false
     @State var scrollProxy: ScrollViewProxy?
-    @State var frameHeight: CGFloat = 0
     /// Chain asset the user tried to enable that requires an MLDSA key the
     /// vault doesn't have yet (today: QBTC). Persisted across the keygen
     /// hop so we can auto-add it on `qbtcQuantumKeygenCompleted`.
@@ -43,7 +42,8 @@ struct VaultMainScreen: View {
     // Capture geometry width to avoid circular layout dependency during sheet presentation
     @State private var capturedGeometryWidth: CGFloat = 400
 
-    private let scrollReferenceId = "vaultMainScreenBottomContentId"
+    private let searchAnchorId = "vaultMainSearchHeaderAnchor"
+    private let sectionHeaderHeight: CGFloat = 42
     private let contentInset: CGFloat = 78
     private let horizontalPadding: CGFloat = 16
 
@@ -84,13 +84,10 @@ struct VaultMainScreen: View {
                     }
                 }
                 .onChange(of: showSearchHeader) { _, showSearchHeader in
-                    if showSearchHeader {
-                        focusSearch = true
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
-                            withAnimation {
-                                scrollProxy?.scrollTo(scrollReferenceId, anchor: .center)
-                            }
-                        }
+                    guard showSearchHeader else { return }
+                    focusSearch = true
+                    withAnimation {
+                        scrollProxy?.scrollTo(searchAnchorId, anchor: .top)
                     }
                 }
                 .crossPlatformSheet(isPresented: $showChainSelection) {
@@ -196,7 +193,8 @@ struct VaultMainScreen: View {
                 }
             }
             .transition(.opacity)
-            .frame(height: 42)
+            .frame(height: sectionHeaderHeight)
+            .background(searchScrollAnchor)
             .padding(.bottom, 16)
 
             VaultMainChainListView(
@@ -204,14 +202,24 @@ struct VaultMainScreen: View {
                 onCopy: onCopy,
                 onCustomizeChains: onCustomizeChains
             )
-            .background(
-                // Reference to scroll when search gets presented
-                VStack {}
-                    .frame(height: 300)
-                    .id(scrollReferenceId)
-            )
         }
         .id(vault.id)
+    }
+
+    /// Where the section header is parked when search opens.
+    ///
+    /// A background is centred on its host and does not affect layout, so a box
+    /// `2 * contentInset` taller than the header has its top edge exactly
+    /// `contentInset` above the header's. Scrolling *that* edge to the top of
+    /// the viewport leaves the header one floating-home-header height down —
+    /// the same clearance `VaultMainScreenScrollView`'s `topInset` gives the
+    /// rest of the content — so the field lands below that header rather than
+    /// behind it, with the results underneath it and above the keyboard.
+    var searchScrollAnchor: some View {
+        Color.clear
+            .frame(height: sectionHeaderHeight + 2 * contentInset)
+            .id(searchAnchorId)
+            .allowsHitTesting(false)
     }
 
     var defaultBottomSectionHeader: some View {
@@ -229,6 +237,7 @@ struct VaultMainScreen: View {
             CircularAccessoryIconButton(icon: .magnifier) {
                 toggleSearch()
             }
+            .accessibilityIdentifier(AccessibilityID.VaultMain.searchButton)
             CircularAccessoryIconButton(icon: .housePen, type: .secondary) {
                 showChainSelection.toggle()
             }
@@ -238,7 +247,11 @@ struct VaultMainScreen: View {
 
     var searchBottomSectionHeader: some View {
         HStack(spacing: 12) {
-            SearchTextField(value: $viewModel.searchText, isFocused: $focusSearch)
+            SearchTextField(
+                value: $viewModel.searchText,
+                isFocused: $focusSearch,
+                accessibilityIdentifier: AccessibilityID.VaultMain.searchField
+            )
             Button(action: clearSearch) {
                 Text("cancel".localized)
                     .foregroundStyle(Theme.colors.textPrimary)
@@ -246,6 +259,7 @@ struct VaultMainScreen: View {
             }
             .buttonStyle(.plain)
             .transition(.opacity)
+            .accessibilityIdentifier(AccessibilityID.VaultMain.searchCancelButton)
         }
     }
 

--- a/VultisigApp/VultisigAppUITests/Tests/PortfolioSearchTests.swift
+++ b/VultisigApp/VultisigAppUITests/Tests/PortfolioSearchTests.swift
@@ -1,0 +1,152 @@
+//
+//  PortfolioSearchTests.swift
+//  VultisigAppUITests
+//
+
+import XCTest
+
+/// Regression coverage for the portfolio search bar scrolling itself out of the
+/// viewport when it takes focus.
+///
+/// Two limits worth knowing before trusting a green run:
+///
+/// - Both cases need a vault on the device. A clean simulator boots into the
+///   create-vault flow, so on CI these skip rather than pass — there is no
+///   seeded-vault launch argument yet.
+/// - The size of the jump scaled with the length of the chain list, so a vault
+///   with only a handful of chains exercises this far more weakly than a full
+///   one: the scroll clamps against the content's end long before the field
+///   leaves the screen.
+final class PortfolioSearchTests: VultisigUITestCase {
+
+    /// The scroll this covers used to fire on a fixed delay after focus, so the
+    /// assertions deliberately settle for longer than that before looking.
+    private let settleDelay: TimeInterval = 1.5
+
+    func testWalletSearchFieldStaysVisibleAfterFocus() throws {
+        launchApp()
+
+        guard isOnHomeScreen else {
+            throw XCTSkip("No vault available; portfolio search scenario not applicable")
+        }
+        homePage.assertVisible()
+
+        try assertSearchStaysVisible(
+            screen: "Wallet",
+            searchButtonID: AccessibilityID.VaultMain.searchButton,
+            searchFieldID: AccessibilityID.VaultMain.searchField,
+            cancelButtonID: AccessibilityID.VaultMain.searchCancelButton
+        )
+    }
+
+    func testDefiSearchFieldStaysVisibleAfterFocus() throws {
+        launchApp()
+
+        guard isOnHomeScreen else {
+            throw XCTSkip("No vault available; DeFi search scenario not applicable")
+        }
+        homePage.assertVisible()
+
+        guard let defiTab = resolvedDefiTab() else {
+            throw XCTSkip("DeFi tab not addressable on this tab-bar style")
+        }
+        defiTab.tap()
+
+        try assertSearchStaysVisible(
+            screen: "DeFi",
+            searchButtonID: AccessibilityID.DefiMain.searchButton,
+            searchFieldID: AccessibilityID.DefiMain.searchField,
+            cancelButtonID: AccessibilityID.DefiMain.searchCancelButton
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// The identifier is only attached on the custom tab bar; the native tab
+    /// bar iOS 26 draws instead exposes the tab by its label.
+    private func resolvedDefiTab() -> XCUIElement? {
+        let byIdentifier = app.buttons[AccessibilityID.Home.defiTab]
+        if byIdentifier.waitForExistence(timeout: 5) {
+            return byIdentifier
+        }
+        let byLabel = app.tabBars.buttons[HomeTabName.defi]
+        return byLabel.waitForExistence(timeout: 5) ? byLabel : nil
+    }
+
+    private func assertSearchStaysVisible(
+        screen: String,
+        searchButtonID: String,
+        searchFieldID: String,
+        cancelButtonID: String
+    ) throws {
+        let searchButton = app.buttons[searchButtonID]
+        guard searchButton.waitForExistence(timeout: 15) else {
+            throw XCTSkip("\(screen) search control not reachable in this state")
+        }
+        searchButton.tap()
+
+        // Not only "did it render": the field used to scroll clean out of the
+        // viewport within a second of the tap, so it can also fail here by
+        // having appeared and then left before the query resolved.
+        let field = app.textFields[searchFieldID]
+        XCTAssertTrue(
+            field.waitForExistence(timeout: 5),
+            "\(screen) search field is not present after tapping search — it never appeared, or it left the viewport first"
+        )
+
+        // Typing proves the field actually took focus, which is the whole
+        // precondition here — a field nothing is typing into cannot be scrolled
+        // away from the typist. It also works with a hardware keyboard attached,
+        // where asserting on `app.keyboards` would not.
+        field.typeText("v")
+        XCTAssertEqual(field.value as? String, "v", "\(screen) search field never took focus")
+
+        Thread.sleep(forTimeInterval: settleDelay)
+
+        assertUsable(field, named: "\(screen) search field")
+
+        let cancel = app.buttons[cancelButtonID]
+        assertUsable(cancel, named: "\(screen) Cancel action")
+
+        takeScreenshot(name: "\(screen) search focused")
+
+        cancel.tap()
+        XCTAssertTrue(
+            searchButton.waitForExistence(timeout: 5),
+            "\(screen) search control did not come back after cancelling"
+        )
+    }
+
+    /// On screen, inside the window, and reachable by a tap — the three things
+    /// the forced scroll took away from the search bar.
+    private func assertUsable(
+        _ element: XCUIElement,
+        named name: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(
+            element.exists,
+            "\(name) left the accessibility tree — it scrolled out of the viewport",
+            file: file,
+            line: line
+        )
+        let window = app.windows.firstMatch.frame
+        XCTAssertTrue(
+            window.contains(element.frame),
+            "\(name) at \(element.frame) is outside the window \(window)",
+            file: file,
+            line: line
+        )
+        XCTAssertTrue(
+            element.isHittable,
+            "\(name) is not hittable — it is off-screen or covered",
+            file: file,
+            line: line
+        )
+    }
+}
+
+private enum HomeTabName {
+    static let defi = "DeFi"
+}

--- a/VultisigApp/VultisigAppUITests/Tests/PortfolioSearchTests.swift
+++ b/VultisigApp/VultisigAppUITests/Tests/PortfolioSearchTests.swift
@@ -94,21 +94,28 @@ final class PortfolioSearchTests: VultisigUITestCase {
             "\(screen) search field is not present after tapping search — it never appeared, or it left the viewport first"
         )
 
-        // Typing proves the field actually took focus, which is the whole
-        // precondition here — a field nothing is typing into cannot be scrolled
-        // away from the typist. It also works with a hardware keyboard attached,
-        // where asserting on `app.keyboards` would not.
+        // Assert on the *untouched* focused state first. Order matters: typing
+        // narrows the list, which shrinks the scroll content and clamps the
+        // offset back, and on a short list that is enough to drag a runaway
+        // field back into view — masking the very bug this covers.
+        Thread.sleep(forTimeInterval: settleDelay)
+
+        let cancel = app.buttons[cancelButtonID]
+        assertUsable(field, named: "\(screen) search field")
+        assertUsable(cancel, named: "\(screen) Cancel action")
+
+        takeScreenshot(name: "\(screen) search focused")
+
+        // Then prove the field genuinely holds focus, and that typing into it
+        // does not push it out of reach either. Typing is used rather than
+        // `app.keyboards` so an attached hardware keyboard cannot break this.
         field.typeText("v")
         XCTAssertEqual(field.value as? String, "v", "\(screen) search field never took focus")
 
         Thread.sleep(forTimeInterval: settleDelay)
 
-        assertUsable(field, named: "\(screen) search field")
-
-        let cancel = app.buttons[cancelButtonID]
-        assertUsable(cancel, named: "\(screen) Cancel action")
-
-        takeScreenshot(name: "\(screen) search focused")
+        assertUsable(field, named: "\(screen) search field after typing")
+        assertUsable(cancel, named: "\(screen) Cancel action after typing")
 
         cancel.tap()
         XCTAssertTrue(

--- a/VultisigApp/project.yml
+++ b/VultisigApp/project.yml
@@ -337,6 +337,11 @@ targets:
       - path: VultisigAppUITests
         excludes:
           - "**/.DS_Store"
+      # A UI-test bundle links nothing from the app, so the shared identifier
+      # constants have to be compiled into it as well. Without this the whole
+      # target fails to build ("cannot find 'AccessibilityID' in scope") and
+      # every UI test is unrunnable, not merely skipped.
+      - path: VultisigApp/Core/Utils/AccessibilityID.swift
 
     settings:
       base:


### PR DESCRIPTION
## Problem

Tapping the magnifier in the Wallet portfolio header focuses the chain search and raises the keyboard — and then, 0.7 seconds later, throws the search bar clean off the top of the screen. The user is left typing into a field they cannot see, looking at mid-list results. `DefiMainScreen` carried the same pattern.

## Runtime evidence

Confirmed in the simulator before writing anything, not reasoned about. A temporary DEBUG-only seeder put a 41-chain vault on a clean simulator, a temporary OSLog probe sampled the section header's global frame / scroll offset / keyboard frame / bottom safe-area inset at 10 Hz, and a temporary XCUITest drove the taps and read element frames. All of it was stripped before commit.

**iPhone 17 / iOS 26.5, 41 chains** — `headerY` is the section header's global y:

| t (s) | event | headerY | keyboard top | bottom safe area |
|---|---|---|---|---|
| 0.17 | focus set | 500 | — | 83 |
| 0.28 | `keyboardWillShow` | 500 | 539 | 335 |
| 0.70 | the app's 0.7 s timer fires | 500 | 539 | 335 |
| 0.91 | forced scroll running | −423 | 539 | 335 |
| 1.12 | settled | **−1074** | 539 | 335 |

The field ends 1074 points above the screen and leaves the accessibility tree entirely (`exists == 0`). The settled screenshot is a pixel match for the one attached to the issue.

Reproduced on both tab-bar paths: iPhone 16 / iOS 18.4 (custom tab bar) goes 497 → **−1116**, and there the keyboard additionally dismisses itself mid-scroll because the first responder has left the screen.

## Root cause

`VaultMainScreen` waited 0.7 s after focus and then called `scrollTo(marker, anchor: .center)`. That marker is a 300 pt `VStack` used as the **`.background` of `VaultMainChainListView`** — and a background is centred on its host, so the marker's centre is *the chain list's centre*. `anchor: .center` therefore scrolls the middle of a 2600 pt list to the middle of the viewport, which for any real vault is a scroll of well over a thousand points.

The trace confirms it exactly rather than approximately: the marker settles at `markerY = 150.3` and is 300 pt tall, so its centre lands at 300.3 — the centre of the keyboard-adjusted viewport (≈ 59 + (539 − 59)/2).

`DefiMainScreen` repeated the pattern against a zero-height `VStack {}` placed *after* its list — same bug, different wrong target.

`git log -S 'vaultMainScreenBottomContentId'` returns one commit, `67115f760` "feat: Defi Main Tab (#3204)", which is the commit that created these screens. **The delay was never patching a later regression**, so removing it does not revert anyone's fix.

One expectation the measurement corrected: the bottom safe-area inset moves 83 → 335 on keyboard show on *both* tab-bar paths, so SwiftUI keyboard avoidance is live here. The `.ignoresSafeArea(.all)` on `VultiTabBar.legacyTabBar` does not disable it, because the per-page `safeAreaInset` is published inside it.

## Fix, and why the smaller one was not enough

**Option A — just delete the forced scroll.** Measured: the header stays at 500 for the whole trace and the field is hittable, but typing `sol` puts the first matching row at y = 570 against a keyboard top of 539 — behind the keyboard, `isHittable == 0`. That fails the Must-Do "keep the first matching result visible above the keyboard", so Option A does not stand on its own.

**Option B — shipped.** Both screens now scroll on the `showSearchHeader` change itself, with no timer, to an anchor that parks the section header one `contentInset` below the top of the viewport. `scrollTo(anchor: .top)` on its own would put the header *behind* the floating home header, so the anchor is a clear box `2 * contentInset` taller than the 42 pt header slot, used as its `.background`: a background is centred on its host and takes no part in layout, so its top edge sits exactly `contentInset` above the header. That is the same clearance `VaultMainScreenScrollView`'s `topInset` already gives the rest of the content — no new constant, no device-specific offset, no delay.

(A first attempt using a zero-height anchor with negative top padding was measured and rejected: SwiftUI resolved the scroll against the padded container, the header landed at y = 62 behind the home header, `isHittable == 0`.)

**Option C** — lifting the header into `.safeAreaInset(edge: .top)` — was not needed.

Also removed: DeFi's now-dead `searchScrollTask` and its `onDisappear` cancel, and `VaultMainScreen`'s unused `@State var frameHeight`.

### After the fix

| device / OS | list | field on open | first match after typing | keyboard top |
|---|---|---|---|---|
| iPhone 17 / iOS 26.5 (native tab bar) | 41 chains | 151 | 458 | 539 |
| iPhone 16 / iOS 18.4 (custom tab bar) | 41 chains | 148 | 315 | — |
| iPhone SE 3rd gen / iOS 26.5 | 3 chains | 145 | 327 | 407 |

All hittable. Cancel is hittable throughout; cancelling dismisses the keyboard; reopening returns to a byte-identical offset (151 → 151). Pull-to-refresh and the collapsing balance header are untouched.

### The DeFi tab, measured separately

DeFi ships identical code, but its geometry is not Wallet's, so it was measured on its own rather than assumed: `CoinAction.defiChains` has **8 entries**, so that list can never exceed 8 rows, and DeFi's top section is only `DefiMainBalanceView` + a separator where Wallet also carries `CoinActionsView` and `BannersCarousel`. The section header starts at y ≈ 316 on DeFi versus 500 on Wallet.

**Before the fix, iPhone 17 / iOS 26.5, 8 DeFi chains:** the field settles at **y = −30.3**, `isHittable = 0`, Cancel `isHittable = 0`. The same defect, two orders of magnitude smaller than Wallet's −1074 purely because the list is capped at 8 rows.

**After the fix:**

| device / OS | header before tap | header settled | field | first match | keyboard top |
|---|---|---|---|---|---|
| iPhone 17 / iOS 26.5 | 316 | 140 | 150.7 | 395.7 | 539 |
| iPhone 16 / iOS 18.4 | 258 | 137 | 147.7 | 324.7 | 516 |
| iPhone SE 3rd gen / iOS 26.5 | 275 | 98 | 108.5 | 336.5 | 407 |

Field, Cancel and first match hittable in every row; the header settles by t ≈ 0.4 s and does not move again through t = 1.8 s, well past the old timer.

**Short and empty DeFi lists** — the case where the scroll cannot reach the anchor: with 1 chain and with 0 chains (the customize-chains empty state), the header stays at 316 and `onScrollOffsetChange` never fires at all, because the content is not scrollable and `scrollTo` is a no-op. That is the right outcome rather than a failure — the field sits at 326.7 against a keyboard top of 539, first match at 395.7, Cancel hittable, and nothing jumps. The anchor only moves the header when there is something to scroll.

## Tests — and whether they actually execute

`VultisigAppUITests` **has never compiled.** It referenced `AccessibilityID`, but `project.yml` only fed it `VultisigAppUITests/`, and a UI-test bundle links nothing from the app — so every UI test was *unrunnable*, not merely skipped, since `8e4d61086` "feat: ui testing foundation (#4049)". CI never noticed: the only workflow does not run `ui_test`. This PR adds `AccessibilityID.swift` to that target's sources (separate products, so no duplicate-symbol risk).

New `PortfolioSearchTests` covers Wallet and DeFi: open search, type a character and assert the field's value (proving focus without depending on the software keyboard), settle for 1.5 s — past the delay the removed scroll used — then assert the field and Cancel are present, inside the window, and hittable, and that cancelling restores the search control.

Honest status:

- **On a clean CI simulator these SKIP, they do not pass.** Every home-screen test is guarded by `guard isOnHomeScreen else { throw XCTSkip(...) }` and a clean simulator has no vault. Verified on a freshly erased simulator: `** TEST SUCCEEDED **`, both new tests reported `skipped`.
- **On a simulator carrying a vault they execute and pass**, and both **fail against the old code** — verified by restoring each screen's delayed centre-scroll in turn. Wallet fails on the presence assertion (the field has left the viewport within a second of the tap); DeFi fails on the window-bounds assertion (`DeFi search field at (52.0, -30.33, 235.67, 21.0) is outside the window (0.0, 0.0, 402.0, 874.0)`).
- **The DeFi case executes on iOS 26, it does not skip.** `AccessibilityID.Home.defiTab` genuinely does not exist on the iOS 26 native tab bar (measured: `exists = 0`), but `app.tabBars.buttons["DeFi"]` does and switches tabs; on iOS 18.4 the identifier exists and works instead. `resolvedDefiTab()` tries both, so the tab-bar skip gate does not fire on either OS.
- **A caught false pass.** The first version of this suite typed the focus-proving character *before* asserting visibility. On Wallet that was harmless, but on DeFi it made the test green against the bug: the field settles at y = −30 but is still in the accessibility tree, and typing filters the 8-row list to empty, which shrinks the content, clamps the scroll back and returns the field to view before the assertion runs. The assertions now run on the untouched focused layout first, then typing proves focus, then they run again.
- Coverage is weak on a *short* vault: with few chains the scroll clamps against the content's end before the field can leave the screen. Documented in the test file.

**Proposal, not built here:** a DEBUG-only seeded-vault launch argument would turn these from skips into real CI coverage. Happy to do it in a follow-up if you want it — I used exactly such a seeder as throwaway scaffolding to get this measured.

## Gates

- `make build-check` — `** BUILD SUCCEEDED **`
- `make test` — `** TEST SUCCEEDED **`, 6480 test cases passed, 0 failures
- `make ui_test` on a clean simulator — `** TEST SUCCEEDED **` (new tests skip, as above)
- `swiftlint --config VultisigApp/.swiftlint.yml` — 0 violations on all touched files
- Read-only Codex review, 2 rounds — one P2 on the test's determinism, addressed; no blocking findings remaining

## What is not verified

- **macOS and iPad.** The change is vertical-scroll-only in shared code, but neither was exercised at runtime.
- **Two pre-existing UI-test failures, unrelated to this change.** Now that the target compiles, `testHomeScreenShowsWalletTab` and `testNavigateToSettings` fail *when a vault exists* — the first because the iOS 26 native tab bar carries no accessibility identifiers and `HomePage.assertTabsExist()` also asserts an "Agent" tab that `HomeTab` does not have; the second at `SettingsPage.assertVisible()`. Both skip on a clean simulator, so `make ui_test` is green there. Left alone deliberately as out of scope — worth a follow-up issue.

Plan and full measurements: `wiki/pages/projects/vultisig/vault-chain-list/search-focus-scroll-5177-plan.md`.

Closes #5177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added accessibility identifiers for Wallet and DeFi search controls.
  * Search fields now support improved automated accessibility.

* **Bug Fixes**
  * Improved search behavior so results scroll into position immediately when search opens.
  * Search focus and cancellation now behave more consistently across Wallet and DeFi screens.

* **Tests**
  * Added UI coverage for search focus, scrolling, visibility, cancellation, and restoration in Wallet and DeFi.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->