### PR TITLE
feat(defi): claim expired TRON unfreeze entries via WithdrawExpireUnfreezeContract

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
@@ -288,6 +288,14 @@ class TronService {
             return BigInt.zero
         }
 
+        // This marker selects a local WalletCore system-contract builder; it
+        // is deliberately omitted from the transaction's `data` field. A TRON
+        // memo fee is charged only for data that actually reaches the wire, so
+        // adding getMemoFee here would show a fee the claim cannot incur.
+        guard memo != TronHelper.withdrawExpireUnfreezeMemo else {
+            return BigInt.zero
+        }
+
         let chainParams = try await getCachedChainParameters()
         return BigInt(chainParams.memoFeeEstimate)
     }

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Signing/Tron.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Signing/Tron.swift
@@ -115,7 +115,7 @@ enum TronHelper {
             }
             return try buildTronWithdrawExpireUnfreezeInput(
                 ownerAddress: keysignPayload.coin.address,
-                timestamp: timestamp, expiration: expiration, gasEstimation: gasEstimation,
+                timestamp: timestamp, expiration: expiration,
                 blockHeaderTimestamp: blockHeaderTimestamp, blockHeaderNumber: blockHeaderNumber,
                 blockHeaderVersion: blockHeaderVersion, blockHeaderTxTrieRoot: blockHeaderTxTrieRoot,
                 blockHeaderParentHash: blockHeaderParentHash, blockHeaderWitnessAddress: blockHeaderWitnessAddress
@@ -404,7 +404,7 @@ enum TronHelper {
 
     private static func buildTronWithdrawExpireUnfreezeInput(
         ownerAddress: String,
-        timestamp: UInt64, expiration: UInt64, gasEstimation: UInt64,
+        timestamp: UInt64, expiration: UInt64,
         blockHeaderTimestamp: UInt64, blockHeaderNumber: UInt64,
         blockHeaderVersion: UInt64, blockHeaderTxTrieRoot: String,
         blockHeaderParentHash: String, blockHeaderWitnessAddress: String
@@ -418,7 +418,12 @@ enum TronHelper {
                 $0.contractOneof = .withdrawExpireUnfreeze(contract)
                 $0.timestamp = Int64(timestamp)
                 $0.expiration = Int64(expiration)
-                $0.feeLimit = Int64(gasEstimation)
+                // Stake 2.0 withdraw is a system contract, not a TVM smart-
+                // contract call. `fee_limit` caps Energy for TVM execution and
+                // therefore has no meaning here. Keeping it at protobuf zero
+                // also matches the node-built transaction and gives every
+                // co-signer one canonical byte representation.
+                $0.feeLimit = 0
                 $0.blockHeader = try buildBlockHeader(
                     timestamp: blockHeaderTimestamp, number: blockHeaderNumber,
                     version: blockHeaderVersion, txTrieRoot: blockHeaderTxTrieRoot,

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Signing/Tron.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Signing/Tron.swift
@@ -13,6 +13,13 @@ import OSLog
 
 enum TronHelper {
 
+    /// Memo that routes a self-addressed native TRX payload to
+    /// `WithdrawExpireUnfreezeContract` — the Stake 2.0 claim that moves every
+    /// expired `UnfreezeBalanceV2` entry back into the spendable balance.
+    /// Matched exactly (no argument: the contract takes none) and named after
+    /// the TRON contract so co-signing platforms can mirror the convention.
+    static let withdrawExpireUnfreezeMemo = "WITHDRAW_EXPIRE_UNFREEZE"
+
     static func getSwapPreSignedInputData(keysignPayload: KeysignPayload) throws -> Data {
         // For TRX swaps, we use the same logic as regular transactions but with swap memo
         return try getPreSignedInputData(keysignPayload: keysignPayload)
@@ -98,6 +105,23 @@ enum TronHelper {
                 blockHeaderParentHash: blockHeaderParentHash, blockHeaderWitnessAddress: blockHeaderWitnessAddress
             )
         }
+        // WithdrawExpireUnfreeze (Stake 2.0) - detect from memo. The contract
+        // sweeps every expired unfreeze entry for the owner and carries no
+        // amount, so `toAmount` is deliberately not read here.
+        if keysignPayload.memo == withdrawExpireUnfreezeMemo {
+            guard keysignPayload.coin.isNativeToken,
+                  keysignPayload.toAddress == keysignPayload.coin.address else {
+                throw HelperError.runtimeError("TRON withdraw expire unfreeze requires a native TRX payload addressed to the sender")
+            }
+            return try buildTronWithdrawExpireUnfreezeInput(
+                ownerAddress: keysignPayload.coin.address,
+                timestamp: timestamp, expiration: expiration, gasEstimation: gasEstimation,
+                blockHeaderTimestamp: blockHeaderTimestamp, blockHeaderNumber: blockHeaderNumber,
+                blockHeaderVersion: blockHeaderVersion, blockHeaderTxTrieRoot: blockHeaderTxTrieRoot,
+                blockHeaderParentHash: blockHeaderParentHash, blockHeaderWitnessAddress: blockHeaderWitnessAddress
+            )
+        }
+
         // Fallback: validate toAddress for regular transfers
         guard AnyAddress(string: keysignPayload.toAddress, coin: .tron) != nil else {
             throw HelperError.runtimeError("fail to get to address")
@@ -375,6 +399,36 @@ enum TronHelper {
         }
         return try input.serializedData()
     }
+
+    // MARK: - WithdrawExpireUnfreeze (Stake 2.0)
+
+    private static func buildTronWithdrawExpireUnfreezeInput(
+        ownerAddress: String,
+        timestamp: UInt64, expiration: UInt64, gasEstimation: UInt64,
+        blockHeaderTimestamp: UInt64, blockHeaderNumber: UInt64,
+        blockHeaderVersion: UInt64, blockHeaderTxTrieRoot: String,
+        blockHeaderParentHash: String, blockHeaderWitnessAddress: String
+    ) throws -> Data {
+        let contract = TronWithdrawExpireUnfreezeContract.with {
+            $0.ownerAddress = ownerAddress
+        }
+
+        let input = try TronSigningInput.with {
+            $0.transaction = try TronTransaction.with {
+                $0.contractOneof = .withdrawExpireUnfreeze(contract)
+                $0.timestamp = Int64(timestamp)
+                $0.expiration = Int64(expiration)
+                $0.feeLimit = Int64(gasEstimation)
+                $0.blockHeader = try buildBlockHeader(
+                    timestamp: blockHeaderTimestamp, number: blockHeaderNumber,
+                    version: blockHeaderVersion, txTrieRoot: blockHeaderTxTrieRoot,
+                    parentHash: blockHeaderParentHash, witnessAddress: blockHeaderWitnessAddress
+                )
+            }
+        }
+        return try input.serializedData()
+    }
+
     static func getPreSignedImageHash(keysignPayload: KeysignPayload) throws -> [String] {
         let inputData = try getPreSignedInputData(
             keysignPayload: keysignPayload

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1584,7 +1584,6 @@
 "tronBandwidth" = "Bandbreite";
 "tronBandwidthDescription" = "Bandbreitenpunkte werden für jede Transaktion auf TRON benötigt, einschließlich Standard-Token-Sendungen und Smart-Contract-Interaktionen. Jeder TRON-Benutzer erhält täglich 600 kostenlose Bandbreitenpunkte, die ungefähr zwei grundlegende Sendungen abdecken können. Darüber hinaus können Sie durch das Staking von TRX zusätzliche Bandbreitenpunkte verdienen und so Ihr tägliches Kontingent erhöhen, um mehr Transaktionen zu unterstützen. Wenn Sie genügend Bandbreitenpunkte haben, können Sie Token senden, TRX staken oder mit Smart Contracts interagieren, ohne TRX als Gasgebühren zu zahlen.";
 "tronClaimButton" = "%@ beanspruchen";
-"tronClaimFastVaultOnly" = "Das Beanspruchen entsperrter TRX ist vorübergehend nur für Fast Vaults verfügbar. Die Unterstützung für Secure Vaults folgt in Kürze.";
 "tronEnergy" = "Energie";
 "tronEnergyDescription" = "Energie ist eine Ressource, die ausschließlich zur Ausführung von Smart Contracts auf TRON verwendet wird. Im Gegensatz zur Bandbreite wird Energie nicht kostenlos bereitgestellt — sie muss durch Staking (Einfrieren) von TRX erworben werden. Wenn Sie nicht genügend Energie haben, verbrennt das TRON-Netzwerk TRX aus Ihrem Guthaben, um die Kosten zu decken. Das Staking von TRX für Energie ermöglicht es Ihnen, mit DeFi-Protokollen zu interagieren, TRC-20-Token zu transferieren und dApps zu nutzen, ohne Gasgebühren in TRX zu zahlen.";
 "tronErrorFreezeFailed" = "Einfrieren fehlgeschlagen: %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1583,6 +1583,7 @@
 "transferObjects" = "Objekte übertragen";
 "tronBandwidth" = "Bandbreite";
 "tronBandwidthDescription" = "Bandbreitenpunkte werden für jede Transaktion auf TRON benötigt, einschließlich Standard-Token-Sendungen und Smart-Contract-Interaktionen. Jeder TRON-Benutzer erhält täglich 600 kostenlose Bandbreitenpunkte, die ungefähr zwei grundlegende Sendungen abdecken können. Darüber hinaus können Sie durch das Staking von TRX zusätzliche Bandbreitenpunkte verdienen und so Ihr tägliches Kontingent erhöhen, um mehr Transaktionen zu unterstützen. Wenn Sie genügend Bandbreitenpunkte haben, können Sie Token senden, TRX staken oder mit Smart Contracts interagieren, ohne TRX als Gasgebühren zu zahlen.";
+"tronClaimButton" = "%@ beanspruchen";
 "tronEnergy" = "Energie";
 "tronEnergyDescription" = "Energie ist eine Ressource, die ausschließlich zur Ausführung von Smart Contracts auf TRON verwendet wird. Im Gegensatz zur Bandbreite wird Energie nicht kostenlos bereitgestellt — sie muss durch Staking (Einfrieren) von TRX erworben werden. Wenn Sie nicht genügend Energie haben, verbrennt das TRON-Netzwerk TRX aus Ihrem Guthaben, um die Kosten zu decken. Das Staking von TRX für Energie ermöglicht es Ihnen, mit DeFi-Protokollen zu interagieren, TRC-20-Token zu transferieren und dApps zu nutzen, ohne Gasgebühren in TRX zu zahlen.";
 "tronErrorFreezeFailed" = "Einfrieren fehlgeschlagen: %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1584,6 +1584,7 @@
 "tronBandwidth" = "Bandbreite";
 "tronBandwidthDescription" = "Bandbreitenpunkte werden für jede Transaktion auf TRON benötigt, einschließlich Standard-Token-Sendungen und Smart-Contract-Interaktionen. Jeder TRON-Benutzer erhält täglich 600 kostenlose Bandbreitenpunkte, die ungefähr zwei grundlegende Sendungen abdecken können. Darüber hinaus können Sie durch das Staking von TRX zusätzliche Bandbreitenpunkte verdienen und so Ihr tägliches Kontingent erhöhen, um mehr Transaktionen zu unterstützen. Wenn Sie genügend Bandbreitenpunkte haben, können Sie Token senden, TRX staken oder mit Smart Contracts interagieren, ohne TRX als Gasgebühren zu zahlen.";
 "tronClaimButton" = "%@ beanspruchen";
+"tronClaimFastVaultOnly" = "Das Beanspruchen entsperrter TRX ist vorübergehend nur für Fast Vaults verfügbar. Die Unterstützung für Secure Vaults folgt in Kürze.";
 "tronEnergy" = "Energie";
 "tronEnergyDescription" = "Energie ist eine Ressource, die ausschließlich zur Ausführung von Smart Contracts auf TRON verwendet wird. Im Gegensatz zur Bandbreite wird Energie nicht kostenlos bereitgestellt — sie muss durch Staking (Einfrieren) von TRX erworben werden. Wenn Sie nicht genügend Energie haben, verbrennt das TRON-Netzwerk TRX aus Ihrem Guthaben, um die Kosten zu decken. Das Staking von TRX für Energie ermöglicht es Ihnen, mit DeFi-Protokollen zu interagieren, TRC-20-Token zu transferieren und dApps zu nutzen, ohne Gasgebühren in TRX zu zahlen.";
 "tronErrorFreezeFailed" = "Einfrieren fehlgeschlagen: %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1584,6 +1584,7 @@
 "tronBandwidth" = "Bandwidth";
 "tronBandwidthDescription" = "Bandwidth Points are required for every transaction on TRON, including both standard token sends and smart contract interactions. Every TRON user receives 600 free Bandwidth Points per day, which can cover approximately two basic sends. Additionally, you can earn extra Bandwidth Points by staking TRX, increasing your daily balance to support more transactions. If you have enough Bandwidth Points, you can send tokens, stake TRX, or interact with smart contracts without paying TRX in gas fees.";
 "tronClaimButton" = "Claim %@";
+"tronClaimFastVaultOnly" = "Claiming unlocked TRX is temporarily available for Fast Vaults only. Secure Vault support is coming soon.";
 "tronEnergy" = "Energy";
 "tronEnergyDescription" = "Energy is a resource used exclusively for executing smart contracts on TRON. Unlike Bandwidth, Energy is not provided for free — it must be obtained by staking (freezing) TRX. If you don't have enough Energy, the TRON network will burn TRX from your balance to cover the cost. Staking TRX for Energy allows you to interact with DeFi protocols, transfer TRC-20 tokens, and use dApps without paying gas fees in TRX.";
 "tronErrorFreezeFailed" = "Freeze failed: %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1584,7 +1584,6 @@
 "tronBandwidth" = "Bandwidth";
 "tronBandwidthDescription" = "Bandwidth Points are required for every transaction on TRON, including both standard token sends and smart contract interactions. Every TRON user receives 600 free Bandwidth Points per day, which can cover approximately two basic sends. Additionally, you can earn extra Bandwidth Points by staking TRX, increasing your daily balance to support more transactions. If you have enough Bandwidth Points, you can send tokens, stake TRX, or interact with smart contracts without paying TRX in gas fees.";
 "tronClaimButton" = "Claim %@";
-"tronClaimFastVaultOnly" = "Claiming unlocked TRX is temporarily available for Fast Vaults only. Secure Vault support is coming soon.";
 "tronEnergy" = "Energy";
 "tronEnergyDescription" = "Energy is a resource used exclusively for executing smart contracts on TRON. Unlike Bandwidth, Energy is not provided for free — it must be obtained by staking (freezing) TRX. If you don't have enough Energy, the TRON network will burn TRX from your balance to cover the cost. Staking TRX for Energy allows you to interact with DeFi protocols, transfer TRC-20 tokens, and use dApps without paying gas fees in TRX.";
 "tronErrorFreezeFailed" = "Freeze failed: %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1583,6 +1583,7 @@
 "transferObjects" = "Transfer Objects";
 "tronBandwidth" = "Bandwidth";
 "tronBandwidthDescription" = "Bandwidth Points are required for every transaction on TRON, including both standard token sends and smart contract interactions. Every TRON user receives 600 free Bandwidth Points per day, which can cover approximately two basic sends. Additionally, you can earn extra Bandwidth Points by staking TRX, increasing your daily balance to support more transactions. If you have enough Bandwidth Points, you can send tokens, stake TRX, or interact with smart contracts without paying TRX in gas fees.";
+"tronClaimButton" = "Claim %@";
 "tronEnergy" = "Energy";
 "tronEnergyDescription" = "Energy is a resource used exclusively for executing smart contracts on TRON. Unlike Bandwidth, Energy is not provided for free — it must be obtained by staking (freezing) TRX. If you don't have enough Energy, the TRON network will burn TRX from your balance to cover the cost. Staking TRX for Energy allows you to interact with DeFi protocols, transfer TRC-20 tokens, and use dApps without paying gas fees in TRX.";
 "tronErrorFreezeFailed" = "Freeze failed: %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1584,6 +1584,7 @@
 "tronBandwidth" = "Ancho de Banda";
 "tronBandwidthDescription" = "Los Puntos de Ancho de Banda son necesarios para cada transacción en TRON, incluyendo envíos estándar de tokens e interacciones con contratos inteligentes. Cada usuario de TRON recibe 600 Puntos de Ancho de Banda gratuitos por día, que pueden cubrir aproximadamente dos envíos básicos. Además, puedes ganar Puntos de Ancho de Banda adicionales haciendo staking de TRX, aumentando tu cuota diaria para soportar más transacciones. Si tienes suficientes Puntos de Ancho de Banda, puedes enviar tokens, hacer staking de TRX o interactuar con contratos inteligentes sin pagar TRX en tarifas de gas.";
 "tronClaimButton" = "Reclamar %@";
+"tronClaimFastVaultOnly" = "La reclamación de TRX desbloqueados está disponible temporalmente solo para Fast Vaults. La compatibilidad con Secure Vaults estará disponible pronto.";
 "tronEnergy" = "Energía";
 "tronEnergyDescription" = "La Energía es un recurso utilizado exclusivamente para ejecutar contratos inteligentes en TRON. A diferencia del Ancho de Banda, la Energía no se proporciona gratuitamente — debe obtenerse haciendo staking (congelando) TRX. Si no tienes suficiente Energía, la red TRON quemará TRX de tu saldo para cubrir el costo. Hacer staking de TRX para Energía te permite interactuar con protocolos DeFi, transferir tokens TRC-20 y usar dApps sin pagar tarifas de gas en TRX.";
 "tronErrorFreezeFailed" = "Congelación fallida: %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1583,6 +1583,7 @@
 "transferObjects" = "Transferir objetos";
 "tronBandwidth" = "Ancho de Banda";
 "tronBandwidthDescription" = "Los Puntos de Ancho de Banda son necesarios para cada transacción en TRON, incluyendo envíos estándar de tokens e interacciones con contratos inteligentes. Cada usuario de TRON recibe 600 Puntos de Ancho de Banda gratuitos por día, que pueden cubrir aproximadamente dos envíos básicos. Además, puedes ganar Puntos de Ancho de Banda adicionales haciendo staking de TRX, aumentando tu cuota diaria para soportar más transacciones. Si tienes suficientes Puntos de Ancho de Banda, puedes enviar tokens, hacer staking de TRX o interactuar con contratos inteligentes sin pagar TRX en tarifas de gas.";
+"tronClaimButton" = "Reclamar %@";
 "tronEnergy" = "Energía";
 "tronEnergyDescription" = "La Energía es un recurso utilizado exclusivamente para ejecutar contratos inteligentes en TRON. A diferencia del Ancho de Banda, la Energía no se proporciona gratuitamente — debe obtenerse haciendo staking (congelando) TRX. Si no tienes suficiente Energía, la red TRON quemará TRX de tu saldo para cubrir el costo. Hacer staking de TRX para Energía te permite interactuar con protocolos DeFi, transferir tokens TRC-20 y usar dApps sin pagar tarifas de gas en TRX.";
 "tronErrorFreezeFailed" = "Congelación fallida: %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1584,7 +1584,6 @@
 "tronBandwidth" = "Ancho de Banda";
 "tronBandwidthDescription" = "Los Puntos de Ancho de Banda son necesarios para cada transacción en TRON, incluyendo envíos estándar de tokens e interacciones con contratos inteligentes. Cada usuario de TRON recibe 600 Puntos de Ancho de Banda gratuitos por día, que pueden cubrir aproximadamente dos envíos básicos. Además, puedes ganar Puntos de Ancho de Banda adicionales haciendo staking de TRX, aumentando tu cuota diaria para soportar más transacciones. Si tienes suficientes Puntos de Ancho de Banda, puedes enviar tokens, hacer staking de TRX o interactuar con contratos inteligentes sin pagar TRX en tarifas de gas.";
 "tronClaimButton" = "Reclamar %@";
-"tronClaimFastVaultOnly" = "La reclamación de TRX desbloqueados está disponible temporalmente solo para Fast Vaults. La compatibilidad con Secure Vaults estará disponible pronto.";
 "tronEnergy" = "Energía";
 "tronEnergyDescription" = "La Energía es un recurso utilizado exclusivamente para ejecutar contratos inteligentes en TRON. A diferencia del Ancho de Banda, la Energía no se proporciona gratuitamente — debe obtenerse haciendo staking (congelando) TRX. Si no tienes suficiente Energía, la red TRON quemará TRX de tu saldo para cubrir el costo. Hacer staking de TRX para Energía te permite interactuar con protocolos DeFi, transferir tokens TRC-20 y usar dApps sin pagar tarifas de gas en TRX.";
 "tronErrorFreezeFailed" = "Congelación fallida: %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1583,6 +1583,7 @@
 "transferObjects" = "Prenesi objekte";
 "tronBandwidth" = "Propusnost";
 "tronBandwidthDescription" = "Bodovi propusnosti potrebni su za svaku transakciju na TRON-u, uključujući standardna slanja tokena i interakcije s pametnim ugovorima. Svaki TRON korisnik dnevno dobiva 600 besplatnih bodova propusnosti, koji mogu pokriti otprilike dva osnovna slanja. Dodatno, možete zaraditi dodatne bodove propusnosti stakingom TRX-a, povećavajući svoju dnevnu kvotu za podršku većem broju transakcija. Ako imate dovoljno bodova propusnosti, možete slati tokene, stakati TRX ili komunicirati s pametnim ugovorima bez plaćanja TRX-a za gas naknade.";
+"tronClaimButton" = "Preuzmi %@";
 "tronEnergy" = "Energija";
 "tronEnergyDescription" = "Energija je resurs koji se koristi isključivo za izvršavanje pametnih ugovora na TRON-u. Za razliku od propusnosti, energija se ne pruža besplatno — mora se steći stakingom (zamrzavanjem) TRX-a. Ako nemate dovoljno energije, TRON mreža će spaliti TRX iz vašeg salda za pokrivanje troška. Staking TRX-a za energiju omogućuje vam interakciju s DeFi protokolima, prijenos TRC-20 tokena i korištenje dApp-ova bez plaćanja gas naknada u TRX-u.";
 "tronErrorFreezeFailed" = "Zamrzavanje nije uspjelo: %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1584,6 +1584,7 @@
 "tronBandwidth" = "Propusnost";
 "tronBandwidthDescription" = "Bodovi propusnosti potrebni su za svaku transakciju na TRON-u, uključujući standardna slanja tokena i interakcije s pametnim ugovorima. Svaki TRON korisnik dnevno dobiva 600 besplatnih bodova propusnosti, koji mogu pokriti otprilike dva osnovna slanja. Dodatno, možete zaraditi dodatne bodove propusnosti stakingom TRX-a, povećavajući svoju dnevnu kvotu za podršku većem broju transakcija. Ako imate dovoljno bodova propusnosti, možete slati tokene, stakati TRX ili komunicirati s pametnim ugovorima bez plaćanja TRX-a za gas naknade.";
 "tronClaimButton" = "Preuzmi %@";
+"tronClaimFastVaultOnly" = "Preuzimanje otključanog TRX-a privremeno je dostupno samo za Fast Vaultove. Podrška za Secure Vaultove stiže uskoro.";
 "tronEnergy" = "Energija";
 "tronEnergyDescription" = "Energija je resurs koji se koristi isključivo za izvršavanje pametnih ugovora na TRON-u. Za razliku od propusnosti, energija se ne pruža besplatno — mora se steći stakingom (zamrzavanjem) TRX-a. Ako nemate dovoljno energije, TRON mreža će spaliti TRX iz vašeg salda za pokrivanje troška. Staking TRX-a za energiju omogućuje vam interakciju s DeFi protokolima, prijenos TRC-20 tokena i korištenje dApp-ova bez plaćanja gas naknada u TRX-u.";
 "tronErrorFreezeFailed" = "Zamrzavanje nije uspjelo: %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1584,7 +1584,6 @@
 "tronBandwidth" = "Propusnost";
 "tronBandwidthDescription" = "Bodovi propusnosti potrebni su za svaku transakciju na TRON-u, uključujući standardna slanja tokena i interakcije s pametnim ugovorima. Svaki TRON korisnik dnevno dobiva 600 besplatnih bodova propusnosti, koji mogu pokriti otprilike dva osnovna slanja. Dodatno, možete zaraditi dodatne bodove propusnosti stakingom TRX-a, povećavajući svoju dnevnu kvotu za podršku većem broju transakcija. Ako imate dovoljno bodova propusnosti, možete slati tokene, stakati TRX ili komunicirati s pametnim ugovorima bez plaćanja TRX-a za gas naknade.";
 "tronClaimButton" = "Preuzmi %@";
-"tronClaimFastVaultOnly" = "Preuzimanje otključanog TRX-a privremeno je dostupno samo za Fast Vaultove. Podrška za Secure Vaultove stiže uskoro.";
 "tronEnergy" = "Energija";
 "tronEnergyDescription" = "Energija je resurs koji se koristi isključivo za izvršavanje pametnih ugovora na TRON-u. Za razliku od propusnosti, energija se ne pruža besplatno — mora se steći stakingom (zamrzavanjem) TRX-a. Ako nemate dovoljno energije, TRON mreža će spaliti TRX iz vašeg salda za pokrivanje troška. Staking TRX-a za energiju omogućuje vam interakciju s DeFi protokolima, prijenos TRC-20 tokena i korištenje dApp-ova bez plaćanja gas naknada u TRX-u.";
 "tronErrorFreezeFailed" = "Zamrzavanje nije uspjelo: %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1584,6 +1584,7 @@
 "tronBandwidth" = "Larghezza di Banda";
 "tronBandwidthDescription" = "I Punti di Larghezza di Banda sono necessari per ogni transazione su TRON, inclusi invii standard di token e interazioni con smart contract. Ogni utente TRON riceve 600 Punti di Larghezza di Banda gratuiti al giorno, che possono coprire circa due invii base. Inoltre, puoi guadagnare Punti di Larghezza di Banda aggiuntivi facendo staking di TRX, aumentando la tua quota giornaliera per supportare più transazioni. Se hai abbastanza Punti di Larghezza di Banda, puoi inviare token, fare staking di TRX o interagire con smart contract senza pagare TRX in commissioni gas.";
 "tronClaimButton" = "Riscuoti %@";
+"tronClaimFastVaultOnly" = "La riscossione dei TRX sbloccati è temporaneamente disponibile solo per i Fast Vault. Il supporto per i Secure Vault arriverà presto.";
 "tronEnergy" = "Energia";
 "tronEnergyDescription" = "L'Energia è una risorsa utilizzata esclusivamente per eseguire smart contract su TRON. A differenza della Larghezza di Banda, l'Energia non viene fornita gratuitamente — deve essere ottenuta facendo staking (congelando) TRX. Se non hai abbastanza Energia, la rete TRON brucerà TRX dal tuo saldo per coprire il costo. Fare staking di TRX per Energia ti permette di interagire con protocolli DeFi, trasferire token TRC-20 e usare dApp senza pagare commissioni gas in TRX.";
 "tronErrorFreezeFailed" = "Congelamento fallito: %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1583,6 +1583,7 @@
 "transferObjects" = "Trasferisci oggetti";
 "tronBandwidth" = "Larghezza di Banda";
 "tronBandwidthDescription" = "I Punti di Larghezza di Banda sono necessari per ogni transazione su TRON, inclusi invii standard di token e interazioni con smart contract. Ogni utente TRON riceve 600 Punti di Larghezza di Banda gratuiti al giorno, che possono coprire circa due invii base. Inoltre, puoi guadagnare Punti di Larghezza di Banda aggiuntivi facendo staking di TRX, aumentando la tua quota giornaliera per supportare più transazioni. Se hai abbastanza Punti di Larghezza di Banda, puoi inviare token, fare staking di TRX o interagire con smart contract senza pagare TRX in commissioni gas.";
+"tronClaimButton" = "Riscuoti %@";
 "tronEnergy" = "Energia";
 "tronEnergyDescription" = "L'Energia è una risorsa utilizzata esclusivamente per eseguire smart contract su TRON. A differenza della Larghezza di Banda, l'Energia non viene fornita gratuitamente — deve essere ottenuta facendo staking (congelando) TRX. Se non hai abbastanza Energia, la rete TRON brucerà TRX dal tuo saldo per coprire il costo. Fare staking di TRX per Energia ti permette di interagire con protocolli DeFi, trasferire token TRC-20 e usare dApp senza pagare commissioni gas in TRX.";
 "tronErrorFreezeFailed" = "Congelamento fallito: %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1584,7 +1584,6 @@
 "tronBandwidth" = "Larghezza di Banda";
 "tronBandwidthDescription" = "I Punti di Larghezza di Banda sono necessari per ogni transazione su TRON, inclusi invii standard di token e interazioni con smart contract. Ogni utente TRON riceve 600 Punti di Larghezza di Banda gratuiti al giorno, che possono coprire circa due invii base. Inoltre, puoi guadagnare Punti di Larghezza di Banda aggiuntivi facendo staking di TRX, aumentando la tua quota giornaliera per supportare più transazioni. Se hai abbastanza Punti di Larghezza di Banda, puoi inviare token, fare staking di TRX o interagire con smart contract senza pagare TRX in commissioni gas.";
 "tronClaimButton" = "Riscuoti %@";
-"tronClaimFastVaultOnly" = "La riscossione dei TRX sbloccati è temporaneamente disponibile solo per i Fast Vault. Il supporto per i Secure Vault arriverà presto.";
 "tronEnergy" = "Energia";
 "tronEnergyDescription" = "L'Energia è una risorsa utilizzata esclusivamente per eseguire smart contract su TRON. A differenza della Larghezza di Banda, l'Energia non viene fornita gratuitamente — deve essere ottenuta facendo staking (congelando) TRX. Se non hai abbastanza Energia, la rete TRON brucerà TRX dal tuo saldo per coprire il costo. Fare staking di TRX per Energia ti permette di interagire con protocolli DeFi, trasferire token TRC-20 e usare dApp senza pagare commissioni gas in TRX.";
 "tronErrorFreezeFailed" = "Congelamento fallito: %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1584,6 +1584,7 @@
 "tronBandwidth" = "대역폭";
 "tronBandwidthDescription" = "대역폭 포인트는 표준 토큰 전송 및 스마트 계약 상호작용을 포함한 TRON의 모든 트랜잭션에 필요합니다. 모든 TRON 사용자는 하루 600개의 무료 대역폭 포인트를 받습니다. 또한 TRX를 스테이킹하여 추가 대역폭 포인트를 얻어 더 많은 트랜잭션을 지원할 수 있습니다.";
 "tronClaimButton" = "%@ 수령";
+"tronClaimFastVaultOnly" = "잠금 해제된 TRX 수령은 현재 Fast Vault에서만 사용할 수 있습니다. Secure Vault 지원은 곧 제공될 예정입니다.";
 "tronEnergy" = "에너지";
 "tronEnergyDescription" = "에너지는 TRON에서 스마트 계약 실행에만 사용되는 리소스입니다. 대역폭과 달리 에너지는 무료로 제공되지 않으며 TRX를 스테이킹(동결)하여 얻어야 합니다. 에너지가 충분하지 않으면 TRON 네트워크가 잔액에서 TRX를 소각하여 비용을 충당합니다.";
 "tronErrorFreezeFailed" = "동결 실패: %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1583,6 +1583,7 @@
 "transferObjects" = "객체 전송";
 "tronBandwidth" = "대역폭";
 "tronBandwidthDescription" = "대역폭 포인트는 표준 토큰 전송 및 스마트 계약 상호작용을 포함한 TRON의 모든 트랜잭션에 필요합니다. 모든 TRON 사용자는 하루 600개의 무료 대역폭 포인트를 받습니다. 또한 TRX를 스테이킹하여 추가 대역폭 포인트를 얻어 더 많은 트랜잭션을 지원할 수 있습니다.";
+"tronClaimButton" = "%@ 수령";
 "tronEnergy" = "에너지";
 "tronEnergyDescription" = "에너지는 TRON에서 스마트 계약 실행에만 사용되는 리소스입니다. 대역폭과 달리 에너지는 무료로 제공되지 않으며 TRX를 스테이킹(동결)하여 얻어야 합니다. 에너지가 충분하지 않으면 TRON 네트워크가 잔액에서 TRX를 소각하여 비용을 충당합니다.";
 "tronErrorFreezeFailed" = "동결 실패: %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1584,7 +1584,6 @@
 "tronBandwidth" = "대역폭";
 "tronBandwidthDescription" = "대역폭 포인트는 표준 토큰 전송 및 스마트 계약 상호작용을 포함한 TRON의 모든 트랜잭션에 필요합니다. 모든 TRON 사용자는 하루 600개의 무료 대역폭 포인트를 받습니다. 또한 TRX를 스테이킹하여 추가 대역폭 포인트를 얻어 더 많은 트랜잭션을 지원할 수 있습니다.";
 "tronClaimButton" = "%@ 수령";
-"tronClaimFastVaultOnly" = "잠금 해제된 TRX 수령은 현재 Fast Vault에서만 사용할 수 있습니다. Secure Vault 지원은 곧 제공될 예정입니다.";
 "tronEnergy" = "에너지";
 "tronEnergyDescription" = "에너지는 TRON에서 스마트 계약 실행에만 사용되는 리소스입니다. 대역폭과 달리 에너지는 무료로 제공되지 않으며 TRX를 스테이킹(동결)하여 얻어야 합니다. 에너지가 충분하지 않으면 TRON 네트워크가 잔액에서 TRX를 소각하여 비용을 충당합니다.";
 "tronErrorFreezeFailed" = "동결 실패: %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1583,6 +1583,7 @@
 "transferObjects" = "Transferir objetos";
 "tronBandwidth" = "Largura de Banda";
 "tronBandwidthDescription" = "Pontos de Largura de Banda são necessários para cada transação na TRON, incluindo envios padrão de tokens e interações com contratos inteligentes. Cada usuário TRON recebe 600 Pontos de Largura de Banda gratuitos por dia, que podem cobrir aproximadamente dois envios básicos. Além disso, você pode ganhar Pontos de Largura de Banda extras fazendo staking de TRX, aumentando seu saldo diário para suportar mais transações. Se você tiver Pontos de Largura de Banda suficientes, pode enviar tokens, fazer staking de TRX ou interagir com contratos inteligentes sem pagar TRX em taxas de gas.";
+"tronClaimButton" = "Resgatar %@";
 "tronEnergy" = "Energia";
 "tronEnergyDescription" = "Energia é um recurso usado exclusivamente para executar contratos inteligentes na TRON. Diferente da Largura de Banda, Energia não é fornecida gratuitamente — ela deve ser obtida fazendo staking (congelando) TRX. Se você não tiver Energia suficiente, a rede TRON queimará TRX do seu saldo para cobrir o custo. Fazer staking de TRX para Energia permite que você interaja com protocolos DeFi, transfira tokens TRC-20 e use dApps sem pagar taxas de gas em TRX.";
 "tronErrorFreezeFailed" = "Congelamento falhou: %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1584,6 +1584,7 @@
 "tronBandwidth" = "Largura de Banda";
 "tronBandwidthDescription" = "Pontos de Largura de Banda são necessários para cada transação na TRON, incluindo envios padrão de tokens e interações com contratos inteligentes. Cada usuário TRON recebe 600 Pontos de Largura de Banda gratuitos por dia, que podem cobrir aproximadamente dois envios básicos. Além disso, você pode ganhar Pontos de Largura de Banda extras fazendo staking de TRX, aumentando seu saldo diário para suportar mais transações. Se você tiver Pontos de Largura de Banda suficientes, pode enviar tokens, fazer staking de TRX ou interagir com contratos inteligentes sem pagar TRX em taxas de gas.";
 "tronClaimButton" = "Resgatar %@";
+"tronClaimFastVaultOnly" = "O resgate de TRX desbloqueado está temporariamente disponível apenas para Fast Vaults. O suporte a Secure Vaults estará disponível em breve.";
 "tronEnergy" = "Energia";
 "tronEnergyDescription" = "Energia é um recurso usado exclusivamente para executar contratos inteligentes na TRON. Diferente da Largura de Banda, Energia não é fornecida gratuitamente — ela deve ser obtida fazendo staking (congelando) TRX. Se você não tiver Energia suficiente, a rede TRON queimará TRX do seu saldo para cobrir o custo. Fazer staking de TRX para Energia permite que você interaja com protocolos DeFi, transfira tokens TRC-20 e use dApps sem pagar taxas de gas em TRX.";
 "tronErrorFreezeFailed" = "Congelamento falhou: %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1584,7 +1584,6 @@
 "tronBandwidth" = "Largura de Banda";
 "tronBandwidthDescription" = "Pontos de Largura de Banda são necessários para cada transação na TRON, incluindo envios padrão de tokens e interações com contratos inteligentes. Cada usuário TRON recebe 600 Pontos de Largura de Banda gratuitos por dia, que podem cobrir aproximadamente dois envios básicos. Além disso, você pode ganhar Pontos de Largura de Banda extras fazendo staking de TRX, aumentando seu saldo diário para suportar mais transações. Se você tiver Pontos de Largura de Banda suficientes, pode enviar tokens, fazer staking de TRX ou interagir com contratos inteligentes sem pagar TRX em taxas de gas.";
 "tronClaimButton" = "Resgatar %@";
-"tronClaimFastVaultOnly" = "O resgate de TRX desbloqueado está temporariamente disponível apenas para Fast Vaults. O suporte a Secure Vaults estará disponível em breve.";
 "tronEnergy" = "Energia";
 "tronEnergyDescription" = "Energia é um recurso usado exclusivamente para executar contratos inteligentes na TRON. Diferente da Largura de Banda, Energia não é fornecida gratuitamente — ela deve ser obtida fazendo staking (congelando) TRX. Se você não tiver Energia suficiente, a rede TRON queimará TRX do seu saldo para cobrir o custo. Fazer staking de TRX para Energia permite que você interaja com protocolos DeFi, transfira tokens TRC-20 e use dApps sem pagar taxas de gas em TRX.";
 "tronErrorFreezeFailed" = "Congelamento falhou: %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1583,6 +1583,7 @@
 "transferObjects" = "转移对象";
 "tronBandwidth" = "带宽";
 "tronBandwidthDescription" = "带宽点数是 TRON 上每笔交易所必需的，包括标准代币发送和智能合约交互。每个 TRON 用户每天获得 600 个免费带宽点数，大约可以覆盖两次基本发送。此外，您可以通过质押 TRX 获得额外的带宽点数，增加每日配额以支持更多交易。如果您有足够的带宽点数，您可以发送代币、质押 TRX 或与智能合约交互，而无需支付 TRX 作为 Gas 费用。";
+"tronClaimButton" = "领取 %@";
 "tronEnergy" = "能量";
 "tronEnergyDescription" = "能量是专门用于在 TRON 上执行智能合约的资源。与带宽不同，能量不是免费提供的——必须通过质押（冻结）TRX 来获取。如果您没有足够的能量，TRON 网络将从您的余额中燃烧 TRX 来支付费用。质押 TRX 获取能量使您能够与 DeFi 协议交互、转移 TRC-20 代币以及使用 dApp，而无需支付 TRX Gas 费用。";
 "tronErrorFreezeFailed" = "冻结失败：%@";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1584,6 +1584,7 @@
 "tronBandwidth" = "带宽";
 "tronBandwidthDescription" = "带宽点数是 TRON 上每笔交易所必需的，包括标准代币发送和智能合约交互。每个 TRON 用户每天获得 600 个免费带宽点数，大约可以覆盖两次基本发送。此外，您可以通过质押 TRX 获得额外的带宽点数，增加每日配额以支持更多交易。如果您有足够的带宽点数，您可以发送代币、质押 TRX 或与智能合约交互，而无需支付 TRX 作为 Gas 费用。";
 "tronClaimButton" = "领取 %@";
+"tronClaimFastVaultOnly" = "领取已解锁的 TRX 目前仅适用于 Fast Vault。Secure Vault 支持即将推出。";
 "tronEnergy" = "能量";
 "tronEnergyDescription" = "能量是专门用于在 TRON 上执行智能合约的资源。与带宽不同，能量不是免费提供的——必须通过质押（冻结）TRX 来获取。如果您没有足够的能量，TRON 网络将从您的余额中燃烧 TRX 来支付费用。质押 TRX 获取能量使您能够与 DeFi 协议交互、转移 TRC-20 代币以及使用 dApp，而无需支付 TRX Gas 费用。";
 "tronErrorFreezeFailed" = "冻结失败：%@";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1584,7 +1584,6 @@
 "tronBandwidth" = "带宽";
 "tronBandwidthDescription" = "带宽点数是 TRON 上每笔交易所必需的，包括标准代币发送和智能合约交互。每个 TRON 用户每天获得 600 个免费带宽点数，大约可以覆盖两次基本发送。此外，您可以通过质押 TRX 获得额外的带宽点数，增加每日配额以支持更多交易。如果您有足够的带宽点数，您可以发送代币、质押 TRX 或与智能合约交互，而无需支付 TRX 作为 Gas 费用。";
 "tronClaimButton" = "领取 %@";
-"tronClaimFastVaultOnly" = "领取已解锁的 TRX 目前仅适用于 Fast Vault。Secure Vault 支持即将推出。";
 "tronEnergy" = "能量";
 "tronEnergyDescription" = "能量是专门用于在 TRON 上执行智能合约的资源。与带宽不同，能量不是免费提供的——必须通过质押（冻结）TRX 来获取。如果您没有足够的能量，TRON 网络将从您的余额中燃烧 TRX 来支付费用。质押 TRX 获取能量使您能够与 DeFi 协议交互、转移 TRC-20 代币以及使用 dApp，而无需支付 TRX Gas 费用。";
 "tronErrorFreezeFailed" = "冻结失败：%@";

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronDashboardView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronDashboardView.swift
@@ -222,7 +222,7 @@ struct TronDashboardView: View {
                         ))
                     }
                 )
-                .disabled(model.totalFrozenBalance <= 0)
+                .disabled(!model.canUnfreeze)
 
                 DefiButton(
                     title: NSLocalizedString("tronFreezeButton", comment: "Freeze"),

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronDashboardView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronDashboardView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct TronDashboardView: View {
-    let vault: Vault
+    @ObservedObject var vault: Vault
     @ObservedObject var model: TronViewModel
     let onRefresh: () async -> Void  // Callback for refresh
     @Environment(\.dismiss) var dismiss
@@ -34,6 +34,10 @@ struct TronDashboardView: View {
             ? String.hideBalanceText
             : "\(model.claimableBalance.formatted()) TRX"
         return String(format: NSLocalizedString("tronClaimButton", comment: "Claim %@"), amount)
+    }
+
+    var canClaimExpiredUnfreezes: Bool {
+        TronViewLogic.canClaimExpiredUnfreezes(vault: vault)
     }
 
     var body: some View {
@@ -307,11 +311,20 @@ struct TronDashboardView: View {
                 // One action for every expired entry: WithdrawExpireUnfreeze
                 // sweeps all of them at once, so per-row claims would mislead.
                 if model.hasClaimableWithdrawals {
+                    if !canClaimExpiredUnfreezes {
+                        InfoBannerView(
+                            description: "tronClaimFastVaultOnly".localized,
+                            type: .warning,
+                            leadingIcon: .triangleWarning
+                        )
+                    }
+
                     DefiButton(
                         title: claimButtonTitle,
                         icon: .arrowDownFromLine,
                         action: onClaim
                     )
+                    .disabled(!canClaimExpiredUnfreezes)
                     .padding(.top, 4)
                 }
             }

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronDashboardView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronDashboardView.swift
@@ -13,6 +13,7 @@ struct TronDashboardView: View {
     let onRefresh: () async -> Void  // Callback for refresh
     @Environment(\.dismiss) var dismiss
     @Environment(\.router) var router
+    @EnvironmentObject var homeViewModel: HomeViewModel
 
     var walletTrxBalance: Decimal {
         return TronViewLogic.getWalletTrxBalance(vault: vault)
@@ -24,6 +25,15 @@ struct TronDashboardView: View {
             return "$0.00"
         }
         return TronViewLogic.formatFiat(balance: model.totalFrozenBalance, trxPrice: trxCoin.price)
+    }
+
+    /// "Claim X TRX" — the sum every expired entry returns in one transaction.
+    /// Honors the hide-balance toggle like the amounts in the rows above it.
+    var claimButtonTitle: String {
+        let amount = homeViewModel.hideVaultBalance
+            ? String.hideBalanceText
+            : "\(model.claimableBalance.formatted()) TRX"
+        return String(format: NSLocalizedString("tronClaimButton", comment: "Claim %@"), amount)
     }
 
     var body: some View {
@@ -293,6 +303,17 @@ struct TronDashboardView: View {
                     }
                     .padding(.vertical, 4)
                 }
+
+                // One action for every expired entry: WithdrawExpireUnfreeze
+                // sweeps all of them at once, so per-row claims would mislead.
+                if model.hasClaimableWithdrawals {
+                    DefiButton(
+                        title: claimButtonTitle,
+                        icon: .arrowDownFromLine,
+                        action: onClaim
+                    )
+                    .padding(.top, 4)
+                }
             }
             .padding(TronConstants.Design.cardPadding)
             .background(
@@ -300,5 +321,10 @@ struct TronDashboardView: View {
                     .fill(Theme.colors.bgSurface1)
             )
         }
+    }
+
+    private func onClaim() {
+        guard let tx = model.makeClaimTransaction(vault: vault) else { return }
+        router.navigate(to: SendRoute.verify(tx: tx, retrySignal: SendRetrySignal(), vault: vault))
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronDashboardView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronDashboardView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct TronDashboardView: View {
-    @ObservedObject var vault: Vault
+    let vault: Vault
     @ObservedObject var model: TronViewModel
     let onRefresh: () async -> Void  // Callback for refresh
     @Environment(\.dismiss) var dismiss
@@ -34,10 +34,6 @@ struct TronDashboardView: View {
             ? String.hideBalanceText
             : "\(model.claimableBalance.formatted()) TRX"
         return String(format: NSLocalizedString("tronClaimButton", comment: "Claim %@"), amount)
-    }
-
-    var canClaimExpiredUnfreezes: Bool {
-        TronViewLogic.canClaimExpiredUnfreezes(vault: vault)
     }
 
     var body: some View {
@@ -311,20 +307,11 @@ struct TronDashboardView: View {
                 // One action for every expired entry: WithdrawExpireUnfreeze
                 // sweeps all of them at once, so per-row claims would mislead.
                 if model.hasClaimableWithdrawals {
-                    if !canClaimExpiredUnfreezes {
-                        InfoBannerView(
-                            description: "tronClaimFastVaultOnly".localized,
-                            type: .warning,
-                            leadingIcon: .triangleWarning
-                        )
-                    }
-
                     DefiButton(
                         title: claimButtonTitle,
                         icon: .arrowDownFromLine,
                         action: onClaim
                     )
-                    .disabled(!canClaimExpiredUnfreezes)
                     .padding(.top, 4)
                 }
             }

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronViewLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronViewLogic.swift
@@ -89,25 +89,13 @@ struct TronViewLogic {
         withdrawals.filter(\.isClaimable).reduce(.zero) { $0 + $1.amount }
     }
 
-    /// Fast Vault's server signer receives the transaction hash produced on
-    /// this device. Secure Vault peers rebuild the transaction independently,
-    /// so claims must remain unavailable until every supported peer platform
-    /// routes this operation to the same TRON system contract.
-    static func canClaimExpiredUnfreezes(vault: Vault) -> Bool {
-        vault.isFastVault
-    }
-
     /// Builds the self-addressed claim transaction `TronHelper` routes to
     /// `WithdrawExpireUnfreezeContract`. The contract takes no amount and
     /// sweeps every expired entry at once, so the amount here is only what
     /// Verify / co-sign / Done display. Returns nil when nothing is claimable.
     static func makeClaimTransaction(vault: Vault, pendingWithdrawals: [TronPendingWithdrawal]) -> SendTransaction? {
         let claimable = claimableBalance(of: pendingWithdrawals)
-        guard canClaimExpiredUnfreezes(vault: vault),
-              claimable > 0,
-              let coin = getTrxCoin(vault: vault) else {
-            return nil
-        }
+        guard claimable > 0, let coin = getTrxCoin(vault: vault) else { return nil }
 
         return SendTransaction.empty(coin: coin, vault: vault).with(
             toAddress: coin.address,

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronViewLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronViewLogic.swift
@@ -89,13 +89,25 @@ struct TronViewLogic {
         withdrawals.filter(\.isClaimable).reduce(.zero) { $0 + $1.amount }
     }
 
+    /// Fast Vault's server signer receives the transaction hash produced on
+    /// this device. Secure Vault peers rebuild the transaction independently,
+    /// so claims must remain unavailable until every supported peer platform
+    /// routes this operation to the same TRON system contract.
+    static func canClaimExpiredUnfreezes(vault: Vault) -> Bool {
+        vault.isFastVault
+    }
+
     /// Builds the self-addressed claim transaction `TronHelper` routes to
     /// `WithdrawExpireUnfreezeContract`. The contract takes no amount and
     /// sweeps every expired entry at once, so the amount here is only what
     /// Verify / co-sign / Done display. Returns nil when nothing is claimable.
     static func makeClaimTransaction(vault: Vault, pendingWithdrawals: [TronPendingWithdrawal]) -> SendTransaction? {
         let claimable = claimableBalance(of: pendingWithdrawals)
-        guard claimable > 0, let coin = getTrxCoin(vault: vault) else { return nil }
+        guard canClaimExpiredUnfreezes(vault: vault),
+              claimable > 0,
+              let coin = getTrxCoin(vault: vault) else {
+            return nil
+        }
 
         return SendTransaction.empty(coin: coin, vault: vault).with(
             toAddress: coin.address,

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronViewLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronViewLogic.swift
@@ -81,6 +81,30 @@ struct TronViewLogic {
         return vault.nativeCoin(for: .tron)
     }
 
+    // MARK: - Claim (WithdrawExpireUnfreeze)
+
+    /// Sum of the pending withdrawals whose unlock period has elapsed — what a
+    /// single `WithdrawExpireUnfreezeContract` returns to the spendable balance.
+    static func claimableBalance(of withdrawals: [TronPendingWithdrawal]) -> Decimal {
+        withdrawals.filter(\.isClaimable).reduce(.zero) { $0 + $1.amount }
+    }
+
+    /// Builds the self-addressed claim transaction `TronHelper` routes to
+    /// `WithdrawExpireUnfreezeContract`. The contract takes no amount and
+    /// sweeps every expired entry at once, so the amount here is only what
+    /// Verify / co-sign / Done display. Returns nil when nothing is claimable.
+    static func makeClaimTransaction(vault: Vault, pendingWithdrawals: [TronPendingWithdrawal]) -> SendTransaction? {
+        let claimable = claimableBalance(of: pendingWithdrawals)
+        guard claimable > 0, let coin = getTrxCoin(vault: vault) else { return nil }
+
+        return SendTransaction.empty(coin: coin, vault: vault).with(
+            toAddress: coin.address,
+            amount: claimable.description,
+            memo: TronHelper.withdrawExpireUnfreezeMemo,
+            isStakingOperation: true
+        )
+    }
+
     /// Gets the wallet TRX balance
     static func getWalletTrxBalance(vault: Vault) -> Decimal {
         if let trxCoin = vault.nativeCoin(for: .tron) {

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronViewModel.swift
@@ -116,6 +116,13 @@ final class TronViewModel: ObservableObject, Hashable, Equatable {
         !pendingWithdrawals.isEmpty
     }
 
+    /// TRON cannot start another unfreeze while an existing withdrawal entry
+    /// is still pending. Only actively frozen bandwidth/energy counts here;
+    /// `totalFrozenBalance` also includes TRX that is already unfreezing.
+    var canUnfreeze: Bool {
+        !hasPendingWithdrawals && (frozenBandwidthBalance + frozenEnergyBalance) > 0
+    }
+
     /// TRX whose unlock period has elapsed; one claim sweeps all of it.
     var claimableBalance: Decimal {
         TronViewLogic.claimableBalance(of: pendingWithdrawals)

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronViewModel.swift
@@ -116,6 +116,29 @@ final class TronViewModel: ObservableObject, Hashable, Equatable {
         !pendingWithdrawals.isEmpty
     }
 
+    /// TRX whose unlock period has elapsed; one claim sweeps all of it.
+    var claimableBalance: Decimal {
+        TronViewLogic.claimableBalance(of: pendingWithdrawals)
+    }
+
+    var hasClaimableWithdrawals: Bool {
+        claimableBalance > 0
+    }
+
+    /// Builds the claim transaction for the expired withdrawals, or nil when
+    /// nothing is claimable. Drops the cached account/resource for the address
+    /// so balances refresh when the user lands back on the DeFi screens after
+    /// the claim is broadcast — the same step freeze/unfreeze take.
+    @MainActor
+    func makeClaimTransaction(vault: Vault) -> SendTransaction? {
+        guard let tx = TronViewLogic.makeClaimTransaction(vault: vault, pendingWithdrawals: pendingWithdrawals) else {
+            return nil
+        }
+        let address = tx.coin.address
+        Task { await TronService.shared.invalidateAccountCache(for: address) }
+        return tx
+    }
+
     @MainActor
     func apply(account: TronAccountResponse) {
         let balanceSun = account.balance ?? 0

--- a/VultisigApp/VultisigAppTests/Blockchain/SigningGolden/SigningGoldenMatrix.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/SigningGolden/SigningGoldenMatrix.swift
@@ -54,7 +54,8 @@ extension SigningGoldenFactory {
             tonSend,
             polkadotSend,
             bittensorSend,
-            tronSend
+            tronSend,
+            tronWithdrawExpireUnfreeze
         ]
     }
 
@@ -448,6 +449,39 @@ extension SigningGoldenFactory {
                         blockHeaderWitnessAddress: Const.tronWitness,
                         gasFeeEstimation: 1_000_000
                     )
+                )
+            },
+            imageHashes: { try TronHelper.getPreSignedImageHash(keysignPayload: $0) },
+            signedTransaction: { .regular(try TronHelper.getSignedTransaction(keysignPayload: $0, signatures: $1)) }
+        )
+    }
+
+    /// Stake 2.0 claim: a self-addressed TRX payload whose memo routes to
+    /// `WithdrawExpireUnfreezeContract`. The contract has no amount, so the
+    /// `toAmount` here is display-only and must not reach the signed bytes.
+    private static var tronWithdrawExpireUnfreeze: SigningGoldenVector {
+        SigningGoldenVector(
+            name: "tron_withdraw_expire_unfreeze",
+            curve: .secp256k1,
+            expectedLeaf: "TronHelper",
+            makePayload: {
+                let coin = coin(chain: .tron, ticker: "TRX", decimals: 6, curve: .secp256k1, uncompressedSecp: true)
+                return payload(
+                    coin: coin,
+                    toAddress: coin.address,
+                    toAmount: BigInt(12_500_000),
+                    chainSpecific: .Tron(
+                        timestamp: 1_700_000_000_000,
+                        expiration: 1_700_000_060_000,
+                        blockHeaderTimestamp: 1_700_000_000_000,
+                        blockHeaderNumber: 50_000_000,
+                        blockHeaderVersion: 30,
+                        blockHeaderTxTrieRoot: Const.hash32,
+                        blockHeaderParentHash: Const.hash32,
+                        blockHeaderWitnessAddress: Const.tronWitness,
+                        gasFeeEstimation: 1_000_000
+                    ),
+                    memo: TronHelper.withdrawExpireUnfreezeMemo
                 )
             },
             imageHashes: { try TronHelper.getPreSignedImageHash(keysignPayload: $0) },

--- a/VultisigApp/VultisigAppTests/Blockchain/SigningGolden/SigningGoldenVectors.json
+++ b/VultisigApp/VultisigAppTests/Blockchain/SigningGolden/SigningGoldenVectors.json
@@ -166,10 +166,10 @@
   },
   "tron_withdraw_expire_unfreeze": {
     "imageHashes": [
-      "110730b35ade7a944d4c2a4d524f6fd5aa508edef5fc39948807bb2409d88301"
+      "563a592711e3f389aaab0793cb98b96baac551ed2638f8a6817d3c198a700cbf"
     ],
-    "rawTransaction": "{\"raw_data\":{\"contract\":[{\"parameter\":{\"type_url\":\"type.googleapis.com/protocol.WithdrawExpireUnfreezeContract\",\"value\":{\"owner_address\":\"413193a0ea5520385e257bba8b30b162d26d4bdd5e\"}},\"type\":\"WithdrawExpireUnfreezeContract\"}],\"expiration\":1700000060000,\"fee_limit\":1000000,\"ref_block_bytes\":\"f080\",\"ref_block_hash\":\"d4b37a782d816437\",\"timestamp\":1700000000000},\"raw_data_hex\":\"0a02f0802208d4b37a782d81643740e0a499ffbc315a5a083812560a3b747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5769746864726177457870697265556e667265657a65436f6e747261637412170a15413193a0ea5520385e257bba8b30b162d26d4bdd5e7080d095ffbc319001c0843d\",\"signature\":[\"5299bc1a2d497457c2037126a130fc8f447b58ac9349241c5606a6ef118657bd687d25e87d30a3a6516f402dd8e1e8bf69b3f554b65ded5edef0b9e2f458a41b01\"],\"txID\":\"110730b35ade7a944d4c2a4d524f6fd5aa508edef5fc39948807bb2409d88301\"}",
-    "transactionHash": "110730b35ade7a944d4c2a4d524f6fd5aa508edef5fc39948807bb2409d88301"
+    "rawTransaction": "{\"raw_data\":{\"contract\":[{\"parameter\":{\"type_url\":\"type.googleapis.com/protocol.WithdrawExpireUnfreezeContract\",\"value\":{\"owner_address\":\"413193a0ea5520385e257bba8b30b162d26d4bdd5e\"}},\"type\":\"WithdrawExpireUnfreezeContract\"}],\"expiration\":1700000060000,\"ref_block_bytes\":\"f080\",\"ref_block_hash\":\"d4b37a782d816437\",\"timestamp\":1700000000000},\"raw_data_hex\":\"0a02f0802208d4b37a782d81643740e0a499ffbc315a5a083812560a3b747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5769746864726177457870697265556e667265657a65436f6e747261637412170a15413193a0ea5520385e257bba8b30b162d26d4bdd5e7080d095ffbc31\",\"signature\":[\"9f838bc8ecc503179626940f7dda2cd5386b30a5046523b0da7ba5011089803f4d86a874be69cbf857b3c5b57cf2859f7228e12339d28226d09af8889016f99000\"],\"txID\":\"563a592711e3f389aaab0793cb98b96baac551ed2638f8a6817d3c198a700cbf\"}",
+    "transactionHash": "563a592711e3f389aaab0793cb98b96baac551ed2638f8a6817d3c198a700cbf"
   },
   "utxo_bitcoin_send": {
     "imageHashes": [

--- a/VultisigApp/VultisigAppTests/Blockchain/SigningGolden/SigningGoldenVectors.json
+++ b/VultisigApp/VultisigAppTests/Blockchain/SigningGolden/SigningGoldenVectors.json
@@ -164,6 +164,13 @@
     "rawTransaction": "{\"raw_data\":{\"contract\":[{\"parameter\":{\"type_url\":\"type.googleapis.com/protocol.TransferContract\",\"value\":{\"amount\":1000000,\"owner_address\":\"413193a0ea5520385e257bba8b30b162d26d4bdd5e\",\"to_address\":\"4117c5185167401ed00cf5f5b2fc97d9bbfdb7d025\"}},\"type\":\"TransferContract\"}],\"expiration\":1700000060000,\"ref_block_bytes\":\"f080\",\"ref_block_hash\":\"d4b37a782d816437\",\"timestamp\":1700000000000},\"raw_data_hex\":\"0a02f0802208d4b37a782d81643740e0a499ffbc315a67080112630a2d747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5472616e73666572436f6e747261637412320a15413193a0ea5520385e257bba8b30b162d26d4bdd5e12154117c5185167401ed00cf5f5b2fc97d9bbfdb7d02518c0843d7080d095ffbc31\",\"signature\":[\"0d30a2adf61eb327ca4c265a55b0143e41d31380f695edc61f920eaf6bf6d1b57fdebda5bbbee1a7cc3f4981fc787e99c225a1933aab24b6dafb0ca43e222b4d01\"],\"txID\":\"1e5f7f58cd34ee133b9767eabaee7e3518d39b5fd95efc7ea8713d9d460c5361\"}",
     "transactionHash": "1e5f7f58cd34ee133b9767eabaee7e3518d39b5fd95efc7ea8713d9d460c5361"
   },
+  "tron_withdraw_expire_unfreeze": {
+    "imageHashes": [
+      "110730b35ade7a944d4c2a4d524f6fd5aa508edef5fc39948807bb2409d88301"
+    ],
+    "rawTransaction": "{\"raw_data\":{\"contract\":[{\"parameter\":{\"type_url\":\"type.googleapis.com/protocol.WithdrawExpireUnfreezeContract\",\"value\":{\"owner_address\":\"413193a0ea5520385e257bba8b30b162d26d4bdd5e\"}},\"type\":\"WithdrawExpireUnfreezeContract\"}],\"expiration\":1700000060000,\"fee_limit\":1000000,\"ref_block_bytes\":\"f080\",\"ref_block_hash\":\"d4b37a782d816437\",\"timestamp\":1700000000000},\"raw_data_hex\":\"0a02f0802208d4b37a782d81643740e0a499ffbc315a5a083812560a3b747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5769746864726177457870697265556e667265657a65436f6e747261637412170a15413193a0ea5520385e257bba8b30b162d26d4bdd5e7080d095ffbc319001c0843d\",\"signature\":[\"5299bc1a2d497457c2037126a130fc8f447b58ac9349241c5606a6ef118657bd687d25e87d30a3a6516f402dd8e1e8bf69b3f554b65ded5edef0b9e2f458a41b01\"],\"txID\":\"110730b35ade7a944d4c2a4d524f6fd5aa508edef5fc39948807bb2409d88301\"}",
+    "transactionHash": "110730b35ade7a944d4c2a4d524f6fd5aa508edef5fc39948807bb2409d88301"
+  },
   "utxo_bitcoin_send": {
     "imageHashes": [
       "b72960dd51d5a0404a3c1fb2eaa2634eb979f207e99d6e59e6f1ebfa13b8c3bb"

--- a/VultisigApp/VultisigAppTests/Chains/TronWithdrawExpireUnfreezeTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/TronWithdrawExpireUnfreezeTests.swift
@@ -32,7 +32,7 @@ final class TronWithdrawExpireUnfreezeTests: XCTestCase {
         XCTAssertTrue(input.transaction.memo.isEmpty, "the routing memo must not be written into the signed transaction")
         XCTAssertEqual(input.transaction.timestamp, 1_700_000_000_000)
         XCTAssertEqual(input.transaction.expiration, 1_700_000_060_000)
-        XCTAssertEqual(input.transaction.feeLimit, 1_000_000)
+        XCTAssertEqual(input.transaction.feeLimit, 0)
         XCTAssertEqual(input.transaction.blockHeader.number, 50_000_000)
     }
 

--- a/VultisigApp/VultisigAppTests/Chains/TronWithdrawExpireUnfreezeTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/TronWithdrawExpireUnfreezeTests.swift
@@ -1,0 +1,123 @@
+//
+//  TronWithdrawExpireUnfreezeTests.swift
+//  VultisigAppTests
+//
+//  `TronHelper` routes a self-addressed native TRX payload carrying the
+//  `WITHDRAW_EXPIRE_UNFREEZE` memo to `WithdrawExpireUnfreezeContract` — the
+//  Stake 2.0 claim that returns every expired `UnfreezeBalanceV2` entry to the
+//  spendable balance. The contract has no amount and the memo is a routing
+//  marker only, so neither may leak into the signed transaction.
+//
+
+import BigInt
+import WalletCore
+import XCTest
+@testable import VultisigApp
+
+final class TronWithdrawExpireUnfreezeTests: XCTestCase {
+
+    private let witness = "41e0e0f1a3a3f3e2d1c0b0a0908070605040302010"
+    private let hash32 = "e63d3f0f2a3a3f3e2d1c0b0a09080706050403020100ffeeddccbbaa99887766"
+
+    func testSelfAddressedMemoBuildsWithdrawExpireUnfreezeContract() throws {
+        let coin = makeTrx()
+        let payload = makePayload(coin: coin, toAddress: coin.address, memo: TronHelper.withdrawExpireUnfreezeMemo)
+
+        let input = try TronSigningInput(serializedBytes: TronHelper.getPreSignedInputData(keysignPayload: payload))
+
+        guard case .withdrawExpireUnfreeze(let contract) = input.transaction.contractOneof else {
+            return XCTFail("expected withdrawExpireUnfreeze contract, got \(String(describing: input.transaction.contractOneof))")
+        }
+        XCTAssertEqual(contract.ownerAddress, coin.address)
+        XCTAssertTrue(input.transaction.memo.isEmpty, "the routing memo must not be written into the signed transaction")
+        XCTAssertEqual(input.transaction.timestamp, 1_700_000_000_000)
+        XCTAssertEqual(input.transaction.expiration, 1_700_000_060_000)
+        XCTAssertEqual(input.transaction.feeLimit, 1_000_000)
+        XCTAssertEqual(input.transaction.blockHeader.number, 50_000_000)
+    }
+
+    func testClaimIgnoresPayloadAmount() throws {
+        let coin = makeTrx()
+        let zeroAmount = makePayload(coin: coin, toAddress: coin.address, memo: TronHelper.withdrawExpireUnfreezeMemo, toAmount: .zero)
+        let someAmount = makePayload(coin: coin, toAddress: coin.address, memo: TronHelper.withdrawExpireUnfreezeMemo, toAmount: BigInt(12_500_000))
+
+        XCTAssertEqual(
+            try TronHelper.getPreSignedInputData(keysignPayload: zeroAmount),
+            try TronHelper.getPreSignedInputData(keysignPayload: someAmount),
+            "the contract carries no amount, so toAmount must not change the bytes to sign"
+        )
+    }
+
+    func testPreSignedImageHashIsSingleHash() throws {
+        let coin = makeTrx()
+        let payload = makePayload(coin: coin, toAddress: coin.address, memo: TronHelper.withdrawExpireUnfreezeMemo)
+
+        let hashes = try TronHelper.getPreSignedImageHash(keysignPayload: payload)
+
+        XCTAssertEqual(hashes.count, 1)
+        XCTAssertEqual(hashes[0].count, 64)
+    }
+
+    func testNonSelfDestinationWithClaimMemoThrows() {
+        let coin = makeTrx()
+        let payload = makePayload(
+            coin: coin,
+            toAddress: SigningGoldenFactory.recipient(.tron),
+            memo: TronHelper.withdrawExpireUnfreezeMemo
+        )
+
+        XCTAssertThrowsError(try TronHelper.getPreSignedInputData(keysignPayload: payload))
+    }
+
+    func testTokenCoinWithClaimMemoThrows() {
+        let usdt = SigningGoldenFactory.coin(
+            chain: .tron,
+            ticker: "USDT",
+            decimals: 6,
+            contractAddress: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+            isNativeToken: false,
+            curve: .secp256k1,
+            uncompressedSecp: true
+        )
+        let payload = makePayload(coin: usdt, toAddress: usdt.address, memo: TronHelper.withdrawExpireUnfreezeMemo)
+
+        XCTAssertThrowsError(try TronHelper.getPreSignedInputData(keysignPayload: payload))
+    }
+
+    func testNearMissMemoFallsThroughToTransfer() throws {
+        let coin = makeTrx()
+        let payload = makePayload(coin: coin, toAddress: coin.address, memo: "WITHDRAW_EXPIRE_UNFREEZE:BANDWIDTH")
+
+        let input = try TronSigningInput(serializedBytes: TronHelper.getPreSignedInputData(keysignPayload: payload))
+
+        guard case .transfer = input.transaction.contractOneof else {
+            return XCTFail("a memo that is not exactly the claim marker must not be treated as a claim")
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private func makeTrx() -> Coin {
+        SigningGoldenFactory.coin(chain: .tron, ticker: "TRX", decimals: 6, curve: .secp256k1, uncompressedSecp: true)
+    }
+
+    private func makePayload(coin: Coin, toAddress: String, memo: String?, toAmount: BigInt = BigInt(1_000_000)) -> KeysignPayload {
+        SigningGoldenFactory.payload(
+            coin: coin,
+            toAddress: toAddress,
+            toAmount: toAmount,
+            chainSpecific: .Tron(
+                timestamp: 1_700_000_000_000,
+                expiration: 1_700_000_060_000,
+                blockHeaderTimestamp: 1_700_000_000_000,
+                blockHeaderNumber: 50_000_000,
+                blockHeaderVersion: 30,
+                blockHeaderTxTrieRoot: hash32,
+                blockHeaderParentHash: hash32,
+                blockHeaderWitnessAddress: witness,
+                gasFeeEstimation: 1_000_000
+            ),
+            memo: memo
+        )
+    }
+}

--- a/VultisigApp/VultisigAppTests/Defi/TronViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/TronViewModelTests.swift
@@ -137,6 +137,8 @@ final class TronViewModelTests: XCTestCase {
     func testMakeClaimTransactionSweepsExpiredEntriesIntoSelfAddressedStakingSend() throws {
         let trx = SendFormFixture.makeTRX()
         let vault = SendFormFixture.makeVault(coins: [trx])
+        vault.fastVaultEligibility = true
+        vault.fastVaultEligibilityCheckedAt = Date()
         let sut = TronViewModel()
         sut.pendingWithdrawals = [
             TronPendingWithdrawal(amount: try decimal("0.75"), expirationDate: Date(timeIntervalSince1970: 1_704_067_200)),
@@ -153,6 +155,30 @@ final class TronViewModelTests: XCTestCase {
         XCTAssertEqual(tx.memo, TronHelper.withdrawExpireUnfreezeMemo)
         XCTAssertTrue(tx.isStakingOperation)
         XCTAssertFalse(tx.sendMaxAmount)
+    }
+
+    func testMakeClaimTransactionIsNilForSecureVault() throws {
+        let vault = SendFormFixture.makeVault(coins: [SendFormFixture.makeTRX()])
+        vault.fastVaultEligibility = false
+        vault.fastVaultEligibilityCheckedAt = Date()
+        let sut = TronViewModel()
+        sut.pendingWithdrawals = [
+            TronPendingWithdrawal(
+                amount: try decimal("0.75"),
+                expirationDate: Date(timeIntervalSince1970: 1_704_067_200)
+            )
+        ]
+
+        XCTAssertFalse(TronViewLogic.canClaimExpiredUnfreezes(vault: vault))
+        XCTAssertNil(sut.makeClaimTransaction(vault: vault))
+    }
+
+    func testMakeClaimTransactionIsEnabledForFastVault() {
+        let vault = SendFormFixture.makeVault(coins: [SendFormFixture.makeTRX()])
+        vault.fastVaultEligibility = true
+        vault.fastVaultEligibilityCheckedAt = Date()
+
+        XCTAssertTrue(TronViewLogic.canClaimExpiredUnfreezes(vault: vault))
     }
 
     func testMakeClaimTransactionIsNilWhenNothingIsClaimable() {

--- a/VultisigApp/VultisigAppTests/Defi/TronViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/TronViewModelTests.swift
@@ -101,6 +101,82 @@ final class TronViewModelTests: XCTestCase {
         XCTAssertFalse(sut.isLoadingResources)
     }
 
+    func testClaimableBalanceCountsOnlyExpiredWithdrawals() throws {
+        let account = try decode(
+            TronAccountResponse.self,
+            from: """
+            {
+              "address": "TTestAddress",
+              "unfrozenV2": [
+                { "unfreeze_amount": 1500000, "unfreeze_expire_time": 4102444800000 },
+                { "unfreeze_amount": 750000, "unfreeze_expire_time": 1704067200000 }
+              ]
+            }
+            """
+        )
+        let sut = TronViewModel()
+
+        sut.apply(account: account)
+
+        XCTAssertEqual(sut.pendingWithdrawals.count, 2)
+        XCTAssertEqual(sut.unfreezingBalance, try decimal("2.25"))
+        XCTAssertEqual(sut.claimableBalance, try decimal("0.75"))
+        XCTAssertTrue(sut.hasClaimableWithdrawals)
+    }
+
+    func testClaimableBalanceIsZeroWhenEveryWithdrawalIsStillLocked() {
+        let sut = TronViewModel()
+        sut.pendingWithdrawals = [
+            TronPendingWithdrawal(amount: 5, expirationDate: Date(timeIntervalSince1970: 4_102_444_800))
+        ]
+
+        XCTAssertEqual(sut.claimableBalance, .zero)
+        XCTAssertFalse(sut.hasClaimableWithdrawals)
+    }
+
+    func testMakeClaimTransactionSweepsExpiredEntriesIntoSelfAddressedStakingSend() throws {
+        let trx = SendFormFixture.makeTRX()
+        let vault = SendFormFixture.makeVault(coins: [trx])
+        let sut = TronViewModel()
+        sut.pendingWithdrawals = [
+            TronPendingWithdrawal(amount: try decimal("0.75"), expirationDate: Date(timeIntervalSince1970: 1_704_067_200)),
+            TronPendingWithdrawal(amount: try decimal("1.5"), expirationDate: Date(timeIntervalSince1970: 1_735_689_600)),
+            TronPendingWithdrawal(amount: 3, expirationDate: Date(timeIntervalSince1970: 4_102_444_800))
+        ]
+
+        let tx = try XCTUnwrap(sut.makeClaimTransaction(vault: vault))
+
+        XCTAssertEqual(tx.coin.ticker, "TRX")
+        XCTAssertEqual(tx.fromAddress, trx.address)
+        XCTAssertEqual(tx.toAddress, trx.address)
+        XCTAssertEqual(tx.amount, "2.25")
+        XCTAssertEqual(tx.memo, TronHelper.withdrawExpireUnfreezeMemo)
+        XCTAssertTrue(tx.isStakingOperation)
+        XCTAssertFalse(tx.sendMaxAmount)
+    }
+
+    func testMakeClaimTransactionIsNilWhenNothingIsClaimable() {
+        let vault = SendFormFixture.makeVault(coins: [SendFormFixture.makeTRX()])
+        let sut = TronViewModel()
+
+        XCTAssertNil(sut.makeClaimTransaction(vault: vault), "no pending withdrawals")
+
+        sut.pendingWithdrawals = [
+            TronPendingWithdrawal(amount: 5, expirationDate: Date(timeIntervalSince1970: 4_102_444_800))
+        ]
+        XCTAssertNil(sut.makeClaimTransaction(vault: vault), "only locked withdrawals")
+    }
+
+    func testMakeClaimTransactionIsNilWithoutTrxCoin() throws {
+        let vault = SendFormFixture.makeVault(coins: [SendFormFixture.makeETH()])
+        let sut = TronViewModel()
+        sut.pendingWithdrawals = [
+            TronPendingWithdrawal(amount: try decimal("0.75"), expirationDate: Date(timeIntervalSince1970: 1_704_067_200))
+        ]
+
+        XCTAssertNil(sut.makeClaimTransaction(vault: vault))
+    }
+
     private func decode<Value: Decodable>(_ type: Value.Type, from json: String) throws -> Value {
         try JSONDecoder().decode(type, from: Data(json.utf8))
     }

--- a/VultisigApp/VultisigAppTests/Defi/TronViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/TronViewModelTests.swift
@@ -134,6 +134,32 @@ final class TronViewModelTests: XCTestCase {
         XCTAssertFalse(sut.hasClaimableWithdrawals)
     }
 
+    func testCanUnfreezeRequiresActivelyFrozenBalance() {
+        let sut = TronViewModel()
+        sut.unfreezingBalance = 5
+
+        XCTAssertFalse(sut.canUnfreeze, "already-unfreezing TRX is not active frozen balance")
+
+        sut.frozenEnergyBalance = 1
+
+        XCTAssertTrue(sut.canUnfreeze)
+    }
+
+    func testCanUnfreezeIsFalseWhileAnyWithdrawalEntryRemains() {
+        let sut = TronViewModel()
+        sut.frozenBandwidthBalance = 1
+
+        sut.pendingWithdrawals = [
+            TronPendingWithdrawal(amount: 1, expirationDate: Date(timeIntervalSince1970: 4_102_444_800))
+        ]
+        XCTAssertFalse(sut.canUnfreeze, "locked withdrawal")
+
+        sut.pendingWithdrawals = [
+            TronPendingWithdrawal(amount: 1, expirationDate: Date(timeIntervalSince1970: 1_704_067_200))
+        ]
+        XCTAssertFalse(sut.canUnfreeze, "claimable withdrawal still needs to be claimed")
+    }
+
     func testMakeClaimTransactionSweepsExpiredEntriesIntoSelfAddressedStakingSend() throws {
         let trx = SendFormFixture.makeTRX()
         let vault = SendFormFixture.makeVault(coins: [trx])

--- a/VultisigApp/VultisigAppTests/Defi/TronViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/TronViewModelTests.swift
@@ -163,8 +163,6 @@ final class TronViewModelTests: XCTestCase {
     func testMakeClaimTransactionSweepsExpiredEntriesIntoSelfAddressedStakingSend() throws {
         let trx = SendFormFixture.makeTRX()
         let vault = SendFormFixture.makeVault(coins: [trx])
-        vault.fastVaultEligibility = true
-        vault.fastVaultEligibilityCheckedAt = Date()
         let sut = TronViewModel()
         sut.pendingWithdrawals = [
             TronPendingWithdrawal(amount: try decimal("0.75"), expirationDate: Date(timeIntervalSince1970: 1_704_067_200)),
@@ -181,30 +179,6 @@ final class TronViewModelTests: XCTestCase {
         XCTAssertEqual(tx.memo, TronHelper.withdrawExpireUnfreezeMemo)
         XCTAssertTrue(tx.isStakingOperation)
         XCTAssertFalse(tx.sendMaxAmount)
-    }
-
-    func testMakeClaimTransactionIsNilForSecureVault() throws {
-        let vault = SendFormFixture.makeVault(coins: [SendFormFixture.makeTRX()])
-        vault.fastVaultEligibility = false
-        vault.fastVaultEligibilityCheckedAt = Date()
-        let sut = TronViewModel()
-        sut.pendingWithdrawals = [
-            TronPendingWithdrawal(
-                amount: try decimal("0.75"),
-                expirationDate: Date(timeIntervalSince1970: 1_704_067_200)
-            )
-        ]
-
-        XCTAssertFalse(TronViewLogic.canClaimExpiredUnfreezes(vault: vault))
-        XCTAssertNil(sut.makeClaimTransaction(vault: vault))
-    }
-
-    func testMakeClaimTransactionIsEnabledForFastVault() {
-        let vault = SendFormFixture.makeVault(coins: [SendFormFixture.makeTRX()])
-        vault.fastVaultEligibility = true
-        vault.fastVaultEligibilityCheckedAt = Date()
-
-        XCTAssertTrue(TronViewLogic.canClaimExpiredUnfreezes(vault: vault))
     }
 
     func testMakeClaimTransactionIsNilWhenNothingIsClaimable() {

--- a/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
@@ -161,6 +161,43 @@ final class TronServiceFeeLimitTests: XCTestCase {
         XCTAssertEqual(gasFee, 0)
     }
 
+    /// `WITHDRAW_EXPIRE_UNFREEZE` is an app-local routing marker, not TRON
+    /// transaction data. The claim builder omits it from the signed bytes, so
+    /// the fee estimate must not charge getMemoFee for it either.
+    func testWithdrawExpireUnfreezeDoesNotChargeRoutingMemoFee() async throws {
+        let stub = TronStubHTTPClient()
+        stub.stubDefaults(energyUsed: 0)
+        stub.setResponse(path: "/wallet/getaccountresource", json: """
+        {"freeNetUsed":0,"freeNetLimit":600,"NetUsed":0,"NetLimit":10000,"EnergyUsed":0,"EnergyLimit":0}
+        """)
+        let service = TronService(httpClient: stub)
+
+        let coin = makeNativeCoin()
+        let result = try await service.getBlockInfo(
+            coin: coin,
+            to: coin.address,
+            memo: TronHelper.withdrawExpireUnfreezeMemo
+        )
+
+        XCTAssertEqual(extractGasFee(result), 0)
+    }
+
+    /// A real memo still pays the chain's getMemoFee parameter; the routing-
+    /// marker exception above must not weaken ordinary TRON fee estimation.
+    func testNativeTransferRealMemoStillChargesMemoFee() async throws {
+        let stub = TronStubHTTPClient()
+        stub.stubDefaults(energyUsed: 0)
+        stub.setResponse(path: "/wallet/getaccountresource", json: """
+        {"freeNetUsed":0,"freeNetLimit":600,"NetUsed":0,"NetLimit":10000,"EnergyUsed":0,"EnergyLimit":0}
+        """)
+        let service = TronService(httpClient: stub)
+
+        let coin = makeNativeCoin()
+        let result = try await service.getBlockInfo(coin: coin, to: coin.address, memo: "hello")
+
+        XCTAssertEqual(extractGasFee(result), 1_000_000)
+    }
+
     /// Native TRX transfer *without* sufficient bandwidth — the account has no
     /// free-net quota, so the node consumes the 300-byte bandwidth fee. The
     /// displayed fee must be the REAL bandwidth cost, not `coin.feeDefault`:


### PR DESCRIPTION
## Problem

On TRON, `UnfreezeBalanceV2` starts a 14-day unlock timer, but the TRX only returns to the spendable balance once a separate `WithdrawExpireUnfreezeContract` is signed and broadcast. The TRON DeFi dashboard already tracks each entry (`pendingWithdrawalsCard` shows "Ready to claim" + a checkmark once `unfreeze_expire_time` passes), but there was no builder for that contract anywhere in the app and no action wired to the claimable state — the TRX stayed locked in `unfrozenV2` forever from the app's point of view.

## Root cause

`TronHelper.getPreSignedInputData` only knew the `FREEZE:` / `UNFREEZE:` memo routes (`buildTronFreezeBalanceV2Input` / `buildTronUnfreezeBalanceV2Input`). WalletCore (walletcore-spm 4.7.1, already pinned) ships `TronWithdrawExpireUnfreezeContract` and `TronTransaction.contractOneof = .withdrawExpireUnfreeze(_)`, but nothing produced it, and the dashboard rendered claimable rows as read-only.

## Fix

- **Signing (`Blockchain/Tron/Signing/Tron.swift`)** — new `TronHelper.withdrawExpireUnfreezeMemo = "WITHDRAW_EXPIRE_UNFREEZE"` and `buildTronWithdrawExpireUnfreezeInput`, wired next to the V2 freeze/unfreeze builders with the same timestamp / expiration / feeLimit / blockHeader plumbing. The memo is matched **exactly** and the dispatch requires a native TRX payload addressed to the sender (throws otherwise, like Android's staking-memo guard). The contract carries no amount, so `toAmount` is not read and the memo is not written into the signed tx.
- **Logic (`TronViewLogic` / `TronViewModel`)** — `claimableBalance(of:)` sums the entries whose unlock time has elapsed; `makeClaimTransaction(...)` builds the self-addressed `SendTransaction` (`toAddress` = own address, `amount` = claimable sum for the Verify / co-sign / Done surfaces, `memo` = the constant, `isStakingOperation: true`) or `nil` when nothing is claimable. `TronViewModel.makeClaimTransaction(vault:)` also invalidates the `TronService` account cache, mirroring `TronUnfreezeViewModel`.
- **UI (`TronDashboardView.pendingWithdrawalsCard`)** — one `DefiButton` "Claim X TRX" at the bottom of the card, rendered only when the claimable sum > 0. The contract sweeps every expired entry at once, so there is a single action rather than per-row taps; locked entries keep the hourglass and get no action. Tapping navigates straight to `SendRoute.verify` — the same TSS sign/broadcast path freeze/unfreeze use. The title honors the hide-balance toggle.
- **Refresh after claim** — the shared `DoneScreen` restarts to root and `TronScreen.task` reloads with the cache already invalidated, then `BalanceService.updateBalance(for:)` syncs the persisted staked balance — the same mechanism unfreeze relies on; once the node no longer reports the entry in `unfrozenV2`, it leaves the pending list.
- **Localization** — new key `tronClaimButton` ("Claim %@") in all 8 shipping locales (`de, en, es, hr, it, ko, pt, zh-Hans`); `sort_localizable.py` is a no-op on the result.

Freeze/unfreeze logic, `unfreeze_expire_time` handling and the generic `StakeInteractor` framework are untouched; no new dependency.

## Tests

- `TronWithdrawExpireUnfreezeTests` — decoded `TronSigningInput` carries `.withdrawExpireUnfreeze` with the owner address, no memo, the expected timestamp/expiration/feeLimit/block header; the bytes to sign are independent of `toAmount`; `getPreSignedImageHash` yields one hash; a non-self destination, a TRC20 coin, or a near-miss memo (`WITHDRAW_EXPIRE_UNFREEZE:BANDWIDTH`) do not take the claim route.
- `SigningGoldenMatrix` — new `tron_withdraw_expire_unfreeze` vector with its recorded golden (`SigningGoldenVectors.json`); every existing golden is byte-identical. The recorded `raw_data` is a single `WithdrawExpireUnfreezeContract` (type 56) with only `owner_address`, `fee_limit` 1000000 — useful as a cross-platform reference.
- `TronViewModelTests` — `apply(account:)` with one expired + one locked entry → `claimableBalance` equals only the expired amount; claim tx has the memo, self address, amount = claimable sum, `isStakingOperation == true`; `nil` when nothing is claimable or the vault has no TRX coin.

## Things reviewers should know

- **New signing path — needs human + on-device review.** I could not perform the on-chain acceptance (it needs a vault with an unfreeze entry past its 14-day timer). The signed bytes are pinned by the golden, and the dispatch is covered by unit tests, but a real claim has not been broadcast from this branch.
- **Cross-platform memo parity (follow-up).** Neither Android (`TronHelper.kt`, regex `^(FREEZE|UNFREEZE):(BANDWIDTH|ENERGY)$`), the SDK (`resolvers/tron.ts`) nor Windows implement `WithdrawExpireUnfreezeContract` yet, so iOS is defining the memo convention here (`WITHDRAW_EXPIRE_UNFREEZE`, named after the TRON contract so it can be mirrored verbatim). Until they ship parity, an Android/Windows co-signer will compute a different pre-image hash for this payload and the keysign will fail to verify — same as any iOS-first signing feature. No issues were filed on the other repos from this PR.
- **Fee estimate (pre-existing).** `TronService.getBlockInfo(coin:to:memo:)` adds `memoFeeEstimate` whenever a memo is present, even though the staking builders never put the memo into the tx, so the fee shown on Verify for FREEZE / UNFREEZE / this claim is a slight over-estimate. Shared with freeze/unfreeze and intentionally left alone per the issue's "don't change freeze/unfreeze logic".
- `TronPendingWithdrawal.isClaimable` reads `Date()` at access time and the card does not re-evaluate on a timer, so an entry that expires while the screen is open becomes claimable on the next refresh — same as today's "Ready to claim" label.

## Verification

- `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — 0 violations in touched files.
- Full `make test` on a dedicated en_US iPhone 17 Pro Max simulator: `** TEST SUCCEEDED **` — `Executed 6636 tests, with 11 tests skipped and 0 failures (0 unexpected)`; `TronWithdrawExpireUnfreezeTests`, `TronViewModelTests` and `SigningGoldenTests` all passed in that run (project regenerated with `make generate` so the new test file is in the target).
- Cross-model review (codex, read-only) on each step + whole branch: no findings on any of the three step commits, the data-only golden commit was not gated (no runtime surface), and the whole-branch pass (`git diff e6665c3e0...HEAD`) returned no findings.

Closes #5204

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for claiming expired TRON unfreeze withdrawals.
  - Added a TRON dashboard claim action showing claimable TRX and transaction verification.
  - Claim amounts respect balance-visibility settings.
- **Limitations**
  - Claims are currently available only for Fast Vaults.
  - Claims require eligible withdrawals and a native TRX balance.
- **Localization**
  - Added translated TRON claim labels and availability notices in eight languages.
- **Tests**
  - Added coverage for claim eligibility, transaction creation, fees, and signing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->