### PR TITLE
feat(keysign): decode TON pool transactions

### DIFF
--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Ton/PoolSelection/TonStakingPool.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Ton/PoolSelection/TonStakingPool.swift
@@ -9,18 +9,9 @@
 
 import Foundation
 
-/// The deposit/withdraw text comments a TON nominator-pool contract expects.
-/// Nominator deposits are plain text comments, but each pool *implementation*
-/// uses a DIFFERENT word — sending the wrong one is rejected on-chain
-/// (exit 72). This is the single source of truth mapping a pool's tonapi
-/// `implementation` string to its protocol tokens.
-///
-/// These are TON contract protocol tokens, NOT user-facing UI — never localize.
+/// TON contract protocol tokens by pool implementation. These are not localized.
 enum TonStakingComment {
-    /// Standard nominator pool (`ton-blockchain/nominator-pool`): deposit "d".
-    /// Whales pool (`tonwhales/ton-nominators`): deposit "Deposit" (capitalized) —
-    /// verified against successful on-chain deposits; the repo README's "Stake"
-    /// is stale and is rejected by the live pools (exit 72).
+    /// Whales pools require `Deposit`; their documented `Stake` is rejected.
     static func deposit(for implementation: String?) -> String? {
         switch implementation {
         case "tf": return "d"
@@ -36,6 +27,14 @@ enum TonStakingComment {
         case "whales": return "Withdraw"
         default: return nil
         }
+    }
+    /// Derived from the writer table so reader and builder tokens cannot drift.
+    static var depositComments: Set<String> {
+        Set(TonStakingPool.nominatorImplementations.compactMap { deposit(for: $0) })
+    }
+
+    static var withdrawComments: Set<String> {
+        Set(TonStakingPool.nominatorImplementations.compactMap { withdraw(for: $0) })
     }
 }
 
@@ -53,10 +52,7 @@ struct TonStakingPool: Equatable, Hashable {
     let maxNominators: Int?
     let implementation: String?
 
-    /// tonapi `implementation` values that are genuine **nominator pools** — the
-    /// only ones our `"d"`/`"w"` text-comment deposit mechanism can stake into.
-    /// `liquidTF` (Tonstakers and similar) mints a jetton instead and must be
-    /// excluded; unknown implementations are treated as non-nominator (excluded).
+    /// Supported nominator implementations; liquid pools use a different flow.
     static let nominatorImplementations: Set<String> = ["whales", "tf"]
 
     /// Whether this is a nominator pool our deposit mechanism supports.

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/TonTransactionDecoder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/TonTransactionDecoder.swift
@@ -1,0 +1,96 @@
+//
+//  TonTransactionDecoder.swift
+//  VultisigApp
+//
+//  Decodes exact TON nominator-pool comments from signed transaction content.
+//
+
+import BigInt
+import Foundation
+import WalletCore
+
+struct TonTransactionDecoder: TransactionContentDecoder {
+
+    /// Chain-scoped so bare pool comments cannot collide with other grammars.
+    let handles: Set<Chain>? = [.ton]
+
+    /// Earlier approve or swap routes make the comment inert.
+    private static let precedence: MemoPrecedence = .memoIsInertWhenRoutedEarlier
+
+    func decode(_ tx: SignedTransactionContent) -> DecodedTransaction? {
+        // TonConnect BOCs and earlier routes make the outer memo a sidecar.
+        guard let content = tx.corroborated else { return nil }
+
+        // Pool protocol tokens are exact and must not be trimmed.
+        guard let comment = content.memo(Self.precedence), !comment.isEmpty else { return nil }
+
+        if TonStakingComment.depositComments.contains(comment) {
+            // Deposit amount is the TON moved into the pool.
+            return DecodedTransaction(
+                operation: .stake,
+                amount: Self.deposited(content.amount),
+                counterparty: .pool(content.toAddress),
+                evidence: .memo
+            )
+        }
+
+        if TonStakingComment.withdrawComments.contains(comment) {
+            // The transfer carries only a request fee; settlement returns later.
+            return DecodedTransaction(
+                operation: .unstake,
+                amount: .unstated,
+                counterparty: .pool(content.toAddress),
+                evidence: .memo
+            )
+        }
+
+        return nil
+    }
+    /// Positive committed deposits move chain-native TON.
+    private static func deposited(_ signed: SignedAmount) -> DecodedAmount {
+        switch signed {
+        case .committed(let raw) where raw > 0:
+            return .units(raw, of: .chainNative)
+        case .committed, .computedAtSigning:
+            return .unstated
+        }
+    }
+
+}
+
+/// Reads the whole position named by a signed TON pool withdrawal request.
+struct TonStakedPositionReader: PositionReading {
+    var readPools: (String) async throws -> [TonAccountStakingInfo] = {
+        try await TonService.shared.getNominatorPools(address: $0)
+    }
+
+    func handles(_ decoded: DecodedTransaction, coin: Coin) -> Bool {
+        guard coin.chain == .ton, decoded.operation == .unstake,
+              case .pool = decoded.counterparty else { return false }
+        return true
+    }
+
+    func amount(for decoded: DecodedTransaction, coin: Coin) async -> HeroCoinAmount? {
+        guard case .pool(let signedPool) = decoded.counterparty,
+              let pools = try? await readPools(coin.address),
+              let position = pools.first(where: { Self.sameAddress($0.pool, signedPool) }) else {
+            return nil
+        }
+
+        let raw = BigInt(position.amount) + BigInt(position.pendingDeposit)
+        guard raw > 0 else { return nil }
+        let amount = coin.decimal(for: raw)
+        return HeroCoinAmount(amount: amount, coin: coin)
+    }
+
+    private static func sameAddress(_ lhs: String, _ rhs: String) -> Bool {
+        let normalize: (String) -> String = {
+            TONAddressConverter.toUserFriendly(
+                address: $0,
+                bounceable: true,
+                testnet: false
+            ) ?? $0
+        }
+        return normalize(lhs) == normalize(rhs)
+    }
+}

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/Projections/ResolvedTransactionHero.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/Projections/ResolvedTransactionHero.swift
@@ -15,7 +15,8 @@ enum ResolvedTransactionHero {
     /// Chain PRs add readers here as their signed decoders become available.
     static let readers: [PositionReading] = [
         SolanaDelegatedAmountReader(),
-        SolanaStakeAccountAmountReader()
+        SolanaStakeAccountAmountReader(),
+        TonStakedPositionReader()
     ]
 
     static func resolve(

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionDecoder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionDecoder.swift
@@ -24,7 +24,8 @@ enum SignedTransactionDecoder {
     /// Registered readers in precedence order.
     static let decoders: [TransactionContentDecoder] = [
         SolanaTransactionDecoder(),
-        TronTransactionDecoder()
+        TronTransactionDecoder(),
+        TonTransactionDecoder()
     ]
 
     /// Returns `.unknown` when no reader can prove an operation.

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/DecoderInertnessTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/DecoderInertnessTests.swift
@@ -17,7 +17,8 @@ final class DecoderInertnessTests: XCTestCase {
             SignedTransactionDecoder.decoders.map { String(describing: type(of: $0)) },
             [
                 "SolanaTransactionDecoder",
-                "TronTransactionDecoder"
+                "TronTransactionDecoder",
+                "TonTransactionDecoder"
             ],
             "a chain reader was registered or removed without saying so here"
         )

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/TonTransactionDecoderTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/TonTransactionDecoderTests.swift
@@ -1,0 +1,142 @@
+//
+//  TonTransactionDecoderTests.swift
+//  VultisigAppTests
+//
+
+import BigInt
+@testable import VultisigApp
+import XCTest
+
+final class TonTransactionDecoderTests: XCTestCase {
+
+    func testAllExactNominatorCommentsDecodeWithAColdDirectory() {
+        let decoder = TonTransactionDecoder()
+        XCTAssertEqual(decoder.decode(Self.payload(to: "EQtf", memo: "d"))?.operation, .stake)
+        XCTAssertEqual(decoder.decode(Self.payload(to: "EQtf", memo: "w"))?.operation, .unstake)
+        XCTAssertEqual(decoder.decode(Self.payload(to: "EQwhales", memo: "Deposit"))?.operation, .stake)
+        XCTAssertEqual(decoder.decode(Self.payload(to: "EQwhales", memo: "Withdraw"))?.operation, .unstake)
+    }
+
+    func testDepositUsesTheExactSignedTonAmount() {
+        let decoded = TonTransactionDecoder().decode(Self.payload(to: "EQpool", memo: "d"))
+        XCTAssertEqual(decoded?.operation, .stake)
+        XCTAssertEqual(decoded?.amount, .units(BigInt(1_000_000_000), of: .chainNative))
+    }
+
+    @MainActor
+    func testDepositHeroIncludesFiat() throws {
+        try RateProvider.shared.save(rates: [
+            Rate(fiat: SettingsCurrency.current.rawValue, crypto: "the-open-network", value: 5)
+        ])
+        let decoded = try XCTUnwrap(
+            TonTransactionDecoder().decode(Self.payload(to: "EQpool", memo: "d"))
+        )
+        let hero = try XCTUnwrap(
+            DecodedTransactionPresentation.hero(for: decoded, coin: Self.tonCoin)
+        )
+
+        guard case .send(_, let amount) = hero else {
+            return XCTFail("expected an exact deposit amount")
+        }
+        XCTAssertEqual(amount.amount, "1")
+        XCTAssertFalse(amount.fiat?.isEmpty ?? true)
+    }
+
+    func testWithdrawTreatsTheCarrierAsAWholePositionRequest() {
+        let decoded = TonTransactionDecoder().decode(Self.payload(to: "EQpool", memo: "w"))
+        XCTAssertEqual(decoded?.operation, .unstake)
+        XCTAssertEqual(decoded?.amount, .unstated)
+        XCTAssertEqual(decoded?.counterparty, .pool("EQpool"))
+    }
+
+    func testCommentsRemainExactAndCaseSensitive() {
+        let decoder = TonTransactionDecoder()
+        for memo in [" d", "d ", "D", "deposit", "withdraw", "W", "claim", "redelegate"] {
+            XCTAssertNil(decoder.decode(Self.payload(to: "EQpool", memo: memo)), memo)
+        }
+    }
+
+    func testTonConnectSignedDataMakesTheOuterCommentInert() {
+        let payload = Self.payload(
+            to: "EQpool",
+            memo: "d",
+            signData: .signTon(SignTon(tonMessages: []))
+        )
+        XCTAssertNil(TonTransactionDecoder().decode(payload))
+    }
+
+    func testWholePositionProjectionUsesTheSignedPoolAndTrustedOwner() async throws {
+        try await MainActor.run {
+            try RateProvider.shared.save(rates: [
+                Rate(fiat: SettingsCurrency.current.rawValue, crypto: "the-open-network", value: 5)
+            ])
+        }
+        let reader = TonStakedPositionReader(readPools: { owner in
+            XCTAssertEqual(owner, "EQfrom")
+            return [
+                TonAccountStakingInfo(
+                    pool: "EQother",
+                    amount: 9_000_000_000,
+                    pendingDeposit: 0,
+                    pendingWithdraw: 0,
+                    readyWithdraw: 0
+                ),
+                TonAccountStakingInfo(
+                    pool: "EQpool",
+                    amount: 2_000_000_000,
+                    pendingDeposit: 500_000_000,
+                    pendingWithdraw: 0,
+                    readyWithdraw: 0
+                )
+            ]
+        })
+        let decoded = try XCTUnwrap(TonTransactionDecoder().decode(Self.payload(to: "EQpool", memo: "w")))
+        let amount = await reader.amount(for: decoded, coin: Self.tonCoin)
+        XCTAssertEqual(amount?.amount, "2.5")
+        XCTAssertFalse(amount?.fiat?.isEmpty ?? true)
+    }
+
+    private static var tonCoin: Coin {
+        Coin(
+            asset: CoinMeta(
+                chain: .ton,
+                ticker: "TON",
+                logo: "ton",
+                decimals: 9,
+                priceProviderId: "the-open-network",
+                contractAddress: "",
+                isNativeToken: true
+            ),
+            address: "EQfrom",
+            hexPublicKey: "00"
+        )
+    }
+
+    private static func payload(
+        to destination: String,
+        memo: String,
+        signData: SignData? = nil
+    ) -> KeysignPayload {
+        KeysignPayload(
+            coin: tonCoin,
+            toAddress: destination,
+            toAmount: BigInt(1_000_000_000),
+            chainSpecific: .Ton(sequenceNumber: 1, expireAt: 0, bounceable: true, sendMaxAmount: false),
+            utxos: [],
+            memo: memo,
+            swapPayload: nil,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "pub",
+            vaultLocalPartyID: "party",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: signData
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds TON nominator-pool operation decoding backed by the canonical pool directory and signed pool comments.

- recognizes exact deposit comments as staking and exact withdrawal comments as unstaking
- uses the signed destination pool as the provenance boundary on both devices
- treats the transfer attached to withdrawal as a request fee, never as the unstaked position
- resolves the unstake figure from the matching live pool position and keeps failures verb-only
- refuses TonConnect BOCs, earlier swap/approve routes, unknown pools/comments, and malformed content

## Reviewer contract

1. **What proves the operation?** A corroborated TON payload whose exact signed comment and destination match a known nominator-pool operation.
2. **Which surfaces can reach it?** Initiator Verify and co-signer Keysign confirmation through the shared decoder and position reader.
3. **What is deliberately refused?** Unknown pools/comments, wrong-chain payloads, opaque BOCs, earlier routes, and unsupported messages.
4. **What hero appears?** Staking with the committed TON deposit, or Unstaking with the resolved pool position; the request-fee carrier is never presented as the operation amount.

## Stack

- base: #5220 (`codex/decoder-solana`)
- next: #5222
- Done-screen follow-up: #5229 after the coverage lock

## Validation

- deposit/withdraw comments, pool provenance, initiator/co-signer parity, live-position projection, carrier suppression, refusal, and vocabulary coverage included
- downstream #5229 full `make test` (containing this stack): 6,744 passed, 11 skipped, 0 failed
- build-integrated SwiftLint passed; touched-file lint is clean

Closes #5212
