### PR TITLE
fix(wallet): sort chains after rate cache hydration

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/Rates/RateProvider.swift
+++ b/VultisigApp/VultisigApp/Core/Services/Rates/RateProvider.swift
@@ -12,6 +12,11 @@ import OSLog
 
 final class RateProvider {
 
+    enum CacheChange {
+        case persistedHydration
+        case ratesUpdated
+    }
+
     enum CryptoId {
         case priceProvider(String)
         case contract(String)
@@ -28,14 +33,15 @@ final class RateProvider {
 
     static let shared = RateProvider()
 
-    /// Fires on the main actor whenever the cached rate set changes — the initial
-    /// load of persisted rates and every `save(rates:)`.
+    /// Fires on the main actor whenever the cached rate set changes, identifying
+    /// whether the change is the coherent persisted snapshot loaded at startup
+    /// or an incremental update from `save(rates:)`.
     ///
     /// Rates are an otherwise silent cache: callers that render a *precomputed*
     /// fiat value (rather than reading `rate(for:)` inside `body`) have no way to
     /// learn that a rate arrived, so their fiat stays frozen at whatever was
     /// cached when they last recomputed. This signal is that missing link.
-    let ratesDidChange = PassthroughSubject<Void, Never>()
+    let ratesDidChange = PassthroughSubject<CacheChange, Never>()
 
     static func cryptoId(for coin: CoinMeta) -> CryptoId {
         switch coin.chain.chainType {
@@ -122,7 +128,7 @@ final class RateProvider {
             // Persisted rates make fiat renderable immediately on a warm
             // start; announce them so views that cached a pre-load fiat
             // value recompute instead of waiting on a network refresh.
-            ratesDidChange.send()
+            ratesDidChange.send(.persistedHydration)
         } catch {
             Log.chain.service.error("Failed to load rates: \(error.localizedDescription, privacy: .public)")
         }
@@ -195,7 +201,7 @@ final class RateProvider {
         // changed — announce it even if the persistence below throws, or a
         // failed write would leave the UI showing fiat that contradicts the
         // cache until the next refresh.
-        defer { ratesDidChange.send() }
+        defer { ratesDidChange.send(.ratesUpdated) }
 
         // Update existing or insert new rates
         for rate in rates {

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
@@ -9,6 +9,7 @@ import Combine
 import Foundation
 import SwiftUI
 
+@MainActor
 class VaultDetailViewModel: ObservableObject {
     /// Preformatted vault total tagged with the vault it was computed for. The
     /// tag is load-bearing: on a vault switch the previous vault's total stays

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
@@ -67,30 +67,43 @@ class VaultDetailViewModel: ObservableObject {
         // is pure and network-free.
         rateProvider.ratesDidChange
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] in self?.rebuildRowsForRateChange() }
+            .sink { [weak self] change in self?.rebuildRowsForRateChange(change) }
             .store(in: &cancellables)
     }
 
-    /// Recomputes the projection's fiat against the currently cached rates,
-    /// **keeping the current row order**.
+    /// Recomputes the projection's fiat against the currently cached rates.
     ///
-    /// `chainRows(vault:)` orders by fiat descending, and rates land once per
-    /// chain group, so re-sorting here would reshuffle the list under the user
-    /// several times per refresh. A rate arriving should refresh the values, not
-    /// reorder — the authoritative fiat-desc re-sort stays on `updateBalance`'s
-    /// tail, which keeps the deliberate "no stale-then-fresh double reorder"
-    /// behaviour intact. No-ops when nothing changed.
-    private func rebuildRowsForRateChange() {
+    /// The one persisted-cache hydration is a coherent snapshot and may correct
+    /// the zero-rate order produced by the synchronous startup seed. Incremental
+    /// network rates land once per chain group, so those refresh values in place
+    /// and leave the authoritative re-sort on `updateBalance`'s tail. This keeps
+    /// the deliberate "no stale-then-fresh double reorder" behaviour intact.
+    private func rebuildRowsForRateChange(_ change: RateProvider.CacheChange) {
         guard let vault = rowsVault else { return }
         refreshTotalFiatBalance(vault: vault)
         guard !rows.isEmpty else { return }
-        let byChain = Dictionary(
-            logic.chainRows(vault: vault).map { ($0.chain, $0) },
-            uniquingKeysWith: { _, latest in latest }
-        )
-        let rebuilt = rows.compactMap { byChain[$0.chain] }
-        guard rebuilt.count == rows.count, rebuilt != rows else { return }
-        rows = rebuilt
+
+        let sortedRows = logic.chainRows(vault: vault)
+        switch change {
+        case .persistedHydration:
+            let sortedChains = sortedRows.map(\.chain)
+            if sortedChains != chains {
+                chains = sortedChains
+            }
+            if sortedRows != rows {
+                rows = sortedRows
+            }
+            chainsVaultPubKeyECDSA = vault.pubKeyECDSA
+
+        case .ratesUpdated:
+            let byChain = Dictionary(
+                sortedRows.map { ($0.chain, $0) },
+                uniquingKeysWith: { _, latest in latest }
+            )
+            let rebuilt = rows.compactMap { byChain[$0.chain] }
+            guard rebuilt.count == rows.count, rebuilt != rows else { return }
+            rows = rebuilt
+        }
     }
 
     /// Recomputes the preformatted vault total. Cheap relative to the row

--- a/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
@@ -127,8 +127,9 @@ final class VaultDetailViewModelTests: XCTestCase {
         let vm = VaultDetailViewModel()
         vm.groupChains(vault: vault)
         let orderBefore = vm.rows.map(\.chain)
+        XCTAssertEqual(orderBefore, [.ethereum, .bitcoin], "precondition: zero-rate rows use the chain-index tie-break")
 
-        // Price ETH far above BTC. A re-sorting rebuild would flip the order.
+        // Price BTC far above ETH. A re-sorting rebuild would flip the order.
         let rebuilt = expectation(description: "fiat refreshed")
         rateCancellable = vm.$rows.dropFirst().sink { rows in
             if rows.contains(where: { $0.fiatBalance != Decimal.zero.formatToFiat(includeCurrencySymbol: true) }) {
@@ -136,11 +137,54 @@ final class VaultDetailViewModelTests: XCTestCase {
             }
         }
         try RateProvider.shared.save(rates: [
-            Rate(fiat: SettingsCurrency.current.rawValue, crypto: ethId, value: 900_000)
+            Rate(fiat: SettingsCurrency.current.rawValue, crypto: btcId, value: 900_000)
         ])
         await fulfillment(of: [rebuilt], timeout: 2)
 
         XCTAssertEqual(vm.rows.map(\.chain), orderBefore, "a rate arrival must not reorder the list")
+    }
+
+    /// Persisted rates arrive as one coherent startup snapshot. Unlike
+    /// incremental network saves, hydration must repair the zero-rate seed order
+    /// immediately and keep the selector's `chains` projection aligned with the
+    /// rendered rows.
+    func testPersistedRateHydrationReordersRowsAndChainsImmediately() async throws {
+        let btcId = "hydration-btc-\(UUID().uuidString)"
+        let ethId = "hydration-eth-\(UUID().uuidString)"
+        let vault = makeVault(pubKey: "vault-hydration", chains: [])
+        vault.coins = [
+            makePricedCoin(chain: .bitcoin, ticker: "BTC", providerId: btcId, rawBalance: "100000000"),
+            makePricedCoin(chain: .ethereum, ticker: "ETH", providerId: ethId, rawBalance: "1000000000000000000")
+        ]
+
+        let vm = VaultDetailViewModel()
+        vm.groupChains(vault: vault)
+        XCTAssertEqual(vm.rows.map(\.chain), [.ethereum, .bitcoin], "precondition: startup seed has no rates")
+
+        let incrementalRefresh = expectation(description: "incremental rate refreshed in place")
+        rateCancellable = vm.$rows.dropFirst().sink { rows in
+            let bitcoin = rows.first(where: { $0.chain == .bitcoin })
+            if bitcoin?.fiatBalance != Decimal.zero.formatToFiat(includeCurrencySymbol: true) {
+                incrementalRefresh.fulfill()
+            }
+        }
+        try RateProvider.shared.save(rates: [
+            Rate(fiat: SettingsCurrency.current.rawValue, crypto: btcId, value: 900_000)
+        ])
+        await fulfillment(of: [incrementalRefresh], timeout: 2)
+        XCTAssertEqual(vm.rows.map(\.chain), [.ethereum, .bitcoin])
+
+        let hydrated = expectation(description: "persisted hydration sorted projection")
+        rateCancellable = vm.$rows.dropFirst().sink { rows in
+            if rows.map(\.chain) == [.bitcoin, .ethereum] {
+                hydrated.fulfill()
+            }
+        }
+        RateProvider.shared.ratesDidChange.send(.persistedHydration)
+        await fulfillment(of: [hydrated], timeout: 2)
+
+        XCTAssertEqual(vm.rows.map(\.chain), [.bitcoin, .ethereum])
+        XCTAssertEqual(vm.chains, vm.rows.map(\.chain), "chain selectors and rendered rows must stay in lockstep")
     }
 
     /// A rate for a coin this vault does not hold must not republish `rows` —


### PR DESCRIPTION
## Description

Fix the delayed Home chain ordering after a cold startup by distinguishing the initial persisted-rate snapshot from later incremental rate updates.

- Publish typed rate-cache events for persisted hydration and incremental saves.
- Immediately sort the hydrated Home projection and update `rows` and `chains` together.
- Keep incremental network-rate updates in the existing row order, preserving the anti-flicker behavior introduced by #4337.
- Correct the existing ordering test so its price update genuinely would reverse a sorted projection, and add hydration/row-chain alignment coverage.

Fixes #5227

## Which feature is affected?

- [x] Wallet / Home chain list
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable)

Not applicable; this changes when the existing value-sorted list projection is published, without changing its visual design.

## Additional context

- Focused ordering regression tests passed.
- Full `make test`: 6,626 tests executed, 11 skipped, 0 failures (`** TEST SUCCEEDED **`).
- Full SwiftLint matched the existing baseline: 26 warnings, 0 serious violations. The three changed files have 0 violations.
- The independent Claude review passes were skipped at the user's request after the local reviewer stalled without producing findings.

## Agent Metadata (if applicable)

- **Agent**: Codex
- **Issue**: #5227
- **Confidence**: high
- **Needs human review for**: cold-launch event ordering and on-device startup behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Wallet detail views now update fiat values as exchange rates arrive without unexpectedly changing asset order.
  - Previously saved rates are restored immediately and used to correctly reorder chains and wallet rows.
  - Wallet data remains synchronized with the displayed order after rate restoration.

- **Bug Fixes**
  - Fixed inconsistencies between chain ordering and the rows shown in wallet details after rates are loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->