### PR TITLE
fix(defi): fade the banner over its own height, not half of it

### DIFF
--- a/VultisigApp/VultisigApp/Features/Defi/DefiMain/View/DefiMainBalanceView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiMain/View/DefiMainBalanceView.swift
@@ -8,6 +8,15 @@
 import SwiftUI
 
 struct DefiMainBalanceView: View {
+    /// Height of the banner card.
+    ///
+    /// Named because the home header's collapse ramp is derived from it: the
+    /// banner is faded out by scroll, and `.opacity` does not reclaim layout, so
+    /// a ramp shorter than this height empties the card while it is still on
+    /// screen and leaves a blank gap. `HeaderCollapseProgress` carries the
+    /// matching distance, and a test pins the two together.
+    static let bannerHeight: CGFloat = 135
+
     @ObservedObject var vault: Vault
     @EnvironmentObject var homeViewModel: HomeViewModel
 
@@ -30,7 +39,7 @@ struct DefiMainBalanceView: View {
                 )
             }
         }
-        .frame(height: 135)
+        .frame(height: Self.bannerHeight)
         .background(
             Theme.colors.bgSurface1
                 .overlay(gradientBackground.clipped())

--- a/VultisigApp/VultisigApp/Features/Home/Model/HeaderCollapseProgress.swift
+++ b/VultisigApp/VultisigApp/Features/Home/Model/HeaderCollapseProgress.swift
@@ -11,13 +11,19 @@ import Foundation
 /// the scroll offset, plus the two fade ramps that value drives.
 ///
 /// The large balance in the scroll content and the balance in the top bar are
-/// faded over **non-overlapping** halves of the progress: everything belonging
-/// to the expanded state fades out over `0…0.5`, everything belonging to the
-/// collapsed state fades in over `0.5…1`. `expandedOpacity` and
-/// `collapsedOpacity` are therefore never both greater than zero, so the two
-/// balances can never be legible at the same time — and because the whole
-/// transition is a function of the scroll offset it scrubs with the drag and
-/// reverses with it, instead of running on its own wall-clock timeline.
+/// faded over **non-overlapping** stretches of the progress, meeting at
+/// `midpoint`: everything belonging to the expanded state fades out over
+/// `0…midpoint`, everything belonging to the collapsed state fades in over
+/// `midpoint…1`. `expandedOpacity` and `collapsedOpacity` are therefore never
+/// both greater than zero, so the two balances can never be legible at the same
+/// time — and because the whole transition is a function of the scroll offset it
+/// scrubs with the drag and reverses with it, instead of running on its own
+/// wall-clock timeline.
+///
+/// The two stretches are not halves in general. They measure different things —
+/// the first is the height of the content being faded, the second is the fixed
+/// `barFadeDistance` — so `midpoint` sits wherever the tab's content ends. It is
+/// one half only where those two coincide, as they do on the wallet tab.
 struct HeaderCollapseProgress: Equatable {
     /// Scroll distance over which the top bar's own chrome — its balance and its
     /// opaque background — comes in, once the content's balance has gone.
@@ -120,14 +126,15 @@ struct HeaderCollapseProgress: Equatable {
 
     /// Opacity of everything that belongs to the expanded state — the large
     /// balance in the content, and the top bar's toolbar buttons. `1 → 0` over
-    /// the first half of the collapse.
+    /// `0…midpoint`, i.e. the height of the content being faded.
     var expandedOpacity: Double {
         max(1 - value / midpoint, 0)
     }
 
     /// Opacity of everything that belongs to the collapsed state — the balance
-    /// in the top bar and the bar's own opaque background. `0 → 1` over the
-    /// second half of the collapse.
+    /// in the top bar and the bar's own opaque background. `0 → 1` over
+    /// `midpoint…1`, i.e. the fixed `barFadeDistance`, so the bar's entrance is
+    /// the same length however tall the content that just left was.
     var collapsedOpacity: Double {
         max((value - midpoint) / (1 - midpoint), 0)
     }

--- a/VultisigApp/VultisigApp/Features/Home/Model/HeaderCollapseProgress.swift
+++ b/VultisigApp/VultisigApp/Features/Home/Model/HeaderCollapseProgress.swift
@@ -29,6 +29,33 @@ struct HeaderCollapseProgress: Equatable {
     /// header edge; the second half brings the header balance in.
     static let defaultDistance: CGFloat = 110
 
+    /// The DeFi tab's collapse distance.
+    ///
+    /// Twice the height of `DefiMainBalanceView`'s banner, because the expanded
+    /// half of the ramp is what fades that banner out and it must not finish
+    /// early: `.opacity` does not reclaim layout, so a banner emptied while it is
+    /// still on screen reads as a blank gap between the top bar and the list —
+    /// most visibly when the user stops mid-scroll.
+    ///
+    /// The wallet tab keeps `defaultDistance`: the balance it fades is text, not
+    /// a fixed-height card, and is short enough that the default ramp already
+    /// finishes as it leaves the viewport.
+    ///
+    /// Stated here rather than read off the view — this is the home model and
+    /// must not reach into a feature's view layer — so a test pins it to
+    /// `DefiMainBalanceView.bannerHeight` instead, and the gate catches a drift
+    /// that would otherwise only show up as the original bug.
+    static let defiBannerDistance: CGFloat = 270
+
+    /// The collapse distance for `tab`, since what each tab fades is a different
+    /// height and the ramp has to match it.
+    static func distance(for tab: HomeTab) -> CGFloat {
+        switch tab {
+        case .defi: defiBannerDistance
+        case .wallet, .camera: defaultDistance
+        }
+    }
+
     static let expanded = HeaderCollapseProgress(value: 0)
 
     /// `0` = fully expanded (large balance in the content), `1` = fully

--- a/VultisigApp/VultisigApp/Features/Home/Model/HeaderCollapseProgress.swift
+++ b/VultisigApp/VultisigApp/Features/Home/Model/HeaderCollapseProgress.swift
@@ -19,33 +19,57 @@ import Foundation
 /// transition is a function of the scroll offset it scrubs with the drag and
 /// reverses with it, instead of running on its own wall-clock timeline.
 struct HeaderCollapseProgress: Equatable {
+    /// Scroll distance over which the top bar's own chrome — its balance and its
+    /// opaque background — comes in, once the content's balance has gone.
+    ///
+    /// Fixed, and deliberately independent of what the tab fades OUT. The
+    /// background is what stops the list showing through the bar, so the window
+    /// where content is under a still-translucent bar is exactly this long on
+    /// every tab. Scaling it with the outgoing content's height instead would
+    /// stretch that window in proportion — on the DeFi tab, to the entire height
+    /// of the banner.
+    static let barFadeDistance: CGFloat = 55
+
     /// Where the expanded state has finished fading out and the collapsed state
-    /// starts fading in. The top bar swaps its contents exactly here, which is
-    /// the one point where both ramps are zero.
-    private static let midpoint: Double = 0.5
+    /// starts fading in, as a fraction of the whole collapse. The top bar swaps
+    /// its contents exactly here, which is the one point where both ramps are
+    /// zero.
+    ///
+    /// Derived rather than fixed at one half, because the two sides measure
+    /// different things: the expanded side is the height of the content being
+    /// faded (per-tab), the collapsed side is `barFadeDistance` (constant). They
+    /// coincide at one half only for a tab whose content happens to be
+    /// `barFadeDistance` tall — which the wallet's is, so its behaviour is
+    /// unchanged to the point.
+    let midpoint: Double
 
     /// Scroll distance, in points, over which the whole collapse plays out. The
     /// first half of it fades the large balance away as it travels towards the
     /// header edge; the second half brings the header balance in.
     static let defaultDistance: CGFloat = 110
 
-    /// The DeFi tab's collapse distance.
+    /// The DeFi tab's collapse distance: the banner's height, then the fixed
+    /// `barFadeDistance` for the top bar to come in.
     ///
-    /// Twice the height of `DefiMainBalanceView`'s banner, because the expanded
-    /// half of the ramp is what fades that banner out and it must not finish
-    /// early: `.opacity` does not reclaim layout, so a banner emptied while it is
-    /// still on screen reads as a blank gap between the top bar and the list —
-    /// most visibly when the user stops mid-scroll.
+    /// The banner's height, because the expanded ramp is what fades it out and
+    /// it must not finish early: `.opacity` does not reclaim layout, so a banner
+    /// emptied while it is still on screen reads as a blank gap between the top
+    /// bar and the list — most visibly when the user stops mid-scroll.
     ///
-    /// The wallet tab keeps `defaultDistance`: the balance it fades is text, not
-    /// a fixed-height card, and is short enough that the default ramp already
-    /// finishes as it leaves the viewport.
+    /// Added to rather than scaled, so the bar's entrance stays the same length
+    /// as everywhere else. Doubling the whole distance instead would also double
+    /// the window in which the list scrolls under a bar that has not finished
+    /// becoming opaque — trading the blank gap for a see-through header.
+    ///
+    /// The wallet tab keeps `defaultDistance`: the balance it fades is text
+    /// rather than a fixed-height card, and `barFadeDistance` tall, so its ramps
+    /// are unchanged to the point.
     ///
     /// Stated here rather than read off the view — this is the home model and
     /// must not reach into a feature's view layer — so a test pins it to
     /// `DefiMainBalanceView.bannerHeight` instead, and the gate catches a drift
     /// that would otherwise only show up as the original bug.
-    static let defiBannerDistance: CGFloat = 270
+    static let defiBannerDistance: CGFloat = 135 + barFadeDistance
 
     /// The collapse distance for `tab`, since what each tab fades is a different
     /// height and the ramp has to match it.
@@ -56,14 +80,21 @@ struct HeaderCollapseProgress: Equatable {
         }
     }
 
-    static let expanded = HeaderCollapseProgress(value: 0)
+    static let expanded = HeaderCollapseProgress(value: 0, midpoint: 0.5)
 
     /// `0` = fully expanded (large balance in the content), `1` = fully
     /// collapsed (balance in the top bar).
     let value: Double
 
-    private init(value: Double) {
+    private init(value: Double, midpoint: Double) {
         self.value = value
+        self.midpoint = midpoint
+    }
+
+    /// The fraction of `distance` after which the content has finished fading.
+    private static func midpoint(for distance: CGFloat) -> Double {
+        guard distance > barFadeDistance else { return 0.5 }
+        return Double((distance - barFadeDistance) / distance)
     }
 
     /// - Parameters:
@@ -77,30 +108,33 @@ struct HeaderCollapseProgress: Equatable {
     ///     complete.
     init(offset: CGFloat, restingOffset: CGFloat, distance: CGFloat = Self.defaultDistance) {
         guard distance > 0 else {
-            self.init(value: offset < restingOffset ? 1 : 0)
+            self.init(value: offset < restingOffset ? 1 : 0, midpoint: 0.5)
             return
         }
         let scrolled = restingOffset - offset
-        self.init(value: Double(min(max(scrolled / distance, 0), 1)))
+        self.init(
+            value: Double(min(max(scrolled / distance, 0), 1)),
+            midpoint: Self.midpoint(for: distance)
+        )
     }
 
     /// Opacity of everything that belongs to the expanded state — the large
     /// balance in the content, and the top bar's toolbar buttons. `1 → 0` over
     /// the first half of the collapse.
     var expandedOpacity: Double {
-        max(1 - value / Self.midpoint, 0)
+        max(1 - value / midpoint, 0)
     }
 
     /// Opacity of everything that belongs to the collapsed state — the balance
     /// in the top bar and the bar's own opaque background. `0 → 1` over the
     /// second half of the collapse.
     var collapsedOpacity: Double {
-        max((value - Self.midpoint) / (1 - Self.midpoint), 0)
+        max((value - midpoint) / (1 - midpoint), 0)
     }
 
     /// Whether the top bar shows the balance instead of the toolbar buttons.
     /// Flips where both ramps are zero, so the swap itself is invisible.
     var isCollapsed: Bool {
-        value >= Self.midpoint
+        value >= midpoint
     }
 }

--- a/VultisigApp/VultisigApp/Features/Home/Model/HomeHeaderCollapse.swift
+++ b/VultisigApp/VultisigApp/Features/Home/Model/HomeHeaderCollapse.swift
@@ -46,7 +46,13 @@ final class HomeHeaderCollapse: ObservableObject {
     ///   - offset: the scroll content's `minY` in the scroll view's space.
     ///   - restingOffset: that value at scroll position zero (the top inset).
     func update(tab: HomeTab, offset: CGFloat, restingOffset: CGFloat) {
-        let progress = HeaderCollapseProgress(offset: offset, restingOffset: restingOffset)
+        // Per-tab distance: the ramp has to match the height of whatever that
+        // tab fades, or the content empties before it has left the screen.
+        let progress = HeaderCollapseProgress(
+            offset: offset,
+            restingOffset: restingOffset,
+            distance: HeaderCollapseProgress.distance(for: tab)
+        )
         guard progress != self.progress(for: tab) else { return }
 
         switch tab {

--- a/VultisigApp/VultisigApp/Features/Home/Model/HomeHeaderCollapse.swift
+++ b/VultisigApp/VultisigApp/Features/Home/Model/HomeHeaderCollapse.swift
@@ -21,9 +21,10 @@ import Foundation
 ///
 /// Two properties keep the per-frame write cheap:
 /// - `update` compares before it publishes, and
-/// - the progress saturates at `0`/`1` outside a
-///   `HeaderCollapseProgress.defaultDistance`-point window, so all but that
-///   window of a scroll publishes nothing at all.
+/// - the progress saturates at `0`/`1` outside the collapse window, so all but
+///   that window of a scroll publishes nothing at all. The window is per-tab
+///   (`HeaderCollapseProgress.distance(for:)`) and the DeFi tab's is the longer
+///   of the two, since it spans the banner it fades.
 ///
 /// Both tabs are stored separately because both screens stay alive inside the
 /// tab view — each one keeps its own scroll position, and the top bar reads

--- a/VultisigApp/VultisigAppTests/Features/Home/HeaderCollapseProgressTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/Home/HeaderCollapseProgressTests.swift
@@ -221,14 +221,58 @@ final class HeaderCollapseProgressTests: XCTestCase {
     /// down its own height, and `.opacity` does not reclaim layout — so stopping
     /// mid-scroll left a blank gap where the card still was.
     ///
-    /// The expanded ramp finishes at half the collapse distance, so the distance
-    /// has to be twice the height of whatever it fades.
-    func testDefiRampIsTwiceTheBannerHeight() {
+    /// The expanded ramp has to span the banner, and the bar's entrance is added
+    /// after it rather than scaled with it.
+    func testDefiRampIsTheBannerPlusTheBarFade() {
         XCTAssertEqual(
             HeaderCollapseProgress.distance(for: .defi),
-            DefiMainBalanceView.bannerHeight * 2,
+            DefiMainBalanceView.bannerHeight + HeaderCollapseProgress.barFadeDistance,
             "the ramp and the banner it fades must not drift apart"
         )
+    }
+
+    /// Why it is added and not scaled: the top bar's opaque background rides the
+    /// collapsed ramp, and that background is what stops the list showing
+    /// through the bar. Scaling the whole distance with the banner would stretch
+    /// the window in which content scrolls under a half-transparent header to
+    /// the banner's full height — trading the blank gap for a see-through
+    /// header. The window has to be the same length on every tab.
+    func testTheBarComesInOverTheSameDistanceOnEveryTab() {
+        for tab in [HomeTab.wallet, .defi] {
+            let total = HeaderCollapseProgress.distance(for: tab)
+
+            func progress(scrolled: CGFloat) -> HeaderCollapseProgress {
+                HeaderCollapseProgress(offset: resting - scrolled, restingOffset: resting, distance: total)
+            }
+
+            // The bar starts coming in exactly where the content has gone...
+            let contentGone = total - HeaderCollapseProgress.barFadeDistance
+            XCTAssertEqual(progress(scrolled: contentGone).expandedOpacity, 0, accuracy: 0.0001,
+                           "\(tab): content must be gone here")
+            XCTAssertEqual(progress(scrolled: contentGone).collapsedOpacity, 0, accuracy: 0.0001,
+                           "\(tab): and the bar must not have started")
+
+            // ...and is fully in exactly `barFadeDistance` later, on every tab.
+            XCTAssertEqual(progress(scrolled: total).collapsedOpacity, 1, accuracy: 0.0001,
+                           "\(tab): the bar must be fully opaque after the same distance everywhere")
+            XCTAssertEqual(
+                progress(scrolled: contentGone + HeaderCollapseProgress.barFadeDistance / 2).collapsedOpacity,
+                0.5,
+                accuracy: 0.0001,
+                "\(tab): and get there on the same schedule"
+            )
+        }
+    }
+
+    /// The wallet tab's content is exactly `barFadeDistance` tall, so splitting
+    /// the ramp in two must leave it bit-for-bit where it was: a midpoint of one
+    /// half over the same 110pt.
+    func testWalletRampIsUnchangedByTheSplit() {
+        let progress = makeProgress(scrolled: HeaderCollapseProgress.defaultDistance / 2)
+        XCTAssertEqual(progress.midpoint, 0.5, accuracy: 0.0001)
+        XCTAssertEqual(progress.expandedOpacity, 0, accuracy: 0.0001)
+        XCTAssertEqual(progress.collapsedOpacity, 0, accuracy: 0.0001)
+        XCTAssertTrue(progress.isCollapsed)
     }
 
     func testWalletRampIsUnchanged() {
@@ -236,9 +280,15 @@ final class HeaderCollapseProgressTests: XCTestCase {
         XCTAssertEqual(HeaderCollapseProgress.distance(for: .camera), HeaderCollapseProgress.defaultDistance)
     }
 
-    /// The acceptance criterion in the issue, stated directly: the banner is
-    /// still drawn everywhere it is still on screen, and reaches zero exactly
-    /// where it has finished scrolling past.
+    /// The acceptance criterion, as far as a value type can carry it: the banner
+    /// is still drawn at every offset below its own height, and reaches zero
+    /// exactly at it.
+    ///
+    /// This pins the ramp against the banner's height, and nothing else. That
+    /// the height is also where the banner clears the header is a fact about
+    /// `DefiMainScreen`'s composition — its top inset and the banner being the
+    /// first item — which this test does not observe and would not notice
+    /// changing.
     func testDefiBannerIsStillDrawnWhileAnyOfItIsOnScreen() {
         let banner = DefiMainBalanceView.bannerHeight
         let defiDistance = HeaderCollapseProgress.distance(for: .defi)

--- a/VultisigApp/VultisigAppTests/Features/Home/HeaderCollapseProgressTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/Home/HeaderCollapseProgressTests.swift
@@ -264,9 +264,12 @@ final class HeaderCollapseProgressTests: XCTestCase {
         }
     }
 
-    /// The wallet tab's content is exactly `barFadeDistance` tall, so splitting
-    /// the ramp in two must leave it bit-for-bit where it was: a midpoint of one
-    /// half over the same 110pt.
+    /// Splitting the ramp in two must leave the wallet tab bit-for-bit where it
+    /// was. It does because of the arithmetic, not because anything about the
+    /// rendered balance is pinned: `(defaultDistance - barFadeDistance) /
+    /// defaultDistance` is exactly one half in binary floating point, which is
+    /// the midpoint the old fixed constant used. The exactness matters — the
+    /// opacity guards compare against zero with `==`.
     func testWalletRampIsUnchangedByTheSplit() {
         let progress = makeProgress(scrolled: HeaderCollapseProgress.defaultDistance / 2)
         XCTAssertEqual(progress.midpoint, 0.5, accuracy: 0.0001)

--- a/VultisigApp/VultisigAppTests/Features/Home/HeaderCollapseProgressTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/Home/HeaderCollapseProgressTests.swift
@@ -181,7 +181,9 @@ final class HeaderCollapseProgressTests: XCTestCase {
         XCTAssertEqual(collapse.progress(for: .wallet).value, 1)
         XCTAssertEqual(collapse.progress(for: .defi), .expanded)
 
-        collapse.update(tab: .defi, offset: resting - distance * 0.25, restingOffset: resting)
+        // Scrolled against the DeFi tab's own (longer) ramp, not the wallet's.
+        let defiDistance = HeaderCollapseProgress.distance(for: .defi)
+        collapse.update(tab: .defi, offset: resting - defiDistance * 0.25, restingOffset: resting)
         XCTAssertEqual(collapse.progress(for: .defi).value, 0.25, accuracy: 0.0001)
         XCTAssertEqual(collapse.progress(for: .wallet).value, 1, "the wallet tab must not move")
     }
@@ -211,5 +213,80 @@ final class HeaderCollapseProgressTests: XCTestCase {
         let collapse = HomeHeaderCollapse()
         collapse.update(tab: .camera, offset: resting - distance, restingOffset: resting)
         XCTAssertEqual(collapse.progress(for: .camera), .expanded)
+    }
+
+    // MARK: - Per-tab ramp length
+
+    /// The reported bug: the DeFi banner went fully transparent about halfway
+    /// down its own height, and `.opacity` does not reclaim layout — so stopping
+    /// mid-scroll left a blank gap where the card still was.
+    ///
+    /// The expanded ramp finishes at half the collapse distance, so the distance
+    /// has to be twice the height of whatever it fades.
+    func testDefiRampIsTwiceTheBannerHeight() {
+        XCTAssertEqual(
+            HeaderCollapseProgress.distance(for: .defi),
+            DefiMainBalanceView.bannerHeight * 2,
+            "the ramp and the banner it fades must not drift apart"
+        )
+    }
+
+    func testWalletRampIsUnchanged() {
+        XCTAssertEqual(HeaderCollapseProgress.distance(for: .wallet), HeaderCollapseProgress.defaultDistance)
+        XCTAssertEqual(HeaderCollapseProgress.distance(for: .camera), HeaderCollapseProgress.defaultDistance)
+    }
+
+    /// The acceptance criterion in the issue, stated directly: the banner is
+    /// still drawn everywhere it is still on screen, and reaches zero exactly
+    /// where it has finished scrolling past.
+    func testDefiBannerIsStillDrawnWhileAnyOfItIsOnScreen() {
+        let banner = DefiMainBalanceView.bannerHeight
+        let defiDistance = HeaderCollapseProgress.distance(for: .defi)
+
+        func progress(scrolled: CGFloat) -> HeaderCollapseProgress {
+            HeaderCollapseProgress(offset: resting - scrolled, restingOffset: resting, distance: defiDistance)
+        }
+
+        // Every point at which part of the card is still on screen.
+        for step in stride(from: CGFloat(0), to: banner, by: 0.5) {
+            XCTAssertGreaterThan(
+                progress(scrolled: step).expandedOpacity, 0,
+                "\(banner - step)pt of banner is still on screen at \(step)pt, but it is already invisible"
+            )
+        }
+
+        XCTAssertEqual(progress(scrolled: banner).expandedOpacity, 0, accuracy: 0.0001,
+                       "and it is gone exactly when the banner has scrolled past")
+    }
+
+    /// The old ramp's zero point. Before the fix the banner was fully
+    /// transparent here with ~80pt of it still on screen — the blank gap.
+    func testDefiBannerIsMostlyVisibleAtTheOldRampsZeroPoint() {
+        let oldZero = HeaderCollapseProgress.defaultDistance / 2
+        let progress = HeaderCollapseProgress(
+            offset: resting - oldZero,
+            restingOffset: resting,
+            distance: HeaderCollapseProgress.distance(for: .defi)
+        )
+        XCTAssertGreaterThan(progress.expandedOpacity, 0.5,
+                             "most of the banner is still on screen here, so most of it must still be drawn")
+    }
+
+    /// The invariant the rest of this file pins for the default ramp has to hold
+    /// for the DeFi ramp too — a longer ramp must not let the banner and the top
+    /// bar's balance be legible at the same time.
+    func testTheTwoBalancesAreNeverBothVisibleOnTheDefiRamp() {
+        let defiDistance = HeaderCollapseProgress.distance(for: .defi)
+        for step in stride(from: CGFloat(-40), through: defiDistance + 40, by: 0.25) {
+            let progress = HeaderCollapseProgress(
+                offset: resting - step,
+                restingOffset: resting,
+                distance: defiDistance
+            )
+            XCTAssertTrue(
+                progress.expandedOpacity == 0 || progress.collapsedOpacity == 0,
+                "both legible at \(step)pt: expanded \(progress.expandedOpacity), collapsed \(progress.collapsedOpacity)"
+            )
+        }
     }
 }


### PR DESCRIPTION
## Description

On the DeFi tab the portfolio banner faded to fully transparent about halfway down its own height. `.opacity` does not reclaim layout, so stopping mid-scroll left the card's 135pt still occupying the screen with nothing drawn in it — a blank gap between the top bar and the portfolio list.

Fixes #5198

### Cause

The collapse ramp was a single global 110pt (`HeaderCollapseProgress.defaultDistance`), and its expanded half — the one that fades the content's balance out — therefore finished after 55pt. That suits the wallet tab, whose balance is text roughly that tall. The DeFi banner is a fixed 135pt illustrated card, so the same constant emptied it with ~80pt still on screen.

### What changed

The two sides of the collapse measure different things, and no longer share one length:

- the **expanded** ramp spans the height of whatever that tab fades out — the banner, on DeFi;
- the **collapsed** ramp is a fixed `barFadeDistance`, *added* after it, so the top bar's entrance is the same length on every tab.

`midpoint` is derived from the two rather than fixed at one half.

The first attempt simply doubled the shared distance to 270pt, and review caught that this trades one visual bug for another: the top bar's **opaque background** rides the collapsed ramp, so the separator and the portfolio header would have scrolled under a still-translucent bar from ~155pt all the way to 270pt. Adding a fixed bar ramp instead of scaling the whole distance keeps that window at 55pt — the same as the wallet tab has always had.

### The wallet tab is untouched

Not by inspection but by arithmetic: `(110 - 55) / 110` is exactly one half in binary floating point, which is the midpoint the old fixed constant used. Every existing wallet expectation passes unchanged, and the exactness matters — `headerCollapseOpacity` gates hit-testing and VoiceOver on `opacity > 0` / `opacity == 0` comparisons.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Tests

7 new, on top of the existing suite for this type:

- The banner is still drawn at every offset below its own height, and reaches zero exactly at it.
- At the old ramp's zero point (55pt) it is still more than half visible — the blank gap, stated as an assertion.
- **The bar comes in over the same distance on every tab** — the property the first attempt broke.
- The wallet's midpoint is still exactly `0.5` over the same 110pt.
- The suite's existing never-both-legible sweep now runs against the DeFi ramp too.
- The ramp is pinned to `DefiMainBalanceView.bannerHeight`, so the two cannot drift apart silently.

One pre-existing test (`testStoreKeepsTheTabsIndependent`) asserted a value derived from the old shared constant and moved with the change; review confirmed that is a legitimate expectation change, not a masked regression (reverting the production code while keeping the tests fails it).

Gate: `** TEST SUCCEEDED **` — **6523 tests, 11 skipped, 0 failures**. SwiftLint clean on every touched file.

## Additional context

Two `codex exec --sandbox read-only` passes. Round 1 found the merge-blocking Major described above; round 2 found no Major or Minor, only two documentation nits (both fixed — the type doc still described "halves", and a test comment credited the wallet's stability to a 55pt content height that nothing establishes).

Not verified on device: reported on macOS, and the screen is shared SwiftUI so iOS should match, but this is a scroll-feel change and is worth a look on both before merge.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #5198
- **Confidence**: high
- **Needs human review for**: the scroll feel itself — the DeFi collapse now runs over 190pt instead of 110pt, which is a deliberate but subjective change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Improved the DeFi header collapse transition with a longer banner fade window.
  * Kept the DeFi banner visible while it scrolls offscreen, preventing overlap with the collapsed balance.
  * Preserved existing collapse behavior for Wallet and Camera tabs.
  * Standardized the DeFi banner height for consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->