### PR TITLE
feat(keysign): establish signed transaction decoder core

### DIFF
--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/DecodedTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/DecodedTransaction.swift
@@ -1,0 +1,133 @@
+//
+//  DecodedTransaction.swift
+//  VultisigApp
+//
+//  A provenance-aware reading of signed transaction content. Amounts remain in
+//  raw base units; scaling with unsigned display metadata happens later.
+//
+
+import BigInt
+import Foundation
+
+/// What the amount is denominated in.
+enum DecodedAsset: Hashable {
+
+    /// A denomination named by signed content.
+    case denom(String)
+
+    /// The transaction coin; its display metadata is resolved separately.
+    case transactionCoin
+
+    /// The instruction's fixed native asset, rendered from bundled metadata.
+    case chainNative
+}
+
+/// The quantity, or the share of a position, a transaction moves.
+enum DecodedAmount: Hashable {
+
+    /// Base units exactly as the signed content carries them.
+    case units(BigInt, of: DecodedAsset)
+
+    /// A signed share in basis points; resolving the position is enrichment.
+    case fraction(basisPoints: Int, of: DecodedAsset)
+
+    /// The signed operation names no quantity.
+    case unstated
+}
+
+/// One asset-independent verb per operation. `CaseIterable` lets vocabulary
+/// tests require an explicit presentation decision for every case.
+enum DecodedOperation: Hashable, CaseIterable {
+    case transfer
+    case swap
+    case approve
+    case stake
+    case unstake
+    case bond
+    case unbond
+    case rebond
+    case leave
+    case delegate
+    case undelegate
+    case redelegate
+    case claimRewards
+    case mint
+    case redeem
+    case addLiquidity
+    case removeLiquidity
+    case merge
+    case unmerge
+    case ibcTransfer
+    case vote
+    /// Moving a token into THORChain's secured-asset layer, or back out.
+    case securedAssetDeposit
+    case securedAssetWithdraw
+    /// Moving a token to THORChain from the chain it lives on now.
+    case switchChain
+    case limitOrderPlacement
+    case limitOrderCancel
+    /// Recognised as a contract call without a known shape behind it.
+    case contractCall
+
+    /// Nothing readable identified the operation; never inferred as a transfer.
+    case unknown
+}
+
+/// Who or what the operation is directed at, when the transaction names one.
+enum DecodedCounterparty: Hashable {
+    case node(String)
+    case validator(String)
+    case pool(String)
+    case contract(String)
+}
+
+/// Evidence for the reading, ordered strongest first.
+enum DecodedEvidence: Int, Comparable, Hashable {
+    /// The literal object being signed — a SignDoc, a raw transaction, a BOC.
+    case signedData = 0
+    /// The contract call that gets signed, naming its own action.
+    case wasmExecuteMsg = 1
+    /// The string the chain itself parses.
+    case memo = 2
+    /// Structured intent that builds the signed bytes.
+    case structuredPayload = 3
+    /// The wire discriminator that selects the signing shape.
+    case wireTransactionType = 4
+    /// Nothing was read. Only ever paired with `.unknown`.
+    case unread = 5
+
+    static func < (lhs: DecodedEvidence, rhs: DecodedEvidence) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    /// Whether this evidence is at least as strong as `other`.
+    func isNoWeaker(than other: DecodedEvidence) -> Bool {
+        rawValue <= other.rawValue
+    }
+}
+
+struct DecodedTransaction: Hashable {
+    let operation: DecodedOperation
+    let amount: DecodedAmount
+    let counterparty: DecodedCounterparty?
+    let evidence: DecodedEvidence
+
+    init(
+        operation: DecodedOperation,
+        amount: DecodedAmount,
+        counterparty: DecodedCounterparty? = nil,
+        evidence: DecodedEvidence
+    ) {
+        self.operation = operation
+        self.amount = amount
+        self.counterparty = counterparty
+        self.evidence = evidence
+    }
+
+    /// Nothing readable identified this transaction.
+    static let unreadable = DecodedTransaction(
+        operation: .unknown,
+        amount: .unstated,
+        evidence: .unread
+    )
+}

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionContent.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionContent.swift
@@ -1,0 +1,302 @@
+//
+//  SignedTransactionContent.swift
+//  VultisigApp
+//
+//  A shared, deliberately narrow view of what initiators and co-signers sign.
+//  It excludes display metadata, hides sidecars when opaque content is active,
+//  and mirrors the signer's routing precedence.
+//
+
+import BigInt
+import Foundation
+import VultisigCommonData
+
+/// The quantity a transaction moves, or the fact that it does not carry one.
+enum SignedAmount: Hashable {
+
+    /// Base units carried by the transaction.
+    case committed(BigInt)
+
+    /// A max-send amount derived from balance and fee during signing. No preview
+    /// value is exposed to decoders.
+    case computedAtSigning
+}
+
+/// How a chain's grammar relates to the routes that are signed before its own
+/// helper runs.
+/// There is no default: every memo reader must state its precedence.
+enum MemoPrecedence {
+
+    /// An earlier approve or swap route makes the sidecar memo inert.
+    case memoIsInertWhenRoutedEarlier
+
+    /// The earlier route carries the memo into the signed transaction.
+    case memoTravelsWithTheEarlierRoute
+}
+
+struct CorroboratedContent {
+    /// Available only when opaque signed content does not supersede sidecars.
+    let toAddress: String
+    let amount: SignedAmount
+    /// Private so callers must state memo precedence.
+    private let rawMemo: String?
+    let transactionType: VSTransactionType
+    let wasmPayload: WasmExecuteContractPayload?
+    let swap: SwapPayload?
+    let approve: ERC20ApprovePayload?
+
+    init(
+        toAddress: String,
+        amount: SignedAmount,
+        rawMemo: String?,
+        transactionType: VSTransactionType,
+        wasmPayload: WasmExecuteContractPayload?,
+        swap: SwapPayload?,
+        approve: ERC20ApprovePayload?
+    ) {
+        self.toAddress = toAddress
+        self.amount = amount
+        self.rawMemo = rawMemo
+        self.transactionType = transactionType
+        self.wasmPayload = wasmPayload
+        self.swap = swap
+        self.approve = approve
+    }
+
+    /// Returns the memo only when the reader's precedence permits it.
+    func memo(_ precedence: MemoPrecedence) -> String? {
+        switch precedence {
+        case .memoIsInertWhenRoutedEarlier:
+            return routedBeforeTheChainHelper ? nil : rawMemo
+        case .memoTravelsWithTheEarlierRoute:
+            return rawMemo
+        }
+    }
+}
+
+protocol SignedTransactionContent {
+
+    /// The signed chain scope. Display-only `Coin` metadata stays out of reach.
+    var chain: Chain { get }
+
+    /// Whether the chain settles the moved asset as its native coin.
+    var isNativeCoin: Bool { get }
+
+    // MARK: Ungated fields
+    // Decoders should prefer `corroborated`; `raw` access requires explicit proof.
+
+    var rawToAddress: String { get }
+
+    /// The quantity, or the fact that the signer computes it.
+    var rawAmount: SignedAmount { get }
+
+    var signedData: SignData? { get }
+
+    /// Whether `signDirect.bodyBytes` is the active body consumed by the signer.
+    /// Approve, swap, and rebuilt Cosmos routes can make it inactive.
+    var signedDataBodyIsActive: Bool { get }
+
+    /// Whether opaque signed content supersedes all flat sidecar fields. Both
+    /// devices report this from the representation they hold.
+    var hasOpaqueSignedContent: Bool { get }
+
+    var rawMemo: String? { get }
+    var rawTransactionType: VSTransactionType { get }
+    var rawWasmPayload: WasmExecuteContractPayload? { get }
+    var rawSwap: SwapPayload? { get }
+    var rawApprove: ERC20ApprovePayload? { get }
+
+    /// A Solana pre-image the initiator's signer will encode. Co-signers have
+    /// signed bytes instead and return `nil`.
+    var stakingIntent: SolanaStakingPayload? { get }
+
+    /// The Cosmos staking structure that the initiator's signing path will turn
+    /// into a SignDoc. A co-signer answers `nil` and reads that SignDoc instead.
+    var cosmosStakingIntent: CosmosStakingPayload? { get }
+
+    /// Whether an earlier signing route makes the memo inert.
+    var memoIsOutranked: Bool { get }
+}
+
+extension CorroboratedContent {
+
+    /// Approve and swap routes run before chain helpers. Each memo reader decides
+    /// whether that makes its memo inert; THORChain swaps carry theirs forward.
+    var routedBeforeTheChainHelper: Bool {
+        swap != nil || approve != nil
+    }
+}
+
+extension SignedTransactionContent {
+
+    var signedDataBodyIsActive: Bool { false }
+
+    /// Wasm outranks the memo everywhere it appears; chains with further
+    /// precedence of their own say so by overriding this.
+    var memoIsOutranked: Bool { rawWasmPayload != nil }
+
+    /// A coherent set of sidecars, withheld together when opaque content wins.
+    var corroborated: CorroboratedContent? {
+        guard !hasOpaqueSignedContent else { return nil }
+
+        let wasm = rawWasmPayload
+
+        return CorroboratedContent(
+            toAddress: rawToAddress,
+            amount: rawAmount,
+            // Wasm and chain-specific higher-priority routes make sidecar memos inert.
+            rawMemo: memoIsOutranked ? nil : rawMemo,
+            transactionType: rawTransactionType,
+            wasmPayload: wasm,
+            swap: rawSwap,
+            approve: rawApprove
+        )
+    }
+}
+
+// MARK: - A co-signer's view
+
+extension KeysignPayload: SignedTransactionContent {
+
+    var chain: Chain { coin.chain }
+
+    var isNativeCoin: Bool { coin.isNativeToken }
+
+    var rawToAddress: String { toAddress }
+
+    var rawAmount: SignedAmount {
+        chainSpecific.sendsMaxAmount ? .computedAtSigning : .committed(toAmount)
+    }
+
+    var rawMemo: String? {
+        guard let memo, !memo.isEmpty else { return nil }
+        return memo
+    }
+
+    var rawTransactionType: VSTransactionType { chainSpecific.transactionType }
+
+    var rawWasmPayload: WasmExecuteContractPayload? { wasmExecuteContractPayload }
+
+    var rawSwap: SwapPayload? { swapPayload }
+
+    var rawApprove: ERC20ApprovePayload? { approvePayload }
+
+    var signedData: SignData? { signData }
+
+    var signedDataBodyIsActive: Bool {
+        guard case .signDirect? = signData,
+              approvePayload == nil,
+              swapPayload == nil
+        else { return false }
+
+        switch coin.chain {
+        case .gaiaChain, .kujira, .osmosis, .noble, .akash:
+            switch chainSpecific.transactionType {
+            case .unspecified, .genericContract:
+                return true
+            default:
+                return false
+            }
+        case .terra, .terraClassic:
+            return true
+        case .dydx:
+            return chainSpecific.transactionType != .vote
+        case .qbtc:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var hasOpaqueSignedContent: Bool { signData != nil }
+
+    var stakingIntent: SolanaStakingPayload? { nil }
+
+    var cosmosStakingIntent: CosmosStakingPayload? { nil }
+
+    /// Mirrors TRON signing precedence: typed contracts outrank staking memos.
+    var memoIsOutranked: Bool {
+        rawWasmPayload != nil
+            || tronTransferContractPayload != nil
+            || tronTriggerSmartContractPayload != nil
+            || tronTransferAssetContractPayload != nil
+    }
+}
+
+// MARK: - An initiator's view
+
+/// The initiator's pre-payload transaction viewed through the same decoder API.
+/// Structured staking intents are exposed because the signer builds from them.
+struct InitiatingTransactionContent: SignedTransactionContent {
+
+    let transaction: SendTransaction
+
+    init(_ transaction: SendTransaction) {
+        self.transaction = transaction
+    }
+
+    var chain: Chain { transaction.coin.chain }
+
+    var isNativeCoin: Bool { transaction.coin.isNativeToken }
+
+    var rawToAddress: String { transaction.toAddress }
+
+    /// Max and auto-adjusted amounts are still changing and cannot be stated.
+    var rawAmount: SignedAmount {
+        let refitted = transaction.sendMaxAmount || transaction.amountWasAutoAdjusted
+        return refitted ? .computedAtSigning : .committed(transaction.amountInRaw)
+    }
+
+    var rawMemo: String? {
+        transaction.memo.isEmpty ? nil : transaction.memo
+    }
+
+    var rawTransactionType: VSTransactionType { transaction.transactionType }
+
+    var rawWasmPayload: WasmExecuteContractPayload? { transaction.wasmContractPayload }
+
+    var rawSwap: SwapPayload? { nil }
+
+    var rawApprove: ERC20ApprovePayload? { nil }
+
+    var signedData: SignData? { nil }
+
+    var stakingIntent: SolanaStakingPayload? { transaction.solanaStakingPayload }
+
+    var cosmosStakingIntent: CosmosStakingPayload? { transaction.cosmosStakingPayload }
+
+    /// Staking intents become opaque signed content when the payload is built.
+    var hasOpaqueSignedContent: Bool {
+        transaction.cosmosStakingPayload != nil || transaction.solanaStakingPayload != nil
+    }
+}
+
+// MARK: - Reading the chain-specific case
+
+extension BlockChainSpecific {
+
+    /// Whether signing derives the amount from balance and fee.
+    var sendsMaxAmount: Bool {
+        switch self {
+        case .UTXO(_, let sendMaxAmount, _): return sendMaxAmount
+        case .Cardano(_, let sendMaxAmount, _): return sendMaxAmount
+        case .Ton(_, _, _, let sendMaxAmount, _, _): return sendMaxAmount
+        default: return false
+        }
+    }
+
+    /// The wire discriminator, or `.unspecified` when the chain carries none.
+    var transactionType: VSTransactionType {
+        switch self {
+        case .THORChain(_, _, _, _, let transactionType):
+            return VSTransactionType(rawValue: transactionType) ?? .unspecified
+        case .Cosmos(_, _, _, let transactionType, _, _):
+            return VSTransactionType(rawValue: transactionType) ?? .unspecified
+        case .Ripple(_, _, _, _, let transactionType):
+            return VSTransactionType(rawValue: transactionType) ?? .unspecified
+        case .UTXO, .Cardano, .Ethereum, .MayaChain, .Solana, .Sui,
+             .Polkadot, .Ton, .Tron:
+            return .unspecified
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionDecoder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionDecoder.swift
@@ -1,0 +1,37 @@
+//
+//  SignedTransactionDecoder.swift
+//  VultisigApp
+//
+//  Reads operations from content that will actually be signed. The foundation
+//  registers no chain readers, so every transaction remains unreadable.
+//
+
+import Foundation
+
+/// A reader for one chain family's signed grammar. `handles == nil` requires
+/// the reader to establish provenance from the transaction itself.
+protocol TransactionContentDecoder {
+
+    /// The chains this decoder's grammar is meaningful on, or `nil` for one
+    /// that establishes its own provenance from the transaction.
+    var handles: Set<Chain>? { get }
+
+    func decode(_ tx: SignedTransactionContent) -> DecodedTransaction?
+}
+
+enum SignedTransactionDecoder {
+
+    /// Registered readers in precedence order. Empty in the foundation.
+    static let decoders: [TransactionContentDecoder] = []
+
+    /// Returns `.unknown` when no reader can prove an operation.
+    static func decode(_ tx: SignedTransactionContent) -> DecodedTransaction {
+        for decoder in decoders where decoder.handles?.contains(tx.chain) ?? true {
+            if let decoded = decoder.decode(tx) {
+                return decoded
+            }
+        }
+
+        return .unreadable
+    }
+}

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/SignedTransactionDecoderFoundationTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/SignedTransactionDecoderFoundationTests.swift
@@ -1,0 +1,72 @@
+//
+//  SignedTransactionDecoderFoundationTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import BigInt
+import VultisigCommonData
+import XCTest
+
+final class SignedTransactionDecoderFoundationTests: XCTestCase {
+
+    func testRegistryStartsEmpty() {
+        XCTAssertTrue(SignedTransactionDecoder.decoders.isEmpty)
+    }
+
+    func testUnregisteredContentIsUnreadable() {
+        let decoded = SignedTransactionDecoder.decode(StubContent())
+
+        XCTAssertEqual(decoded, .unreadable)
+        XCTAssertEqual(decoded.operation, .unknown)
+        XCTAssertEqual(decoded.amount, .unstated)
+        XCTAssertEqual(decoded.evidence, .unread)
+    }
+
+    func testOpaqueSignedContentWithholdsEverySidecar() {
+        let content = StubContent(hasOpaqueSignedContent: true)
+
+        XCTAssertNil(content.corroborated)
+    }
+
+    func testCorroboratedContentKeepsCommittedFieldsTogether() {
+        let content = StubContent(hasOpaqueSignedContent: false)
+        let corroborated = content.corroborated
+
+        XCTAssertEqual(corroborated?.toAddress, "destination")
+        XCTAssertEqual(corroborated?.amount, .committed(BigInt(42)))
+        XCTAssertEqual(
+            corroborated?.memo(.memoIsInertWhenRoutedEarlier),
+            "memo"
+        )
+    }
+
+    func testEvidenceStrengthFollowsSignedProvenance() {
+        XCTAssertTrue(DecodedEvidence.signedData.isNoWeaker(than: .memo))
+        XCTAssertTrue(DecodedEvidence.memo.isNoWeaker(than: .structuredPayload))
+        XCTAssertFalse(DecodedEvidence.unread.isNoWeaker(than: .signedData))
+    }
+}
+
+private extension SignedTransactionDecoderFoundationTests {
+
+    struct StubContent: SignedTransactionContent {
+        let chain: Chain = .ton
+        let isNativeCoin = true
+        let rawToAddress = "destination"
+        let rawAmount = SignedAmount.committed(BigInt(42))
+        let signedData: SignData? = nil
+        let hasOpaqueSignedContent: Bool
+        let rawMemo: String? = "memo"
+        let rawTransactionType = VSTransactionType.unspecified
+        let rawWasmPayload: WasmExecuteContractPayload? = nil
+        let rawSwap: SwapPayload? = nil
+        let rawApprove: ERC20ApprovePayload? = nil
+        let stakingIntent: SolanaStakingPayload? = nil
+        let cosmosStakingIntent: CosmosStakingPayload? = nil
+
+        init(hasOpaqueSignedContent: Bool = false) {
+            self.hasOpaqueSignedContent = hasOpaqueSignedContent
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Establishes the behaviorally inert core for decoding what a signed transaction proves.

- adds the `DecodedTransaction` domain model, evidence strength, and raw amount semantics
- adds `SignedTransactionContent` as the firewall between signed content and unsigned sidecars
- adds chain-scoped, ordered decoder dispatch with an intentionally empty registry
- adds focused provenance, corroboration, unreadable-content, and inertness coverage

## Reviewer contract

1. **What proves the operation?** Nothing is enabled in this slice. It defines the evidence boundary later readers must satisfy.
2. **Which surfaces can reach it?** None yet; the empty registry resolves to `.unknown` and preserves existing presentation.
3. **What is deliberately refused?** Opaque or unsupported signed content, unsigned sidecars without corroboration, and every unregistered operation.
4. **What hero appears?** No decoded hero. Verify integration begins in #5218; Done integration is the separate follow-up #5229.

## Stack

- base: `main`
- next: #5218
- decoder sequence: #5217 → #5218 → #5219 → #5220 → #5221 → #5222 → #5223 → #5224 → #5225
- Done-screen follow-up: #5229, stacked on #5225

## Validation

- foundation provenance and inertness tests included in this slice
- downstream #5229 full `make test` (containing this stack): 6,744 passed, 11 skipped, 0 failed
- build-integrated SwiftLint passed; touched-file lint is clean
- `git diff --check`: clean

Closes #5208
