### PR TITLE
fix(wallet): stop offering DeFi receipts in the token-selection sheet

### DIFF
--- a/VultisigApp/VultisigApp/Core/Extensions/CoinExtension.swift
+++ b/VultisigApp/VultisigApp/Core/Extensions/CoinExtension.swift
@@ -15,10 +15,14 @@ extension Coin {
         return chain.coinType
     }
 
-    static let defiOnlyTickers: Set<String> = ["STCY", "YBRUNE"]
+    /// Forwards to `CoinMeta.defiOnlyTickers`, which is the single definition.
+    /// A `Coin` and the `CoinMeta` it came from must never disagree about
+    /// whether a ticker names a DeFi position — the selection surfaces reason in
+    /// `CoinMeta`, everything downstream of a save reasons in `Coin`.
+    static var defiOnlyTickers: Set<String> { CoinMeta.defiOnlyTickers }
 
     var isDefiOnly: Bool {
-        Coin.defiOnlyTickers.contains(ticker.uppercased())
+        CoinMeta.defiOnlyTickers.contains(ticker.uppercased())
     }
 
     /// The balance in base units, read exactly.

--- a/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/Screens/TokenSelectionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/Screens/TokenSelectionScreen.swift
@@ -102,14 +102,21 @@ struct TokenSelectionScreen: View {
     }
 
     private func persistSelection() {
-        // Held DeFi positions are carried through explicitly: this sheet never
-        // renders them, so the selection cannot speak for them, and a save is
-        // otherwise a removal for anything the selection omits.
-        let selection = TokenSelectionLogic.selectionPreservingDefiPositions(
-            selection: coinViewModel.selection,
-            vaultCoins: vault.coins
-        )
         Task {
+            // Held DeFi positions are carried through explicitly: this sheet
+            // never renders them, so the selection cannot speak for them, and a
+            // save is otherwise a removal for anything the selection omits.
+            //
+            // Read immediately before the save rather than before this task:
+            // token discovery is the concurrent producer at the heart of this
+            // bug, and a union formed earlier would not carry a coin that
+            // landed in between.
+            let selection = await MainActor.run {
+                TokenSelectionLogic.selectionPreservingDefiPositions(
+                    selection: coinViewModel.selection,
+                    vaultCoins: vault.coins
+                )
+            }
             await CoinService.saveAssets(for: vault, selection: selection)
             await MainActor.run { isPresented = false }
         }

--- a/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/Screens/TokenSelectionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/Screens/TokenSelectionScreen.swift
@@ -102,8 +102,15 @@ struct TokenSelectionScreen: View {
     }
 
     private func persistSelection() {
+        // Held DeFi positions are carried through explicitly: this sheet never
+        // renders them, so the selection cannot speak for them, and a save is
+        // otherwise a removal for anything the selection omits.
+        let selection = TokenSelectionLogic.selectionPreservingDefiPositions(
+            selection: coinViewModel.selection,
+            vaultCoins: vault.coins
+        )
         Task {
-            await CoinService.saveAssets(for: vault, selection: coinViewModel.selection)
+            await CoinService.saveAssets(for: vault, selection: selection)
             await MainActor.run { isPresented = false }
         }
     }

--- a/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/ViewModels/CustomTokenViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/ViewModels/CustomTokenViewModel.swift
@@ -165,7 +165,14 @@ final class CustomTokenViewModel: ObservableObject {
         guard case .found(let customToken) = searchState else { return false }
         isAddingToken = true
         coinSelectionViewModel.handleSelection(isSelected: true, asset: customToken)
-        await CoinService.saveAssets(for: vault, selection: coinSelectionViewModel.selection)
+        // The other exit from the same sheet, and it saves the same shared
+        // selection — so it needs the same carry-through, or adding a custom
+        // token silently drops a held DeFi position the sheet never rendered.
+        let selection = TokenSelectionLogic.selectionPreservingDefiPositions(
+            selection: coinSelectionViewModel.selection,
+            vaultCoins: vault.coins
+        )
+        await CoinService.saveAssets(for: vault, selection: selection)
         isAddingToken = false
         return true
     }

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/TokenSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/TokenSelectionViewModel.swift
@@ -337,12 +337,20 @@ struct TokenSelectionLogic {
     /// shared state seeded by chain detail's periodic refresh, not by opening
     /// this sheet, so a receipt the vault acquired since that seed is missing
     /// from it. Without this, saving a change about entirely different tokens
-    /// would delete the user's staking position and hide it thereafter — and
-    /// because the row can't render, there would be nothing to notice or undo.
+    /// deletes the local receipt coin and hides it thereafter — and because the
+    /// row can't render, there would be nothing to notice or undo. The on-chain
+    /// position survives, but the wallet stops tracking it and the DeFi card
+    /// that unwinds it reads the held coin.
     ///
     /// A position is carried through only while its chain keeps its native
-    /// token. When the user is removing the whole chain, the position goes with
-    /// it, rather than being resurrected as a token stranded without a native.
+    /// token, so removing a chain still removes its positions rather than
+    /// stranding a token with no native. That guard is deliberately not load
+    /// bearing for the case above: `findAllCoinsToRemove` already removes EVERY
+    /// coin on a chain whose native is absent from the selection, so a receipt
+    /// unioned in there would be removed regardless. The residual hazard — a
+    /// selection stale enough to be missing the native itself — is the general
+    /// stale-selection behaviour of this shared model, predates this rule, and
+    /// applies to every token rather than to DeFi receipts.
     static func selectionPreservingDefiPositions(
         selection: Set<CoinMeta>,
         vaultCoins: [Coin]

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/TokenSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/TokenSelectionViewModel.swift
@@ -328,6 +328,35 @@ struct TokenSelectionLogic {
         return tokens.filter { $0.ticker.lowercased().contains(query) }
     }
 
+    /// The selection to actually persist: whatever the user expressed, plus the
+    /// DeFi positions the vault already holds.
+    ///
+    /// This sheet deliberately never renders a DeFi receipt, so it can never
+    /// express an intent to KEEP one — and `CoinService.saveAssets` removes
+    /// every held coin absent from the selection it is handed. The selection is
+    /// shared state seeded by chain detail's periodic refresh, not by opening
+    /// this sheet, so a receipt the vault acquired since that seed is missing
+    /// from it. Without this, saving a change about entirely different tokens
+    /// would delete the user's staking position and hide it thereafter — and
+    /// because the row can't render, there would be nothing to notice or undo.
+    ///
+    /// A position is carried through only while its chain keeps its native
+    /// token. When the user is removing the whole chain, the position goes with
+    /// it, rather than being resurrected as a token stranded without a native.
+    static func selectionPreservingDefiPositions(
+        selection: Set<CoinMeta>,
+        vaultCoins: [Coin]
+    ) -> Set<CoinMeta> {
+        let chainsKeepingTheirNative = Set(
+            selection.filter { $0.isNativeToken }.map { $0.chain }
+        )
+        let heldPositions = vaultCoins
+            .filter { $0.isDefiOnly && chainsKeepingTheirNative.contains($0.chain) }
+            .map { $0.toCoinMeta() }
+
+        return selection.union(heldPositions)
+    }
+
     /// Local-first dedup merge: earlier lists win a `uniqueId` collision (so the
     /// curated/local meta is kept), novel tokens are appended in order. Pure +
     /// `static` so the pool ordering/dedup is unit-tested directly.

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/TokenSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/TokenSelectionViewModel.swift
@@ -242,6 +242,12 @@ struct TokenSelectionLogic {
     /// ticker (e.g. a fake `USDC` on a different contract) ride into the held set
     /// and auto-surface in browse. Each held coin yields exactly one row — the
     /// catalog meta when present, else the coin's own meta.
+    ///
+    /// Held DeFi receipts are dropped: THORChain discovery adds whatever denoms
+    /// the address carries, so a staker's vault genuinely holds a ybRUNE /
+    /// sTCY `Coin`, and without this the sheet offers the position back as a
+    /// spendable token. Dropping the ROW does not drop the COIN — the pending
+    /// selection is seeded from `vault.coins`, not from what this renders.
     func selectedTokens(chainCoins: [Coin], tokens: [CoinMeta]) -> [CoinMeta] {
         let catalogByUniqueId = Dictionary(
             tokens.map { ($0.uniqueId, $0) },
@@ -249,7 +255,7 @@ struct TokenSelectionLogic {
         )
 
         return chainCoins
-            .filter { !$0.isNativeToken }
+            .filter { !$0.isNativeToken && !$0.isDefiOnly }
             .map { coin in
                 let coinMeta = coin.toCoinMeta()
                 return catalogByUniqueId[coinMeta.uniqueId] ?? coinMeta
@@ -275,6 +281,7 @@ struct TokenSelectionLogic {
         return BundledTokensProvider.curatedTokens(for: chain, defaults: .standard)
             .filter { token in
                 !token.isNativeToken &&
+                !token.isDefiOnly &&
                 !heldIds.contains(token.uniqueId) &&
                 !hiddenTokens.contains { $0.matches(token) }
             }
@@ -284,8 +291,16 @@ struct TokenSelectionLogic {
     /// and not user-hidden. Preserves input order — used to fold the dynamic
     /// breadth in *after* the curated/local tokens without duplicating or
     /// re-surfacing a token the user removed.
+    ///
+    /// DeFi-only is filtered here too, and that is not belt-and-braces: the
+    /// curated `TokensStore` presets reach this screen twice — directly through
+    /// `preExistingTokens`, and again through the catalog, because
+    /// `BundledTokensProvider` is registered into `TokenCatalogRepository` and
+    /// its tokens are `.curated`, so they auto-surface. Excluding a receipt from
+    /// the presets alone just re-admits it here as provider breadth.
     func providerTokens(_ tokens: [CoinMeta], excludingLocal localIds: Set<String>, hiddenTokens: [HiddenToken]) -> [CoinMeta] {
         tokens.filter { token in
+            !token.isDefiOnly &&
             !localIds.contains(token.uniqueId) &&
             !hiddenTokens.contains { $0.matches(token) }
         }

--- a/VultisigApp/VultisigApp/Model/CoinMeta.swift
+++ b/VultisigApp/VultisigApp/Model/CoinMeta.swift
@@ -61,6 +61,30 @@ struct CoinMeta: Hashable, Codable {
     }
 }
 
+extension CoinMeta {
+
+    /// Tickers that name a DeFi *position* rather than a spendable wallet token.
+    ///
+    /// These are receipts a staking contract mints — sTCY for staked TCY,
+    /// ybRUNE (`x/staking-x/brune`) for bonded bRUNE. A vault legitimately holds
+    /// them (THORChain discovery adds whatever denoms the address carries, and
+    /// the DeFi cards read the held coin), so this is not about whether the coin
+    /// exists — it is about which surfaces may offer one as an ordinary token.
+    /// They are excluded from the wallet token list, the token-selection sheet,
+    /// the swap picker's held tokens and the vault's fiat total; they are
+    /// enabled and unwound through the DeFi position picker instead, which
+    /// sources its own list from `TokensStore` rather than the token catalog.
+    ///
+    /// Lives on `CoinMeta` because the selection surfaces are `CoinMeta`-typed
+    /// throughout — `Coin.isDefiOnly` forwards here so both sides can never
+    /// disagree about what counts.
+    static let defiOnlyTickers: Set<String> = ["STCY", "YBRUNE"]
+
+    var isDefiOnly: Bool {
+        CoinMeta.defiOnlyTickers.contains(ticker.uppercased())
+    }
+}
+
 extension CoinMeta: Equatable {
     static func == (lhs: CoinMeta, rhs: CoinMeta) -> Bool {
         return lhs.chain == rhs.chain &&

--- a/VultisigApp/VultisigAppTests/Extensions/CoinExtensionTests.swift
+++ b/VultisigApp/VultisigAppTests/Extensions/CoinExtensionTests.swift
@@ -35,6 +35,43 @@ final class CoinExtensionTests: XCTestCase {
         XCTAssertTrue(Coin.defiOnlyTickers.contains("STCY"))
     }
 
+    // MARK: - CoinMeta parity
+
+    /// The selection surfaces reason in `CoinMeta`; everything downstream of a
+    /// save reasons in `Coin`. If the two ever disagreed, a token could be
+    /// hidden from one surface and offered by the next.
+    func testCoinMetaAndCoinAgreeOnDefiOnly() {
+        for ticker in ["STCY", "ybRUNE", "bRUNE", "BTC", "RUNE", "TCY", "yRUNE"] {
+            let meta = makeMeta(ticker: ticker)
+            let coin = makeCoin(ticker: ticker, chain: .thorChain, isNative: false)
+            XCTAssertEqual(
+                meta.isDefiOnly,
+                coin.isDefiOnly,
+                "CoinMeta and Coin disagree about whether \(ticker) is DeFi-only"
+            )
+        }
+    }
+
+    func testCoinMetaIsDefiOnlyIsCaseInsensitive() {
+        for ticker in ["ybrune", "ybRUNE", "YBRUNE", "YbRuNe"] {
+            XCTAssertTrue(makeMeta(ticker: ticker).isDefiOnly, "Expected \(ticker) to be DeFi-only")
+        }
+    }
+
+    /// bRUNE is a plain wallet token — only the receipt it mints is DeFi-only,
+    /// and the two tickers differ by a single leading character. The THORChain
+    /// discovery filter next door matches these same tickers by *anchored
+    /// prefix*, so pin that this set matches a whole ticker and never a prefix:
+    /// a prefix rule here would delist bRUNE from the wallet entirely.
+    func testBRuneIsNotDefiOnlyDespiteBeingAPrefixOfYbRune() {
+        XCTAssertFalse(makeMeta(ticker: "bRUNE").isDefiOnly)
+        XCTAssertTrue(makeMeta(ticker: "ybRUNE").isDefiOnly)
+    }
+
+    func testCoinDefiOnlyTickersForwardsToCoinMeta() {
+        XCTAssertEqual(Coin.defiOnlyTickers, CoinMeta.defiOnlyTickers)
+    }
+
     func test_totalBalanceInFiatDecimal_emptyArrayReturnsZero() {
         let coins: [Coin] = []
         XCTAssertEqual(coins.totalBalanceInFiatDecimal, 0)
@@ -103,6 +140,18 @@ final class CoinExtensionTests: XCTestCase {
     }
 
     // MARK: - Helpers
+
+    private func makeMeta(ticker: String, chain: Chain = .thorChain) -> CoinMeta {
+        CoinMeta(
+            chain: chain,
+            ticker: ticker,
+            logo: "",
+            decimals: 8,
+            priceProviderId: "",
+            contractAddress: "",
+            isNativeToken: false
+        )
+    }
 
     private func makeCoin(
         ticker: String,

--- a/VultisigApp/VultisigAppTests/Features/Wallet/TokenSelectionPoolTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/Wallet/TokenSelectionPoolTests.swift
@@ -407,4 +407,115 @@ final class TokenSelectionPoolTests: XCTestCase {
 
         XCTAssertEqual(capped.map { $0.uniqueId }, breadth.metas.map { $0.uniqueId })
     }
+
+    // MARK: - DeFi receipts are never offered as spendable tokens
+
+    /// The repro from the field: right after an import, THORChain -> Select
+    /// tokens listed ybRUNE (`x/staking-x/brune`), the auto-compounding receipt
+    /// for bonded bRUNE, as an ordinary selectable token.
+    ///
+    /// The vault genuinely HOLDS the receipt — THORChain discovery adds whatever
+    /// denoms the address carries — so this drives the view model the way the
+    /// screen does rather than testing the pure filter in isolation.
+    func testHeldDefiReceiptIsOfferedNowhereOnTheSheet() async {
+        let vault = Vault(name: "holds-ybrune")
+        vault.coins = [
+            Coin(asset: TokensStore.ybrune, address: "thoraddr", hexPublicKey: "pub"),
+            Coin(asset: TokensStore.brune, address: "thoraddr", hexPublicKey: "pub")
+        ]
+
+        let vm = TokenSelectionViewModel(loadCatalog: { _ in
+            TokenSearchResult(surfaceable: [], unverified: [],
+                              verificationByUniqueId: [:], sourceKindByUniqueId: [:])
+        })
+        await vm.load(chain: .thorChain, vault: vault)
+
+        let browse = vm.selectedTokens + vm.preExistTokens + vm.browseProviderTokens
+        XCTAssertFalse(browse.contains { $0.isDefiOnly },
+                       "A DeFi receipt must not be browsable as a wallet token")
+
+        // Searching `yb` is the other half of the report.
+        vm.searchText = "yb"
+        XCTAssertFalse(vm.searchedTokens.contains { $0.uniqueId == TokensStore.ybrune.uniqueId },
+                       "Searching for the receipt must not surface it either")
+
+        // …while the plain wallet token beside it is untouched.
+        XCTAssertTrue(browse.contains { $0.uniqueId == TokensStore.brune.uniqueId },
+                      "bRUNE is a spendable token and must stay on the sheet")
+    }
+
+    /// The catalog reaches this screen twice — the curated presets go in
+    /// directly, and again through `TokenCatalogRepository` (the bundled
+    /// provider's tokens are `.curated`, so they auto-surface as breadth).
+    /// Filtering the presets alone would just re-admit the receipt here, so the
+    /// provider path is pinned separately.
+    func testProviderBreadthDropsDefiReceipts() {
+        let breadth = TokenSelectionLogic.shared.providerTokens(
+            [TokensStore.ybrune, TokensStore.brune],
+            excludingLocal: [],
+            hiddenTokens: []
+        )
+
+        XCTAssertEqual(breadth.map { $0.uniqueId }, [TokensStore.brune.uniqueId],
+                       "Provider breadth keeps bRUNE and drops the receipt")
+    }
+
+    func testCuratedPresetsDropDefiReceiptsButKeepTheirUnderlyingTokens() {
+        let presets = TokenSelectionLogic.shared.preExistingTokens(
+            chain: .thorChain,
+            chainCoins: [],
+            hiddenTokens: []
+        )
+
+        XCTAssertFalse(presets.contains { $0.isDefiOnly },
+                       "No DeFi receipt is offered as a curated preset")
+        XCTAssertTrue(presets.contains { $0.uniqueId == TokensStore.brune.uniqueId },
+                      "bRUNE stays — only the receipt it mints is DeFi-only")
+        XCTAssertTrue(presets.contains { $0.uniqueId == TokensStore.tcy.uniqueId },
+                      "TCY stays — sTCY is the receipt, TCY is the token")
+    }
+
+    /// Generic over the rule rather than over ybRUNE: a third DeFi ticker is
+    /// covered the day it is added to `defiOnlyTickers`, without a new test.
+    func testEveryDefiOnlyPresetIsExcludedFromEveryChainSheet() {
+        let defiPresets = TokensStore.TokenSelectionAssets.filter { $0.isDefiOnly }
+        XCTAssertFalse(defiPresets.isEmpty, "Guard against the rule silently matching nothing")
+
+        for preset in defiPresets {
+            let presets = TokenSelectionLogic.shared.preExistingTokens(
+                chain: preset.chain,
+                chainCoins: [],
+                hiddenTokens: []
+            )
+            XCTAssertFalse(presets.contains { $0.uniqueId == preset.uniqueId },
+                           "\(preset.ticker) is DeFi-only and must not be offered on \(preset.chain.name)")
+        }
+    }
+
+    /// The one way this change could harm a user: hiding the row must not drop
+    /// the coin. The pending selection is seeded from `vault.coins` and saved
+    /// wholesale, so a held position survives a save it was never rendered for.
+    func testHidingTheReceiptRowDoesNotDropItFromThePendingSelection() {
+        let vault = Vault(name: "keeps-ybrune")
+        vault.coins = [Coin(asset: TokensStore.ybrune, address: "thoraddr", hexPublicKey: "pub")]
+
+        let coinViewModel = CoinSelectionViewModel()
+        coinViewModel.setData(for: vault)
+
+        XCTAssertTrue(coinViewModel.selection.contains { $0.uniqueId == TokensStore.ybrune.uniqueId },
+                      "A held DeFi position stays in the selection that gets saved, unrendered or not")
+    }
+
+    /// Reachability, pinned next to the exclusion it depends on: the receipt is
+    /// enabled through the DeFi position picker, which builds its list straight
+    /// from `TokensStore` and never through the token catalog. If that ever
+    /// changed, the exclusion above would strand the position.
+    func testDefiPositionPickerStillOffersTheReceipt() {
+        let positions = DefiPositionsService().stakeCoins(for: .thorChain)
+
+        XCTAssertTrue(positions.contains { $0.uniqueId == TokensStore.ybrune.uniqueId },
+                      "ybRUNE must remain enable-able as a DeFi position")
+        XCTAssertTrue(positions.contains { $0.uniqueId == TokensStore.stcy.uniqueId },
+                      "sTCY likewise")
+    }
 }

--- a/VultisigApp/VultisigAppTests/Features/Wallet/TokenSelectionPoolTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/Wallet/TokenSelectionPoolTests.swift
@@ -492,18 +492,86 @@ final class TokenSelectionPoolTests: XCTestCase {
         }
     }
 
-    /// The one way this change could harm a user: hiding the row must not drop
-    /// the coin. The pending selection is seeded from `vault.coins` and saved
-    /// wholesale, so a held position survives a save it was never rendered for.
-    func testHidingTheReceiptRowDoesNotDropItFromThePendingSelection() {
-        let vault = Vault(name: "keeps-ybrune")
-        vault.coins = [Coin(asset: TokensStore.ybrune, address: "thoraddr", hexPublicKey: "pub")]
+    // MARK: - a hidden row must never become a deleted coin
 
-        let coinViewModel = CoinSelectionViewModel()
-        coinViewModel.setData(for: vault)
+    /// The one way this change could harm a user, driven through the real save.
+    ///
+    /// The selection is shared state seeded by chain detail's periodic refresh,
+    /// not by opening the sheet, so it can predate a receipt the vault has since
+    /// acquired — and `saveAssets` removes every held coin the selection omits.
+    /// Since the row can no longer render, nothing would put it back.
+    func testSavingWithoutTheReceiptStillKeepsTheHeldPosition() async throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
 
-        XCTAssertTrue(coinViewModel.selection.contains { $0.uniqueId == TokensStore.ybrune.uniqueId },
-                      "A held DeFi position stays in the selection that gets saved, unrendered or not")
+        let vault = TestStore.makeVault(pubKey: "defi-preserved")
+        let rune = Coin(asset: TokensStore.rune, address: "thoraddr", hexPublicKey: "pub")
+        let receipt = Coin(asset: TokensStore.ybrune, address: "thoraddr", hexPublicKey: "pub")
+        vault.coins = [rune, receipt]
+        Storage.shared.insert([rune, receipt])
+
+        // What the sheet can express: RUNE only — the receipt is unrenderable.
+        let expressed: Set<CoinMeta> = [TokensStore.rune]
+
+        await CoinService.saveAssets(
+            for: vault,
+            selection: TokenSelectionLogic.selectionPreservingDefiPositions(
+                selection: expressed,
+                vaultCoins: vault.coins
+            )
+        )
+
+        XCTAssertTrue(vault.coins.contains { $0.uniqueId == receipt.uniqueId },
+                      "A held DeFi position must survive a save it was never rendered for")
+        XCTAssertFalse(vault.hiddenTokens.contains { $0.ticker.uppercased() == "YBRUNE" },
+                       "…and must not be suppressed from every later list either")
+    }
+
+    /// The control that makes the test above mean something: hand `saveAssets`
+    /// the raw selection and the position is deleted and hidden. This is the
+    /// behaviour `selectionPreservingDefiPositions` exists to prevent.
+    func testSavingTheRawSelectionWouldHaveDeletedTheHeldPosition() async throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let vault = TestStore.makeVault(pubKey: "defi-unprotected")
+        let rune = Coin(asset: TokensStore.rune, address: "thoraddr", hexPublicKey: "pub")
+        let receipt = Coin(asset: TokensStore.ybrune, address: "thoraddr", hexPublicKey: "pub")
+        vault.coins = [rune, receipt]
+        Storage.shared.insert([rune, receipt])
+
+        await CoinService.saveAssets(for: vault, selection: [TokensStore.rune])
+
+        XCTAssertFalse(vault.coins.contains { $0.uniqueId == receipt.uniqueId },
+                       "Control: an omitted coin is removed — which is why the carry-through is needed")
+        XCTAssertTrue(vault.hiddenTokens.contains { $0.ticker.uppercased() == "YBRUNE" },
+                      "Control: and hidden thereafter")
+    }
+
+    /// Carrying positions through must not resurrect one on a chain the user is
+    /// removing outright — that would leave a token with no native coin.
+    func testAPositionIsNotCarriedThroughWhenItsChainIsBeingRemoved() {
+        let receipt = Coin(asset: TokensStore.ybrune, address: "thoraddr", hexPublicKey: "pub")
+
+        let preserved = TokenSelectionLogic.selectionPreservingDefiPositions(
+            selection: [],   // no THORChain native => the whole chain is going
+            vaultCoins: [receipt]
+        )
+
+        XCTAssertTrue(preserved.isEmpty,
+                      "Removing the chain removes its positions with it")
+    }
+
+    func testCarryThroughLeavesOrdinaryTokensAlone() {
+        let bRune = Coin(asset: TokensStore.brune, address: "thoraddr", hexPublicKey: "pub")
+
+        let preserved = TokenSelectionLogic.selectionPreservingDefiPositions(
+            selection: [TokensStore.rune],
+            vaultCoins: [bRune]
+        )
+
+        XCTAssertEqual(preserved, [TokensStore.rune],
+                       "Only DeFi positions are carried through; a deselected wallet token is still a removal")
     }
 
     /// Reachability, pinned next to the exclusion it depends on: the receipt is

--- a/VultisigApp/VultisigAppTests/Wallet/CustomTokenViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Wallet/CustomTokenViewModelTests.swift
@@ -164,6 +164,54 @@ final class CustomTokenViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.searchState, .idle)
     }
 
+    // MARK: - saving a custom token must not drop a held DeFi position
+
+    /// The custom-token screen is the other exit from the token-selection sheet
+    /// and saves the same shared selection. That selection is seeded by chain
+    /// detail's periodic refresh, so it can predate a DeFi receipt discovery has
+    /// since added — and the sheet never renders receipts, so nothing puts it
+    /// back. Adding an unrelated custom token must not delete the position.
+    func testAddingACustomTokenKeepsAHeldDefiPosition() async throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+
+        let vault = TestStore.makeVault(pubKey: "custom-token-defi")
+        let rune = Coin(asset: TokensStore.rune, address: "thoraddr", hexPublicKey: "pub")
+        let receipt = Coin(asset: TokensStore.ybrune, address: "thoraddr", hexPublicKey: "pub")
+        vault.coins = [rune, receipt]
+        Storage.shared.insert([rune, receipt])
+
+        let custom = CoinMeta(
+            chain: .thorChain,
+            ticker: "LQDY",
+            logo: "lqdy",
+            decimals: 8,
+            priceProviderId: "",
+            contractAddress: "thor.lqdy",
+            isNativeToken: false
+        )
+        let resolver = MockCustomTokenResolver(
+            validateHandler: { _ in true },
+            fetchInfoHandler: { _ in custom }
+        )
+        let viewModel = CustomTokenViewModel(vault: vault, chain: .thorChain, resolver: resolver)
+        viewModel.contractAddress = "thor.lqdy"
+        viewModel.validateAddress("thor.lqdy")
+        await viewModel.search().value
+
+        // The stale selection: RUNE only — the receipt is missing from it, and
+        // the sheet has no row that could put it back.
+        let coinSelectionViewModel = CoinSelectionViewModel()
+        coinSelectionViewModel.selection = [TokensStore.rune]
+
+        _ = await viewModel.saveAssets(coinSelectionViewModel: coinSelectionViewModel)
+
+        XCTAssertTrue(vault.coins.contains { $0.uniqueId == receipt.uniqueId },
+                      "Adding a custom token must not delete an unrelated held DeFi position")
+        XCTAssertFalse(vault.hiddenTokens.contains { $0.ticker.uppercased() == "YBRUNE" },
+                       "…nor suppress it from every later list")
+    }
+
     /// Drives a search that suspends inside the resolver, runs `interrupt` while it is
     /// in flight, then releases the lookup and asserts the stale result was discarded.
     @discardableResult


### PR DESCRIPTION
## Description

Right after a vault import, THORChain → **Select tokens** listed **ybRUNE** (`x/staking-x/brune`) — the auto-compounding receipt for bonded bRUNE — as an ordinary selectable wallet token, so a DeFi position could be enabled into the wallet token list. `Coin.isDefiOnly` / `defiOnlyTickers` (`["STCY", "YBRUNE"]`) already gated the chain-detail list, the swap picker's held tokens and the vault fiat total; this surface never consulted it.

Fixes #5194

### Three paths, not one

Closing any single one of these changes nothing:

1. **Held** — THORChain discovery (`ThorchainService.fetchTokens`) adds whatever denoms the address carries, and its ybRUNE/sTCY handling is *casing-only*, excluding nothing. A staker's vault genuinely holds a ybRUNE `Coin`, so it arrives as a held token. This is the path the issue's recording shows.
2. **Curated preset** — `TokensStore.ybrune` is in `TokenSelectionAssets`, so it arrives again via `preExistingTokens`.
3. **Catalog breadth** — `BundledTokensProvider` is registered into `TokenCatalogRepository` and its tokens are `.curated`, so they auto-surface. Dropping the receipt from the presets alone simply re-admits it as `browseProviderTokens`.

All three producers in `TokenSelectionLogic` now filter it, which covers browse and search together since the search pool is merged from exactly those lists. `defiOnlyTickers` moves onto `CoinMeta` (the selection surfaces are `CoinMeta`-typed end to end) with `Coin` forwarding to it, so the two can never disagree.

bRUNE and TCY are unaffected — the rule matches a **whole ticker, not a prefix**, which is worth stating because the `ThorchainService` filter next door matches these same tickers by anchored prefix. Pinned by a test.

### The part that isn't the filter

Hiding the row left a way to delete the coin. `CoinService.saveAssets` removes every held coin absent from the selection it is handed, and that selection is shared state seeded by `ChainDetailScreen`'s **periodic refresh** — not by opening the sheet. So a receipt discovery added since the last seed was deleted and hidden by a save the user made about entirely different tokens.

That hazard pre-existed for every token, but the row used to render (unchecked), so it was visible and recoverable by hand. Once the receipt cannot render at all, the same save is silent — for exactly the coins that represent staked funds. `TokenSelectionLogic.selectionPreservingDefiPositions` now carries held positions through at save time, so the guarantee comes from the save path rather than from when the seed last ran. The sheet has **two** exits and both are covered (`TokenSelectionScreen` and the custom-token screen, which saves the same shared selection).

The on-chain position was never at risk; what was lost is the local receipt coin and the wallet's tracking of it — including the DeFi card that unwinds it, which reads the held coin.

### Reachability is unchanged

The receipt stays enable-able through the DeFi position picker, which builds its list from `TokensStore` directly and never through the token catalog (`DefiPositionsService.stakeCoins`). Pinned by a test. sTCY has lived under exactly this arrangement since it was added.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Tests

14 new tests. The ones that matter:

- The issue's repro at view-model level — a vault holding ybRUNE loads `.thorChain`; the receipt is absent from browse *and* from a search for `yb`, while bRUNE stays.
- One per producer (held / curated preset / provider breadth), plus a generic one over **every** ticker in `defiOnlyTickers` present in `TokenSelectionAssets`, so a third DeFi ticker is covered the day it is added rather than needing a new test.
- The save path driven for real through `CoinService.saveAssets`, from both sheet exits — **with a control asserting the raw selection genuinely deletes and hides the receipt**, so the protection is provably load-bearing rather than passing by construction.
- bRUNE is not DeFi-only despite being a prefix of the receipt it mints.

Gate: `** TEST SUCCEEDED **` — **6530 tests, 11 skipped, 0 failures** (6516 on the base + 14). All 14 confirmed present and passing in the log rather than inferred from the marker.

## Additional context

Three whole-branch `codex exec --sandbox read-only` passes; the final pass is clean. The review is what surfaced the save-path defect above and the fact that the sheet has two exits — the first version of this fix covered only one, and its "non-destruction" test was vacuous (it would have passed with the whole fix reverted). One Major was rejected with reason and the rejection independently re-verified: the native-token guard is outcome-neutral because `findAllCoinsToRemove` already removes every coin on a chain whose native is absent.

**Known, deliberately out of scope — the swap picker leaks the same receipts.** `SwapCoinSelectionViewModel.assemble` filters `isDefiOnly` on the **vault-held** tokens only; its `externalTokens` come from `TokenSearchService.loadTokens` → the same catalog that carries the curated `ybrune`, unfiltered, on both the source and destination sides. So ybRUNE/sTCY are still offered as swap assets. Not fixed here to keep this PR to the reported surface; happy to fold it in or file it separately.

Not verified on device: the issue is labelled `mac` and asks for an iOS confirmation before closing. The sheet is shared SwiftUI so behaviour should be identical, but that is reasoning, not a device run.

Related: android [#5583](https://github.com/vultisig/vultisig-android/issues/5583) hid the same receipt from the wallet token list.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #5194
- **Confidence**: high
- **Needs human review for**: the save-path carry-through (`selectionPreservingDefiPositions`) — it changes what a token-selection save persists, and the shared `CoinSelectionViewModel` seeding it is stale-prone in ways that predate this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved DeFi token handling in wallet token selection.
  - Held DeFi positions remain preserved when saving token selections or adding custom tokens.
  - DeFi-only receipts are excluded from general browsing and search while remaining available in the DeFi position picker.

- **Bug Fixes**
  - Prevented held DeFi positions from being unintentionally removed when updating token selections.
  - DeFi token classification now consistently recognizes supported tickers regardless of letter casing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->