### PR TITLE
test(keysign): lock decoder operation coverage

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService.swift
@@ -27,6 +27,24 @@ class ThorchainService: ThorchainSwapProvider {
 
     private var cacheFeePrice = ThreadSafeDictionary<String, (data: ThorchainNetworkInfo, timestamp: Date)>()
     private var cacheInboundAddresses = ThreadSafeDictionary<String, (data: [InboundAddress], timestamp: Date)>()
+
+    /// The inbound vaults already known, without asking the network.
+    ///
+    /// ⚠️ **Exists so a signing screen can corroborate a destination without a
+    /// fetch.** An LP deposit leaves Bitcoin, so nothing about the chain it is on
+    /// says THORChain — the only corroboration is that its destination IS a
+    /// THORChain inbound vault, and that answer comes from THORChain rather than
+    /// from whoever composed the payload.
+    ///
+    /// Returns `nil` on a cold or stale cache rather than blocking, and a `nil`
+    /// means the reading is refused: exactly what happened before any of this
+    /// existed, which makes a cold cache a missed improvement rather than a wrong
+    /// answer.
+    func cachedInboundAddresses(maxAge: TimeInterval = 300) -> [InboundAddress]? {
+        cacheInboundAddresses.allItems().values
+            .first { Date().timeIntervalSince($0.timestamp) <= maxAge }?
+            .data
+    }
     private var cacheAssetPrices = ThreadSafeDictionary<String, (data: Double, timestamp: Date)>()
     private var cacheLPPools = ThreadSafeDictionary<String, (data: [ThorchainPool], timestamp: Date)>()
     private var cacheSecuredAssets = ThreadSafeDictionary<String, (data: [ThorchainSecuredAsset], timestamp: Date)>()

--- a/VultisigApp/VultisigApp/Components/Hero/TransactionHeroResolver.swift
+++ b/VultisigApp/VultisigApp/Components/Hero/TransactionHeroResolver.swift
@@ -36,6 +36,7 @@ struct TransactionHeroProvider {
 
     enum ID: Hashable {
         case rippleTrustSet
+        case quotedWithdrawal
         case limitOrderCancel
         case limitOrderPlacement
         case simulated
@@ -54,6 +55,7 @@ enum TransactionHeroResolver {
     /// evidence and can be retitled with the decoded verb.
     static let providers: [TransactionHeroProvider] = [
         .rippleTrustSet,
+        .quotedWithdrawal,
         .limitOrderCancel,
         .limitOrderPlacement,
         .simulated,
@@ -136,7 +138,20 @@ extension TransactionHeroProvider {
         }
     )
 
-    /// Inert until a chain reader is registered.
+    /// Initiator-only exact payout, ahead of the decoded fraction.
+    static let quotedWithdrawal = TransactionHeroProvider(
+        id: .quotedWithdrawal,
+        surfaces: [.functionCallVerify],
+        hero: { subject in
+            switch subject {
+            case .initiating(let transaction):
+                return QuotedWithdrawalPresentation.hero(for: transaction)
+            case .cosigning:
+                return nil
+            }
+        }
+    )
+
     static let decoded = TransactionHeroProvider(
         id: .decoded,
         // Done keeps its existing amount presentation.

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1835,6 +1835,7 @@
 "youreUnmerging" = "Du trennst";
 "youreBridging" = "Du überträgst kettenübergreifend";
 "scopeYourWholeStake" = "dein gesamter Stake";
+"scopeDelegatedAmountAfterRent" = "der delegierte Betrag nach Abzug der Mietreserve";
 "scopeRewardsAccruedSoFar" = "bisher angefallene Belohnungen";
 "withdrawingShareOfStakedPosition" = "%@ deiner Stake-Position";
 "youreStaking" = "Du stakst";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1835,6 +1835,7 @@
 "youreUnmerging" = "You’re unmerging";
 "youreBridging" = "You’re bridging";
 "scopeYourWholeStake" = "your whole stake";
+"scopeDelegatedAmountAfterRent" = "the delegated amount after the rent reserve";
 "scopeRewardsAccruedSoFar" = "rewards accrued so far";
 "withdrawingShareOfStakedPosition" = "%@ of your staked position";
 "youreStaking" = "You’re staking";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1835,6 +1835,7 @@
 "youreUnmerging" = "Estás separando";
 "youreBridging" = "Estás transfiriendo entre cadenas";
 "scopeYourWholeStake" = "todo tu stake";
+"scopeDelegatedAmountAfterRent" = "el importe delegado después de la reserva de alquiler";
 "scopeRewardsAccruedSoFar" = "recompensas acumuladas hasta ahora";
 "withdrawingShareOfStakedPosition" = "%@ de tu posición en staking";
 "youreStaking" = "Estás haciendo staking";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1835,6 +1835,7 @@
 "youreUnmerging" = "Razdvajate";
 "youreBridging" = "Premošćujete";
 "scopeYourWholeStake" = "cijeli vaš ulog";
+"scopeDelegatedAmountAfterRent" = "delegirani iznos nakon rezerve za najam";
 "scopeRewardsAccruedSoFar" = "do sada stečene nagrade";
 "withdrawingShareOfStakedPosition" = "%@ vaše uložene pozicije";
 "youreStaking" = "Stakate";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1835,6 +1835,7 @@
 "youreUnmerging" = "Stai separando";
 "youreBridging" = "Stai trasferendo tra catene";
 "scopeYourWholeStake" = "tutto il tuo stake";
+"scopeDelegatedAmountAfterRent" = "l’importo delegato dopo la riserva di affitto";
 "scopeRewardsAccruedSoFar" = "ricompense maturate finora";
 "withdrawingShareOfStakedPosition" = "%@ della tua posizione in stake";
 "youreStaking" = "Stai mettendo in stake";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1835,6 +1835,7 @@
 "youreUnmerging" = "병합 해제 중";
 "youreBridging" = "브리지 중";
 "scopeYourWholeStake" = "스테이킹 전액";
+"scopeDelegatedAmountAfterRent" = "임대 예치금을 제외한 위임 금액";
 "scopeRewardsAccruedSoFar" = "현재까지 누적된 보상";
 "withdrawingShareOfStakedPosition" = "스테이킹 포지션의 %@";
 "youreStaking" = "스테이킹 중";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1835,6 +1835,7 @@
 "youreUnmerging" = "Você está separando";
 "youreBridging" = "Você está transferindo entre cadeias";
 "scopeYourWholeStake" = "todo o seu stake";
+"scopeDelegatedAmountAfterRent" = "o valor delegado após a reserva de aluguel";
 "scopeRewardsAccruedSoFar" = "recompensas acumuladas até agora";
 "withdrawingShareOfStakedPosition" = "%@ da sua posição em stake";
 "youreStaking" = "Você está fazendo stake";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1835,6 +1835,7 @@
 "youreUnmerging" = "您正在取消合并";
 "youreBridging" = "您正在跨链转账";
 "scopeYourWholeStake" = "您的全部质押";
+"scopeDelegatedAmountAfterRent" = "扣除租金储备后的委托金额";
 "scopeRewardsAccruedSoFar" = "至今累积的奖励";
 "withdrawingShareOfStakedPosition" = "您质押仓位的 %@";
 "youreStaking" = "您正在质押";

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Common/View/CosmosStakingVerifySummaryView.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Common/View/CosmosStakingVerifySummaryView.swift
@@ -3,11 +3,9 @@
 //  VultisigApp
 //
 //  Staking-aware verify summary for the four LUNA / LUNC operations.
-//  Mirrors the desktop client's `StakeOverview.tsx` — the headline
-//  changes per op ("You're staking / unstaking / moving / claiming"),
-//  the destination is labeled as a validator (with resolved moniker +
-//  commission), and redelegate renders two stacked rows (source then
-//  destination).
+//  The hero uses the shared decoded-operation vocabulary, while the destination
+//  remains labeled as a validator (with resolved moniker + commission) and
+//  redelegate renders two stacked rows (source then destination).
 //
 //  Falls back to truncated valopers while the validators fetch is in
 //  flight. The validators query is cached at `CosmosStakingService` for
@@ -82,40 +80,15 @@ struct CosmosStakingVerifySummaryView: View {
         .padding(1)
     }
 
-    private var headlineKey: String {
-        switch transaction.cosmosStakingPayload?.opType {
-        case .delegate: return "youreStaking"
-        case .undelegate: return "youreUnstaking"
-        case .redelegate: return "youreMoving"
-        case .withdrawRewards: return "youreClaiming"
-        case .none: return "verify"
-        }
-    }
-
+    @ViewBuilder
     private var heroHeader: some View {
-        VStack(spacing: 8) {
-            Text(headlineKey.localized)
-                .foregroundStyle(Theme.colors.textSecondary)
-                .font(Theme.fonts.bodyMMedium)
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-            HStack(spacing: 8) {
-                Image(transaction.coin.logo)
-                    .resizable()
-                    .frame(width: 24, height: 24)
-                    .cornerRadius(Theme.radius.pill)
-
-                Text(transaction.amountDecimal.formatForDisplay())
-                    .foregroundStyle(Theme.colors.textPrimary)
-
-                Text(transaction.coin.ticker)
-                    .foregroundStyle(Theme.colors.textTertiary)
-
-                Spacer()
-            }
-            .font(Theme.fonts.bodyLMedium)
+        if let hero = TransactionHeroResolver.hero(
+            on: .functionCallVerify,
+            for: .initiating(transaction)
+        ) {
+            VerifyHeroContentView(content: hero)
+                .padding(.bottom, 8)
         }
-        .padding(.bottom, 8)
     }
 
     @ViewBuilder

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
@@ -186,7 +186,10 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
                 basisPoints: basisPoints,
                 autoCompoundAmount: autocompoundBalance,
                 sendMaxAmount: isMaxAmount,
-                isAutoCompound: isAutocompound
+                isAutoCompound: isAutocompound,
+                // The staked position the form resolved, so Verify can quote the
+                // payout instead of the memo's literal "0".
+                stakedAmount: availableAmount
             )
         case "BRUNE":
             // Carries the typed amount rather than a whole percentage of the

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Ton/PoolSelection/TonStakingPool.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Ton/PoolSelection/TonStakingPool.swift
@@ -9,18 +9,9 @@
 
 import Foundation
 
-/// The deposit/withdraw text comments a TON nominator-pool contract expects.
-/// Nominator deposits are plain text comments, but each pool *implementation*
-/// uses a DIFFERENT word — sending the wrong one is rejected on-chain
-/// (exit 72). This is the single source of truth mapping a pool's tonapi
-/// `implementation` string to its protocol tokens.
-///
-/// These are TON contract protocol tokens, NOT user-facing UI — never localize.
+/// TON contract protocol tokens by pool implementation. These are not localized.
 enum TonStakingComment {
-    /// Standard nominator pool (`ton-blockchain/nominator-pool`): deposit "d".
-    /// Whales pool (`tonwhales/ton-nominators`): deposit "Deposit" (capitalized) —
-    /// verified against successful on-chain deposits; the repo README's "Stake"
-    /// is stale and is rejected by the live pools (exit 72).
+    /// Whales pools require `Deposit`; their documented `Stake` is rejected.
     static func deposit(for implementation: String?) -> String? {
         switch implementation {
         case "tf": return "d"
@@ -36,6 +27,14 @@ enum TonStakingComment {
         case "whales": return "Withdraw"
         default: return nil
         }
+    }
+    /// Derived from the writer table so reader and builder tokens cannot drift.
+    static var depositComments: Set<String> {
+        Set(TonStakingPool.nominatorImplementations.compactMap { deposit(for: $0) })
+    }
+
+    static var withdrawComments: Set<String> {
+        Set(TonStakingPool.nominatorImplementations.compactMap { withdraw(for: $0) })
     }
 }
 
@@ -53,10 +52,7 @@ struct TonStakingPool: Equatable, Hashable {
     let maxNominators: Int?
     let implementation: String?
 
-    /// tonapi `implementation` values that are genuine **nominator pools** — the
-    /// only ones our `"d"`/`"w"` text-comment deposit mechanism can stake into.
-    /// `liquidTF` (Tonstakers and similar) mints a jetton instead and must be
-    /// excluded; unknown implementations are treated as non-nominator (excluded).
+    /// Supported nominator implementations; liquid pools use a different flow.
     static let nominatorImplementations: Set<String> = ["whales", "tf"]
 
     /// Whether this is a nominator pool our deposit mechanism supports.

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/QuotedWithdrawalPresentation.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/QuotedWithdrawalPresentation.swift
@@ -1,0 +1,32 @@
+//
+//  QuotedWithdrawalPresentation.swift
+//  VultisigApp
+//
+//  Presents a builder-quoted withdrawal payout instead of the transaction
+//  carrier's zero amount.
+//
+
+import Foundation
+
+enum QuotedWithdrawalPresentation {
+
+    /// Uses the builder's quote so presentation cannot re-derive from a different
+    /// position than the form used.
+    static func hero(for transaction: SendTransaction) -> HeroContent? {
+        guard let amount = transaction.withdrawDisplayAmount else { return nil }
+        // Prefer the signed operation's verb over the neutral fallback.
+        let decoded = SignedTransactionDecoder.decode(InitiatingTransactionContent(transaction))
+        let title = DecodedTransactionPresentation.title(for: decoded.operation) ?? "quotedWithdrawalVerifyTitle".localized
+        let coin = HeroCoinAmount(
+            // Match base-unit settlement by truncating at the asset's precision;
+            // abbreviated display formatting would hide the exact payout.
+            amount: amount.formatToDecimal(digits: transaction.coin.decimals),
+            ticker: transaction.coin.ticker,
+            logo: transaction.coin.logo
+        )
+        if let projected = ProjectionCoordinator.hero(for: decoded, title: title, estimate: coin) {
+            return projected
+        }
+        return .send(title: title, coin: coin)
+    }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/RUJI/RUJILiquidUnbondTransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/RUJI/RUJILiquidUnbondTransactionBuilder.swift
@@ -40,6 +40,23 @@ struct RUJILiquidUnbondTransactionBuilder: TransactionBuilder {
 
     var amount: String { "0" }
 
+    /// The RUJI this redemption pays out, quantised to the shares it actually
+    /// spends — so the Verify screen states a figure instead of falling through to
+    /// the generic header with none. `amount` is the literal `"0"`; the funds are
+    /// the instruction. See `QuotedWithdrawalPresentation`.
+    ///
+    /// ⚠️ **A projection from two reads, not a commitment.** `stakedAmount` comes
+    /// from the persisted DeFi card; `receiptShares` (behind `heldUnits`) is a
+    /// separate live read. If they disagree the figure moves with them — the
+    /// accepted shape of a fractional withdrawal, and it never claims more than was
+    /// asked because the share count is truncated (`ReceiptShareRedemptionTests`).
+    var withdrawDisplayAmount: Decimal? {
+        let held = heldUnits
+        let redeemed = redeemedUnits
+        guard stakedAmount > 0, held >= 1, redeemed >= 1 else { return nil }
+        return (stakedAmount * redeemed) / held
+    }
+
     var memo: String { "" }
 
     var memoFunctionDictionary: ThreadSafeDictionary<String, String> {

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/RUJI/RUJIUnstakeTransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/RUJI/RUJIUnstakeTransactionBuilder.swift
@@ -18,6 +18,17 @@ struct RUJIUnstakeTransactionBuilder: TransactionBuilder {
         coin.decimalToCrypto(value: amount.toDecimal()).description
     }
 
+    /// The RUJI this bonded withdrawal pays out. Unlike the fractional TCY memo,
+    /// `account.withdraw` carries an ABSOLUTE amount (`withdraw:<contract>:<raw>`),
+    /// so this is exact — the figure the user typed — not a projection. `amount`
+    /// the protocol requirement is the typed value here, but the Verify hero reads
+    /// what will be signed, so it is surfaced explicitly. See
+    /// `QuotedWithdrawalPresentation`.
+    var withdrawDisplayAmount: Decimal? {
+        let value = amount.toDecimal()
+        return value > 0 ? value : nil
+    }
+
     var memo: String {
         "withdraw:\(coin.contractAddress):\(rawAmount)"
     }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/TCY/TCYUnstakeTransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/TCY/TCYUnstakeTransactionBuilder.swift
@@ -19,8 +19,28 @@ struct TCYUnstakeTransactionBuilder: TransactionBuilder {
     let autoCompoundAmount: Decimal
     let sendMaxAmount: Bool
     let isAutoCompound: Bool
+    /// The staked TCY the sheet was showing — `availableAmount` from the unstake
+    /// form. Local display context only, never signed; it exists so the Verify
+    /// screen can quote the payout `basisPoints` implies rather than the memo's
+    /// literal `"0"`.
+    let stakedAmount: Decimal
 
     var amount: String { "0" }
+
+    /// The TCY this withdrawal pays out — the memo's fraction applied to the staked
+    /// position — so the Verify screen states a figure instead of "You're sending
+    /// 0 TCY". See `QuotedWithdrawalPresentation`.
+    ///
+    /// ⚠️ **A projection, not a commitment.** `tcy-:<bps>` commits to a FRACTION
+    /// applied to whatever is staked when THORChain executes it; this applies that
+    /// fraction to the balance the form was showing, which is the closest an
+    /// absolute figure can get. `nil` for the auto-compound (sTCY) position, whose
+    /// `stakedAmount` is a receipt-share count worth more than 1 TCY each — quoting
+    /// a fraction of it as "X TCY" would understate the payout.
+    var withdrawDisplayAmount: Decimal? {
+        guard !isAutoCompound, stakedAmount > 0, basisPoints > 0 else { return nil }
+        return (stakedAmount * Decimal(basisPoints)) / Decimal(WithdrawBasisPoints.max)
+    }
 
     var memo: String {
         if !isAutoCompound {

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/TransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/TransactionBuilder.swift
@@ -5,6 +5,7 @@
 //  Created by Gaston Mazzeo on 04/11/2025.
 //
 
+import Foundation
 import VultisigCommonData
 
 protocol TransactionBuilder {
@@ -31,6 +32,20 @@ protocol TransactionBuilder {
     /// this specific order — the memo alone identifies the order only to
     /// THORChain, not to our own table.
     var limitCancelContext: LimitOrderCancelRequest? { get }
+
+    /// What this transaction withdraws, when `amount` cannot say.
+    ///
+    /// A THORChain staking withdrawal is a memo-only `MsgDeposit`: its `amount`
+    /// is the literal `"0"` and the instruction is a *fraction* of the staked
+    /// position (`tcy-:<bps>`), so nothing downstream can recover the figure —
+    /// which is how the verify screen came to announce "You're sending 0 TCY"
+    /// over a withdrawal of a thousand of them.
+    ///
+    /// Already quantised to what the memo can express, so it is what the chain
+    /// will pay out rather than the raw string that was typed. Populated by the
+    /// TCY unstake and RUJI liquid-unbond builders; every other builder uses the
+    /// default `nil` and keeps its existing presentation.
+    var withdrawDisplayAmount: Decimal? { get }
 }
 
 extension TransactionBuilder {
@@ -44,6 +59,9 @@ extension TransactionBuilder {
 
     /// Default — only the limit-order cancel builder overrides this.
     var limitCancelContext: LimitOrderCancelRequest? { nil }
+
+    /// Default — only the TCY unstake and RUJI liquid-unbond builders override this.
+    var withdrawDisplayAmount: Decimal? { nil }
 
     /// Builds the immutable `SendTransaction` struct directly, with `gas` /
     /// `fee` and runtime-only fields left at the construction-time zero state.
@@ -79,7 +97,8 @@ extension TransactionBuilder {
             feeCoin: SendTransaction.resolveFeeCoin(coin: coin, vault: vault),
             cosmosStakingPayload: cosmosStakingPayload,
             solanaStakingPayload: solanaStakingPayload,
-            limitCancelContext: limitCancelContext
+            limitCancelContext: limitCancelContext,
+            withdrawDisplayAmount: withdrawDisplayAmount
         )
     }
 

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
@@ -78,6 +78,12 @@ class JoinKeysignViewModel: ObservableObject {
     @Published var blockaidSimulation: BlockaidSimulationInfo?
     @Published var securityScannerState: SecurityScannerState = .idle
     @Published var didLoadSimulation: Bool = false
+    /// The hero for a transaction that only resolves after an on-chain read — a
+    /// fractional unstake read against the signer's own position, today, but
+    /// general over any operation whose figure is settled against a balance the
+    /// signed content does not carry. Once resolution finishes, a failed read
+    /// still yields the projection's signed scope without an estimate. Only the
+    /// Verify screen consumes this; the Done screen matches main and never does.
     @Published var resolvedHero: HeroContent?
 
     var encryptionKeyHex: String = ""
@@ -685,7 +691,10 @@ class JoinKeysignViewModel: ObservableObject {
         didLoadSimulation = true
     }
 
-    /// Resolves optional chain state without making it a signing dependency.
+    /// Resolves the hero for a transaction whose figure needs an on-chain read, so
+    /// the co-signer's Verify matches the initiator's. The read lives in the decoder
+    /// layer; this view model asks for a hero and knows nothing of which operation
+    /// or chain needed one. `nil` leaves the verb-only hero in place.
     func loadResolvedHero() async {
         guard let payload = keysignPayload else { return }
         resolvedHero = await ResolvedTransactionHero.resolve(for: payload, trustedCoins: vault.coins)

--- a/VultisigApp/VultisigApp/Features/Send/Models/SendTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Models/SendTransaction.swift
@@ -191,6 +191,13 @@ struct SendTransaction: Hashable {
     /// says nothing about our own storage key.
     let limitCancelContext: LimitOrderCancelRequest?
 
+    /// What this transaction withdraws, when `amount` cannot say — see
+    /// `TransactionBuilder.withdrawDisplayAmount`.
+    ///
+    /// Local-only, like `limitCancelContext`: it is display context for the
+    /// screens around signing, not part of what gets signed.
+    let withdrawDisplayAmount: Decimal?
+
     /// Native coin that pays for gas — `coin` itself for native sends, the
     /// chain's native sibling (e.g. ETH for a USDC source) otherwise.
     /// Precomputed at construction so Verify/Done don't need the vault's
@@ -240,7 +247,8 @@ extension SendTransaction {
             lhs.feeCoinSnapshot == rhs.feeCoinSnapshot &&
             lhs.cosmosStakingPayload == rhs.cosmosStakingPayload &&
             lhs.solanaStakingPayload == rhs.solanaStakingPayload &&
-            lhs.limitCancelContext == rhs.limitCancelContext
+            lhs.limitCancelContext == rhs.limitCancelContext &&
+            lhs.withdrawDisplayAmount == rhs.withdrawDisplayAmount
     }
 
     func hash(into hasher: inout Hasher) {
@@ -269,6 +277,7 @@ extension SendTransaction {
         hasher.combine(cosmosStakingPayload)
         hasher.combine(solanaStakingPayload)
         hasher.combine(limitCancelContext)
+        hasher.combine(withdrawDisplayAmount)
     }
 }
 
@@ -298,6 +307,7 @@ extension SendTransaction {
         cosmosStakingPayload: CosmosStakingPayload? = nil,
         solanaStakingPayload: SolanaStakingPayload? = nil,
         limitCancelContext: LimitOrderCancelRequest? = nil,
+        withdrawDisplayAmount: Decimal? = nil,
         amountWasAutoAdjusted: Bool = false
     ) {
         self.coin = coin
@@ -328,6 +338,7 @@ extension SendTransaction {
         self.cosmosStakingPayload = cosmosStakingPayload
         self.solanaStakingPayload = solanaStakingPayload
         self.limitCancelContext = limitCancelContext
+        self.withdrawDisplayAmount = withdrawDisplayAmount
     }
 }
 
@@ -469,6 +480,10 @@ extension SendTransaction {
             // comment warning. A field-by-field copy is the shape that invites
             // it — every new field is one someone must remember to add here.
             limitCancelContext: limitCancelContext,
+            // Carried through unconditionally for the same reason, and it is the
+            // `copy(gas:)` on the function-call path that would drop it — the one
+            // this field exists to survive.
+            withdrawDisplayAmount: withdrawDisplayAmount,
             amountWasAutoAdjusted: amountWasAutoAdjusted ?? self.amountWasAutoAdjusted
         )
     }

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/CosmosSignDocDecoder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/CosmosSignDocDecoder.swift
@@ -1,0 +1,93 @@
+//
+//  CosmosSignDocDecoder.swift
+//  VultisigApp
+//
+//  Reads initiator Cosmos staking pre-images or the active SignDoc body sent to
+//  a co-signer, never adjacent flat sidecars.
+//
+
+import BigInt
+import Foundation
+
+struct CosmosSignDocDecoder: TransactionContentDecoder {
+
+    /// Only chains whose signing paths consume Cosmos SignDocs.
+    var handles: Set<Chain>? {
+        Set(Chain.allCases.filter { $0.chainType == .Cosmos })
+    }
+
+    func decode(_ tx: SignedTransactionContent) -> DecodedTransaction? {
+        if let intent = tx.cosmosStakingIntent {
+            return decode(intent)
+        }
+
+        guard tx.signedDataBodyIsActive,
+              case .signDirect(let direct)? = tx.signedData,
+              let reading = CosmosSignDocReader.read(bodyBytes: direct.bodyBytes)
+        else { return nil }
+
+        return DecodedTransaction(
+            operation: reading.operation,
+            amount: reading.amount,
+            counterparty: reading.counterparty,
+            evidence: .signedData
+        )
+    }
+
+    /// Maps a validated initiator pre-image into the SignDoc vocabulary.
+    private func decode(_ intent: CosmosStakingPayload) -> DecodedTransaction? {
+        func amount() -> DecodedAmount? {
+            guard !intent.denom.isEmpty,
+                  let text = intent.amount,
+                  let value = BigInt(text),
+                  value >= 0
+            else { return nil }
+            return .units(value, of: .denom(intent.denom))
+        }
+
+        switch intent.opType {
+        case .delegate:
+            guard let validator = intent.validatorAddress, !validator.isEmpty,
+                  let amount = amount() else { return nil }
+            return DecodedTransaction(
+                operation: .delegate,
+                amount: amount,
+                counterparty: .validator(validator),
+                evidence: .structuredPayload
+            )
+
+        case .undelegate:
+            guard let validator = intent.validatorAddress, !validator.isEmpty,
+                  let amount = amount() else { return nil }
+            return DecodedTransaction(
+                operation: .undelegate,
+                amount: amount,
+                counterparty: .validator(validator),
+                evidence: .structuredPayload
+            )
+
+        case .redelegate:
+            guard let source = intent.validatorSrcAddress, !source.isEmpty,
+                  let destination = intent.validatorDstAddress, !destination.isEmpty,
+                  let amount = amount() else { return nil }
+            return DecodedTransaction(
+                operation: .redelegate,
+                amount: amount,
+                counterparty: .validator(destination),
+                evidence: .structuredPayload
+            )
+
+        case .withdrawRewards:
+            guard let validators = intent.validators,
+                  (1...64).contains(validators.count),
+                  validators.allSatisfy({ !$0.isEmpty })
+            else { return nil }
+            return DecodedTransaction(
+                operation: .claimRewards,
+                amount: .unstated,
+                counterparty: validators.count == 1 ? .validator(validators[0]) : nil,
+                evidence: .structuredPayload
+            )
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/CosmosTransactionDecoder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/CosmosTransactionDecoder.swift
@@ -1,0 +1,76 @@
+//
+//  CosmosTransactionDecoder.swift
+//  VultisigApp
+//
+//  Reads Cosmos operations represented by an active memo or wire discriminator.
+//  SignDoc-contained operations are handled by `CosmosSignDocDecoder` first.
+//
+
+import BigInt
+import Foundation
+
+struct CosmosTransactionDecoder: TransactionContentDecoder {
+
+    let handles: Set<Chain>? = [.gaiaChain, .kujira, .osmosis, .noble, .akash, .dydx]
+
+    /// Earlier approve or swap routes make the memo inert.
+    private static let precedence: MemoPrecedence = .memoIsInertWhenRoutedEarlier
+
+    func decode(_ tx: SignedTransactionContent) -> DecodedTransaction? {
+        guard let content = tx.corroborated else { return nil }
+        if let memo = content.memo(Self.precedence), let decoded = decodeMemo(memo, content: content) {
+            return decoded
+        }
+        return decodeWireType(content)
+    }
+
+    private func decodeMemo(_ memo: String, content: CorroboratedContent) -> DecodedTransaction? {
+        let fields = memo.split(separator: ":", omittingEmptySubsequences: false).map(String.init)
+        guard let head = fields.first else { return nil }
+
+        // Match the chain's case-insensitive heads.
+        switch head.uppercased() {
+        // `SWITCH` moves the asset to the sender's THORChain address.
+        case "SWITCH":
+            guard fields.count > 1, !fields[1].isEmpty else { return nil }
+            return DecodedTransaction(
+                operation: .switchChain,
+                amount: Self.carried(content.amount),
+                evidence: .memo
+            )
+
+        // Governance votes move no quantity.
+        case "DYDX_VOTE":
+            guard fields.count > 2, !fields[2].isEmpty else { return nil }
+            return DecodedTransaction(operation: .vote, amount: .unstated, evidence: .memo)
+
+        default:
+            return nil
+        }
+    }
+
+    private func decodeWireType(_ content: CorroboratedContent) -> DecodedTransaction? {
+        switch content.transactionType {
+        case .ibcTransfer:
+            return DecodedTransaction(
+                operation: .ibcTransfer,
+                amount: Self.carried(content.amount),
+                evidence: .wireTransactionType
+            )
+        case .vote:
+            return DecodedTransaction(operation: .vote, amount: .unstated, evidence: .wireTransactionType)
+        default:
+            return nil
+        }
+    }
+    /// What the transaction carries, when it carries a figure at all.
+    private static func carried(_ signed: SignedAmount) -> DecodedAmount {
+        switch signed {
+        case .committed(let raw) where raw > 0:
+            return .units(raw, of: .transactionCoin)
+        case .committed, .computedAtSigning:
+            return .unstated
+        }
+    }
+
+}

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/InboundVaultCorroborating.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/InboundVaultCorroborating.swift
@@ -1,0 +1,40 @@
+//
+//  InboundVaultCorroborating.swift
+//  VultisigApp
+//
+//  Whether a signed destination is somewhere THORChain actually receives.
+//
+
+import Foundation
+
+protocol InboundVaultCorroborating {
+
+    /// Checks signed destination and chain against THORChain's inbound set.
+    func corroborates(destination: String, chain: Chain, isNative: Bool) -> Bool
+}
+
+struct ThorchainInboundVaults: InboundVaultCorroborating {
+
+    func corroborates(destination: String, chain: Chain, isNative: Bool) -> Bool {
+        guard !destination.isEmpty,
+              let known = ThorchainService.shared.cachedInboundAddresses()
+        else { return false }
+
+        // Only this transaction's chain can corroborate its route.
+        let candidates = known.filter { $0.chain.caseInsensitiveCompare(chain.swapAsset) == .orderedSame }
+        guard !candidates.isEmpty else { return false }
+
+        return candidates.contains { entry in
+            // Native deposits use the vault; tokens use the router.
+            let expected = isNative ? entry.address : (entry.router ?? "")
+            return !expected.isEmpty && Self.sameAddress(expected, destination, on: chain)
+        }
+    }
+
+    /// EVM addresses are case-insensitive; other address families are not.
+    private static func sameAddress(_ lhs: String, _ rhs: String, on chain: Chain) -> Bool {
+        chain.chainType == .EVM
+            ? lhs.caseInsensitiveCompare(rhs) == .orderedSame
+            : lhs == rhs
+    }
+}

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/MayaChainTransactionDecoder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/MayaChainTransactionDecoder.swift
@@ -1,0 +1,91 @@
+//
+//  MayaChainTransactionDecoder.swift
+//  VultisigApp
+//
+//  Decodes MAYAChain pool and node memos. It precedes the chain-agnostic
+//  THORChain grammar because their shared heads use different field layouts.
+//
+
+import BigInt
+import Foundation
+
+struct MayaChainTransactionDecoder: TransactionContentDecoder {
+
+    let handles: Set<Chain>? = [.mayaChain]
+
+    /// Earlier approve or swap routes make the memo inert.
+    private static let precedence: MemoPrecedence = .memoIsInertWhenRoutedEarlier
+
+    func decode(_ tx: SignedTransactionContent) -> DecodedTransaction? {
+        guard let content = tx.corroborated else { return nil }
+        guard let memo = content.memo(Self.precedence) else { return nil }
+
+        let fields = memo.split(separator: ":", omittingEmptySubsequences: false).map(String.init)
+        guard let head = fields.first else { return nil }
+
+        switch head.uppercased() {
+        case "POOL+":
+            return DecodedTransaction(
+                operation: .stake,
+                amount: Self.carried(content.amount),
+                evidence: .memo
+            )
+
+        case "POOL-":
+            // Field 1 is basis points; later fields may name a single-sided asset.
+            guard fields.count > 1, let bps = Int(fields[1]), bps > 0, bps <= 10_000 else {
+                return nil
+            }
+            return DecodedTransaction(
+                operation: .unstake,
+                amount: .fraction(basisPoints: bps, of: .transactionCoin),
+                evidence: .memo
+            )
+
+        // `BOND:<asset>:<units>:<node>`
+        case "BOND":
+            guard fields.count > 3, !fields[3].isEmpty else { return nil }
+            return DecodedTransaction(
+                operation: .bond,
+                amount: Self.lpUnits(from: fields),
+                counterparty: .node(fields[3]),
+                evidence: .memo
+            )
+
+        case "UNBOND":
+            guard fields.count > 3, !fields[3].isEmpty else { return nil }
+            return DecodedTransaction(
+                operation: .unbond,
+                amount: Self.lpUnits(from: fields),
+                counterparty: .node(fields[3]),
+                evidence: .memo
+            )
+
+        case "LEAVE":
+            guard fields.count > 1, !fields[1].isEmpty else { return nil }
+            return DecodedTransaction(
+                operation: .leave,
+                amount: .unstated,
+                counterparty: .node(fields[1]),
+                evidence: .memo
+            )
+
+        default:
+            return nil
+        }
+    }
+    /// LP units are not asset base units, so they cannot use a currency amount.
+    private static func lpUnits(from fields: [String]) -> DecodedAmount {
+        // A future presentation needs an explicit "LP units of pool" model.
+        _ = fields
+        return .unstated
+    }
+
+    private static func carried(_ signed: SignedAmount) -> DecodedAmount {
+        switch signed {
+        case .committed(let raw) where raw > 0: return .units(raw, of: .transactionCoin)
+        case .committed, .computedAtSigning: return .unstated
+        }
+    }
+
+}

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/SolanaTransactionDecoder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/SolanaTransactionDecoder.swift
@@ -1,0 +1,118 @@
+//
+//  SolanaTransactionDecoder.swift
+//  VultisigApp
+//
+//  Reads initiator staking pre-images or the opaque transaction bytes sent to a
+//  co-signer. Flat sidecars are never consulted for relayed transactions.
+//
+
+import BigInt
+import Foundation
+
+struct SolanaTransactionDecoder: TransactionContentDecoder {
+
+    var handles: Set<Chain>? { [.solana] }
+
+    func decode(_ tx: SignedTransactionContent) -> DecodedTransaction? {
+        // Initiators hold the pre-image; co-signers hold its encoded bytes.
+        if let intent = tx.stakingIntent {
+            return read(intent)
+        }
+
+        guard case .signSolana(let solana)? = tx.signedData else { return nil }
+
+        // Multiple relayed transactions have no single operation.
+        guard solana.rawTransactions.count == 1,
+              let raw = solana.rawTransactions.first,
+              let reading = SolanaTransactionReader.read(base64: raw)
+        else { return nil }
+
+        return DecodedTransaction(
+            operation: reading.operation,
+            amount: reading.amount,
+            counterparty: reading.counterparty,
+            evidence: .signedData
+        )
+    }
+    /// Reads the operation committed by an initiator staking pre-image.
+    private func read(_ intent: SolanaStakingPayload) -> DecodedTransaction {
+        switch intent.opType {
+        case .delegate:
+            let amount: DecodedAmount = intent.lamports.map {
+                .accountFunding(BigInt($0), of: .chainNative)
+            } ?? .unstated
+            return DecodedTransaction(
+                operation: .delegate,
+                amount: amount,
+                counterparty: intent.votePubkey.map(DecodedCounterparty.validator),
+                evidence: .structuredPayload
+            )
+        case .unstake:
+            // Funds move only on the later withdrawal.
+            return DecodedTransaction(
+                operation: .unstake,
+                amount: .unstated,
+                counterparty: intent.stakeAccount.map(DecodedCounterparty.stakeAccount),
+                evidence: .structuredPayload
+            )
+        case .withdraw:
+            // Withdraw lamports are the committed quantity.
+            let amount: DecodedAmount = intent.lamports.map { .units(BigInt($0), of: .chainNative) } ?? .unstated
+            return DecodedTransaction(
+                operation: .withdrawStake,
+                amount: amount,
+                counterparty: intent.stakeAccount.map(DecodedCounterparty.stakeAccount),
+                evidence: .structuredPayload
+            )
+        }
+    }
+
+}
+
+/// Converts exact stake-account funding into active stake using the live rent reserve.
+struct SolanaDelegatedAmountReader: PositionReading {
+    var readRentReserve: () async throws -> UInt64 = {
+        try await SolanaStakingService.shared.fetchRentReserve()
+    }
+
+    func handles(_ decoded: DecodedTransaction, coin: Coin) -> Bool {
+        guard coin.chain == .solana, decoded.operation == .delegate,
+              case .accountFunding = decoded.amount else { return false }
+        return true
+    }
+
+    func amount(for decoded: DecodedTransaction, coin: Coin) async -> HeroCoinAmount? {
+        guard case .accountFunding(let funding, .chainNative) = decoded.amount,
+              let reserve = try? await readRentReserve(),
+              funding > BigInt(reserve) else { return nil }
+        return Self.heroAmount(raw: funding - BigInt(reserve), coin: coin)
+    }
+
+    fileprivate static func heroAmount(raw: BigInt, coin: Coin) -> HeroCoinAmount? {
+        guard raw > 0 else { return nil }
+        let amount = coin.decimal(for: raw)
+        return HeroCoinAmount(amount: amount, coin: coin)
+    }
+}
+
+/// Resolves a whole-account deactivate to the exact delegated lamports in that account.
+struct SolanaStakeAccountAmountReader: PositionReading {
+    var readStakeAccounts: (String) async throws -> [SolanaStakeAccount] = {
+        try await SolanaStakingService.shared.fetchStakeAccounts(owner: $0)
+    }
+
+    func handles(_ decoded: DecodedTransaction, coin: Coin) -> Bool {
+        guard coin.chain == .solana, decoded.operation == .unstake,
+              case .stakeAccount = decoded.counterparty else { return false }
+        return true
+    }
+
+    func amount(for decoded: DecodedTransaction, coin: Coin) async -> HeroCoinAmount? {
+        guard case .stakeAccount(let address) = decoded.counterparty,
+              let accounts = try? await readStakeAccounts(coin.address),
+              let stake = accounts.first(where: { $0.pubkey == address })?.delegation?.stake else {
+            return nil
+        }
+        return SolanaDelegatedAmountReader.heroAmount(raw: BigInt(stake), coin: coin)
+    }
+}

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/THORChainTransactionDecoder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/THORChainTransactionDecoder.swift
@@ -1,0 +1,363 @@
+//
+//  THORChainTransactionDecoder.swift
+//  VultisigApp
+//
+//  Reads THORChain memos and wasm messages only when signed content proves the
+//  native or inbound route. Uncorroborated lookalike memos stay unknown.
+//
+
+import BigInt
+import Foundation
+
+struct THORChainTransactionDecoder: TransactionContentDecoder {
+
+    /// Inbound routes may originate on any chain, so provenance gates decoding.
+    let handles: Set<Chain>? = nil
+
+    static let nativeChains: Set<Chain> = [.thorChain, .thorChainChainnet, .thorChainStagenet]
+
+    /// Inbound memos travel with the earlier THORChain route rather than being
+    /// unsigned sidecars beside it.
+    private static let precedence: MemoPrecedence = .memoTravelsWithTheEarlierRoute
+
+    func decode(_ tx: SignedTransactionContent) -> DecodedTransaction? {
+        // Flat fields beside an opaque signed artifact are untrusted sidecars.
+        guard let content = tx.corroborated else { return nil }
+
+        switch provenance(of: tx, content: content) {
+        case .unrelated:
+            return nil
+
+        case .native:
+            if let wasm = content.wasmPayload, let decoded = decodeWasm(wasm, content: content) {
+                return decoded
+            }
+            if let memo = content.memo(Self.precedence), let decoded = decodeMemo(memo, content: content) {
+                return decoded
+            }
+            return decodeWireType(content)
+
+        case .inbound:
+            // Foreign-chain wasm payloads cannot be THORChain contract calls.
+            guard let memo = content.memo(Self.precedence) else { return nil }
+            return decodeMemo(memo, content: content)
+        }
+    }
+
+    private enum Provenance {
+        /// The transaction is on a THORChain-family chain.
+        case native
+        /// Signed content names a THORChain vault as the destination.
+        case inbound
+        /// Nothing corroborates THORChain, so its grammar does not apply.
+        case unrelated
+    }
+
+    private func provenance(of tx: SignedTransactionContent, content: CorroboratedContent) -> Provenance {
+        if Self.nativeChains.contains(tx.chain) { return .native }
+
+        switch content.swap {
+        case .thorchain, .thorchainChainnet, .thorchainStagenet:
+            return .inbound
+        default:
+            // An active approve or non-THOR swap outranks flat destination data.
+            guard content.swap == nil, content.approve == nil else {
+                return .unrelated
+            }
+            // A cached inbound vault can corroborate signed LP destinations.
+            // Cold caches refuse rather than blocking a signing screen.
+            return Self.inboundVaults.corroborates(
+                destination: content.toAddress,
+                chain: tx.chain,
+                isNative: tx.isNativeCoin
+            ) ? .inbound : .unrelated
+        }
+    }
+
+    /// Injectable cached-vault source; decoding never performs network reads.
+    static var inboundVaults: InboundVaultCorroborating = ThorchainInboundVaults()
+
+    // MARK: - Contract calls
+
+    private func decodeWasm(
+        _ wasm: WasmExecuteContractPayload,
+        content: CorroboratedContent
+    ) -> DecodedTransaction? {
+        guard let operation = operation(inExecuteMsg: wasm.executeMsg) else {
+            return DecodedTransaction(
+                operation: .contractCall,
+                amount: .unstated,
+                counterparty: .contract(wasm.contractAddress),
+                evidence: .wasmExecuteMsg
+            )
+        }
+
+        return DecodedTransaction(
+            operation: operation,
+            amount: amount(for: operation, wasm: wasm, content: content),
+            counterparty: .contract(wasm.contractAddress),
+            evidence: .wasmExecuteMsg
+        )
+    }
+
+    /// What the operation moves, in the units the signed content states them.
+    private func amount(
+        for operation: DecodedOperation,
+        wasm: WasmExecuteContractPayload,
+        content: CorroboratedContent
+    ) -> DecodedAmount {
+        // Mint output is execution-set; attached funds are the input, not output.
+        if operation == .mint { return .unstated }
+
+        // Multiple attached denoms are ambiguous; never present only `.first`.
+        if wasm.coins.count == 1,
+           let funds = wasm.coins.first,
+           let units = BigInt(funds.amount), units > 0 {
+            return .units(units, of: .denom(funds.denom))
+        }
+
+        // Rujira account operations put exact raw amounts in their memo.
+        if let memo = content.memo(Self.precedence) {
+            let fields = memo.split(separator: ":", omittingEmptySubsequences: false).map(String.init)
+            if fields.count > 2, !fields[1].isEmpty, let raw = BigInt(fields[2]), raw > 0 {
+                return .units(raw, of: .denom(fields[1]))
+            }
+        }
+
+        return .unstated
+    }
+
+    /// Parses direct Rujira JSON and base64-wrapped yVault JSON. Ambiguous action
+    /// sets are refused instead of depending on dictionary order.
+    private func operation(inExecuteMsg executeMsg: String) -> DecodedOperation? {
+        guard let data = executeMsg.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+
+        if let envelope = object["execute"] as? [String: Any],
+           let encoded = envelope["msg"] as? String,
+           let innerData = Data(base64Encoded: encoded),
+           let inner = try? JSONSerialization.jsonObject(with: innerData) as? [String: Any] {
+            let actions = inner.keys.compactMap { vaultActions[$0] }
+            return actions.count == 1 ? actions[0] : nil
+        }
+
+        return rujiraOperation(in: object, depth: 0)
+    }
+
+    private let vaultActions: [String: DecodedOperation] = [
+        "deposit": .mint,
+        "withdraw": .redeem
+    ]
+
+    private let rujiraActions: [String: DecodedOperation] = [
+        "unbond": .unstake,
+        "withdraw": .unstake,
+        "bond": .stake,
+        "deposit": .stake,
+        "claim": .claimRewards,
+        "withdraw_rewards": .claimRewards
+    ]
+
+    /// Searches one namespace level; deeper keys are action parameters.
+    private func rujiraOperation(in object: [String: Any], depth: Int) -> DecodedOperation? {
+        let actions = object.keys.compactMap { rujiraActions[$0] }
+        if actions.count == 1 { return actions[0] }
+        if actions.count > 1 { return nil }
+
+        guard depth == 0 else { return nil }
+
+        // Sorting keeps malformed multi-namespace messages deterministic.
+        let nested = object.keys.sorted().compactMap { object[$0] as? [String: Any] }
+        let found = nested.compactMap { rujiraOperation(in: $0, depth: depth + 1) }
+        return found.count == 1 ? found[0] : nil
+    }
+
+    // MARK: - Memo grammar
+
+    /// Memo heads are case-folded like THORNode. Shared THORChain/Rujira verbs
+    /// are distinguished by contract-address and numeric-amount shape.
+    private func decodeMemo(_ memo: String, content: CorroboratedContent) -> DecodedTransaction? {
+        let fields = memo.split(separator: ":", omittingEmptySubsequences: false).map(String.init)
+        guard let head = fields.first else { return nil }
+
+        // The numeric third field separates Rujira from THORChain node memos.
+        let isRujiraForm = fields.count > 2
+            && fields[1].hasPrefix("thor1")
+            && BigInt(fields[2]) != nil
+
+        switch head.lowercased() {
+        case "m=<":
+            guard fields.count > 2 else { return nil }
+            return DecodedTransaction(operation: .limitOrderCancel, amount: .unstated, evidence: .memo)
+
+        case "=<":
+            guard fields.count > 2 else { return nil }
+            return DecodedTransaction(
+                operation: .limitOrderPlacement,
+                amount: Self.carriedAmount(content.amount),
+                evidence: .memo
+            )
+
+        case "bond" where isRujiraForm:
+            return rujira(.stake, fields: fields)
+
+        case "withdraw" where isRujiraForm:
+            return rujira(.unstake, fields: fields)
+
+        case "claim" where isRujiraForm:
+            return rujira(.claimRewards, fields: fields)
+
+        case "bond":
+            guard fields.count > 1, !fields[1].isEmpty else { return nil }
+            return DecodedTransaction(
+                operation: .bond,
+                amount: Self.carriedAmount(content.amount),
+                counterparty: .node(fields[1]),
+                evidence: .memo
+            )
+
+        case "unbond":
+            // UNBOND carries positive base units in its third field.
+            guard fields.count > 2, !fields[1].isEmpty,
+                  let units = BigInt(fields[2]), units > 0 else { return nil }
+            return DecodedTransaction(
+                operation: .unbond,
+                amount: .units(units, of: .transactionCoin),
+                counterparty: .node(fields[1]),
+                evidence: .memo
+            )
+
+        case "rebond":
+            guard fields.count > 2, !fields[1].isEmpty else { return nil }
+            return DecodedTransaction(
+                operation: .rebond,
+                amount: .unstated,
+                counterparty: .node(fields[1]),
+                evidence: .memo
+            )
+
+        case "leave":
+            guard fields.count > 1, !fields[1].isEmpty else { return nil }
+            return DecodedTransaction(
+                operation: .leave,
+                amount: .unstated,
+                counterparty: .node(fields[1]),
+                evidence: .memo
+            )
+
+        case "tcy+":
+            return DecodedTransaction(
+                operation: .stake,
+                amount: Self.carriedAmount(content.amount),
+                evidence: .memo
+            )
+
+        case "tcy-":
+            guard fields.count > 1, let fraction = fraction(fields[1]) else { return nil }
+            return DecodedTransaction(operation: .unstake, amount: fraction, evidence: .memo)
+
+        case "secure+":
+            guard fields.count > 1, !fields[1].isEmpty else { return nil }
+            return DecodedTransaction(
+                operation: .securedAssetDeposit,
+                amount: Self.carriedAmount(content.amount),
+                evidence: .memo
+            )
+
+        case "secure-":
+            guard fields.count > 1, !fields[1].isEmpty else { return nil }
+            return DecodedTransaction(
+                operation: .securedAssetWithdraw,
+                amount: Self.carriedAmount(content.amount),
+                evidence: .memo
+            )
+
+        case "merge":
+            guard fields.count > 1, !fields[1].isEmpty else { return nil }
+            return DecodedTransaction(
+                operation: .merge,
+                amount: Self.carriedAmount(content.amount),
+                evidence: .memo
+            )
+
+        case "unmerge":
+            // `unmerge:<token>:<shares>` states its own share count, in the
+            // shares' own units.
+            guard fields.count > 2, !fields[1].isEmpty,
+                  let shares = BigInt(fields[2]), shares > 0 else { return nil }
+            return DecodedTransaction(
+                operation: .unmerge,
+                amount: .units(shares, of: .denom(fields[1])),
+                evidence: .memo
+            )
+
+        case "+":
+            guard fields.count > 1, !fields[1].isEmpty else { return nil }
+            return DecodedTransaction(
+                operation: .addLiquidity,
+                amount: Self.carriedAmount(content.amount),
+                counterparty: .pool(fields[1]),
+                evidence: .memo
+            )
+
+        case "-":
+            // Single-sided withdrawals append an asset after the third-field BPS.
+            guard fields.count > 2, !fields[1].isEmpty,
+                  let fraction = fraction(fields[2]) else { return nil }
+            return DecodedTransaction(
+                operation: .removeLiquidity,
+                amount: fraction,
+                counterparty: .pool(fields[1]),
+                evidence: .memo
+            )
+
+        default:
+            return nil
+        }
+    }
+
+    private func rujira(_ operation: DecodedOperation, fields: [String]) -> DecodedTransaction? {
+        guard let raw = BigInt(fields[2]), raw > 0 else { return nil }
+        return DecodedTransaction(
+            operation: operation,
+            amount: .units(raw, of: .denom(fields[1])),
+            counterparty: .contract(fields[1]),
+            evidence: .memo
+        )
+    }
+
+    /// Refuses out-of-range basis points rather than clamping signed intent.
+    private func fraction(_ field: String) -> DecodedAmount? {
+        guard let bps = Int(field), bps > 0, bps <= 10_000 else { return nil }
+        return .fraction(basisPoints: bps, of: .transactionCoin)
+    }
+
+    // MARK: - Wire type
+
+    private func decodeWireType(_ content: CorroboratedContent) -> DecodedTransaction? {
+        switch content.transactionType {
+        case .thorMerge:
+            return DecodedTransaction(
+                operation: .merge,
+                amount: Self.carriedAmount(content.amount),
+                evidence: .wireTransactionType
+            )
+        case .thorUnmerge:
+            return DecodedTransaction(operation: .unmerge, amount: .unstated, evidence: .wireTransactionType)
+        default:
+            return nil
+        }
+    }
+    /// Max sends expose no committed amount because signing computes it later.
+    private static func carriedAmount(_ signed: SignedAmount) -> DecodedAmount {
+        switch signed {
+        case .committed(let raw) where raw > 0:
+            return .units(raw, of: .transactionCoin)
+        case .committed, .computedAtSigning:
+            return .unstated
+        }
+    }
+
+}

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/TonTransactionDecoder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/TonTransactionDecoder.swift
@@ -1,0 +1,96 @@
+//
+//  TonTransactionDecoder.swift
+//  VultisigApp
+//
+//  Decodes exact TON nominator-pool comments from signed transaction content.
+//
+
+import BigInt
+import Foundation
+import WalletCore
+
+struct TonTransactionDecoder: TransactionContentDecoder {
+
+    /// Chain-scoped so bare pool comments cannot collide with other grammars.
+    let handles: Set<Chain>? = [.ton]
+
+    /// Earlier approve or swap routes make the comment inert.
+    private static let precedence: MemoPrecedence = .memoIsInertWhenRoutedEarlier
+
+    func decode(_ tx: SignedTransactionContent) -> DecodedTransaction? {
+        // TonConnect BOCs and earlier routes make the outer memo a sidecar.
+        guard let content = tx.corroborated else { return nil }
+
+        // Pool protocol tokens are exact and must not be trimmed.
+        guard let comment = content.memo(Self.precedence), !comment.isEmpty else { return nil }
+
+        if TonStakingComment.depositComments.contains(comment) {
+            // Deposit amount is the TON moved into the pool.
+            return DecodedTransaction(
+                operation: .stake,
+                amount: Self.deposited(content.amount),
+                counterparty: .pool(content.toAddress),
+                evidence: .memo
+            )
+        }
+
+        if TonStakingComment.withdrawComments.contains(comment) {
+            // The transfer carries only a request fee; settlement returns later.
+            return DecodedTransaction(
+                operation: .unstake,
+                amount: .unstated,
+                counterparty: .pool(content.toAddress),
+                evidence: .memo
+            )
+        }
+
+        return nil
+    }
+    /// Positive committed deposits move chain-native TON.
+    private static func deposited(_ signed: SignedAmount) -> DecodedAmount {
+        switch signed {
+        case .committed(let raw) where raw > 0:
+            return .units(raw, of: .chainNative)
+        case .committed, .computedAtSigning:
+            return .unstated
+        }
+    }
+
+}
+
+/// Reads the whole position named by a signed TON pool withdrawal request.
+struct TonStakedPositionReader: PositionReading {
+    var readPools: (String) async throws -> [TonAccountStakingInfo] = {
+        try await TonService.shared.getNominatorPools(address: $0)
+    }
+
+    func handles(_ decoded: DecodedTransaction, coin: Coin) -> Bool {
+        guard coin.chain == .ton, decoded.operation == .unstake,
+              case .pool = decoded.counterparty else { return false }
+        return true
+    }
+
+    func amount(for decoded: DecodedTransaction, coin: Coin) async -> HeroCoinAmount? {
+        guard case .pool(let signedPool) = decoded.counterparty,
+              let pools = try? await readPools(coin.address),
+              let position = pools.first(where: { Self.sameAddress($0.pool, signedPool) }) else {
+            return nil
+        }
+
+        let raw = BigInt(position.amount) + BigInt(position.pendingDeposit)
+        guard raw > 0 else { return nil }
+        let amount = coin.decimal(for: raw)
+        return HeroCoinAmount(amount: amount, coin: coin)
+    }
+
+    private static func sameAddress(_ lhs: String, _ rhs: String) -> Bool {
+        let normalize: (String) -> String = {
+            TONAddressConverter.toUserFriendly(
+                address: $0,
+                bounceable: true,
+                testnet: false
+            ) ?? $0
+        }
+        return normalize(lhs) == normalize(rhs)
+    }
+}

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/TronTransactionDecoder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/TronTransactionDecoder.swift
@@ -1,0 +1,62 @@
+//
+//  TronTransactionDecoder.swift
+//  VultisigApp
+//
+//  Decodes TRON resource staking from the memo and amount consumed by the
+//  signer. Typed dApp contracts outrank that memo in `SignedTransactionContent`.
+//
+
+import BigInt
+import Foundation
+
+struct TronTransactionDecoder: TransactionContentDecoder {
+
+    /// The memo grammar is meaningful only on TRON.
+    var handles: Set<Chain>? { [.tron] }
+
+    private static let freeze = "FREEZE:"
+    private static let unfreeze = "UNFREEZE:"
+
+    /// Exact resource names accepted by the signer.
+    private static let resources: Set<String> = ["BANDWIDTH", "ENERGY"]
+
+    func decode(_ tx: SignedTransactionContent) -> DecodedTransaction? {
+        // Approve and swap routes make this sidecar memo inert.
+        guard let content = tx.corroborated,
+              let memo = content.memo(.memoIsInertWhenRoutedEarlier) else { return nil }
+
+        let operation: DecodedOperation
+        let resource: String
+
+        if memo.hasPrefix(Self.freeze) {
+            operation = .stake
+            resource = String(memo.dropFirst(Self.freeze.count))
+        } else if memo.hasPrefix(Self.unfreeze) {
+            operation = .unstake
+            resource = String(memo.dropFirst(Self.unfreeze.count))
+        } else {
+            return nil
+        }
+
+        // Match the signer's case-sensitive validation.
+        guard Self.resources.contains(resource) else { return nil }
+
+        return DecodedTransaction(
+            operation: operation,
+            amount: Self.amount(from: content.amount),
+            counterparty: nil,
+            evidence: .memo
+        )
+    }
+
+    /// Freeze instructions always move chain-native TRX, independent of payload
+    /// display metadata. Only positive, encodable committed amounts are stated.
+    private static func amount(from signed: SignedAmount) -> DecodedAmount {
+        switch signed {
+        case .committed(let raw) where raw > 0 && raw <= BigInt(Int64.max):
+            return .units(raw, of: .chainNative)
+        case .committed, .computedAtSigning:
+            return .unstated
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/CosmosSignDocReader.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/CosmosSignDocReader.swift
@@ -1,0 +1,297 @@
+//
+//  CosmosSignDocReader.swift
+//  VultisigApp
+//
+//  Reads operation, amount, and counterparty from the protobuf body a co-signer
+//  receives. Malformed, mixed, partial, or oversized bodies are refused as a
+//  whole; all peer-supplied lengths and varints are bounded.
+//
+
+import BigInt
+import Foundation
+
+enum CosmosSignDocReader {
+
+    /// What a SignDoc body turned out to be.
+    struct Reading: Hashable {
+        let operation: DecodedOperation
+        let amount: DecodedAmount
+        let counterparty: DecodedCounterparty?
+    }
+
+    // MARK: - Refusal limits
+
+    /// Real staking bodies are well below this limit.
+    private static let maximumBodyBytes = 64 * 1024
+
+    /// Messages in one body. A batched rewards claim sends one per validator.
+    private static let maximumMessages = 64
+
+    /// Bounds unknown-field scans.
+    private static let maximumFields = 512
+
+    // MARK: - Reading
+
+    /// Reads one complete SignDoc body.
+    static func read(bodyBytes base64: String) -> Reading? {
+        guard base64.utf8.count <= maximumBodyBytes * 2,
+              let body = Data(base64Encoded: base64),
+              !body.isEmpty,
+              body.count <= maximumBodyBytes
+        else { return nil }
+
+        guard let messages = messageBodies(in: body), !messages.isEmpty else { return nil }
+
+        // Every message must decode and agree on one operation.
+        var readings: [Reading] = []
+        for message in messages {
+            guard let reading = read(message) else { return nil }
+            readings.append(reading)
+        }
+
+        guard let first = readings.first,
+              readings.allSatisfy({ $0.operation == first.operation })
+        else { return nil }
+
+        // Homogeneous batches have one verb but no single amount or counterparty.
+        guard readings.count == 1 else {
+            return Reading(operation: first.operation, amount: .unstated, counterparty: nil)
+        }
+        return first
+    }
+
+    /// Reads every `Any` in `TxBody.messages`; partial results are refused.
+    private static func messageBodies(in body: Data) -> [(url: String, value: Data)]? {
+        var reader = ByteReader(body)
+        var messages: [(url: String, value: Data)] = []
+        var fields = 0
+
+        while !reader.isAtEnd {
+            fields += 1
+            guard fields <= maximumFields else { return nil }
+            guard let (field, wire) = reader.readTag() else { return nil }
+
+            if field == 1, wire == .lengthDelimited {
+                guard messages.count < maximumMessages else { return nil }
+                guard let any = reader.readLengthDelimited(),
+                      let message = anyContents(any) else { return nil }
+                messages.append(message)
+            } else {
+                guard reader.skip(wire) else { return nil }
+            }
+        }
+
+        return messages
+    }
+
+    /// Reads to the end and preserves protobuf's last-one-wins semantics.
+    private static func anyContents(_ any: Data) -> (url: String, value: Data)? {
+        var reader = ByteReader(any)
+        var url: String?
+        var value: Data?
+        var fields = 0
+
+        while !reader.isAtEnd {
+            fields += 1
+            guard fields <= maximumFields else { return nil }
+            guard let (field, wire) = reader.readTag() else { return nil }
+
+            switch (field, wire) {
+            case (1, .lengthDelimited):
+                guard let raw = reader.readLengthDelimited(),
+                      let text = String(data: raw, encoding: .utf8) else { return nil }
+                url = text
+            case (2, .lengthDelimited):
+                guard let raw = reader.readLengthDelimited() else { return nil }
+                value = raw
+            default:
+                guard reader.skip(wire) else { return nil }
+            }
+        }
+
+        // Missing value is legal protobuf and decodes as an empty message.
+        guard let url else { return nil }
+        return (url, value ?? Data())
+    }
+
+    // MARK: - The messages this can corroborate
+
+    /// Names only message types whose values are decoded here.
+    private static func read(_ message: (url: String, value: Data)) -> Reading? {
+        switch message.url {
+        case "/cosmos.staking.v1beta1.MsgDelegate":
+            // delegator 1, validator 2, amount 3 (Coin)
+            return staking(message.value, operation: .delegate, validatorField: 2, amountField: 3)
+
+        case "/cosmos.staking.v1beta1.MsgUndelegate":
+            return staking(message.value, operation: .undelegate, validatorField: 2, amountField: 3)
+
+        case "/cosmos.staking.v1beta1.MsgBeginRedelegate":
+            // Destination validator is the relevant counterparty.
+            return staking(message.value, operation: .redelegate, validatorField: 3, amountField: 4)
+
+        case "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward":
+            // Reward withdrawal carries no Coin.
+            return staking(message.value, operation: .claimRewards, validatorField: 2, amountField: nil)
+
+        case "/cosmos.bank.v1beta1.MsgSend":
+            // from 1, to 2, amount 3 (repeated Coin)
+            return staking(message.value, operation: .transfer, validatorField: 2, amountField: 3)
+
+        default:
+            return nil
+        }
+    }
+
+    /// Pulls an address and an optional `Coin` out of a message body.
+    private static func staking(
+        _ body: Data,
+        operation: DecodedOperation,
+        validatorField: UInt64,
+        amountField: UInt64?
+    ) -> Reading? {
+        var reader = ByteReader(body)
+        var address: String?
+        var coins: [(denom: String, amount: BigInt)] = []
+        var fields = 0
+
+        while !reader.isAtEnd {
+            fields += 1
+            guard fields <= maximumFields else { return nil }
+            guard let (field, wire) = reader.readTag() else { return nil }
+
+            if field == validatorField, wire == .lengthDelimited {
+                guard let raw = reader.readLengthDelimited(),
+                      let text = String(data: raw, encoding: .utf8) else { return nil }
+                address = text
+            } else if let amountField, field == amountField, wire == .lengthDelimited {
+                guard let raw = reader.readLengthDelimited(), let parsed = coin(raw) else { return nil }
+                coins.append(parsed)
+            } else {
+                guard reader.skip(wire) else { return nil }
+            }
+        }
+
+        // Multi-denom sends have no single amount; an absent address proves nothing.
+        guard let address, !address.isEmpty else { return nil }
+
+        let amount: DecodedAmount = coins.count == 1
+            ? .units(coins[0].amount, of: .denom(coins[0].denom))
+            : .unstated
+        return Reading(
+            operation: operation,
+            amount: amount,
+            counterparty: operation == .transfer ? .contract(address) : .validator(address)
+        )
+    }
+
+    /// `cosmos.base.v1beta1.Coin` — denom 1, amount 2, both strings.
+    private static func coin(_ body: Data) -> (denom: String, amount: BigInt)? {
+        var reader = ByteReader(body)
+        var denom: String?
+        var amount: BigInt?
+        var fields = 0
+
+        while !reader.isAtEnd {
+            fields += 1
+            guard fields <= maximumFields else { return nil }
+            guard let (field, wire) = reader.readTag() else { return nil }
+
+            switch (field, wire) {
+            case (1, .lengthDelimited):
+                guard let raw = reader.readLengthDelimited(),
+                      let text = String(data: raw, encoding: .utf8) else { return nil }
+                denom = text
+            case (2, .lengthDelimited):
+                guard let raw = reader.readLengthDelimited(),
+                      let text = String(data: raw, encoding: .utf8),
+                      let value = BigInt(text), value >= 0 else { return nil }
+                amount = value
+            default:
+                guard reader.skip(wire) else { return nil }
+            }
+        }
+
+        guard let denom, !denom.isEmpty, let amount else { return nil }
+        return (denom, amount)
+    }
+
+    // MARK: - Bounds-checked protobuf reader
+
+    /// Handles malformed peer input and non-zero-index `Data` slices without traps.
+    private struct ByteReader {
+        private let bytes: Data
+        private var index: Data.Index
+
+        init(_ bytes: Data) {
+            self.bytes = bytes
+            self.index = bytes.startIndex
+        }
+
+        var isAtEnd: Bool { index >= bytes.endIndex }
+
+        /// Base-128 varint that refuses UInt64 overflow.
+        mutating func readVarint() -> UInt64? {
+            var value: UInt64 = 0
+            var shift: UInt64 = 0
+
+            while shift < 64 {
+                guard index < bytes.endIndex else { return nil }
+                let byte = bytes[index]
+                index = bytes.index(after: index)
+
+                let payload = UInt64(byte & 0x7F)
+                // Only one payload bit fits at shift 63.
+                if shift == 63, payload > 1 { return nil }
+
+                value |= payload << shift
+                if byte & 0x80 == 0 { return value }
+                shift += 7
+            }
+
+            return nil
+        }
+
+        mutating func readTag() -> (field: UInt64, wire: WireType)? {
+            guard let tag = readVarint(), let wire = WireType(rawValue: tag & 0x07) else { return nil }
+            return (tag >> 3, wire)
+        }
+
+        mutating func readLengthDelimited() -> Data? {
+            guard let length = readVarint(), length <= UInt64(Int.max) else { return nil }
+            let count = Int(length)
+            guard count >= 0, bytes.distance(from: index, to: bytes.endIndex) >= count else { return nil }
+
+            let end = bytes.index(index, offsetBy: count)
+            defer { index = end }
+            return bytes[index..<end]
+        }
+
+        mutating func skip(_ wire: WireType) -> Bool {
+            switch wire {
+            case .varint: return readVarint() != nil
+            case .fixed64: return advance(by: 8)
+            case .lengthDelimited: return readLengthDelimited() != nil
+            case .fixed32: return advance(by: 4)
+            // Deprecated groups are not valid for supported SignDocs.
+            case .startGroup, .endGroup: return false
+            }
+        }
+
+        private mutating func advance(by count: Int) -> Bool {
+            guard bytes.distance(from: index, to: bytes.endIndex) >= count else { return false }
+            index = bytes.index(index, offsetBy: count)
+            return true
+        }
+    }
+
+    /// Protobuf wire types from the low three tag bits.
+    private enum WireType: UInt64 {
+        case varint = 0
+        case fixed64 = 1
+        case lengthDelimited = 2
+        case startGroup = 3
+        case endGroup = 4
+        case fixed32 = 5
+    }
+}

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/DecodedTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/DecodedTransaction.swift
@@ -28,6 +28,10 @@ enum DecodedAmount: Hashable {
     /// Base units exactly as the signed content carries them.
     case units(BigInt, of: DecodedAsset)
 
+    /// Exact funding of a newly created account. The displayed stake may be
+    /// lower because chain state determines the account's reserve.
+    case accountFunding(BigInt, of: DecodedAsset)
+
     /// A signed share in basis points; resolving the position is enrichment.
     case fraction(basisPoints: Int, of: DecodedAsset)
 
@@ -53,6 +57,7 @@ enum DecodedOperation: Hashable, CaseIterable {
     case claimRewards
     case mint
     case redeem
+    case withdrawStake
     case addLiquidity
     case removeLiquidity
     case merge
@@ -77,6 +82,7 @@ enum DecodedOperation: Hashable, CaseIterable {
 enum DecodedCounterparty: Hashable {
     case node(String)
     case validator(String)
+    case stakeAccount(String)
     case pool(String)
     case contract(String)
 }

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/DecodedTransactionPresentation.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/DecodedTransactionPresentation.swift
@@ -53,6 +53,7 @@ enum DecodedTransactionPresentation {
         case .redelegate: return "youreRedelegating"
         case .addLiquidity: return "youreAddingLiquidity"
         case .redeem: return "youreRedeeming"
+        case .withdrawStake: return "youreWithdrawing"
         case .mint: return "youreMinting"
         case .merge: return "youreMerging"
         case .unmerge: return "youreUnmerging"
@@ -95,11 +96,7 @@ enum DecodedTransactionPresentation {
             }
             return .send(
                 title: title,
-                coin: HeroCoinAmount(
-                    amount: amount.formatToDecimal(digits: meta.decimals),
-                    ticker: meta.ticker,
-                    logo: meta.logo
-                )
+                coin: HeroCoinAmount(amount: amount, coin: meta)
             )
 
         case .units(let raw, .denom(let denom)):
@@ -119,6 +116,10 @@ enum DecodedTransactionPresentation {
                     logo: meta.logo
                 )
             )
+
+        case .accountFunding:
+            // The reserve must be read live before this can be shown as stake.
+            return .title(text: title, caption: nil)
 
         case .fraction:
             // Projection and localized scope arrive with fractional readers.

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/DecodedTransactionPresentation.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/DecodedTransactionPresentation.swift
@@ -21,11 +21,7 @@ enum DecodedTransactionPresentation {
         // Nothing useful to add.
         .unknown: "nothing readable identified the transaction",
         .contractCall: "a contract call with no known shape behind it",
-        .vote: "a vote moves no value; the verb alone would be the whole hero",
-        // Naming this would hide its signed carrier charge.
-        .removeLiquidity: "naming it would hide the carrier charge it signs"
-
-        // New named operations require copy in every shipping locale.
+        .vote: "a vote moves no value; the verb alone would be the whole hero"
     ]
 
     /// The localized verb, or `nil` for a deliberately silent operation.
@@ -52,6 +48,7 @@ enum DecodedTransactionPresentation {
         case .undelegate: return "youreUndelegating"
         case .redelegate: return "youreRedelegating"
         case .addLiquidity: return "youreAddingLiquidity"
+        case .removeLiquidity: return "youreRemovingLiquidity"
         case .redeem: return "youreRedeeming"
         case .withdrawStake: return "youreWithdrawing"
         case .mint: return "youreMinting"
@@ -60,7 +57,7 @@ enum DecodedTransactionPresentation {
         case .ibcTransfer: return "youreBridging"
 
         // Exhaustive so new operations require an explicit vocabulary decision.
-        case .transfer, .swap, .approve, .vote, .contractCall, .removeLiquidity, .unknown:
+        case .transfer, .swap, .approve, .vote, .contractCall, .unknown:
             return nil
         }
     }
@@ -155,8 +152,12 @@ enum DecodedTransactionPresentation {
     static func operationTitle(for payload: KeysignPayload) -> String? {
         title(for: SignedTransactionDecoder.decode(payload).operation)
     }
-
-    /// Basis points as a localized percentage without trailing precision noise.
+    /// Basis points as a percentage, without trailing noise: 10000 reads "100%",
+    /// 5006 reads "50.06%".
+    ///
+    /// ⚠️ Formatted with `.percent` rather than by appending an ASCII `%`. Where
+    /// the symbol sits, whether a space precedes it, and which symbol is used at
+    /// all are locale rules.
     static func percentage(fromBasisPoints basisPoints: Int) -> String {
         let fraction = Decimal(basisPoints) / 10_000
         return fraction.formatted(.percent.precision(.fractionLength(0...2)))

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/DecodedTransactionPresentation.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/DecodedTransactionPresentation.swift
@@ -99,6 +99,23 @@ enum DecodedTransactionPresentation {
                 coin: HeroCoinAmount(amount: amount, coin: meta)
             )
 
+        case .units(let raw, .denom(let denom)) where denom == coin.chain.feeUnit:
+            // ⚠️ **The chain's own denom, resolved from the chain rather than
+            // from the payload.** A Cosmos SignDoc names `uatom`, and the
+            // curated table keys ATOM at an empty contract address — so the
+            // lookup below finds nothing and a delegate that states its amount
+            // perfectly well rendered as a bare verb on the co-signer. Matching
+            // the chain's fee unit is what closes that, and it is exact: denoms
+            // are case-sensitive.
+            guard let meta = TokensStore.nativeAsset(for: coin.chain),
+                  let amount = scaled(raw, decimals: meta.decimals), amount > 0 else {
+                return .title(text: title, caption: nil)
+            }
+            return .send(
+                title: title,
+                coin: HeroCoinAmount(amount: amount, coin: meta)
+            )
+
         case .units(let raw, .denom(let denom)):
             // Cosmos denoms are case-sensitive; reject the helper's insensitive match.
             guard let meta = TokensStore.findTokenMeta(chain: coin.chain, contractAddress: denom),
@@ -110,11 +127,7 @@ enum DecodedTransactionPresentation {
             }
             return .send(
                 title: title,
-                coin: HeroCoinAmount(
-                    amount: amount.formatToDecimal(digits: meta.decimals),
-                    ticker: meta.ticker,
-                    logo: meta.logo
-                )
+                coin: HeroCoinAmount(amount: amount, coin: meta)
             )
 
         case .accountFunding:

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/Projections/FractionalWithdrawalAmount.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/Projections/FractionalWithdrawalAmount.swift
@@ -1,0 +1,34 @@
+//
+//  FractionalWithdrawalAmount.swift
+//  VultisigApp
+//
+//  Resolves a signed withdrawal fraction against the signer's own public staked
+//  position. Failed reads leave the verb-only presentation unchanged.
+//
+
+import Foundation
+
+enum FractionalWithdrawalAmount {
+
+    /// Resolves a fractional unstake from a base-unit position reader.
+    static func resolve(
+        for decoded: DecodedTransaction,
+        coin: Coin,
+        readStakedRaw: (String) async -> Decimal
+    ) async -> HeroCoinAmount? {
+        // Absolute amounts already exist in signed content.
+        guard case .fraction(let basisPoints, _) = decoded.amount,
+              basisPoints > 0, basisPoints <= 10_000 else { return nil }
+
+        let rawStaked = await readStakedRaw(coin.address)
+        let divisor = Decimal(sign: .plus, exponent: coin.decimals, significand: 1)
+        let staked = rawStaked / divisor
+        guard staked > 0 else { return nil }
+
+        // Match builder arithmetic: position × BPS, truncated to asset precision.
+        let amount = (staked * Decimal(basisPoints)) / Decimal(10_000)
+        guard amount > 0 else { return nil }
+
+        return HeroCoinAmount(amount: amount, coin: coin)
+    }
+}

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/Projections/ProjectionCoordinator.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/Projections/ProjectionCoordinator.swift
@@ -20,7 +20,9 @@ enum ProjectionCoordinator {
             return "scopeYourWholeStake".localized
         case .unstated where decoded.operation == .claimRewards:
             return "scopeRewardsAccruedSoFar".localized
-        case .unstated, .units:
+        case .accountFunding where decoded.operation == .delegate:
+            return "scopeDelegatedAmountAfterRent".localized
+        case .accountFunding, .unstated, .units:
             return nil
         }
     }

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/Projections/ProjectionCoordinator.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/Projections/ProjectionCoordinator.swift
@@ -2,16 +2,22 @@
 //  ProjectionCoordinator.swift
 //  VultisigApp
 //
+//  Turning a decoded reading into a hero that says what is certain immediately,
+//  and what is estimated when it arrives.
+//
 
 import Foundation
 
 enum ProjectionCoordinator {
+
+    /// Short enough that optional chain state cannot stall signing UI.
     static let timeout: Duration = .seconds(5)
 
-    /// Returns wording that remains true even when optional chain state is unavailable.
+    /// Returns a committed scope only for quantities settled at execution.
     static func scope(for decoded: DecodedTransaction) -> String? {
         switch decoded.amount {
         case .fraction(let basisPoints, _):
+            // The signed share remains exact even when the projected amount is not.
             return String(
                 format: "withdrawingShareOfStakedPosition".localized,
                 DecodedTransactionPresentation.percentage(fromBasisPoints: basisPoints)
@@ -27,6 +33,7 @@ enum ProjectionCoordinator {
         }
     }
 
+    /// Builds the immediate verb-and-scope hero; an estimate is optional.
     static func hero(
         for decoded: DecodedTransaction,
         title: String,
@@ -36,7 +43,7 @@ enum ProjectionCoordinator {
         return .projected(title: title, estimate: estimate, scope: scope)
     }
 
-    /// Every read failure, including a timeout, degrades to the signed scope.
+    /// Reads an optional estimate; every failure degrades to the existing scope.
     static func estimate(
         for decoded: DecodedTransaction,
         using resolvers: [ProjectionResolving]
@@ -54,12 +61,16 @@ enum ProjectionCoordinator {
     static func estimate(
         using read: @escaping () async -> HeroCoinAmount?
     ) async -> HeroCoinAmount? {
+        // A task group would await a cancellation-ignoring loser on scope exit.
+        // The continuation returns on the first result without joining the loser.
         return await withCheckedContinuation { continuation in
             let gate = ResumeOnce(continuation)
+
             Task {
                 let value = await read()
                 await gate.resume(with: value)
             }
+
             Task {
                 try? await Task.sleep(for: timeout)
                 await gate.resume(with: nil)
@@ -67,6 +78,7 @@ enum ProjectionCoordinator {
         }
     }
 
+    /// Serializes the read/timeout race and resumes the continuation once.
     private actor ResumeOnce {
         private var continuation: CheckedContinuation<HeroCoinAmount?, Never>?
 

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/Projections/ResolvedTransactionHero.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/Projections/ResolvedTransactionHero.swift
@@ -13,7 +13,10 @@ protocol PositionReading {
 
 enum ResolvedTransactionHero {
     /// Chain PRs add readers here as their signed decoders become available.
-    static let readers: [PositionReading] = []
+    static let readers: [PositionReading] = [
+        SolanaDelegatedAmountReader(),
+        SolanaStakeAccountAmountReader()
+    ]
 
     static func resolve(
         for content: SignedTransactionContent,

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/Projections/ResolvedTransactionHero.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/Projections/ResolvedTransactionHero.swift
@@ -15,7 +15,8 @@ enum ResolvedTransactionHero {
     /// Chain PRs add readers here as their signed decoders become available.
     static let readers: [PositionReading] = [
         SolanaDelegatedAmountReader(),
-        SolanaStakeAccountAmountReader()
+        SolanaStakeAccountAmountReader(),
+        TonStakedPositionReader()
     ]
 
     static func resolve(

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/Projections/ResolvedTransactionHero.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/Projections/ResolvedTransactionHero.swift
@@ -2,12 +2,18 @@
 //  ResolvedTransactionHero.swift
 //  VultisigApp
 //
+//  Resolves optional chain-state amounts behind decoder-layer readers, keeping
+//  chain knowledge out of keysign view models.
+//
 
 import Foundation
 
 /// Resolves an execution-set amount from chain state.
 protocol PositionReading {
+    /// Whether this reader answers for the decoded transaction on this coin.
     func handles(_ decoded: DecodedTransaction, coin: Coin) -> Bool
+
+    /// The resolved amount, or `nil` when the read failed or returned nothing.
     func amount(for decoded: DecodedTransaction, coin: Coin) async -> HeroCoinAmount?
 }
 
@@ -16,9 +22,11 @@ enum ResolvedTransactionHero {
     static let readers: [PositionReading] = [
         SolanaDelegatedAmountReader(),
         SolanaStakeAccountAmountReader(),
-        TonStakedPositionReader()
+        TonStakedPositionReader(),
+        TcyStakedPositionReader()
     ]
 
+    /// Resolves through the first reader matching a trusted local coin.
     static func resolve(
         for content: SignedTransactionContent,
         trustedCoins: [Coin],
@@ -37,5 +45,28 @@ enum ResolvedTransactionHero {
             return ProjectionCoordinator.hero(for: decoded, title: title, estimate: amount)
         }
         return nil
+    }
+}
+
+/// Reads a THORChain TCY staker's position, for a fractional `tcy-:<bps>` unstake.
+struct TcyStakedPositionReader: PositionReading {
+
+    /// Injected so a test needs no network; production reads the staker endpoint.
+    var readRaw: (String) async -> Decimal = {
+        await ThorchainService.shared.fetchTcyStakedAmount(address: $0)
+    }
+
+    func handles(_ decoded: DecodedTransaction, coin: Coin) -> Bool {
+        guard coin.chain == .thorChain,
+              coin.ticker.uppercased() == "TCY",
+              decoded.operation == .unstake,
+              decoded.evidence == .memo,
+              case .fraction(_, .transactionCoin) = decoded.amount
+        else { return false }
+        return true
+    }
+
+    func amount(for decoded: DecodedTransaction, coin: Coin) async -> HeroCoinAmount? {
+        await FractionalWithdrawalAmount.resolve(for: decoded, coin: coin, readStakedRaw: readRaw)
     }
 }

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/Projections/TransactionProjection.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/Projections/TransactionProjection.swift
@@ -2,15 +2,28 @@
 //  TransactionProjection.swift
 //  VultisigApp
 //
-//  Optional chain-state enrichment for quantities that are settled at execution.
+//  An execution-set quantity pairs an optional estimate with the signed scope
+//  that remains true when no estimate arrives.
 //
 
 import Foundation
 
-/// A chain query key derived only from a counterparty in signed content.
+struct TransactionProjection: Hashable {
+
+    /// What the operation is expected to settle at, when available.
+    let estimate: HeroCoinAmount?
+
+    /// What the transaction commits to, in words. Always present.
+    let scope: String
+}
+
+/// A chain query key derived only from a counterparty in signed content. There is
+/// deliberately no initializer accepting a peer-supplied bare address.
 struct ProjectionQueryKey: Hashable {
+
     let counterparty: DecodedCounterparty
 
+    /// Missing signed counterparties degrade to scope-only presentation.
     init?(_ decoded: DecodedTransaction) {
         guard let counterparty = decoded.counterparty else { return nil }
         self.counterparty = counterparty
@@ -19,6 +32,9 @@ struct ProjectionQueryKey: Hashable {
 
 /// Reads chain state using only a signed-content-derived query key.
 protocol ProjectionResolving {
+    /// Whether this resolver answers for the operation at all.
     func handles(_ operation: DecodedOperation) -> Bool
+
+    /// The projected quantity, or `nil` to retain scope-only presentation.
     func projection(for decoded: DecodedTransaction, key: ProjectionQueryKey) async -> HeroCoinAmount?
 }

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionContent.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionContent.swift
@@ -113,7 +113,6 @@ protocol SignedTransactionContent {
     /// The Cosmos staking structure that the initiator's signing path will turn
     /// into a SignDoc. A co-signer answers `nil` and reads that SignDoc instead.
     var cosmosStakingIntent: CosmosStakingPayload? { get }
-
     /// Whether an earlier signing route makes the memo inert.
     var memoIsOutranked: Bool { get }
 }
@@ -213,7 +212,6 @@ extension KeysignPayload: SignedTransactionContent {
     var stakingIntent: SolanaStakingPayload? { nil }
 
     var cosmosStakingIntent: CosmosStakingPayload? { nil }
-
     /// Mirrors TRON signing precedence: typed contracts outrank staking memos.
     var memoIsOutranked: Bool {
         rawWasmPayload != nil
@@ -264,7 +262,6 @@ struct InitiatingTransactionContent: SignedTransactionContent {
     var stakingIntent: SolanaStakingPayload? { transaction.solanaStakingPayload }
 
     var cosmosStakingIntent: CosmosStakingPayload? { transaction.cosmosStakingPayload }
-
     /// Staking intents become opaque signed content when the payload is built.
     var hasOpaqueSignedContent: Bool {
         transaction.cosmosStakingPayload != nil || transaction.solanaStakingPayload != nil

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionDecoder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionDecoder.swift
@@ -24,8 +24,10 @@ enum SignedTransactionDecoder {
     /// Registered readers in precedence order.
     static let decoders: [TransactionContentDecoder] = [
         SolanaTransactionDecoder(),
+        CosmosSignDocDecoder(),
         TronTransactionDecoder(),
-        TonTransactionDecoder()
+        TonTransactionDecoder(),
+        CosmosTransactionDecoder()
     ]
 
     /// Returns `.unknown` when no reader can prove an operation.

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionDecoder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionDecoder.swift
@@ -2,8 +2,8 @@
 //  SignedTransactionDecoder.swift
 //  VultisigApp
 //
-//  Reads operations from content that will actually be signed. The foundation
-//  registers no chain readers, so every transaction remains unreadable.
+//  Reads operations from content that will actually be signed. Unclaimed
+//  transactions remain `.unknown` and preserve existing presentation.
 //
 
 import Foundation
@@ -21,8 +21,10 @@ protocol TransactionContentDecoder {
 
 enum SignedTransactionDecoder {
 
-    /// Registered readers in precedence order. Empty in the foundation.
-    static let decoders: [TransactionContentDecoder] = []
+    /// Registered readers in precedence order.
+    static let decoders: [TransactionContentDecoder] = [
+        TronTransactionDecoder()
+    ]
 
     /// Returns `.unknown` when no reader can prove an operation.
     static func decode(_ tx: SignedTransactionContent) -> DecodedTransaction {

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionDecoder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionDecoder.swift
@@ -23,6 +23,7 @@ enum SignedTransactionDecoder {
 
     /// Registered readers in precedence order.
     static let decoders: [TransactionContentDecoder] = [
+        SolanaTransactionDecoder(),
         TronTransactionDecoder()
     ]
 

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionDecoder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionDecoder.swift
@@ -27,7 +27,8 @@ enum SignedTransactionDecoder {
         CosmosSignDocDecoder(),
         TronTransactionDecoder(),
         TonTransactionDecoder(),
-        CosmosTransactionDecoder()
+        CosmosTransactionDecoder(),
+        MayaChainTransactionDecoder()
     ]
 
     /// Returns `.unknown` when no reader can prove an operation.

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionDecoder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionDecoder.swift
@@ -21,11 +21,13 @@ protocol TransactionContentDecoder {
 
 enum SignedTransactionDecoder {
 
-    /// Registered readers in precedence order.
+    /// Registered readers in precedence order. Signed-artifact readers precede
+    /// chain grammars so sidecars cannot outrank the signed object.
     static let decoders: [TransactionContentDecoder] = [
         SolanaTransactionDecoder(),
         CosmosSignDocDecoder(),
         TronTransactionDecoder(),
+        THORChainTransactionDecoder(),
         TonTransactionDecoder(),
         CosmosTransactionDecoder(),
         MayaChainTransactionDecoder()

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionDecoder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/SignedTransactionDecoder.swift
@@ -24,7 +24,8 @@ enum SignedTransactionDecoder {
     /// Registered readers in precedence order.
     static let decoders: [TransactionContentDecoder] = [
         SolanaTransactionDecoder(),
-        TronTransactionDecoder()
+        TronTransactionDecoder(),
+        TonTransactionDecoder()
     ]
 
     /// Returns `.unknown` when no reader can prove an operation.

--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/SolanaTransactionReader.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/SolanaTransactionReader.swift
@@ -1,0 +1,407 @@
+//
+//  SolanaTransactionReader.swift
+//  VultisigApp
+//
+//  Reads self-contained Solana staking transactions from the bytes co-signers
+//  receive. Address-table lookups and partial/malformed messages are refused;
+//  every untrusted length and index is bounded.
+//
+
+import BigInt
+import Foundation
+import WalletCore
+
+enum SolanaTransactionReader {
+
+    struct Reading: Hashable {
+        let operation: DecodedOperation
+        let amount: DecodedAmount
+        let counterparty: DecodedCounterparty?
+    }
+
+    /// The System Program funds new stake accounts.
+    private static let systemProgramID: Data? = Base58.decodeNoCheck(
+        string: "11111111111111111111111111111111"
+    )
+
+    /// Compute-budget instructions may accompany staking without moving value.
+    private static let computeBudgetProgramID: Data? = Base58.decodeNoCheck(
+        string: "ComputeBudget111111111111111111111111111111"
+    )
+
+    private static let stakeProgramID: Data? = Base58.decodeNoCheck(
+        string: "Stake11111111111111111111111111111111111111"
+    )
+
+    /// Little-endian stake-program discriminators.
+    private enum StakeInstruction: UInt32 {
+        case initialize = 0
+        case authorize = 1
+        case delegate = 2
+        case split = 3
+        case withdraw = 4
+        case deactivate = 5
+    }
+
+    // MARK: - Refusal limits
+
+    private static let maximumTransactionBytes = 8 * 1024
+    private static let maximumAccounts = 128
+    private static let maximumInstructions = 32
+
+    // MARK: - Reading
+
+    /// Reads one complete relayed transaction or refuses it.
+    static func read(base64 encoded: String) -> Reading? {
+        guard encoded.utf8.count <= maximumTransactionBytes * 2,
+              let bytes = Data(base64Encoded: encoded),
+              !bytes.isEmpty,
+              bytes.count <= maximumTransactionBytes,
+              let stakeProgramID,
+              let computeBudgetProgramID,
+              let systemProgramID
+        else { return nil }
+
+        var reader = ByteReader(bytes)
+
+        // Signatures precede the message.
+        guard let signatureCount = reader.readCompactU16(), signatureCount <= maximumAccounts,
+              reader.skip(Int(signatureCount) * 64)
+        else { return nil }
+
+        // Only legacy and self-contained v0 messages are readable.
+        guard let first = reader.peek() else { return nil }
+        let isVersioned: Bool
+        if first & 0x80 != 0 {
+            guard first & 0x7F == 0, reader.skip(1) else { return nil }
+            isVersioned = true
+        } else {
+            isVersioned = false
+        }
+
+        // Header: required signatures and readonly counts.
+        guard reader.skip(3) else { return nil }
+
+        guard let accountCount = reader.readCompactU16(), accountCount <= maximumAccounts else {
+            return nil
+        }
+        var accounts: [Data] = []
+        accounts.reserveCapacity(Int(accountCount))
+        for _ in 0..<accountCount {
+            guard let key = reader.read(32) else { return nil }
+            accounts.append(key)
+        }
+
+        // Recent blockhash.
+        guard reader.skip(32) else { return nil }
+
+        guard let instructionCount = reader.readCompactU16(),
+              instructionCount <= maximumInstructions
+        else { return nil }
+
+        // Preserve instruction order; ignore value-neutral compute-budget entries.
+        var instructions: [(program: Data, accountIndexes: Data, data: Data)] = []
+
+        for _ in 0..<instructionCount {
+            guard let programIndex = reader.readByte(),
+                  let accountIndexCount = reader.readCompactU16(),
+                  accountIndexCount <= maximumAccounts,
+                  let accountIndexes = reader.read(Int(accountIndexCount)),
+                  let dataLength = reader.readCompactU16(),
+                  let data = reader.read(Int(dataLength))
+            else { return nil }
+
+            guard Int(programIndex) < accounts.count else { return nil }
+            let program = accounts[Int(programIndex)]
+
+            if program == computeBudgetProgramID { continue }
+            instructions.append((program, accountIndexes, data))
+        }
+
+        if isVersioned {
+            // Non-empty address lookups require unavailable network state.
+            guard reader.readCompactU16() == 0 else { return nil }
+        }
+
+        // Every signed byte must be accounted for.
+        guard reader.remaining == 0 else { return nil }
+
+        return read(sequence: instructions, accounts: accounts)
+    }
+
+    /// Matches complete instruction sequences so unrelated transfers cannot hide
+    /// beside a recognized staking instruction.
+    private static func read(
+        sequence: [(program: Data, accountIndexes: Data, data: Data)],
+        accounts: [Data]
+    ) -> Reading? {
+        func stakeInstruction(_ i: Int) -> StakeInstruction? {
+            guard sequence.indices.contains(i), sequence[i].program == stakeProgramID else { return nil }
+            return discriminator(of: sequence[i].data).flatMap(StakeInstruction.init(rawValue:))
+        }
+
+        switch sequence.count {
+        case 1:
+            // Deactivate and withdraw stand alone.
+            guard let only = stakeInstruction(0), only != .delegate else { return nil }
+            return read(instruction: sequence[0].data, accountIndexes: sequence[0].accountIndexes, accounts: accounts)
+
+        case 3:
+            // WalletCore delegation: create + initialize + delegate.
+            guard let funding = createStakeAccountFunding(sequence[0], accounts: accounts),
+                  isInitialize(sequence[1]),
+                  isDelegate(sequence[2]),
+                  let createdStake = accountIndex(at: 1, in: sequence[0].accountIndexes, accounts: accounts),
+                  let initializedStake = accountIndex(at: 0, in: sequence[1].accountIndexes, accounts: accounts),
+                  let delegatedStake = accountIndex(at: 0, in: sequence[2].accountIndexes, accounts: accounts),
+                  createdStake == initializedStake,
+                  initializedStake == delegatedStake,
+                  let payer = accountIndex(at: 0, in: sequence[0].accountIndexes, accounts: accounts),
+                  let authority = accountIndex(at: 5, in: sequence[2].accountIndexes, accounts: accounts),
+                  payer == authority,
+                  authorizedStaker(in: sequence[1].data) == accounts[authority]
+            else { return nil }
+            guard let vote = account(at: 1, in: sequence[2].accountIndexes, accounts: accounts) else {
+                return nil
+            }
+            return Reading(
+                operation: .delegate,
+                amount: .accountFunding(BigInt(funding), of: .chainNative),
+                counterparty: .validator(vote)
+            )
+
+        default:
+            return nil
+        }
+    }
+
+    /// Reads a four-byte little-endian discriminator.
+    private static func discriminator(of data: Data) -> UInt32? {
+        guard data.count >= 4 else { return nil }
+        var value: UInt32 = 0
+        for offset in 0..<4 {
+            value |= UInt32(data[data.index(data.startIndex, offsetBy: offset)]) << (8 * UInt32(offset))
+        }
+        return value
+    }
+
+    private static func createStakeAccountFunding(
+        _ instruction: (program: Data, accountIndexes: Data, data: Data),
+        accounts: [Data]
+    ) -> UInt64? {
+        guard instruction.program == systemProgramID,
+              let kind = discriminator(of: instruction.data),
+              let stakeProgramID,
+              let payer = accountIndex(at: 0, in: instruction.accountIndexes, accounts: accounts),
+              let createdStake = accountIndex(at: 1, in: instruction.accountIndexes, accounts: accounts),
+              payer != createdStake
+        else { return nil }
+
+        switch kind {
+        case 0: // SystemInstruction::CreateAccount
+            guard instruction.accountIndexes.count == 2,
+                  instruction.data.count == 52,
+                  let lamports = littleEndianUInt64(in: instruction.data, at: 4), lamports > 0,
+                  littleEndianUInt64(in: instruction.data, at: 12) == 200
+            else { return nil }
+            return bytes(in: instruction.data, at: 20, count: 32) == stakeProgramID ? lamports : nil
+
+        case 3: // SystemInstruction::CreateAccountWithSeed, emitted by WalletCore
+            guard instruction.accountIndexes.count == 3,
+                  let seedLength = littleEndianUInt64(in: instruction.data, at: 36),
+                  seedLength <= 32,
+                  seedLength <= UInt64(Int.max)
+            else { return nil }
+
+            let seedCount = Int(seedLength)
+            let lamportsOffset = 44 + seedCount
+            let spaceOffset = lamportsOffset + 8
+            let ownerOffset = spaceOffset + 8
+            guard instruction.data.count == ownerOffset + 32,
+                  let lamports = littleEndianUInt64(in: instruction.data, at: lamportsOffset), lamports > 0,
+                  littleEndianUInt64(in: instruction.data, at: spaceOffset) == 200,
+                  bytes(in: instruction.data, at: ownerOffset, count: 32) == stakeProgramID,
+                  let base = accountIndex(at: 2, in: instruction.accountIndexes, accounts: accounts),
+                  base == payer,
+                  bytes(in: instruction.data, at: 4, count: 32) == accounts[base]
+            else { return nil }
+            return lamports
+
+        default:
+            return nil
+        }
+    }
+
+    private static func isInitialize(
+        _ instruction: (program: Data, accountIndexes: Data, data: Data)
+    ) -> Bool {
+        instruction.program == stakeProgramID
+            && instruction.accountIndexes.count == 2
+            && instruction.data.count == 116
+            && discriminator(of: instruction.data) == StakeInstruction.initialize.rawValue
+    }
+
+    private static func isDelegate(
+        _ instruction: (program: Data, accountIndexes: Data, data: Data)
+    ) -> Bool {
+        instruction.program == stakeProgramID
+            && instruction.accountIndexes.count == 6
+            && instruction.data.count == 4
+            && discriminator(of: instruction.data) == StakeInstruction.delegate.rawValue
+    }
+
+    private static func authorizedStaker(in initializeData: Data) -> Data? {
+        guard initializeData.count == 116 else { return nil }
+        let start = initializeData.index(initializeData.startIndex, offsetBy: 4)
+        let end = initializeData.index(start, offsetBy: 32)
+        return initializeData[start..<end]
+    }
+
+    /// One stake-program instruction.
+    private static func read(
+        instruction data: Data,
+        accountIndexes: Data,
+        accounts: [Data]
+    ) -> Reading? {
+        guard data.count >= 4 else { return nil }
+
+        let start = data.startIndex
+        var discriminator: UInt32 = 0
+        for offset in 0..<4 {
+            discriminator |= UInt32(data[data.index(start, offsetBy: offset)]) << (8 * UInt32(offset))
+        }
+
+        guard let instruction = StakeInstruction(rawValue: discriminator) else { return nil }
+
+        switch instruction {
+        case .delegate:
+            // Funding includes rent reserve, so delegation states no amount.
+            guard data.count == 4,
+                  accountIndexes.count == 6,
+                  let vote = account(at: 1, in: accountIndexes, accounts: accounts)
+            else { return nil }
+            return Reading(operation: .delegate, amount: .unstated, counterparty: .validator(vote))
+
+        case .deactivate:
+            // Deactivation cools the whole account and names no quantity.
+            guard data.count == 4,
+                  accountIndexes.count == 3,
+                  let stake = account(at: 0, in: accountIndexes, accounts: accounts)
+            else { return nil }
+            return Reading(operation: .unstake, amount: .unstated, counterparty: .stakeAccount(stake))
+
+        case .withdraw:
+            // Withdraw data carries the lamports leaving the stake account.
+            guard data.count == 12,
+                  accountIndexes.count == 5,
+                  let stake = account(at: 0, in: accountIndexes, accounts: accounts),
+                  let lamports = littleEndianUInt64(in: data, at: 4)
+            else { return nil }
+            return Reading(
+                operation: .withdrawStake,
+                // Stake accounts hold chain-native SOL.
+                amount: .units(BigInt(lamports), of: .chainNative),
+                counterparty: .stakeAccount(stake)
+            )
+
+        // These instructions are not independently emitted by this app.
+        case .initialize, .authorize, .split:
+            return nil
+        }
+    }
+
+    /// The base58 account an instruction references at `position`.
+    private static func account(
+        at position: Int,
+        in indexes: Data,
+        accounts: [Data]
+    ) -> String? {
+        guard position < indexes.count else { return nil }
+        let index = Int(indexes[indexes.index(indexes.startIndex, offsetBy: position)])
+        guard index < accounts.count else { return nil }
+        return Base58.encodeNoCheck(data: accounts[index])
+    }
+
+    private static func accountIndex(
+        at position: Int,
+        in indexes: Data,
+        accounts: [Data]
+    ) -> Int? {
+        guard position < indexes.count else { return nil }
+        let index = Int(indexes[indexes.index(indexes.startIndex, offsetBy: position)])
+        return index < accounts.count ? index : nil
+    }
+
+    private static func littleEndianUInt64(in data: Data, at offset: Int) -> UInt64? {
+        guard data.count >= offset + 8 else { return nil }
+        let start = data.index(data.startIndex, offsetBy: offset)
+
+        var value: UInt64 = 0
+        for byte in 0..<8 {
+            value |= UInt64(data[data.index(start, offsetBy: byte)]) << (8 * UInt64(byte))
+        }
+        return value
+    }
+
+    private static func bytes(in data: Data, at offset: Int, count: Int) -> Data? {
+        guard offset >= 0, count >= 0, data.count >= offset + count else { return nil }
+        let start = data.index(data.startIndex, offsetBy: offset)
+        let end = data.index(start, offsetBy: count)
+        return data[start..<end]
+    }
+
+    // MARK: - A bounds-checked walk
+
+    /// Bounds-checked reader that also supports non-zero-index `Data` slices.
+    private struct ByteReader {
+        private let bytes: Data
+        private var index: Data.Index
+
+        init(_ bytes: Data) {
+            self.bytes = bytes
+            self.index = bytes.startIndex
+        }
+
+        var remaining: Int { bytes.distance(from: index, to: bytes.endIndex) }
+
+        func peek() -> UInt8? {
+            guard index < bytes.endIndex else { return nil }
+            return bytes[index]
+        }
+
+        mutating func readByte() -> UInt8? {
+            guard index < bytes.endIndex else { return nil }
+            let byte = bytes[index]
+            index = bytes.index(after: index)
+            return byte
+        }
+
+        mutating func read(_ count: Int) -> Data? {
+            guard count >= 0, remaining >= count else { return nil }
+            let end = bytes.index(index, offsetBy: count)
+            defer { index = end }
+            return bytes[index..<end]
+        }
+
+        mutating func skip(_ count: Int) -> Bool {
+            guard count >= 0, remaining >= count else { return false }
+            index = bytes.index(index, offsetBy: count)
+            return true
+        }
+
+        /// Solana shortvec, bounded by its three-byte UInt16 encoding.
+        mutating func readCompactU16() -> UInt16? {
+            var value: UInt32 = 0
+
+            for round in 0..<3 {
+                guard let byte = readByte() else { return nil }
+                value |= UInt32(byte & 0x7F) << (7 * UInt32(round))
+                if byte & 0x80 == 0 {
+                    return value <= UInt32(UInt16.max) ? UInt16(value) : nil
+                }
+            }
+
+            return nil
+        }
+    }
+}

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/CosmosSignDocDecoderTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/CosmosSignDocDecoderTests.swift
@@ -1,0 +1,327 @@
+//
+//  CosmosSignDocDecoderTests.swift
+//  VultisigAppTests
+//
+
+import BigInt
+@testable import VultisigApp
+import VultisigCommonData
+import XCTest
+
+final class CosmosSignDocDecoderTests: XCTestCase {
+
+    func testInitiatorAndCosignerHeroesMatchForEveryStakingOperation() {
+        let denom = Chain.terra.feeUnit
+        let amount = "1250000"
+        let validatorA = "terravaloper1source"
+        let validatorB = "terravaloper1destination"
+        let delegator = "terra1delegator"
+        let cases: [(String, CosmosStakingPayload, [Data], DecodedOperation)] = [
+            (
+                "delegate",
+                .delegate(validator: validatorA, denom: denom, amount: amount),
+                [CosmosStakingHelper.encodeDelegate(
+                    delegator: delegator, validator: validatorA, amount: amount, denom: denom
+                )],
+                .delegate
+            ),
+            (
+                "undelegate",
+                .undelegate(validator: validatorA, denom: denom, amount: amount),
+                [CosmosStakingHelper.encodeUndelegate(
+                    delegator: delegator, validator: validatorA, amount: amount, denom: denom
+                )],
+                .undelegate
+            ),
+            (
+                "redelegate",
+                .redelegate(src: validatorA, dst: validatorB, denom: denom, amount: amount),
+                [CosmosStakingHelper.encodeBeginRedelegate(
+                    delegator: delegator,
+                    validatorSrc: validatorA,
+                    validatorDst: validatorB,
+                    amount: amount,
+                    denom: denom
+                )],
+                .redelegate
+            ),
+            (
+                "claim rewards",
+                .withdrawRewards(validators: [validatorA, validatorB], denom: denom),
+                [validatorA, validatorB].map {
+                    CosmosStakingHelper.encodeWithdrawDelegatorReward(delegator: delegator, validator: $0)
+                },
+                .claimRewards
+            )
+        ]
+
+        for (name, intent, messages, operation) in cases {
+            let transaction = Self.transaction(intent: intent)
+            let payload = Self.payload(
+                chain: .terra,
+                transactionType: .unspecified,
+                body: CosmosStakingHelper.buildTxBodyMulti(msgsAny: messages)
+            )
+            let initiator = SignedTransactionDecoder.decode(InitiatingTransactionContent(transaction))
+            let cosigner = SignedTransactionDecoder.decode(payload)
+
+            XCTAssertEqual(initiator.operation, operation, name)
+            XCTAssertEqual(initiator.operation, cosigner.operation, name)
+            XCTAssertEqual(initiator.amount, cosigner.amount, name)
+            XCTAssertEqual(initiator.counterparty, cosigner.counterparty, name)
+            XCTAssertEqual(
+                TransactionHeroResolver.hero(on: .functionCallVerify, for: .initiating(transaction)),
+                TransactionHeroResolver.hero(
+                    on: .keysignConfirm,
+                    for: .cosigning(payload: payload, simulated: { nil })
+                ),
+                name
+            )
+        }
+    }
+
+    func testRewardsHeroStatesItsScopeWithoutInventingAnAmount() {
+        let intent = CosmosStakingPayload.withdrawRewards(
+            validators: ["terravaloper1validator"],
+            denom: Chain.terra.feeUnit
+        )
+        let hero = TransactionHeroResolver.hero(
+            on: .functionCallVerify,
+            for: .initiating(Self.transaction(intent: intent))
+        )
+        guard case .projected(_, let estimate, let scope) = hero else {
+            return XCTFail("a rewards claim should state its signed scope without inventing an amount")
+        }
+        XCTAssertNil(estimate)
+        XCTAssertEqual(scope, "scopeRewardsAccruedSoFar".localized)
+    }
+
+    @MainActor
+    func testExactStakingHeroIncludesFiat() throws {
+        try RateProvider.shared.save(rates: [
+            Rate(fiat: SettingsCurrency.current.rawValue, crypto: "terra-luna-2", value: 1)
+        ])
+        let intent = CosmosStakingPayload.delegate(
+            validator: "terravaloper1validator",
+            denom: Chain.terra.feeUnit,
+            amount: "1250000"
+        )
+        let hero = try XCTUnwrap(
+            TransactionHeroResolver.hero(
+                on: .functionCallVerify,
+                for: .initiating(Self.transaction(intent: intent))
+            )
+        )
+
+        guard case .send(_, let amount) = hero else {
+            return XCTFail("expected an exact delegation amount")
+        }
+        XCTAssertEqual(amount.amount, "1.25")
+        XCTAssertFalse(amount.fiat?.isEmpty ?? true)
+    }
+
+    func testSignDocBodyIsReadOnlyOnRoutesThatConsumeIt() {
+        let accepted: [(Chain, VSTransactionType)] = [
+            (.gaiaChain, .unspecified),
+            (.gaiaChain, .genericContract),
+            (.terra, .ibcTransfer),
+            (.terraClassic, .vote),
+            (.dydx, .unspecified),
+            (.qbtc, .ibcTransfer)
+        ]
+        for (chain, type) in accepted {
+            XCTAssertEqual(
+                SignedTransactionDecoder.decode(Self.payload(chain: chain, transactionType: type)).operation,
+                .delegate,
+                "\(chain) \(type)"
+            )
+        }
+    }
+
+    func testSignDocBodyIsIgnoredWhenTheHelperBuildsAnotherBody() {
+        let rejected: [(Chain, VSTransactionType)] = [
+            (.gaiaChain, .ibcTransfer),
+            (.osmosis, .vote),
+            (.dydx, .vote)
+        ]
+        for (chain, type) in rejected {
+            XCTAssertEqual(
+                SignedTransactionDecoder.decode(Self.payload(chain: chain, transactionType: type)).operation,
+                .unknown,
+                "\(chain) \(type)"
+            )
+        }
+    }
+
+    func testApproveAndSwapRoutesOutrankSignDoc() {
+        let approve = Self.payload(
+            chain: .gaiaChain,
+            transactionType: .unspecified,
+            approve: ERC20ApprovePayload(amount: 1, spender: "router")
+        )
+        let swap = Self.payload(
+            chain: .gaiaChain,
+            transactionType: .unspecified,
+            swap: .thorchain(Self.swapPayload())
+        )
+
+        XCTAssertEqual(SignedTransactionDecoder.decode(approve).operation, .unknown)
+        XCTAssertEqual(SignedTransactionDecoder.decode(swap).operation, .unknown)
+    }
+
+    func testCosmosMemoAndWireDecoderOperations() {
+        let decoder = CosmosTransactionDecoder()
+        let switching = decoder.decode(Self.payload(
+            chain: .gaiaChain,
+            transactionType: .unspecified,
+            body: nil,
+            memo: "SWITCH:thor1destination"
+        ))
+        let ibc = decoder.decode(Self.payload(
+            chain: .gaiaChain,
+            transactionType: .ibcTransfer,
+            body: nil
+        ))
+        let vote = decoder.decode(Self.payload(
+            chain: .dydx,
+            transactionType: .vote,
+            body: nil,
+            memo: "DYDX_VOTE:YES:42"
+        ))
+
+        XCTAssertEqual(switching?.operation, .switchChain)
+        XCTAssertEqual(switching?.amount, .units(BigInt(1), of: .transactionCoin))
+        XCTAssertEqual(ibc?.operation, .ibcTransfer)
+        XCTAssertEqual(vote?.operation, .vote)
+        XCTAssertEqual(vote?.amount, .unstated)
+    }
+
+    func testApproveOutranksCosmosMemoDecoder() {
+        let payload = Self.payload(
+            chain: .gaiaChain,
+            transactionType: .unspecified,
+            body: nil,
+            memo: "SWITCH:thor1destination",
+            approve: ERC20ApprovePayload(amount: 1, spender: "router")
+        )
+        XCTAssertNil(CosmosTransactionDecoder().decode(payload))
+    }
+
+    private static func payload(
+        chain: Chain,
+        transactionType: VSTransactionType,
+        body: Data? = delegateBody,
+        memo: String? = nil,
+        approve: ERC20ApprovePayload? = nil,
+        swap: SwapPayload? = nil
+    ) -> KeysignPayload {
+        let coin = Self.coin(chain: chain)
+        return KeysignPayload(
+            coin: coin,
+            toAddress: "cosmos1destination",
+            toAmount: BigInt(1),
+            chainSpecific: .Cosmos(
+                accountNumber: 1,
+                sequence: 1,
+                gas: 1,
+                transactionType: transactionType.rawValue,
+                ibcDenomTrace: nil,
+                gasLimit: nil
+            ),
+            utxos: [],
+            memo: memo,
+            swapPayload: swap,
+            approvePayload: approve,
+            vaultPubKeyECDSA: "pub",
+            vaultLocalPartyID: "party",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: body.map {
+                .signDirect(SignDirect(
+                    bodyBytes: $0.base64EncodedString(),
+                    authInfoBytes: "",
+                    chainID: "test-1",
+                    accountNumber: "1"
+                ))
+            }
+        )
+    }
+
+    private static var delegateBody: Data {
+        CosmosStakingHelper.buildTxBodyMulti(msgsAny: [
+            CosmosStakingHelper.encodeDelegate(
+                delegator: "cosmos1delegator",
+                validator: "cosmosvaloper1validator",
+                amount: "1000000",
+                denom: "uatom"
+            )
+        ])
+    }
+
+    private static func transaction(intent: CosmosStakingPayload) -> SendTransaction {
+        let coin = Self.coin(chain: .terra)
+        return SendTransaction(
+            coin: coin,
+            vault: .example,
+            fromAddress: coin.address,
+            toAddress: intent.validatorAddress ?? intent.validatorDstAddress ?? "",
+            toAddressLabel: nil,
+            amount: intent.amount == nil ? "0" : "1.25",
+            amountInFiat: "",
+            memo: "",
+            gas: .zero,
+            fee: .zero,
+            feeMode: .default,
+            estimatedGasLimit: nil,
+            customGasLimit: nil,
+            customByteFee: nil,
+            sendMaxAmount: false,
+            isStakingOperation: true,
+            transactionType: .unspecified,
+            memoFunctionDictionary: [:],
+            wasmContractPayload: nil,
+            feeCoin: coin,
+            cosmosStakingPayload: intent
+        )
+    }
+
+    private static func coin(chain: Chain) -> Coin {
+        Coin(
+            asset: CoinMeta(
+                chain: chain,
+                ticker: chain.ticker,
+                logo: chain.logo,
+                decimals: 6,
+                priceProviderId: "",
+                contractAddress: "",
+                isNativeToken: true
+            ),
+            address: "cosmos1delegator",
+            hexPublicKey: "00"
+        )
+    }
+
+    private static func swapPayload() -> THORChainSwapPayload {
+        let coin = coin(chain: .gaiaChain)
+        return THORChainSwapPayload(
+            fromAddress: coin.address,
+            fromCoin: coin,
+            toCoin: coin,
+            vaultAddress: "cosmos1vault",
+            routerAddress: nil,
+            fromAmount: 1,
+            toAmountDecimal: 0,
+            toAmountLimit: "0",
+            streamingInterval: "0",
+            streamingQuantity: "0",
+            expirationTime: 0,
+            isAffiliate: false
+        )
+    }
+}

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/DecoderInertnessTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/DecoderInertnessTests.swift
@@ -15,8 +15,11 @@ final class DecoderInertnessTests: XCTestCase {
     func testTheRegistryContainsExactlyTheExpectedReaders() {
         XCTAssertEqual(
             SignedTransactionDecoder.decoders.map { String(describing: type(of: $0)) },
-             ["TronTransactionDecoder"],
-             "a chain reader was registered or removed without saying so here"
+            [
+                "SolanaTransactionDecoder",
+                "TronTransactionDecoder"
+            ],
+            "a chain reader was registered or removed without saying so here"
         )
     }
 

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/DecoderInertnessTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/DecoderInertnessTests.swift
@@ -20,7 +20,8 @@ final class DecoderInertnessTests: XCTestCase {
                 "CosmosSignDocDecoder",
                 "TronTransactionDecoder",
                 "TonTransactionDecoder",
-                "CosmosTransactionDecoder"
+                "CosmosTransactionDecoder",
+                "MayaChainTransactionDecoder"
             ],
             "a chain reader was registered or removed without saying so here"
         )

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/DecoderInertnessTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/DecoderInertnessTests.swift
@@ -17,8 +17,10 @@ final class DecoderInertnessTests: XCTestCase {
             SignedTransactionDecoder.decoders.map { String(describing: type(of: $0)) },
             [
                 "SolanaTransactionDecoder",
+                "CosmosSignDocDecoder",
                 "TronTransactionDecoder",
-                "TonTransactionDecoder"
+                "TonTransactionDecoder",
+                "CosmosTransactionDecoder"
             ],
             "a chain reader was registered or removed without saying so here"
         )

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/DecoderInertnessTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/DecoderInertnessTests.swift
@@ -17,7 +17,8 @@ final class DecoderInertnessTests: XCTestCase {
             SignedTransactionDecoder.decoders.map { String(describing: type(of: $0)) },
             [
                 "SolanaTransactionDecoder",
-                "TronTransactionDecoder"
+                "TronTransactionDecoder",
+                "TonTransactionDecoder"
             ],
             "a chain reader was registered or removed without saying so here"
         )

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/DecoderInertnessTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/DecoderInertnessTests.swift
@@ -19,6 +19,7 @@ final class DecoderInertnessTests: XCTestCase {
                 "SolanaTransactionDecoder",
                 "CosmosSignDocDecoder",
                 "TronTransactionDecoder",
+                "THORChainTransactionDecoder",
                 "TonTransactionDecoder",
                 "CosmosTransactionDecoder",
                 "MayaChainTransactionDecoder"

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/DecoderInertnessTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/DecoderInertnessTests.swift
@@ -2,7 +2,7 @@
 //  DecoderInertnessTests.swift
 //  VultisigAppTests
 //
-//  Holds the decoder foundation to its behaviorally inert contract.
+//  Pins the exact registry and verifies that unsupported chains stay inert.
 //
 
 @testable import VultisigApp
@@ -11,16 +11,12 @@ import XCTest
 
 final class DecoderInertnessTests: XCTestCase {
 
-    /// No chain reader is registered.
-    func testNoChainDecoderIsRegistered() {
-        XCTAssertTrue(
-            SignedTransactionDecoder.decoders.isEmpty,
-            """
-            A chain reader has been registered. That is the intended next step — \
-            but it makes this change no longer a no-op, so it also needs golden \
-            rows and its locale keys, and this assertion should move rather than \
-            simply be deleted.
-            """
+    /// Pins reader types because some establish provenance without fixed chains.
+    func testTheRegistryContainsExactlyTheExpectedReaders() {
+        XCTAssertEqual(
+            SignedTransactionDecoder.decoders.map { String(describing: type(of: $0)) },
+             ["TronTransactionDecoder"],
+             "a chain reader was registered or removed without saying so here"
         )
     }
 

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/FractionalWithdrawalAmountTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/FractionalWithdrawalAmountTests.swift
@@ -1,0 +1,91 @@
+//
+//  FractionalWithdrawalAmountTests.swift
+//  VultisigAppTests
+//
+
+import BigInt
+import XCTest
+@testable import VultisigApp
+
+final class FractionalWithdrawalAmountTests: XCTestCase {
+
+    private func tcy(address: String = "thor1vault") -> Coin {
+        Coin(
+            asset: CoinMeta(
+                chain: .thorChain, ticker: "TCY", logo: "tcy", decimals: 8,
+                priceProviderId: "tcy", contractAddress: "", isNativeToken: false
+            ),
+            address: address, hexPublicKey: "hex"
+        )
+    }
+
+    private func fraction(_ bps: Int) -> DecodedTransaction {
+        DecodedTransaction(
+            operation: .unstake,
+            amount: .fraction(basisPoints: bps, of: .transactionCoin),
+            evidence: .memo
+        )
+    }
+
+    /// The endpoint returns base units. Scale those exactly once, then apply the
+    /// same position × bps / 10000 arithmetic as the initiator.
+    func testResolvesTheSameFigureTheInitiatorWouldShow() async {
+        let amount = await FractionalWithdrawalAmount.resolve(
+            for: fraction(5006), coin: tcy(),
+            readStakedRaw: { _ in Decimal(200_274_000_000) }
+        )
+        XCTAssertEqual(amount?.ticker, "TCY")
+        // Grouped exactly as the initiator's QuotedWithdrawalPresentation renders
+        // it (same formatToDecimal), so the two devices show the identical string.
+        XCTAssertTrue(
+            amount?.amount.hasPrefix("1,002.571644") ?? false,
+            "expected 1,002.571644…, got \(amount?.amount ?? "nil")"
+        )
+    }
+
+    @MainActor
+    func testResolvedFigureIncludesFiat() async throws {
+        try RateProvider.shared.save(rates: [
+            Rate(fiat: SettingsCurrency.current.rawValue, crypto: "tcy", value: 0.05)
+        ])
+        let amount = await FractionalWithdrawalAmount.resolve(
+            for: fraction(5000), coin: tcy(),
+            readStakedRaw: { _ in Decimal(200_000_000_000) }
+        )
+
+        XCTAssertEqual(amount?.amount, "1,000")
+        XCTAssertFalse(amount?.fiat?.isEmpty ?? true)
+    }
+
+    /// A read that comes back empty leaves the screen showing the verb alone.
+    func testNilWhenNothingIsStaked() async {
+        let amount = await FractionalWithdrawalAmount.resolve(
+            for: fraction(5006), coin: tcy(), readStakedRaw: { _ in 0 }
+        )
+        XCTAssertNil(amount)
+    }
+
+    /// An absolute amount is already in the signed content; no position read applies.
+    func testNilForAnAbsoluteAmount() async {
+        let decoded = DecodedTransaction(
+            operation: .unstake,
+            amount: .units(BigInt(100), of: .transactionCoin),
+            evidence: .memo
+        )
+        let amount = await FractionalWithdrawalAmount.resolve(
+            for: decoded, coin: tcy(), readStakedRaw: { _ in Decimal(100_000_000_000) }
+        )
+        XCTAssertNil(amount, "an absolute amount needs no position read")
+    }
+
+    /// The position read is of the SIGNER'S OWN address — derived on this device,
+    /// not anything the initiator supplied.
+    func testReadsTheSignersOwnAddress() async {
+        var queried: String?
+        _ = await FractionalWithdrawalAmount.resolve(
+            for: fraction(10_000), coin: tcy(address: "thor1me"),
+            readStakedRaw: { addr in queried = addr; return Decimal(50_000_000_000) }
+        )
+        XCTAssertEqual(queried, "thor1me")
+    }
+}

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/MayaChainTransactionDecoderTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/MayaChainTransactionDecoderTests.swift
@@ -1,0 +1,78 @@
+//
+//  MayaChainTransactionDecoderTests.swift
+//  VultisigAppTests
+//
+
+import BigInt
+@testable import VultisigApp
+import XCTest
+
+final class MayaChainTransactionDecoderTests: XCTestCase {
+
+    func testSupportedMemoOperations() {
+        let decoder = MayaChainTransactionDecoder()
+        let cases: [(String, DecodedOperation, DecodedAmount, DecodedCounterparty?)] = [
+            ("POOL+", .stake, .units(BigInt(100_000_000), of: .transactionCoin), nil),
+            ("POOL-:5006", .unstake, .fraction(basisPoints: 5006, of: .transactionCoin), nil),
+            ("BOND:BTC.BTC:123:maya1node", .bond, .unstated, .node("maya1node")),
+            ("UNBOND:BTC.BTC:123:maya1node", .unbond, .unstated, .node("maya1node")),
+            ("LEAVE:maya1node", .leave, .unstated, .node("maya1node"))
+        ]
+
+        for (memo, operation, amount, counterparty) in cases {
+            let decoded = decoder.decode(Self.payload(memo: memo))
+            XCTAssertEqual(decoded?.operation, operation, memo)
+            XCTAssertEqual(decoded?.amount, amount, memo)
+            XCTAssertEqual(decoded?.counterparty, counterparty, memo)
+        }
+    }
+
+    func testMalformedOrOutrankedMemoIsRefused() {
+        let decoder = MayaChainTransactionDecoder()
+        XCTAssertNil(decoder.decode(Self.payload(memo: "POOL-:10001")))
+        XCTAssertNil(decoder.decode(Self.payload(
+            memo: "POOL+",
+            approve: ERC20ApprovePayload(amount: 1, spender: "router")
+        )))
+    }
+
+    private static func payload(
+        memo: String,
+        approve: ERC20ApprovePayload? = nil
+    ) -> KeysignPayload {
+        let coin = Coin(
+            asset: CoinMeta(
+                chain: .mayaChain,
+                ticker: "CACAO",
+                logo: "cacao",
+                decimals: 8,
+                priceProviderId: "cacao",
+                contractAddress: "",
+                isNativeToken: true
+            ),
+            address: "maya1from",
+            hexPublicKey: "00"
+        )
+        return KeysignPayload(
+            coin: coin,
+            toAddress: "maya1dest",
+            toAmount: BigInt(100_000_000),
+            chainSpecific: .MayaChain(accountNumber: 0, sequence: 0, isDeposit: true),
+            utxos: [],
+            memo: memo,
+            swapPayload: nil,
+            approvePayload: approve,
+            vaultPubKeyECDSA: "pub",
+            vaultLocalPartyID: "party",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: nil
+        )
+    }
+}

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/OperationVocabularyTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/OperationVocabularyTests.swift
@@ -6,9 +6,64 @@
 //
 
 @testable import VultisigApp
+import BigInt
+import VultisigCommonData
+import WalletCore
 import XCTest
 
 final class OperationVocabularyTests: XCTestCase {
+
+    private struct DecoderFixture {
+        let name: String
+        let operation: DecodedOperation
+        let payload: KeysignPayload
+    }
+
+    /// Exercises every registry operation except screen-owned swap and approve.
+    func testEveryOperationHasBehavioralUnitCoverage() {
+        let fixtures = Self.decoderFixtures
+        let screenOwned: Set<DecodedOperation> = [.swap, .approve]
+
+        XCTAssertEqual(
+            Set(fixtures.map(\.operation)).union(screenOwned),
+            Set(DecodedOperation.allCases),
+            "an operation was added without a real decoder fixture or an explicit screen-owned exemption"
+        )
+        for fixture in fixtures {
+            XCTAssertEqual(
+                SignedTransactionDecoder.decode(fixture.payload).operation,
+                fixture.operation,
+                fixture.name
+            )
+        }
+    }
+
+    /// Decoder coverage and wording coverage are separate contracts. This walks
+    /// every case through the actual hero builder, ensuring named operations
+    /// produce their own title and deliberately silent operations produce none.
+    func testEveryOperationProducesItsExpectedHeroBehavior() {
+        let decodedByOperation = Self.decoderFixtures.reduce(into: [DecodedOperation: DecodedTransaction]()) { readings, fixture in
+            if readings[fixture.operation] == nil {
+                readings[fixture.operation] = SignedTransactionDecoder.decode(fixture.payload)
+            }
+        }
+        let coin = Self.coin(chain: .thorChain)
+
+        for operation in DecodedOperation.allCases {
+            let decoded = decodedByOperation[operation] ?? DecodedTransaction(
+                operation: operation,
+                amount: .unstated,
+                evidence: .structuredPayload
+            )
+            let hero = DecodedTransactionPresentation.hero(for: decoded, coin: coin)
+
+            if let expectedTitle = DecodedTransactionPresentation.title(for: operation) {
+                XCTAssertEqual(hero?.title, expectedTitle, "\(operation) rendered the wrong hero title")
+            } else {
+                XCTAssertNil(hero, "\(operation) is deliberately silent but rendered a hero")
+            }
+        }
+    }
 
     /// Every operation is either named or deliberately silent.
     func testEveryOperationIsNamedOrDeliberatelySilent() {
@@ -119,5 +174,304 @@ final class OperationVocabularyTests: XCTestCase {
                 )
             }
         }
+    }
+
+    // MARK: - Exhaustive decoder fixtures
+
+    private static var decoderFixtures: [DecoderFixture] {
+        let thorMemos: [(String, DecodedOperation)] = [
+            ("tcy+", .stake),
+            ("tcy-:5006", .unstake),
+            ("BOND:thor1node", .bond),
+            ("UNBOND:thor1node:100", .unbond),
+            ("REBOND:thor1node:thor1newnode", .rebond),
+            ("LEAVE:thor1node", .leave),
+            ("claim:thor1contract:100", .claimRewards),
+            ("+:BTC.BTC", .addLiquidity),
+            ("-:BTC.BTC:5006", .removeLiquidity),
+            ("MERGE:thor1token", .merge),
+            ("UNMERGE:thor1token:100", .unmerge),
+            ("SECURE+:thor1destination", .securedAssetDeposit),
+            ("SECURE-:thor1destination", .securedAssetWithdraw),
+            ("=<:100000000THOR.RUNE:15979057441BTC.BTC:0", .limitOrderPlacement),
+            ("m=<:100000000THOR.RUNE:15979057441BTC.BTC:0", .limitOrderCancel)
+        ]
+        var fixtures = thorMemos.map { memo, operation in
+            DecoderFixture(
+                name: "THORChain memo \(memo)",
+                operation: operation,
+                payload: payload(chain: .thorChain, memo: memo)
+            )
+        }
+
+        fixtures.append(contentsOf: [
+            DecoderFixture(
+                name: "yVault deposit",
+                operation: .mint,
+                payload: payload(chain: .thorChain, wasm: vaultWasm(action: "deposit"))
+            ),
+            DecoderFixture(
+                name: "yVault withdraw",
+                operation: .redeem,
+                payload: payload(chain: .thorChain, wasm: vaultWasm(action: "withdraw"))
+            ),
+            DecoderFixture(
+                name: "unknown wasm action",
+                operation: .contractCall,
+                payload: payload(chain: .thorChain, wasm: unknownWasm)
+            ),
+            cosmosStakingFixture(
+                name: "Cosmos delegate",
+                operation: .delegate,
+                message: CosmosStakingHelper.encodeDelegate(
+                    delegator: "cosmos1delegator",
+                    validator: "cosmosvaloper1validator",
+                    amount: "1000000",
+                    denom: "uatom"
+                )
+            ),
+            cosmosStakingFixture(
+                name: "Cosmos undelegate",
+                operation: .undelegate,
+                message: CosmosStakingHelper.encodeUndelegate(
+                    delegator: "cosmos1delegator",
+                    validator: "cosmosvaloper1validator",
+                    amount: "1000000",
+                    denom: "uatom"
+                )
+            ),
+            cosmosStakingFixture(
+                name: "Cosmos redelegate",
+                operation: .redelegate,
+                message: CosmosStakingHelper.encodeBeginRedelegate(
+                    delegator: "cosmos1delegator",
+                    validatorSrc: "cosmosvaloper1source",
+                    validatorDst: "cosmosvaloper1destination",
+                    amount: "1000000",
+                    denom: "uatom"
+                )
+            ),
+            cosmosStakingFixture(
+                name: "Cosmos claim rewards",
+                operation: .claimRewards,
+                message: CosmosStakingHelper.encodeWithdrawDelegatorReward(
+                    delegator: "cosmos1delegator",
+                    validator: "cosmosvaloper1validator"
+                )
+            ),
+            DecoderFixture(
+                name: "Cosmos MsgSend",
+                operation: .transfer,
+                payload: payload(chain: .gaiaChain, signBody: cosmosSendBody)
+            ),
+            DecoderFixture(
+                name: "Cosmos IBC transfer",
+                operation: .ibcTransfer,
+                payload: payload(chain: .gaiaChain, transactionType: .ibcTransfer)
+            ),
+            DecoderFixture(
+                name: "Cosmos vote",
+                operation: .vote,
+                payload: payload(chain: .gaiaChain, transactionType: .vote)
+            ),
+            DecoderFixture(
+                name: "Cosmos switch",
+                operation: .switchChain,
+                payload: payload(chain: .gaiaChain, memo: "SWITCH:thor1destination")
+            ),
+            DecoderFixture(
+                name: "Solana stake-account withdraw",
+                operation: .withdrawStake,
+                payload: solanaWithdrawPayload
+            ),
+            DecoderFixture(
+                name: "unread transaction",
+                operation: .unknown,
+                payload: payload(chain: .thorChain)
+            )
+        ])
+        return fixtures
+    }
+
+    private static func cosmosStakingFixture(
+        name: String,
+        operation: DecodedOperation,
+        message: Data
+    ) -> DecoderFixture {
+        DecoderFixture(
+            name: name,
+            operation: operation,
+            payload: payload(
+                chain: .gaiaChain,
+                signBody: CosmosStakingHelper.buildTxBodyMulti(msgsAny: [message])
+            )
+        )
+    }
+
+    private static func payload(
+        chain: Chain,
+        memo: String? = nil,
+        transactionType: VSTransactionType = .unspecified,
+        wasm: WasmExecuteContractPayload? = nil,
+        signBody: Data? = nil
+    ) -> KeysignPayload {
+        let coin = coin(chain: chain)
+        let chainSpecific: BlockChainSpecific = chain == .gaiaChain
+            ? .Cosmos(
+                accountNumber: 1,
+                sequence: 1,
+                gas: 1,
+                transactionType: transactionType.rawValue,
+                ibcDenomTrace: nil,
+                gasLimit: nil
+            )
+            : .THORChain(accountNumber: 1, sequence: 1, fee: 1, isDeposit: true)
+
+        return KeysignPayload(
+            coin: coin,
+            toAddress: chain == .gaiaChain ? "cosmos1destination" : "thor1destination",
+            toAmount: BigInt(100_000_000),
+            chainSpecific: chainSpecific,
+            utxos: [],
+            memo: memo,
+            swapPayload: nil,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "pub",
+            vaultLocalPartyID: "party",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: wasm,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: signBody.map {
+                .signDirect(SignDirect(
+                    bodyBytes: $0.base64EncodedString(),
+                    authInfoBytes: "",
+                    chainID: "cosmoshub-4",
+                    accountNumber: "1"
+                ))
+            }
+        )
+    }
+
+    private static func coin(chain: Chain) -> Coin {
+        Coin(
+            asset: CoinMeta(
+                chain: chain,
+                ticker: chain.ticker,
+                logo: chain.logo,
+                decimals: 8,
+                priceProviderId: "",
+                contractAddress: "",
+                isNativeToken: true
+            ),
+            address: chain == .gaiaChain ? "cosmos1sender" : "thor1sender",
+            hexPublicKey: "00"
+        )
+    }
+
+    private static var solanaWithdrawPayload: KeysignPayload {
+        let coin = Coin(
+            asset: CoinMeta(
+                chain: .solana, ticker: "SOL", logo: "solana", decimals: 9,
+                priceProviderId: "solana", contractAddress: "", isNativeToken: true
+            ),
+            address: "owner", hexPublicKey: "00"
+        )
+        return KeysignPayload(
+            coin: coin,
+            toAddress: "owner",
+            toAmount: .zero,
+            chainSpecific: .Solana(
+                recentBlockHash: "11111111111111111111111111111111",
+                priorityFee: 0,
+                priorityLimit: 0,
+                fromAddressPubKey: nil,
+                toAddressPubKey: nil,
+                hasProgramId: false
+            ),
+            utxos: [], memo: nil, swapPayload: nil, approvePayload: nil,
+            vaultPubKeyECDSA: "pub", vaultLocalPartyID: "party",
+            libType: LibType.DKLS.toString(), wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil, tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil, qbtcClaimPayload: nil,
+            isQbtcClaim: false, skipBroadcast: false,
+            signData: .signSolana(SignSolana(rawTransactions: [solanaWithdrawTransaction]))
+        )
+    }
+
+    private static var solanaWithdrawTransaction: String {
+        let stakeProgram = Base58.decodeNoCheck(
+            string: "Stake11111111111111111111111111111111111111"
+        )!
+        let accounts = [
+            stakeProgram,
+            Data(repeating: 0x01, count: 32),
+            Data(repeating: 0x02, count: 32),
+            Data(repeating: 0x03, count: 32),
+            Data(repeating: 0x04, count: 32),
+            Data(repeating: 0x05, count: 32)
+        ]
+        let data = littleEndian(UInt32(4)) + littleEndian(UInt64(2_100_000_000))
+
+        var transaction = compactU16(1) + Data(repeating: 0, count: 64)
+        transaction += Data([1, 0, 1])
+        transaction += compactU16(accounts.count)
+        accounts.forEach { transaction += $0 }
+        transaction += Data(repeating: 0, count: 32)
+        transaction += compactU16(1)
+        transaction += Data([0])
+        transaction += compactU16(5)
+        transaction += Data([1, 2, 3, 4, 5])
+        transaction += compactU16(data.count)
+        transaction += data
+        return transaction.base64EncodedString()
+    }
+
+    private static func compactU16(_ value: Int) -> Data {
+        value < 0x80 ? Data([UInt8(value)]) : Data([UInt8(value & 0x7F | 0x80), UInt8(value >> 7)])
+    }
+
+    private static func littleEndian<T: FixedWidthInteger>(_ value: T) -> Data {
+        Data((0..<MemoryLayout<T>.size).map { UInt8(truncatingIfNeeded: value >> (8 * $0)) })
+    }
+
+    private static func vaultWasm(action: String) -> WasmExecuteContractPayload {
+        let inner = "{\"\(action)\":{}}"
+        let encoded = Data(inner.utf8).base64EncodedString()
+        return WasmExecuteContractPayload(
+            senderAddress: "thor1sender",
+            contractAddress: "thor1vault",
+            executeMsg: "{\"execute\":{\"msg\":\"\(encoded)\"}}",
+            coins: [CosmosCoin(amount: "100000000", denom: "rune")]
+        )
+    }
+
+    private static var unknownWasm: WasmExecuteContractPayload {
+        WasmExecuteContractPayload(
+            senderAddress: "thor1sender",
+            contractAddress: "thor1contract",
+            executeMsg: "{\"mystery\":{}}",
+            coins: []
+        )
+    }
+
+    private static var cosmosSendBody: Data {
+        var coin = Data()
+        coin.appendProtoString(fieldNumber: 1, value: "uatom")
+        coin.appendProtoString(fieldNumber: 2, value: "1000000")
+
+        var message = Data()
+        message.appendProtoString(fieldNumber: 1, value: "cosmos1sender")
+        message.appendProtoString(fieldNumber: 2, value: "cosmos1destination")
+        message.appendProtoBytes(fieldNumber: 3, data: coin)
+
+        var any = Data()
+        any.appendProtoString(fieldNumber: 1, value: "/cosmos.bank.v1beta1.MsgSend")
+        any.appendProtoBytes(fieldNumber: 2, data: message)
+        return CosmosStakingHelper.buildTxBodyMulti(msgsAny: [any])
     }
 }

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/OperationVocabularyTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/OperationVocabularyTests.swift
@@ -67,6 +67,7 @@ final class OperationVocabularyTests: XCTestCase {
             .redelegate: "youreRedelegating",
             .addLiquidity: "youreAddingLiquidity",
             .redeem: "youreRedeeming",
+            .withdrawStake: "youreWithdrawing",
             .mint: "youreMinting",
             .merge: "youreMerging",
             .unmerge: "youreUnmerging",

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/OperationVocabularyTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/OperationVocabularyTests.swift
@@ -66,6 +66,7 @@ final class OperationVocabularyTests: XCTestCase {
             .undelegate: "youreUndelegating",
             .redelegate: "youreRedelegating",
             .addLiquidity: "youreAddingLiquidity",
+            .removeLiquidity: "youreRemovingLiquidity",
             .redeem: "youreRedeeming",
             .withdrawStake: "youreWithdrawing",
             .mint: "youreMinting",

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/ProjectionTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/ProjectionTests.swift
@@ -8,15 +8,78 @@ import BigInt
 import XCTest
 
 final class ProjectionTests: XCTestCase {
-    func testWholePositionUnstakeKeepsScopeWithoutEstimate() throws {
-        let decoded = DecodedTransaction(operation: .unstake, amount: .unstated, evidence: .signedData)
+
+    // MARK: - Signed query key
+
+    /// Query subjects must come from signed content.
+    func testAKeyCannotBeBuiltWithoutASignedCounterparty() {
+        let noCounterparty = DecodedTransaction(
+            operation: .unstake, amount: .unstated, counterparty: nil, evidence: .signedData
+        )
+        XCTAssertNil(ProjectionQueryKey(noCounterparty))
+
+        let named = DecodedTransaction(
+            operation: .unstake, amount: .unstated,
+            counterparty: .validator("StakeAccount111"), evidence: .signedData
+        )
+        XCTAssertEqual(ProjectionQueryKey(named)?.counterparty, .validator("StakeAccount111"))
+    }
+
+    // MARK: - The scope is the floor
+
+    func testAWholePositionUnstakeStatesItsScope() {
+        let decoded = DecodedTransaction(
+            operation: .unstake, amount: .unstated, evidence: .signedData
+        )
+        XCTAssertEqual(ProjectionCoordinator.scope(for: decoded), "scopeYourWholeStake".localized)
+    }
+
+    func testAFractionStatesTheShareItCommitsTo() throws {
+        let decoded = DecodedTransaction(
+            operation: .unstake, amount: .fraction(basisPoints: 5006, of: .transactionCoin), evidence: .memo
+        )
+        let scope = try XCTUnwrap(ProjectionCoordinator.scope(for: decoded))
+        XCTAssertTrue(scope.contains("50.06"), "the committed share should be stated exactly: \(scope)")
+    }
+
+    /// Committed amounts are not projections.
+    func testACommittedAmountIsNeverAProjection() {
+        let committed = DecodedTransaction(
+            operation: .stake, amount: .units(BigInt(1), of: .chainNative), evidence: .memo
+        )
+        XCTAssertNil(ProjectionCoordinator.scope(for: committed))
+        XCTAssertNil(ProjectionCoordinator.hero(for: committed, title: "You’re staking"))
+    }
+
+    /// The hero renders from the decoding alone — nothing is awaited to produce it.
+    func testTheScopeRendersWithoutAnEstimate() throws {
+        let decoded = DecodedTransaction(
+            operation: .unstake, amount: .unstated, evidence: .signedData
+        )
         let hero = try XCTUnwrap(ProjectionCoordinator.hero(for: decoded, title: "You’re unstaking"))
         guard case .projected(let title, let estimate, let scope) = hero else {
-            return XCTFail("expected projected hero")
+            return XCTFail("an unsettled quantity must render as a projection")
         }
         XCTAssertEqual(title, "You’re unstaking")
+        XCTAssertNil(estimate, "the verb and scope must not wait for a read")
+        XCTAssertFalse(scope.isEmpty)
+    }
+
+    // MARK: - Every failure lands in the same place
+
+    func testASuccessfulReadBecomesTheEstimate() async {
+        let estimate = await ProjectionCoordinator.estimate(
+            for: Self.unstakeOfAStakeAccount,
+            using: [StubResolver(result: Self.twelveSol)]
+        )
+        XCTAssertEqual(estimate, Self.twelveSol)
+    }
+
+    func testAFailedReadLeavesNoEstimate() async {
+        let estimate = await ProjectionCoordinator.estimate(
+            for: Self.unstakeOfAStakeAccount, using: [StubResolver(result: nil)]
+        )
         XCTAssertNil(estimate)
-        XCTAssertEqual(scope, "scopeYourWholeStake".localized)
     }
 
     func testDecodedHeroStatesProjectionScopeBeforeAnyRead() throws {
@@ -36,49 +99,71 @@ final class ProjectionTests: XCTestCase {
         XCTAssertEqual(scope, "scopeYourWholeStake".localized)
     }
 
-    func testCommittedAmountIsNotProjected() {
-        let decoded = DecodedTransaction(
-            operation: .stake,
-            amount: .units(BigInt(1), of: .chainNative),
-            evidence: .memo
+    /// Slow optional reads degrade to scope-only presentation.
+    func testASlowReadTimesOutRatherThanHangingTheScreen() async {
+        let estimate = await ProjectionCoordinator.estimate(
+            for: Self.unstakeOfAStakeAccount,
+            using: [StubResolver(result: Self.twelveSol, delay: .seconds(30))]
         )
-        XCTAssertNil(ProjectionCoordinator.scope(for: decoded))
+        XCTAssertNil(estimate, "a slow read must degrade to the scope, not delay the hero")
     }
 
-    func testResolverUsesTrustedCoinAndRetainsScopeWhenReadFails() async throws {
-        let coin = Coin(
-            asset: CoinMeta(
-                chain: .thorChain, ticker: "TCY", logo: "tcy", decimals: 8,
-                priceProviderId: "tcy", contractAddress: "", isNativeToken: false
-            ),
-            address: "thor1local", hexPublicKey: "hex"
+    /// The deadline must hold when the resolver ignores cancellation.
+    func testTheDeadlineHoldsEvenIfTheResolverIgnoresCancellation() async {
+        let started = ContinuousClock.now
+        let estimate = await ProjectionCoordinator.estimate(
+            for: Self.unstakeOfAStakeAccount,
+            using: [UncancellableResolver()]
         )
-        let payload = KeysignPayload(
-            coin: coin,
-            toAddress: "thor1pool",
-            toAmount: .zero,
-            chainSpecific: .THORChain(accountNumber: 0, sequence: 0, fee: 0, isDeposit: true),
-            utxos: [], memo: "tcy-:5000", swapPayload: nil, approvePayload: nil,
-            vaultPubKeyECDSA: "pub", vaultLocalPartyID: "party", libType: LibType.DKLS.toString(),
-            wasmExecuteContractPayload: nil, tronTransferContractPayload: nil,
-            tronTriggerSmartContractPayload: nil, tronTransferAssetContractPayload: nil,
-            qbtcClaimPayload: nil, isQbtcClaim: false, skipBroadcast: false, signData: nil
+        let elapsed = ContinuousClock.now - started
+
+        XCTAssertNil(estimate)
+        XCTAssertLessThan(
+            elapsed, .seconds(15),
+            "the screen waited \(elapsed) on a resolver that never yields — the deadline is not being enforced"
         )
-        let hero = await ResolvedTransactionHero.resolve(
-            for: payload,
-            trustedCoins: [coin],
-            readers: [StubReader()]
-        )
-        XCTAssertNil(hero, "an unrelated reader cannot claim an undecoded transaction")
     }
 
-    private struct StubReader: PositionReading {
-        func handles(_ decoded: DecodedTransaction, coin: Coin) -> Bool {
-            decoded.operation == .unstake && coin.chain == .thorChain
+    func testAnUnhandledOperationAsksNobody() async {
+        let estimate = await ProjectionCoordinator.estimate(
+            for: Self.unstakeOfAStakeAccount,
+            using: [StubResolver(result: Self.twelveSol, handles: .stake)]
+        )
+        XCTAssertNil(estimate)
+    }
+
+    // MARK: - Fixtures
+
+    private static let twelveSol = HeroCoinAmount(amount: "12.5", ticker: "SOL", logo: "solana")
+
+    private static let unstakeOfAStakeAccount = DecodedTransaction(
+        operation: .unstake, amount: .unstated,
+        counterparty: .validator("StakeAccount111"), evidence: .signedData
+    )
+
+    /// Models a client governed by its own timeout.
+    private struct UncancellableResolver: ProjectionResolving {
+        func handles(_: DecodedOperation) -> Bool { true }
+
+        func projection(for _: DecodedTransaction, key _: ProjectionQueryKey) async -> HeroCoinAmount? {
+            let deadline = ContinuousClock.now + .seconds(60)
+            while ContinuousClock.now < deadline {
+                try? await Task.sleep(for: .milliseconds(50))
+            }
+            return HeroCoinAmount(amount: "1", ticker: "SOL", logo: "solana")
         }
-        func amount(for _: DecodedTransaction, coin _: Coin) async -> HeroCoinAmount? {
-            await Task.yield()
-            return nil
+    }
+
+    private struct StubResolver: ProjectionResolving {
+        let result: HeroCoinAmount?
+        var delay: Duration = .zero
+        var handles: DecodedOperation = .unstake
+
+        func handles(_ operation: DecodedOperation) -> Bool { operation == handles }
+
+        func projection(for _: DecodedTransaction, key _: ProjectionQueryKey) async -> HeroCoinAmount? {
+            if delay > .zero { try? await Task.sleep(for: delay) }
+            return result
         }
     }
 }

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/ResolvedTransactionHeroTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/ResolvedTransactionHeroTests.swift
@@ -1,0 +1,131 @@
+//
+//  ResolvedTransactionHeroTests.swift
+//  VultisigAppTests
+//
+
+import BigInt
+import XCTest
+@testable import VultisigApp
+
+final class ResolvedTransactionHeroTests: XCTestCase {
+
+    private struct StubReader: PositionReading {
+        let answers: Bool
+        let value: HeroCoinAmount?
+        func handles(_: DecodedTransaction, coin _: Coin) -> Bool { answers }
+        func amount(for _: DecodedTransaction, coin _: Coin) -> HeroCoinAmount? { value }
+    }
+
+    private static func tcy(address: String = "thor1me", ticker: String = "TCY") -> Coin {
+        Coin(
+            asset: CoinMeta(
+                chain: .thorChain, ticker: ticker, logo: "tcy", decimals: 8,
+                priceProviderId: "tcy", contractAddress: "", isNativeToken: false
+            ),
+            address: address, hexPublicKey: "hex"
+        )
+    }
+
+    private static func tcyUnstakePayload(coin: Coin = tcy()) -> KeysignPayload {
+        KeysignPayload(
+            coin: coin,
+            toAddress: "thor1dest",
+            toAmount: .zero,
+            chainSpecific: .THORChain(accountNumber: 0, sequence: 0, fee: 0, isDeposit: true),
+            utxos: [],
+            memo: "tcy-:5006",
+            swapPayload: nil,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "pub",
+            vaultLocalPartyID: "party",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: nil
+        )
+    }
+
+    /// A reader that answers enriches the projection without making its estimate
+    /// look like an amount committed by the transaction.
+    func testResolvesToAProjectedHeroWhenAReaderAnswers() async {
+        let hero = await ResolvedTransactionHero.resolve(
+            for: Self.tcyUnstakePayload(),
+            trustedCoins: [Self.tcy()],
+            readers: [StubReader(answers: true, value: HeroCoinAmount(amount: "1,002.571644", ticker: "TCY", logo: "tcy"))]
+        )
+        guard case .projected(let title, let estimate, let scope) = hero else {
+            return XCTFail("expected a projected hero, got \(String(describing: hero))")
+        }
+        XCTAssertEqual(estimate?.amount, "1,002.571644")
+        XCTAssertFalse(title.isEmpty, "the verb should be the operation's own")
+        XCTAssertFalse(scope.isEmpty, "the signed fraction should remain visible")
+    }
+
+    func testFailedReadStillReturnsTheCommittedScope() async {
+        let hero = await ResolvedTransactionHero.resolve(
+            for: Self.tcyUnstakePayload(),
+            trustedCoins: [Self.tcy()],
+            readers: [StubReader(answers: true, value: nil)]
+        )
+        guard case .projected(_, let estimate, let scope) = hero else {
+            return XCTFail("expected the projection scope without an estimate")
+        }
+        XCTAssertNil(estimate)
+        XCTAssertFalse(scope.isEmpty)
+    }
+
+    /// Nothing reading it leaves the decoded verb-only hero to describe it.
+    func testNilWhenNoReaderAnswers() async {
+        let hero = await ResolvedTransactionHero.resolve(
+            for: Self.tcyUnstakePayload(), trustedCoins: [Self.tcy()], readers: []
+        )
+        XCTAssertNil(hero)
+    }
+
+    func testUsesTheLocalVaultCoinInsteadOfPeerMetadata() async {
+        let local = Self.tcy(address: "thor1local")
+        let peer = Self.tcy(address: "thor1peer", ticker: "FAKE")
+        let reader = TcyStakedPositionReader(readRaw: { address in
+            XCTAssertEqual(address, local.address)
+            return Decimal(100_000_000)
+        })
+
+        let hero = await ResolvedTransactionHero.resolve(
+            for: Self.tcyUnstakePayload(coin: peer),
+            trustedCoins: [local],
+            readers: [reader]
+        )
+        guard case .projected(_, let estimate, _) = hero else {
+            return XCTFail("expected a trusted TCY projection")
+        }
+        XCTAssertEqual(estimate?.ticker, "TCY")
+    }
+
+    /// The TCY reader gates on chain and on the amount being a fraction — an
+    /// absolute amount is already in the signed content and needs no read.
+    func testTcyReaderGatesOnFractionAndChain() {
+        let reader = TcyStakedPositionReader()
+        let fraction = DecodedTransaction(
+            operation: .unstake, amount: .fraction(basisPoints: 5006, of: .transactionCoin), evidence: .memo
+        )
+        XCTAssertTrue(reader.handles(fraction, coin: Self.tcy()))
+
+        let absolute = DecodedTransaction(
+            operation: .unstake, amount: .units(BigInt(1), of: .transactionCoin), evidence: .memo
+        )
+        XCTAssertFalse(reader.handles(absolute, coin: Self.tcy()))
+
+        let liquidityRemoval = DecodedTransaction(
+            operation: .removeLiquidity,
+            amount: .fraction(basisPoints: 5006, of: .transactionCoin),
+            evidence: .memo
+        )
+        XCTAssertFalse(reader.handles(liquidityRemoval, coin: Self.tcy()))
+        XCTAssertFalse(reader.handles(fraction, coin: Self.tcy(ticker: "RUNE")))
+    }
+}

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/SignedTransactionDecoderFoundationTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/SignedTransactionDecoderFoundationTests.swift
@@ -10,10 +10,6 @@ import XCTest
 
 final class SignedTransactionDecoderFoundationTests: XCTestCase {
 
-    func testRegistryStartsEmpty() {
-        XCTAssertTrue(SignedTransactionDecoder.decoders.isEmpty)
-    }
-
     func testUnregisteredContentIsUnreadable() {
         let decoded = SignedTransactionDecoder.decode(StubContent())
 

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/SolanaTransactionDecoderTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/SolanaTransactionDecoderTests.swift
@@ -1,0 +1,359 @@
+//
+//  SolanaTransactionDecoderTests.swift
+//  VultisigAppTests
+//
+
+import BigInt
+@testable import VultisigApp
+import VultisigCommonData
+import WalletCore
+import XCTest
+
+/// Exercises complete-sequence matching for signed Solana instructions.
+final class SolanaTransactionDecoderTests: XCTestCase {
+
+    func testInitiatorDelegateCarriesFundingForLiveRentProjection() {
+        let decoded = SolanaTransactionDecoder().decode(
+            IntentContent(intent: .delegate(votePubkey: "validator", lamports: 2_100_000_000))
+        )
+        XCTAssertEqual(decoded?.operation, .delegate)
+        XCTAssertEqual(decoded?.amount, .accountFunding(BigInt(2_100_000_000), of: .chainNative))
+    }
+
+    func testInitiatorUnstakeNamesTheWholeStakeAccount() {
+        let decoded = SolanaTransactionDecoder().decode(
+            IntentContent(intent: .unstake(stakeAccount: "stake-account"))
+        )
+        XCTAssertEqual(decoded?.operation, .unstake)
+        XCTAssertEqual(decoded?.counterparty, .stakeAccount("stake-account"))
+        XCTAssertEqual(decoded?.amount, .unstated)
+    }
+
+    func testInitiatorWithdrawUsesTheWithdrawingVerbAndExactAmount() {
+        let decoded = SolanaTransactionDecoder().decode(
+            IntentContent(intent: .withdraw(stakeAccount: "stake-account", lamports: 2_100_000_000))
+        )
+        XCTAssertEqual(decoded?.operation, .withdrawStake)
+        XCTAssertEqual(decoded?.amount, .units(BigInt(2_100_000_000), of: .chainNative))
+    }
+
+    @MainActor
+    func testInitiatorWithdrawHeroIncludesFiat() throws {
+        try RateProvider.shared.save(rates: [
+            Rate(fiat: SettingsCurrency.current.rawValue, crypto: "solana", value: 100)
+        ])
+        let decoded = try XCTUnwrap(
+            SolanaTransactionDecoder().decode(
+                IntentContent(intent: .withdraw(stakeAccount: "stake-account", lamports: 2_100_000_000))
+            )
+        )
+        let hero = try XCTUnwrap(
+            DecodedTransactionPresentation.hero(for: decoded, coin: Self.solanaCoin())
+        )
+
+        guard case .send(_, let amount) = hero else {
+            return XCTFail("expected an exact withdrawal amount")
+        }
+        XCTAssertEqual(amount.amount, "2.1")
+        XCTAssertFalse(amount.fiat?.isEmpty ?? true)
+    }
+
+    /// Accepts WalletCore's create + initialize + delegate sequence.
+    func testTheAppsWalletCoreDelegateSequenceIsAccepted() throws {
+        let privateKey = try XCTUnwrap(PrivateKey(data: Data(repeating: 0x31, count: 32)))
+        let publicKey = privateKey.getPublicKeyEd25519()
+        let validatorKey = try XCTUnwrap(PrivateKey(data: Data(repeating: 0x37, count: 32)))
+        let validator = AnyAddress(publicKey: validatorKey.getPublicKeyEd25519(), coin: .solana).description
+        let coin = Coin(
+            asset: CoinMeta(
+                chain: .solana, ticker: "SOL", logo: "solana", decimals: 9,
+                priceProviderId: "solana", contractAddress: "", isNativeToken: true
+            ),
+            address: AnyAddress(publicKey: publicKey, coin: .solana).description,
+            hexPublicKey: publicKey.data.hexString
+        )
+        let payload = KeysignPayload(
+            coin: coin,
+            toAddress: validator,
+            toAmount: 2_000_000_000,
+            chainSpecific: .Solana(
+                recentBlockHash: Self.systemProgramAddress,
+                priorityFee: 1_000_000,
+                priorityLimit: 100_000,
+                fromAddressPubKey: nil,
+                toAddressPubKey: nil,
+                hasProgramId: false
+            ),
+            utxos: [], memo: nil, swapPayload: nil, approvePayload: nil,
+            vaultPubKeyECDSA: "pub", vaultLocalPartyID: "party",
+            libType: LibType.DKLS.toString(), wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil, tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil, qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            solanaStakingPayload: .delegate(votePubkey: validator, lamports: 2_000_000_000),
+            skipBroadcast: false, signData: nil
+        )
+
+        let raw = try SolanaHelper.buildStakingUnsignedTransaction(keysignPayload: payload)
+        let reading = SolanaTransactionReader.read(base64: raw)
+        XCTAssertEqual(reading?.operation, .delegate, raw)
+        XCTAssertEqual(reading?.amount, .accountFunding(BigInt(2_000_000_000), of: .chainNative))
+    }
+
+    func testACompleteLinkedDelegateSequenceIsAccepted() {
+        let reading = SolanaTransactionReader.read(base64: Self.delegateSequence)
+        XCTAssertEqual(reading?.operation, .delegate)
+        XCTAssertEqual(reading?.amount, .accountFunding(BigInt(2_100_000_000), of: .chainNative))
+    }
+
+    func testFourByteFakeCreateAccountIsRefused() {
+        XCTAssertNil(SolanaTransactionReader.read(base64: Self.makeDelegateSequence(createData: Self.discriminator(0))))
+    }
+
+    func testCreateAccountOwnedByAnotherProgramIsRefused() {
+        XCTAssertNil(
+            SolanaTransactionReader.read(
+                base64: Self.makeDelegateSequence(createData: Self.createAccountData(owner: Data(repeating: 0x99, count: 32)))
+            )
+        )
+    }
+
+    func testDelegateSequenceWithDifferentStakeAccountsIsRefused() {
+        XCTAssertNil(SolanaTransactionReader.read(base64: Self.makeDelegateSequence(createdStakeIndex: 9)))
+    }
+
+    func testSystemTransferFollowedByInitializeAndDelegateIsRefused() {
+        XCTAssertNil(SolanaTransactionReader.read(base64: Self.makeDelegateSequence(createData: Self.systemTransferData)))
+    }
+
+    /// An unrelated SOL transfer cannot hide beside a deactivate.
+    func testATransferBatchedWithADeactivateIsRefused() {
+        XCTAssertNil(
+            SolanaTransactionReader.read(base64: Self.transferPlusDeactivate),
+            "a transaction that also moves SOL elsewhere must not be named for its stake instruction alone"
+        )
+    }
+
+    func testAStandaloneDeactivateIsRead() {
+        let reading = SolanaTransactionReader.read(base64: Self.deactivateOnly)
+        XCTAssertEqual(reading?.operation, .unstake)
+        XCTAssertEqual(reading?.counterparty, .stakeAccount(Base58.encodeNoCheck(data: Self.stakeAccount)))
+    }
+
+    func testAStandaloneWithdrawUsesTheWithdrawingVerbAndExactAmount() {
+        let reading = SolanaTransactionReader.read(base64: Self.withdrawOnly)
+        XCTAssertEqual(reading?.operation, .withdrawStake)
+        XCTAssertEqual(reading?.amount, .units(BigInt(2_100_000_000), of: .chainNative))
+        XCTAssertEqual(reading?.counterparty, .stakeAccount(Base58.encodeNoCheck(data: Self.stakeAccount)))
+    }
+
+    func testDelegateProjectionSubtractsTheLiveRentReserve() async {
+        let coin = Self.solanaCoin()
+        let decoded = DecodedTransaction(
+            operation: .delegate,
+            amount: .accountFunding(BigInt(2_100_000_000), of: .chainNative),
+            counterparty: .validator("validator"),
+            evidence: .signedData
+        )
+        let reader = SolanaDelegatedAmountReader(readRentReserve: { 100_000_000 })
+        let amount = await reader.amount(for: decoded, coin: coin)
+        XCTAssertEqual(amount?.amount, "2")
+    }
+
+    @MainActor
+    func testDelegateProjectionIncludesFiat() async throws {
+        try RateProvider.shared.save(rates: [
+            Rate(fiat: SettingsCurrency.current.rawValue, crypto: "solana", value: 100)
+        ])
+        let decoded = DecodedTransaction(
+            operation: .delegate,
+            amount: .accountFunding(BigInt(2_100_000_000), of: .chainNative),
+            counterparty: .validator("validator"),
+            evidence: .signedData
+        )
+        let reader = SolanaDelegatedAmountReader(readRentReserve: { 100_000_000 })
+        let amount = await reader.amount(for: decoded, coin: Self.solanaCoin())
+
+        XCTAssertFalse(amount?.fiat?.isEmpty ?? true)
+    }
+
+    func testUnstakeProjectionReadsOnlyTheSignedStakeAccount() async {
+        let account = SolanaStakeAccount(
+            pubkey: "signed-stake-account",
+            lamports: 2_100_000_000,
+            rentExemptReserve: 100_000_000,
+            staker: "owner",
+            withdrawer: "owner",
+            delegation: SolanaStakeAccount.Delegation(
+                votePubkey: "validator",
+                activationEpoch: 1,
+                deactivationEpoch: UInt64.max,
+                stake: 2_000_000_000
+            )
+        )
+        let reader = SolanaStakeAccountAmountReader(readStakeAccounts: { owner in
+            XCTAssertEqual(owner, "owner")
+            return [account]
+        })
+        let decoded = DecodedTransaction(
+            operation: .unstake,
+            amount: .unstated,
+            counterparty: .stakeAccount("signed-stake-account"),
+            evidence: .signedData
+        )
+        let amount = await reader.amount(for: decoded, coin: Self.solanaCoin())
+        XCTAssertEqual(amount?.amount, "2")
+    }
+
+    private static func solanaCoin() -> Coin {
+        Coin(
+            asset: CoinMeta(
+                chain: .solana, ticker: "SOL", logo: "solana", decimals: 9,
+                priceProviderId: "solana", contractAddress: "", isNativeToken: true
+            ),
+            address: "owner", hexPublicKey: "hex"
+        )
+    }
+
+    /// A valid prefix must not hide an unparsed signed suffix.
+    func testTrailingBytesAreRefused() {
+        XCTAssertNil(SolanaTransactionReader.read(base64: Self.deactivateWithTrailingBytes))
+    }
+
+    // MARK: - Structured fixtures
+
+    private static let stakeProgramAddress = "Stake11111111111111111111111111111111111111"
+    private static let systemProgramAddress = "11111111111111111111111111111111"
+    private static let stakeProgram = Base58.decodeNoCheck(string: stakeProgramAddress)!
+    private static let systemProgram = Base58.decodeNoCheck(string: systemProgramAddress)!
+    private static let payer = Data(repeating: 0x01, count: 32)
+    private static let stakeAccount = Data(repeating: 0x02, count: 32)
+    private static let validator = Data(repeating: 0x03, count: 32)
+    private static let clock = Data(repeating: 0x04, count: 32)
+    private static let history = Data(repeating: 0x05, count: 32)
+    private static let config = Data(repeating: 0x06, count: 32)
+    private static let rent = Data(repeating: 0x07, count: 32)
+    private static let otherStakeAccount = Data(repeating: 0x08, count: 32)
+
+    private static var deactivateOnly: String {
+        message(
+            accounts: [stakeProgram, stakeAccount, clock, payer],
+            instructions: [(program: 0, accounts: [1, 2, 3], data: discriminator(5))]
+        )
+    }
+
+    private static var withdrawOnly: String {
+        message(
+            accounts: [stakeProgram, stakeAccount, payer, clock, history, otherStakeAccount],
+            instructions: [
+                (
+                    program: 0,
+                    accounts: [1, 5, 2, 4, 3],
+                    data: discriminator(4) + littleEndian(2_100_000_000)
+                )
+            ]
+        )
+    }
+
+    private static var deactivateWithTrailingBytes: String {
+        let base = Data(base64Encoded: deactivateOnly)! + Data([0x01, 0x02, 0x03])
+        return base.base64EncodedString()
+    }
+
+    private static var delegateSequence: String {
+        makeDelegateSequence()
+    }
+
+    private static func makeDelegateSequence(
+        createData: Data = createAccountData(owner: stakeProgram),
+        createdStakeIndex: Int = 3
+    ) -> String {
+        message(
+            accounts: [systemProgram, stakeProgram, payer, stakeAccount, validator, clock, history, config, rent, otherStakeAccount],
+            instructions: [
+                (program: 0, accounts: [2, createdStakeIndex], data: createData),
+                (program: 1, accounts: [3, 8], data: initializeData),
+                (program: 1, accounts: [3, 4, 5, 6, 7, 2], data: discriminator(2))
+            ]
+        )
+    }
+
+    private static var transferPlusDeactivate: String {
+        message(
+            accounts: [systemProgram, stakeProgram, payer, Data(repeating: 0xAA, count: 32), stakeAccount, clock],
+            instructions: [
+                (program: 0, accounts: [2, 3], data: systemTransferData),
+                (program: 1, accounts: [4, 5, 2], data: discriminator(5))
+            ]
+        )
+    }
+
+    private static var initializeData: Data {
+        discriminator(0)
+            + payer
+            + payer
+            + Data(repeating: 0, count: 8 + 8 + 32)
+    }
+
+    private static func createAccountData(owner: Data) -> Data {
+        discriminator(0) + littleEndian(2_100_000_000) + littleEndian(200) + owner
+    }
+
+    private static var systemTransferData: Data {
+        discriminator(2) + littleEndian(1_000_000)
+    }
+
+    private static func littleEndian(_ value: UInt64) -> Data {
+        Data((0..<8).map { UInt8((value >> (UInt64($0) * 8)) & 0xFF) })
+    }
+
+    private static func discriminator(_ value: UInt32) -> Data {
+        Data([UInt8(value & 0xFF), UInt8((value >> 8) & 0xFF), UInt8((value >> 16) & 0xFF), UInt8((value >> 24) & 0xFF)])
+    }
+
+    private static func compactU16(_ value: Int) -> Data {
+        value < 0x80 ? Data([UInt8(value)]) : Data([UInt8(value & 0x7F | 0x80), UInt8(value >> 7)])
+    }
+
+    private static func message(
+        accounts: [Data],
+        instructions: [(program: Int, accounts: [Int], data: Data)]
+    ) -> String {
+        // Relayed transactions include signatures before the message.
+        var out = compactU16(1) + Data(repeating: 0, count: 64)
+
+        out += Data([1, 0, 1])                          // header
+        out += compactU16(accounts.count)
+        for key in accounts {
+            precondition(key.count == 32)
+            out += key
+        }
+        out += Data(repeating: 0, count: 32)            // recent blockhash
+        out += compactU16(instructions.count)
+        for i in instructions {
+            out += Data([UInt8(i.program)])
+            out += compactU16(i.accounts.count)
+            out += Data(i.accounts.map(UInt8.init))
+            out += compactU16(i.data.count)
+            out += i.data
+        }
+        return out.base64EncodedString()
+    }
+
+    private struct IntentContent: SignedTransactionContent {
+        let intent: SolanaStakingPayload
+        var chain: Chain { .solana }
+        var isNativeCoin: Bool { true }
+        var rawToAddress: String { "" }
+        var rawAmount: SignedAmount { .committed(.zero) }
+        var signedData: SignData? { nil }
+        var hasOpaqueSignedContent: Bool { true }
+        var rawMemo: String? { nil }
+        var rawTransactionType: VSTransactionType { .unspecified }
+        var rawWasmPayload: WasmExecuteContractPayload? { nil }
+        var rawSwap: SwapPayload? { nil }
+        var rawApprove: ERC20ApprovePayload? { nil }
+        var stakingIntent: SolanaStakingPayload? { intent }
+        var cosmosStakingIntent: CosmosStakingPayload? { nil }
+    }
+}

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/THORChainTransactionDecoderTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/THORChainTransactionDecoderTests.swift
@@ -1,0 +1,248 @@
+//
+//  THORChainTransactionDecoderTests.swift
+//  VultisigAppTests
+//
+
+import BigInt
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class THORChainTransactionDecoderTests: XCTestCase {
+
+    private var storeToken: TestContextToken?
+    private var inboundVaults: InboundVaultCorroborating?
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        storeToken = try TestStore.installInMemoryContainer()
+        inboundVaults = THORChainTransactionDecoder.inboundVaults
+    }
+
+    override func tearDown() {
+        TestStore.restore(storeToken)
+        storeToken = nil
+        if let inboundVaults {
+            THORChainTransactionDecoder.inboundVaults = inboundVaults
+        }
+        inboundVaults = nil
+        super.tearDown()
+    }
+
+    // MARK: - What it names
+
+    func testTheMemoGrammarNamesItsOperations() {
+        let expected: [(memo: String, operation: DecodedOperation)] = [
+            ("tcy+", .stake),
+            ("tcy-:5006", .unstake),
+            ("BOND:thor1node", .bond),
+            ("UNBOND:thor1node:100", .unbond),
+            ("LEAVE:thor1node", .leave),
+            ("SECURE+:thor1dest", .securedAssetDeposit),
+            ("SECURE-:thor1dest", .securedAssetWithdraw),
+            ("m=<:100000000THOR.RUNE:15979057441BTC.BTC:0", .limitOrderCancel)
+        ]
+
+        for probe in expected {
+            XCTAssertEqual(
+                SignedTransactionDecoder.decode(Self.payload(memo: probe.memo)).operation,
+                probe.operation,
+                probe.memo
+            )
+        }
+    }
+
+    /// A staked withdrawal commits to a fraction, not a settled amount.
+    func testAStakedWithdrawalIsAFractionNotAnAmount() {
+        let decoded = SignedTransactionDecoder.decode(Self.payload(memo: "tcy-:5006"))
+        XCTAssertEqual(decoded.operation, .unstake)
+        XCTAssertEqual(decoded.amount, .fraction(basisPoints: 5006, of: .transactionCoin))
+    }
+
+    /// A memo-only withdrawal must not inherit its zero carrier amount.
+    func testAStakedWithdrawalNeverReadsAsAZeroSend() {
+        let decoded = SignedTransactionDecoder.decode(Self.payload(memo: "tcy-:5006", amount: .zero))
+        XCTAssertNotEqual(decoded.operation, .transfer)
+        XCTAssertEqual(decoded.operation, .unstake)
+    }
+
+    func testADepositStatesWhatItCarries() {
+        let decoded = SignedTransactionDecoder.decode(Self.payload(memo: "tcy+", amount: BigInt(100_000_000)))
+        XCTAssertEqual(decoded.amount, .units(BigInt(100_000_000), of: .transactionCoin))
+    }
+
+    /// A max send carries no figure: the signer derives it at signing time.
+    func testAMaxSendDepositNamesNoAmount() {
+        let decoded = SignedTransactionDecoder.decode(Self.payload(memo: "tcy+", sendMax: true))
+        XCTAssertEqual(decoded.operation, .stake)
+        XCTAssertEqual(decoded.amount, .unstated)
+    }
+
+    // MARK: - Provenance
+
+    /// User-entered lookalike memos on unrelated chains lack provenance.
+    func testTheGrammarDoesNotApplyToAnUnrelatedChain() {
+        let elsewhere = Self.payload(memo: "tcy+", chain: .cardano, ticker: "ADA")
+        XCTAssertEqual(SignedTransactionDecoder.decode(elsewhere).operation, .unknown)
+    }
+
+    /// An inbound deposit leaves another chain, so the swap payload is what
+    /// corroborates that THORChain is the counterparty.
+    func testAnInboundDepositIsReadThroughItsSwapPayload() {
+        let inbound = Self.payload(memo: "SECURE+:thor1dest", chain: .bitcoin, ticker: "BTC", withThorSwap: true)
+        XCTAssertEqual(SignedTransactionDecoder.decode(inbound).operation, .securedAssetDeposit)
+    }
+
+    func testInboundVaultFallbackDoesNotOverrideApproveOrAnotherSwap() {
+        THORChainTransactionDecoder.inboundVaults = AlwaysInboundVaults()
+        let coin = Self.coin(chain: .bitcoin, ticker: "BTC")
+
+        let approve = Self.payload(
+            memo: "SECURE+:thor1dest",
+            chain: .bitcoin,
+            ticker: "BTC",
+            approve: ERC20ApprovePayload(amount: 1, spender: "router")
+        )
+        let otherSwap = Self.payload(
+            memo: "SECURE+:thor1dest",
+            chain: .bitcoin,
+            ticker: "BTC",
+            swap: .mayachain(Self.swapPayload(coin: coin))
+        )
+
+        XCTAssertEqual(SignedTransactionDecoder.decode(approve).operation, .unknown)
+        XCTAssertEqual(SignedTransactionDecoder.decode(otherSwap).operation, .unknown)
+    }
+
+    // MARK: - What it refuses
+
+    /// Opaque signed artifacts outrank flat memo sidecars.
+    func testOpaqueSignedContentIsNotNamedByTheMemoBesideIt() {
+        // Presence of opaque content is sufficient to make the sidecar inert.
+        let opaque = Self.payload(
+            memo: "tcy+",
+            signData: .signDirect(
+                SignDirect(bodyBytes: "", authInfoBytes: "", chainID: "thorchain-1", accountNumber: "0")
+            )
+        )
+        XCTAssertEqual(SignedTransactionDecoder.decode(opaque).operation, .unknown)
+    }
+
+    func testAnUnparsedMemoIsNotASend() {
+        XCTAssertEqual(SignedTransactionDecoder.decode(Self.payload(memo: "hello there")).operation, .unknown)
+    }
+
+    func testNoMemoIsNotAnOperation() {
+        XCTAssertEqual(SignedTransactionDecoder.decode(Self.payload(memo: nil)).operation, .unknown)
+    }
+
+    // MARK: - Both devices
+
+    func testTheReadingIsTheSameOnBothDevices() {
+        for memo in ["tcy+", "tcy-:5006", "BOND:thor1node"] {
+            let coSigner = SignedTransactionDecoder.decode(Self.payload(memo: memo))
+            let initiator = SignedTransactionDecoder.decode(
+                InitiatingTransactionContent(Self.transaction(memo: memo))
+            )
+            XCTAssertEqual(coSigner.operation, initiator.operation, memo)
+            XCTAssertEqual(coSigner.amount, initiator.amount, memo)
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private static func coin(chain: Chain = .thorChain, ticker: String = "TCY") -> Coin {
+        Coin(
+            asset: CoinMeta(
+                chain: chain, ticker: ticker, logo: ticker.lowercased(), decimals: 8,
+                priceProviderId: "thorchain", contractAddress: "", isNativeToken: true
+            ),
+            address: "thor1from",
+            hexPublicKey: "00"
+        )
+    }
+
+    private static func payload(
+        memo: String?,
+        chain: Chain = .thorChain,
+        ticker: String = "TCY",
+        amount: BigInt = BigInt(100_000_000),
+        sendMax: Bool = false,
+        withThorSwap: Bool = false,
+        approve: ERC20ApprovePayload? = nil,
+        swap: SwapPayload? = nil,
+        signData: SignData? = nil
+    ) -> KeysignPayload {
+        let coin = coin(chain: chain, ticker: ticker)
+        return KeysignPayload(
+            coin: coin,
+            toAddress: "thor1dest",
+            toAmount: amount,
+            chainSpecific: sendMax
+                ? .UTXO(byteFee: BigInt(1), sendMaxAmount: true)
+                : .THORChain(accountNumber: 0, sequence: 0, fee: 0, isDeposit: true),
+            utxos: [],
+            memo: memo,
+            swapPayload: swap ?? (withThorSwap ? .thorchain(swapPayload(coin: coin)) : nil),
+            approvePayload: approve,
+            vaultPubKeyECDSA: "pub",
+            vaultLocalPartyID: "party",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: signData
+        )
+    }
+
+    private static func swapPayload(coin: Coin) -> THORChainSwapPayload {
+        THORChainSwapPayload(
+            fromAddress: "thor1from",
+            fromCoin: coin,
+            toCoin: coin,
+            vaultAddress: "thor-vault",
+            routerAddress: nil,
+            fromAmount: BigInt(100_000_000),
+            toAmountDecimal: 0,
+            toAmountLimit: "0",
+            streamingInterval: "0",
+            streamingQuantity: "0",
+            expirationTime: 0,
+            isAffiliate: false
+        )
+    }
+
+    private static func transaction(memo: String) -> SendTransaction {
+        let coin = coin()
+        return SendTransaction(
+            coin: coin,
+            vault: TestStore.makeVault(pubKey: "test-pub-thor-\(memo)"),
+            fromAddress: coin.address,
+            toAddress: "thor1dest",
+            toAddressLabel: nil,
+            amount: "1",
+            amountInFiat: "0",
+            memo: memo,
+            gas: .zero,
+            fee: .zero,
+            feeMode: .normal,
+            estimatedGasLimit: nil,
+            customGasLimit: nil,
+            customByteFee: nil,
+            sendMaxAmount: false,
+            isStakingOperation: true,
+            transactionType: .unspecified,
+            memoFunctionDictionary: [:],
+            wasmContractPayload: nil,
+            feeCoin: coin
+        )
+    }
+
+    private struct AlwaysInboundVaults: InboundVaultCorroborating {
+        func corroborates(destination _: String, chain _: Chain, isNative _: Bool) -> Bool { true }
+    }
+}

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/TonTransactionDecoderTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/TonTransactionDecoderTests.swift
@@ -1,0 +1,142 @@
+//
+//  TonTransactionDecoderTests.swift
+//  VultisigAppTests
+//
+
+import BigInt
+@testable import VultisigApp
+import XCTest
+
+final class TonTransactionDecoderTests: XCTestCase {
+
+    func testAllExactNominatorCommentsDecodeWithAColdDirectory() {
+        let decoder = TonTransactionDecoder()
+        XCTAssertEqual(decoder.decode(Self.payload(to: "EQtf", memo: "d"))?.operation, .stake)
+        XCTAssertEqual(decoder.decode(Self.payload(to: "EQtf", memo: "w"))?.operation, .unstake)
+        XCTAssertEqual(decoder.decode(Self.payload(to: "EQwhales", memo: "Deposit"))?.operation, .stake)
+        XCTAssertEqual(decoder.decode(Self.payload(to: "EQwhales", memo: "Withdraw"))?.operation, .unstake)
+    }
+
+    func testDepositUsesTheExactSignedTonAmount() {
+        let decoded = TonTransactionDecoder().decode(Self.payload(to: "EQpool", memo: "d"))
+        XCTAssertEqual(decoded?.operation, .stake)
+        XCTAssertEqual(decoded?.amount, .units(BigInt(1_000_000_000), of: .chainNative))
+    }
+
+    @MainActor
+    func testDepositHeroIncludesFiat() throws {
+        try RateProvider.shared.save(rates: [
+            Rate(fiat: SettingsCurrency.current.rawValue, crypto: "the-open-network", value: 5)
+        ])
+        let decoded = try XCTUnwrap(
+            TonTransactionDecoder().decode(Self.payload(to: "EQpool", memo: "d"))
+        )
+        let hero = try XCTUnwrap(
+            DecodedTransactionPresentation.hero(for: decoded, coin: Self.tonCoin)
+        )
+
+        guard case .send(_, let amount) = hero else {
+            return XCTFail("expected an exact deposit amount")
+        }
+        XCTAssertEqual(amount.amount, "1")
+        XCTAssertFalse(amount.fiat?.isEmpty ?? true)
+    }
+
+    func testWithdrawTreatsTheCarrierAsAWholePositionRequest() {
+        let decoded = TonTransactionDecoder().decode(Self.payload(to: "EQpool", memo: "w"))
+        XCTAssertEqual(decoded?.operation, .unstake)
+        XCTAssertEqual(decoded?.amount, .unstated)
+        XCTAssertEqual(decoded?.counterparty, .pool("EQpool"))
+    }
+
+    func testCommentsRemainExactAndCaseSensitive() {
+        let decoder = TonTransactionDecoder()
+        for memo in [" d", "d ", "D", "deposit", "withdraw", "W", "claim", "redelegate"] {
+            XCTAssertNil(decoder.decode(Self.payload(to: "EQpool", memo: memo)), memo)
+        }
+    }
+
+    func testTonConnectSignedDataMakesTheOuterCommentInert() {
+        let payload = Self.payload(
+            to: "EQpool",
+            memo: "d",
+            signData: .signTon(SignTon(tonMessages: []))
+        )
+        XCTAssertNil(TonTransactionDecoder().decode(payload))
+    }
+
+    func testWholePositionProjectionUsesTheSignedPoolAndTrustedOwner() async throws {
+        try await MainActor.run {
+            try RateProvider.shared.save(rates: [
+                Rate(fiat: SettingsCurrency.current.rawValue, crypto: "the-open-network", value: 5)
+            ])
+        }
+        let reader = TonStakedPositionReader(readPools: { owner in
+            XCTAssertEqual(owner, "EQfrom")
+            return [
+                TonAccountStakingInfo(
+                    pool: "EQother",
+                    amount: 9_000_000_000,
+                    pendingDeposit: 0,
+                    pendingWithdraw: 0,
+                    readyWithdraw: 0
+                ),
+                TonAccountStakingInfo(
+                    pool: "EQpool",
+                    amount: 2_000_000_000,
+                    pendingDeposit: 500_000_000,
+                    pendingWithdraw: 0,
+                    readyWithdraw: 0
+                )
+            ]
+        })
+        let decoded = try XCTUnwrap(TonTransactionDecoder().decode(Self.payload(to: "EQpool", memo: "w")))
+        let amount = await reader.amount(for: decoded, coin: Self.tonCoin)
+        XCTAssertEqual(amount?.amount, "2.5")
+        XCTAssertFalse(amount?.fiat?.isEmpty ?? true)
+    }
+
+    private static var tonCoin: Coin {
+        Coin(
+            asset: CoinMeta(
+                chain: .ton,
+                ticker: "TON",
+                logo: "ton",
+                decimals: 9,
+                priceProviderId: "the-open-network",
+                contractAddress: "",
+                isNativeToken: true
+            ),
+            address: "EQfrom",
+            hexPublicKey: "00"
+        )
+    }
+
+    private static func payload(
+        to destination: String,
+        memo: String,
+        signData: SignData? = nil
+    ) -> KeysignPayload {
+        KeysignPayload(
+            coin: tonCoin,
+            toAddress: destination,
+            toAmount: BigInt(1_000_000_000),
+            chainSpecific: .Ton(sequenceNumber: 1, expireAt: 0, bounceable: true, sendMaxAmount: false),
+            utxos: [],
+            memo: memo,
+            swapPayload: nil,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "pub",
+            vaultLocalPartyID: "party",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: signData
+        )
+    }
+}

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/TransactionHeroResolverTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/TransactionHeroResolverTests.swift
@@ -187,6 +187,15 @@ final class TransactionHeroResolverTests: XCTestCase {
         }
     }
 
+    func testCosmosStakingSummaryUsesTheSharedHeroVocabulary() throws {
+        let source = try appSource(
+            "Features/FunctionTransaction/Common/View/CosmosStakingVerifySummaryView.swift"
+        )
+        XCTAssertTrue(source.contains("TransactionHeroResolver.hero("))
+        XCTAssertTrue(source.contains("HeroContentView(content: hero)"))
+        XCTAssertFalse(source.contains("private var headlineKey"))
+    }
+
     /// The presentations the registry owns are reached through it, not around it.
     func testNoScreenCallsAProviderPresentationDirectly() throws {
         let screens = [

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/TransactionHeroResolverTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/TransactionHeroResolverTests.swift
@@ -10,16 +10,39 @@ import XCTest
 
 final class TransactionHeroResolverTests: XCTestCase {
 
+    func testFractionalWithdrawalUsesProjectedSemantics() {
+        let coin = Coin(asset: TokensStore.tcy, address: "thor1local", hexPublicKey: "00")
+        let transaction = TCYUnstakeTransactionBuilder(
+            coin: coin,
+            basisPoints: 5_006,
+            autoCompoundAmount: 0,
+            sendMaxAmount: false,
+            isAutoCompound: false,
+            stakedAmount: Decimal(string: "2002.74")!
+        ).buildSendTransaction(vault: .example)
+
+        let hero = TransactionHeroResolver.hero(
+            on: .functionCallVerify,
+            for: .initiating(transaction)
+        )
+        guard case .projected(_, let estimate, let scope) = hero else {
+            return XCTFail("fractional withdrawal must not look like a committed send amount")
+        }
+        XCTAssertTrue(estimate?.amount.hasPrefix("1,002.571644") ?? false)
+        XCTAssertTrue(scope.contains("50.06"), "the committed fraction should remain visible: \(scope)")
+    }
+
     // MARK: - The order
 
     func testProvidersAreAskedInTheDeclaredOrder() {
         XCTAssertEqual(
             TransactionHeroResolver.providers.map(\.id),
-            [.rippleTrustSet, .limitOrderCancel, .limitOrderPlacement, .simulated, .decoded],
+            [.rippleTrustSet, .quotedWithdrawal, .limitOrderCancel, .limitOrderPlacement, .simulated, .decoded],
             """
             The order is the answer to two providers claiming one transaction, \
-            and it has to stay the one the four `??` chains gave. Changing it \
-            changes what a signing screen says.
+            and it has to stay the one the four `??` chains gave, plus \
+            quotedWithdrawal reinstating the fractional-withdrawal hero ahead of \
+            the decoded reading. Changing it changes what a signing screen says.
             """
         )
     }
@@ -91,7 +114,8 @@ final class TransactionHeroResolverTests: XCTestCase {
     /// Surface entitlements preserve the previous, intentionally asymmetric chains.
     func testEachSurfaceAsksExactlyTheProvidersItsOldChainAsked() {
         let expected: [TransactionHeroSurface: [TransactionHeroProvider.ID]] = [
-            .functionCallVerify: [.limitOrderCancel, .decoded],
+            // Exact initiator payout precedes the decoded fraction.
+            .functionCallVerify: [.quotedWithdrawal, .limitOrderCancel, .decoded],
             .sendVerify: [.decoded],
             .sendDone: [.rippleTrustSet, .limitOrderCancel],
             .keysignConfirm: [.limitOrderCancel, .limitOrderPlacement, .simulated, .decoded],

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/TronTransactionDecoderTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/TronTransactionDecoderTests.swift
@@ -1,0 +1,238 @@
+//
+//  TronTransactionDecoderTests.swift
+//  VultisigAppTests
+//
+
+import BigInt
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class TronTransactionDecoderTests: XCTestCase {
+
+    /// Isolates unique-model fixtures from test ordering.
+    private var storeToken: TestContextToken?
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        storeToken = try TestStore.installInMemoryContainer()
+    }
+
+    override func tearDown() {
+        TestStore.restore(storeToken)
+        storeToken = nil
+        super.tearDown()
+    }
+
+    // MARK: - What it names
+
+    func testFreezingForBandwidthIsAStakeWithItsAmount() {
+        let decoded = SignedTransactionDecoder.decode(Self.payload(memo: "FREEZE:BANDWIDTH"))
+        XCTAssertEqual(decoded.operation, .stake)
+        XCTAssertEqual(decoded.amount, .units(BigInt(5_000_000), of: .chainNative))
+        XCTAssertEqual(decoded.evidence, .memo)
+    }
+
+    func testFreezingForEnergyIsAlsoAStake() {
+        XCTAssertEqual(SignedTransactionDecoder.decode(Self.payload(memo: "FREEZE:ENERGY")).operation, .stake)
+    }
+
+    func testUnfreezingIsAnUnstake() {
+        for resource in ["BANDWIDTH", "ENERGY"] {
+            let decoded = SignedTransactionDecoder.decode(Self.payload(memo: "UNFREEZE:\(resource)"))
+            XCTAssertEqual(decoded.operation, .unstake, resource)
+            XCTAssertEqual(decoded.amount, .units(BigInt(5_000_000), of: .chainNative), resource)
+        }
+    }
+
+    /// Both devices must read the same transaction identically.
+    func testTheReadingIsTheSameOnBothDevices() throws {
+        let payload = Self.payload(memo: "FREEZE:ENERGY")
+        let coSigner = SignedTransactionDecoder.decode(payload)
+        let initiator = SignedTransactionDecoder.decode(
+            InitiatingTransactionContent(Self.transaction(memo: "FREEZE:ENERGY"))
+        )
+        XCTAssertEqual(coSigner.operation, initiator.operation)
+        XCTAssertEqual(coSigner.amount, initiator.amount)
+        XCTAssertEqual(coSigner.evidence, initiator.evidence)
+    }
+
+    // MARK: - What it refuses
+
+    /// Typed contract payloads outrank the staking memo in the signer.
+    func testAContractPayloadBesideAStakingMemoIsRefused() {
+        let transfer = TronTransferContractPayload(
+            toAddress: "TRecipient", ownerAddress: "TOwner", amount: "5000000"
+        )
+        let spoofed = Self.payload(memo: "FREEZE:ENERGY", tronTransfer: transfer)
+
+        XCTAssertEqual(
+            SignedTransactionDecoder.decode(spoofed).operation, .unknown,
+            "a transfer payload outranks the memo in the signer, so the memo must not name the transaction"
+        )
+    }
+
+    func testASmartContractPayloadBesideAStakingMemoIsRefused() {
+        let call = TronTriggerSmartContractPayload(
+            ownerAddress: "TOwner", contractAddress: "TContract",
+            callValue: nil, callTokenValue: nil, tokenId: nil, data: "deadbeef"
+        )
+        XCTAssertEqual(
+            SignedTransactionDecoder.decode(Self.payload(memo: "UNFREEZE:BANDWIDTH", tronTrigger: call)).operation,
+            .unknown
+        )
+    }
+
+    /// Unknown or inexact resource names are rejected by the signer.
+    func testAnUnknownResourceIsRefused() {
+        for memo in ["FREEZE:CPU", "FREEZE:bandwidth", "FREEZE:", "FREEZE:BANDWIDTH ", "UNFREEZE:ENERGY!"] {
+            XCTAssertEqual(
+                SignedTransactionDecoder.decode(Self.payload(memo: memo)).operation, .unknown,
+                memo
+            )
+        }
+    }
+
+    /// The grammar must not apply off TRON.
+    func testTheGrammarDoesNotApplyOffTron() {
+        let elsewhere = Self.payload(memo: "FREEZE:ENERGY", chain: .thorChain, ticker: "RUNE")
+        XCTAssertEqual(SignedTransactionDecoder.decode(elsewhere).operation, .unknown)
+    }
+
+    func testAnOrdinaryTransferIsNotClaimed() {
+        XCTAssertEqual(SignedTransactionDecoder.decode(Self.payload(memo: nil)).operation, .unknown)
+    }
+
+    /// Amounts outside the wire's `int64` are not stated.
+    func testAnAmountTheSignerCouldNotEncodeIsNotStated() {
+        let decoded = SignedTransactionDecoder.decode(
+            Self.payload(memo: "FREEZE:ENERGY", amount: BigInt(Int64.max) + 1)
+        )
+        XCTAssertEqual(decoded.operation, .stake)
+        XCTAssertEqual(decoded.amount, .unstated)
+    }
+
+    /// Swap routing outranks the memo.
+    func testAStakingMemoBesideASwapPayloadIsRefused() {
+        XCTAssertEqual(
+            SignedTransactionDecoder.decode(Self.payload(memo: "FREEZE:ENERGY", withSwap: true)).operation,
+            .unknown,
+            "a swap payload is dispatched before the chain helper, so the memo describes nothing signed"
+        )
+    }
+
+    /// Payload metadata cannot change the instruction's native asset.
+    func testATokenDressedPayloadStillReadsAsTheChainsOwnCoin() {
+        let decoded = SignedTransactionDecoder.decode(Self.payload(memo: "FREEZE:ENERGY", native: false))
+        XCTAssertEqual(decoded.operation, .stake)
+        XCTAssertEqual(
+            decoded.amount, .units(BigInt(5_000_000), of: .chainNative),
+            "the asset must come from the chain, not from what the payload calls itself"
+        )
+    }
+
+    /// Rendering uses bundled TRX metadata, not the payload ticker.
+    func testTheRenderedAmountUsesBundledChainMetadata() throws {
+        let decoded = SignedTransactionDecoder.decode(Self.payload(memo: "FREEZE:ENERGY", native: false))
+        let hero = try XCTUnwrap(
+            DecodedTransactionPresentation.hero(for: decoded, coin: Self.coin(native: false))
+        )
+        guard case .send(_, let amount) = hero else {
+            return XCTFail("a stated amount should render as a resolved single-sided figure")
+        }
+        XCTAssertEqual(amount.ticker, "TRX", "rendered against the payload's ticker instead of the chain's own")
+    }
+
+    // MARK: - Fixtures
+
+    private static func coin(chain: Chain = .tron, ticker: String = "TRX", native: Bool = true) -> Coin {
+        Coin(
+            asset: CoinMeta(
+                chain: chain, ticker: ticker, logo: ticker.lowercased(), decimals: 6,
+                priceProviderId: "tron",
+                contractAddress: native ? "" : "TTokenContract",
+                isNativeToken: native
+            ),
+            address: "TOwner",
+            hexPublicKey: "00"
+        )
+    }
+
+    private static func payload(
+        memo: String?,
+        chain: Chain = .tron,
+        ticker: String = "TRX",
+        amount: BigInt = BigInt(5_000_000),
+        native: Bool = true,
+        withSwap: Bool = false,
+        tronTransfer: TronTransferContractPayload? = nil,
+        tronTrigger: TronTriggerSmartContractPayload? = nil
+    ) -> KeysignPayload {
+        KeysignPayload(
+            coin: coin(chain: chain, ticker: ticker, native: native),
+            toAddress: "TOwner",
+            toAmount: amount,
+            chainSpecific: .Tron(timestamp: 0, expiration: 0, blockHeaderTimestamp: 0, blockHeaderNumber: 0,
+                        blockHeaderVersion: 0, blockHeaderTxTrieRoot: "", blockHeaderParentHash: "",
+                        blockHeaderWitnessAddress: "", gasFeeEstimation: 0),
+            utxos: [],
+            memo: memo,
+            swapPayload: withSwap ? .thorchain(swapPayload()) : nil,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "pub",
+            vaultLocalPartyID: "party",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: tronTransfer,
+            tronTriggerSmartContractPayload: tronTrigger,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: nil
+        )
+    }
+
+    private static func swapPayload() -> THORChainSwapPayload {
+        THORChainSwapPayload(
+            fromAddress: "TOwner",
+            fromCoin: coin(),
+            toCoin: coin(),
+            vaultAddress: "thor-vault",
+            routerAddress: nil,
+            fromAmount: BigInt(5_000_000),
+            toAmountDecimal: 0,
+            toAmountLimit: "0",
+            streamingInterval: "0",
+            streamingQuantity: "0",
+            expirationTime: 0,
+            isAffiliate: false
+        )
+    }
+
+    private static func transaction(memo: String) -> SendTransaction {
+        let coin = coin()
+        return SendTransaction(
+            coin: coin,
+            vault: TestStore.makeVault(pubKey: "test-pub-tron-\(memo)"),
+            fromAddress: coin.address,
+            toAddress: "TOwner",
+            toAddressLabel: nil,
+            amount: "5",
+            amountInFiat: "0",
+            memo: memo,
+            gas: .zero,
+            fee: .zero,
+            feeMode: .normal,
+            estimatedGasLimit: nil,
+            customGasLimit: nil,
+            customByteFee: nil,
+            sendMaxAmount: false,
+            isStakingOperation: true,
+            transactionType: .unspecified,
+            memoFunctionDictionary: [:],
+            wasmContractPayload: nil,
+            feeCoin: coin
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds the final test-only lock for the Verify decoder stack.

- sends every decoder-emittable operation through the real ordered registry with a representative signed fixture
- requires every `DecodedOperation` case to have an explicit Verify hero decision
- locks initiator/co-signer semantic parity and deliberate verb-only/silent behavior
- keeps swap and approve as explicit screen-owned exemptions
- makes future unhandled operation additions fail the exhaustive vocabulary matrix

## Reviewer contract

1. **What proves the operation?** Each fixture passes representative signed content through the production registry.
2. **Which surfaces can reach it?** The matrix validates shared behavior consumed by all Verify surfaces.
3. **What is deliberately refused?** Screen-owned swap/approve presentation and deliberately silent operations are named, asserted exemptions.
4. **What hero appears?** Every decoder-owned operation must produce its expected title and truthful amount policy; exemptions must remain outside the generic hero.

## Stack

- base: #5224 (`codex/decoder-thor-rujira`)
- decoder stack tip: this PR
- Done-screen continuation: #5229 (`codex/decoder-done-hero`), stacked directly on this branch

## Validation

- exhaustive registry fixture and operation-vocabulary matrices included
- downstream #5229 full `make test` (containing this stack): 6,744 passed, 11 skipped, 0 failed
- build-integrated SwiftLint passed; changed-file lint is clean
- `git diff --check`: clean

Closes #5216
