### PR TITLE
feat(keysign): decode TRON resource transactions

### DIFF
--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/TronTransactionDecoder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/TronTransactionDecoder.swift
@@ -1,0 +1,62 @@
+//
+//  TronTransactionDecoder.swift
+//  VultisigApp
+//
+//  Decodes TRON resource staking from the memo and amount consumed by the
+//  signer. Typed dApp contracts outrank that memo in `SignedTransactionContent`.
+//
+
+import BigInt
+import Foundation
+
+struct TronTransactionDecoder: TransactionContentDecoder {
+
+    /// The memo grammar is meaningful only on TRON.
+    var handles: Set<Chain>? { [.tron] }
+
+    private static let freeze = "FREEZE:"
+    private static let unfreeze = "UNFREEZE:"
+
+    /// Exact resource names accepted by the signer.
+    private static let resources: Set<String> = ["BANDWIDTH", "ENERGY"]
+
+    func decode(_ tx: SignedTransactionContent) -> DecodedTransaction? {
+        // Approve and swap routes make this sidecar memo inert.
+        guard let content = tx.corroborated,
+              let memo = content.memo(.memoIsInertWhenRoutedEarlier) else { return nil }
+
+        let operation: DecodedOperation
+        let resource: String
+
+        if memo.hasPrefix(Self.freeze) {
+            operation = .stake
+            resource = String(memo.dropFirst(Self.freeze.count))
+        } else if memo.hasPrefix(Self.unfreeze) {
+            operation = .unstake
+            resource = String(memo.dropFirst(Self.unfreeze.count))
+        } else {
+            return nil
+        }
+
+        // Match the signer's case-sensitive validation.
+        guard Self.resources.contains(resource) else { return nil }
+
+        return DecodedTransaction(
+            operation: operation,
+            amount: Self.amount(from: content.amount),
+            counterparty: nil,
+            evidence: .memo
+        )
+    }
+
+    /// Freeze instructions always move chain-native TRX, independent of payload
+    /// display metadata. Only positive, encodable committed amounts are stated.
+    private static func amount(from signed: SignedAmount) -> DecodedAmount {
+        switch signed {
+        case .committed(let raw) where raw > 0 && raw <= BigInt(Int64.max):
+            return .units(raw, of: .chainNative)
+        case .committed, .computedAtSigning:
+            return .unstated
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionDecoder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionDecoder.swift
@@ -2,8 +2,8 @@
 //  SignedTransactionDecoder.swift
 //  VultisigApp
 //
-//  Reads operations from content that will actually be signed. The foundation
-//  registers no chain readers, so every transaction remains unreadable.
+//  Reads operations from content that will actually be signed. Unclaimed
+//  transactions remain `.unknown` and preserve existing presentation.
 //
 
 import Foundation
@@ -21,8 +21,10 @@ protocol TransactionContentDecoder {
 
 enum SignedTransactionDecoder {
 
-    /// Registered readers in precedence order. Empty in the foundation.
-    static let decoders: [TransactionContentDecoder] = []
+    /// Registered readers in precedence order.
+    static let decoders: [TransactionContentDecoder] = [
+        TronTransactionDecoder()
+    ]
 
     /// Returns `.unknown` when no reader can prove an operation.
     static func decode(_ tx: SignedTransactionContent) -> DecodedTransaction {

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/DecoderInertnessTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/DecoderInertnessTests.swift
@@ -2,7 +2,7 @@
 //  DecoderInertnessTests.swift
 //  VultisigAppTests
 //
-//  Holds the decoder foundation to its behaviorally inert contract.
+//  Pins the exact registry and verifies that unsupported chains stay inert.
 //
 
 @testable import VultisigApp
@@ -11,16 +11,12 @@ import XCTest
 
 final class DecoderInertnessTests: XCTestCase {
 
-    /// No chain reader is registered.
-    func testNoChainDecoderIsRegistered() {
-        XCTAssertTrue(
-            SignedTransactionDecoder.decoders.isEmpty,
-            """
-            A chain reader has been registered. That is the intended next step — \
-            but it makes this change no longer a no-op, so it also needs golden \
-            rows and its locale keys, and this assertion should move rather than \
-            simply be deleted.
-            """
+    /// Pins reader types because some establish provenance without fixed chains.
+    func testTheRegistryContainsExactlyTheExpectedReaders() {
+        XCTAssertEqual(
+            SignedTransactionDecoder.decoders.map { String(describing: type(of: $0)) },
+             ["TronTransactionDecoder"],
+             "a chain reader was registered or removed without saying so here"
         )
     }
 

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/SignedTransactionDecoderFoundationTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/SignedTransactionDecoderFoundationTests.swift
@@ -10,10 +10,6 @@ import XCTest
 
 final class SignedTransactionDecoderFoundationTests: XCTestCase {
 
-    func testRegistryStartsEmpty() {
-        XCTAssertTrue(SignedTransactionDecoder.decoders.isEmpty)
-    }
-
     func testUnregisteredContentIsUnreadable() {
         let decoded = SignedTransactionDecoder.decode(StubContent())
 

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/TronTransactionDecoderTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/TronTransactionDecoderTests.swift
@@ -1,0 +1,238 @@
+//
+//  TronTransactionDecoderTests.swift
+//  VultisigAppTests
+//
+
+import BigInt
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class TronTransactionDecoderTests: XCTestCase {
+
+    /// Isolates unique-model fixtures from test ordering.
+    private var storeToken: TestContextToken?
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        storeToken = try TestStore.installInMemoryContainer()
+    }
+
+    override func tearDown() {
+        TestStore.restore(storeToken)
+        storeToken = nil
+        super.tearDown()
+    }
+
+    // MARK: - What it names
+
+    func testFreezingForBandwidthIsAStakeWithItsAmount() {
+        let decoded = SignedTransactionDecoder.decode(Self.payload(memo: "FREEZE:BANDWIDTH"))
+        XCTAssertEqual(decoded.operation, .stake)
+        XCTAssertEqual(decoded.amount, .units(BigInt(5_000_000), of: .chainNative))
+        XCTAssertEqual(decoded.evidence, .memo)
+    }
+
+    func testFreezingForEnergyIsAlsoAStake() {
+        XCTAssertEqual(SignedTransactionDecoder.decode(Self.payload(memo: "FREEZE:ENERGY")).operation, .stake)
+    }
+
+    func testUnfreezingIsAnUnstake() {
+        for resource in ["BANDWIDTH", "ENERGY"] {
+            let decoded = SignedTransactionDecoder.decode(Self.payload(memo: "UNFREEZE:\(resource)"))
+            XCTAssertEqual(decoded.operation, .unstake, resource)
+            XCTAssertEqual(decoded.amount, .units(BigInt(5_000_000), of: .chainNative), resource)
+        }
+    }
+
+    /// Both devices must read the same transaction identically.
+    func testTheReadingIsTheSameOnBothDevices() throws {
+        let payload = Self.payload(memo: "FREEZE:ENERGY")
+        let coSigner = SignedTransactionDecoder.decode(payload)
+        let initiator = SignedTransactionDecoder.decode(
+            InitiatingTransactionContent(Self.transaction(memo: "FREEZE:ENERGY"))
+        )
+        XCTAssertEqual(coSigner.operation, initiator.operation)
+        XCTAssertEqual(coSigner.amount, initiator.amount)
+        XCTAssertEqual(coSigner.evidence, initiator.evidence)
+    }
+
+    // MARK: - What it refuses
+
+    /// Typed contract payloads outrank the staking memo in the signer.
+    func testAContractPayloadBesideAStakingMemoIsRefused() {
+        let transfer = TronTransferContractPayload(
+            toAddress: "TRecipient", ownerAddress: "TOwner", amount: "5000000"
+        )
+        let spoofed = Self.payload(memo: "FREEZE:ENERGY", tronTransfer: transfer)
+
+        XCTAssertEqual(
+            SignedTransactionDecoder.decode(spoofed).operation, .unknown,
+            "a transfer payload outranks the memo in the signer, so the memo must not name the transaction"
+        )
+    }
+
+    func testASmartContractPayloadBesideAStakingMemoIsRefused() {
+        let call = TronTriggerSmartContractPayload(
+            ownerAddress: "TOwner", contractAddress: "TContract",
+            callValue: nil, callTokenValue: nil, tokenId: nil, data: "deadbeef"
+        )
+        XCTAssertEqual(
+            SignedTransactionDecoder.decode(Self.payload(memo: "UNFREEZE:BANDWIDTH", tronTrigger: call)).operation,
+            .unknown
+        )
+    }
+
+    /// Unknown or inexact resource names are rejected by the signer.
+    func testAnUnknownResourceIsRefused() {
+        for memo in ["FREEZE:CPU", "FREEZE:bandwidth", "FREEZE:", "FREEZE:BANDWIDTH ", "UNFREEZE:ENERGY!"] {
+            XCTAssertEqual(
+                SignedTransactionDecoder.decode(Self.payload(memo: memo)).operation, .unknown,
+                memo
+            )
+        }
+    }
+
+    /// The grammar must not apply off TRON.
+    func testTheGrammarDoesNotApplyOffTron() {
+        let elsewhere = Self.payload(memo: "FREEZE:ENERGY", chain: .thorChain, ticker: "RUNE")
+        XCTAssertEqual(SignedTransactionDecoder.decode(elsewhere).operation, .unknown)
+    }
+
+    func testAnOrdinaryTransferIsNotClaimed() {
+        XCTAssertEqual(SignedTransactionDecoder.decode(Self.payload(memo: nil)).operation, .unknown)
+    }
+
+    /// Amounts outside the wire's `int64` are not stated.
+    func testAnAmountTheSignerCouldNotEncodeIsNotStated() {
+        let decoded = SignedTransactionDecoder.decode(
+            Self.payload(memo: "FREEZE:ENERGY", amount: BigInt(Int64.max) + 1)
+        )
+        XCTAssertEqual(decoded.operation, .stake)
+        XCTAssertEqual(decoded.amount, .unstated)
+    }
+
+    /// Swap routing outranks the memo.
+    func testAStakingMemoBesideASwapPayloadIsRefused() {
+        XCTAssertEqual(
+            SignedTransactionDecoder.decode(Self.payload(memo: "FREEZE:ENERGY", withSwap: true)).operation,
+            .unknown,
+            "a swap payload is dispatched before the chain helper, so the memo describes nothing signed"
+        )
+    }
+
+    /// Payload metadata cannot change the instruction's native asset.
+    func testATokenDressedPayloadStillReadsAsTheChainsOwnCoin() {
+        let decoded = SignedTransactionDecoder.decode(Self.payload(memo: "FREEZE:ENERGY", native: false))
+        XCTAssertEqual(decoded.operation, .stake)
+        XCTAssertEqual(
+            decoded.amount, .units(BigInt(5_000_000), of: .chainNative),
+            "the asset must come from the chain, not from what the payload calls itself"
+        )
+    }
+
+    /// Rendering uses bundled TRX metadata, not the payload ticker.
+    func testTheRenderedAmountUsesBundledChainMetadata() throws {
+        let decoded = SignedTransactionDecoder.decode(Self.payload(memo: "FREEZE:ENERGY", native: false))
+        let hero = try XCTUnwrap(
+            DecodedTransactionPresentation.hero(for: decoded, coin: Self.coin(native: false))
+        )
+        guard case .send(_, let amount) = hero else {
+            return XCTFail("a stated amount should render as a resolved single-sided figure")
+        }
+        XCTAssertEqual(amount.ticker, "TRX", "rendered against the payload's ticker instead of the chain's own")
+    }
+
+    // MARK: - Fixtures
+
+    private static func coin(chain: Chain = .tron, ticker: String = "TRX", native: Bool = true) -> Coin {
+        Coin(
+            asset: CoinMeta(
+                chain: chain, ticker: ticker, logo: ticker.lowercased(), decimals: 6,
+                priceProviderId: "tron",
+                contractAddress: native ? "" : "TTokenContract",
+                isNativeToken: native
+            ),
+            address: "TOwner",
+            hexPublicKey: "00"
+        )
+    }
+
+    private static func payload(
+        memo: String?,
+        chain: Chain = .tron,
+        ticker: String = "TRX",
+        amount: BigInt = BigInt(5_000_000),
+        native: Bool = true,
+        withSwap: Bool = false,
+        tronTransfer: TronTransferContractPayload? = nil,
+        tronTrigger: TronTriggerSmartContractPayload? = nil
+    ) -> KeysignPayload {
+        KeysignPayload(
+            coin: coin(chain: chain, ticker: ticker, native: native),
+            toAddress: "TOwner",
+            toAmount: amount,
+            chainSpecific: .Tron(timestamp: 0, expiration: 0, blockHeaderTimestamp: 0, blockHeaderNumber: 0,
+                        blockHeaderVersion: 0, blockHeaderTxTrieRoot: "", blockHeaderParentHash: "",
+                        blockHeaderWitnessAddress: "", gasFeeEstimation: 0),
+            utxos: [],
+            memo: memo,
+            swapPayload: withSwap ? .thorchain(swapPayload()) : nil,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "pub",
+            vaultLocalPartyID: "party",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: tronTransfer,
+            tronTriggerSmartContractPayload: tronTrigger,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: nil
+        )
+    }
+
+    private static func swapPayload() -> THORChainSwapPayload {
+        THORChainSwapPayload(
+            fromAddress: "TOwner",
+            fromCoin: coin(),
+            toCoin: coin(),
+            vaultAddress: "thor-vault",
+            routerAddress: nil,
+            fromAmount: BigInt(5_000_000),
+            toAmountDecimal: 0,
+            toAmountLimit: "0",
+            streamingInterval: "0",
+            streamingQuantity: "0",
+            expirationTime: 0,
+            isAffiliate: false
+        )
+    }
+
+    private static func transaction(memo: String) -> SendTransaction {
+        let coin = coin()
+        return SendTransaction(
+            coin: coin,
+            vault: TestStore.makeVault(pubKey: "test-pub-tron-\(memo)"),
+            fromAddress: coin.address,
+            toAddress: "TOwner",
+            toAddressLabel: nil,
+            amount: "5",
+            amountInFiat: "0",
+            memo: memo,
+            gas: .zero,
+            fee: .zero,
+            feeMode: .normal,
+            estimatedGasLimit: nil,
+            customGasLimit: nil,
+            customByteFee: nil,
+            sendMaxAmount: false,
+            isStakingOperation: true,
+            transactionType: .unspecified,
+            memoFunctionDictionary: [:],
+            wasmContractPayload: nil,
+            feeCoin: coin
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds TRON resource-operation decoding and registers it after signed-artifact readers.

- recognizes freeze/delegate resource operations as staking and unfreeze operations as unstaking
- keeps initiator and co-signer payloads on the same decoder path
- preserves committed TRX amounts only when the signed payload proves them
- refuses malformed, wrong-chain, unrelated, and ambiguous content

## Reviewer contract

1. **What proves the operation?** A TRON payload containing the matching structured contract/memo and required signed fields.
2. **Which surfaces can reach it?** All initiator and co-signer Verify surfaces through the shared resolver.
3. **What is deliberately refused?** Wrong-chain contracts, malformed payloads, missing operation markers, and unrelated TRON content.
4. **What hero appears?** The matching resource verb with the signed amount when present; otherwise an honest verb-only presentation.

## Stack

- base: #5218 (`codex/decoder-verify-foundation`)
- next: #5220
- Done-screen follow-up: #5229 after the coverage lock

## Validation

- TRON decoder, registry, initiator/co-signer parity, and inertness coverage included
- downstream #5229 full `make test` (containing this stack): 6,744 passed, 11 skipped, 0 failed
- build-integrated SwiftLint passed; touched-file lint is clean

Closes #5210
