### PR TITLE
fix(history): keep timed-out transactions resumable

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/PendingTransactionStorage.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/PendingTransactionStorage.swift
@@ -96,10 +96,12 @@ final class StoredPendingTransactionStorage {
         return try modelContext.fetch(descriptor).first
     }
 
-    /// Get all non-terminal pending transactions (for background polling)
+    /// Get all resumable transactions for background polling. `timeout` is a
+    /// legacy client-deadline value, not a chain outcome, so released rows with
+    /// that value get one fresh status check after upgrading.
     func getAllPending() throws -> [StoredPendingTransaction] {
         let predicate = #Predicate<StoredPendingTransaction> { tx in
-            tx.status == "broadcasted" || tx.status == "pending"
+            tx.status == "broadcasted" || tx.status == "pending" || tx.status == "timeout"
         }
         let descriptor = FetchDescriptor(
             predicate: predicate,
@@ -118,14 +120,13 @@ final class StoredPendingTransactionStorage {
     /// signed, so no one else can replace or double-spend it.
     ///
     /// Deliberately *not* `getAllPending()`. That set answers "should the
-    /// status poller still be working on this", which is a question about the
-    /// poller's patience, not about the chain: it drops a transaction once the
-    /// poller gives up (`timeout`) even though a low-fee transaction can sit in
-    /// a mempool for far longer than any poll window. Losing ownership there
-    /// would take a wallet whose confirmed inputs the send already consumed
-    /// straight back to reading zero — the exact failure this lookup exists to
-    /// prevent, just deferred. Only `confirmed` ends the exemption, and it ends
-    /// it harmlessly: a confirmed output carries a block and needs no vouching.
+    /// status poller resume this", which may evolve independently of chain
+    /// truth. A low-fee transaction can sit in a mempool for far longer than
+    /// any client polling window. Losing ownership there would take a wallet
+    /// whose confirmed inputs the send already consumed straight back to
+    /// reading zero — the exact failure this lookup exists to prevent, just
+    /// deferred. Only `confirmed` ends the exemption, and it ends it harmlessly:
+    /// a confirmed output carries a block and needs no vouching.
     ///
     /// The set is deliberately allowed to outlive the transactions in it — a
     /// row stays non-terminal while the poller reports `notFound`, a row can be

--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/TransactionStatusPoller.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/TransactionStatusPoller.swift
@@ -11,6 +11,12 @@ import OSLog
 final class TransactionStatusPoller: ObservableObject {
     static let shared = TransactionStatusPoller()
 
+    enum PollAction: Equatable {
+        case complete(TransactionHistoryStatus, String?)
+        case retry
+        case stop
+    }
+
     @Published private(set) var completedTransactionCount: Int = 0
 
     private let service = TransactionStatusService.shared
@@ -84,35 +90,26 @@ final class TransactionStatusPoller: ObservableObject {
         let config = ChainStatusConfig.config(for: chain)
 
         let task = Task { [weak self] in
-            while !Task.isCancelled {
+            pollingLoop: while !Task.isCancelled {
+                guard let self else { break }
+
                 do {
                     // Ownership is re-checked before every write, not just at
                     // start. A poll that legitimately began under
                     // `trackerOutage` must not still be holding the pen when the
                     // tracker recovers — the gate has to hold for the write, and
                     // the write is what the user sees.
-                    guard self?.isOwnedByTracker(txHash: txHash, pubKeyECDSA: pubKeyECDSA) != true else {
-                        self?.logger.debug("Tracker regained authority mid-poll for \(txHash) — standing down")
+                    guard !self.isOwnedByTracker(txHash: txHash, pubKeyECDSA: pubKeyECDSA) else {
+                        self.logger.debug("Tracker regained authority mid-poll for \(txHash) — standing down")
                         break
                     }
 
                     let elapsed = Date().timeIntervalSince(createdAt)
-                    if elapsed >= config.maxWaitTime {
-                        let timeoutMessage = "timeout".localized
-                        self?.recorder.updateStatus(
-                            txHash: txHash,
-                            pubKeyECDSA: pubKeyECDSA,
-                            status: .error,
-                            errorMessage: timeoutMessage
-                        )
-                        onUpdate(.error, timeoutMessage)
-                        self?.completedTransactionCount += 1
-                        break
-                    }
-
-                    let result = try await self?.service.checkTransactionStatus(
+                    let action = await Self.nextAction(
+                        checker: self.service,
                         txHash: txHash,
-                        chain: chain
+                        chain: chain,
+                        deadlineReached: elapsed >= config.maxWaitTime
                     )
 
                     // `stopAll()` (e.g. the global reset) cancels this task while
@@ -122,34 +119,39 @@ final class TransactionStatusPoller: ObservableObject {
                     // of the loop.
                     if Task.isCancelled { break }
 
-                    if let result, let historyStatus = self?.mapToHistoryStatus(result) {
-                        var errorMessage: String? = nil
-                        if case let .failed(reason) = result.status {
-                            errorMessage = reason
-                        }
+                    switch action {
+                    case let .complete(historyStatus, errorMessage):
                         // Re-checked after the await: the status fetch is a
                         // network round-trip, and the tracker can take ownership
                         // while it is in flight.
-                        guard self?.isOwnedByTracker(txHash: txHash, pubKeyECDSA: pubKeyECDSA) != true else {
-                            self?.logger.debug("Tracker took authority during status fetch for \(txHash) — discarding result")
-                            break
+                        guard !self.isOwnedByTracker(txHash: txHash, pubKeyECDSA: pubKeyECDSA) else {
+                            self.logger.debug("Tracker took authority during status fetch for \(txHash) — discarding result")
+                            break pollingLoop
                         }
-                        self?.recorder.updateStatus(
+                        self.recorder.updateStatus(
                             txHash: txHash,
                             pubKeyECDSA: pubKeyECDSA,
                             status: historyStatus,
                             errorMessage: errorMessage
                         )
                         onUpdate(historyStatus, errorMessage)
-                        self?.completedTransactionCount += 1
-                        break
-                    }
+                        self.completedTransactionCount += 1
+                        break pollingLoop
 
-                    try await Task.sleep(for: .seconds(config.pollInterval))
+                    case .retry:
+                        try await Task.sleep(for: .seconds(config.pollInterval))
+
+                    case .stop:
+                        // The client deadline limits continuous polling; it is
+                        // not evidence that the chain rejected the transaction.
+                        // Leave the row in progress so the next app/history open
+                        // performs another chain-first check.
+                        break pollingLoop
+                    }
                 } catch is CancellationError {
                     break
                 } catch {
-                    try? await Task.sleep(for: .seconds(config.pollInterval))
+                    break
                 }
             }
 
@@ -225,15 +227,29 @@ final class TransactionStatusPoller: ObservableObject {
             && tx.swapTracking?.trackerOutage != true
     }
 
-    /// Returns a terminal TransactionHistoryStatus if the result is terminal, nil if still pending.
-    private func mapToHistoryStatus(_ result: TransactionStatusResult) -> TransactionHistoryStatus? {
-        switch result.status {
-        case .confirmed:
-            return .successful
-        case .failed:
-            return .error
-        case .notFound, .pending:
-            return nil
+    /// Resolve one polling iteration. The chain lookup always happens before
+    /// the client deadline is interpreted, including when a row is already old
+    /// when the app opens.
+    static func nextAction(
+        checker: TransactionStatusChecking,
+        txHash: String,
+        chain: Chain,
+        deadlineReached: Bool
+    ) async -> PollAction {
+        do {
+            let result = try await checker.checkTransactionStatus(txHash: txHash, chain: chain)
+            switch result.status {
+            case .confirmed:
+                return .complete(.successful, nil)
+            case let .failed(reason):
+                return .complete(.error, reason)
+            case .notFound, .pending:
+                return deadlineReached ? .stop : .retry
+            }
+        } catch is CancellationError {
+            return .stop
+        } catch {
+            return deadlineReached ? .stop : .retry
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/Services/TransactionHistoryStorage.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/Services/TransactionHistoryStorage.swift
@@ -28,6 +28,37 @@ final class TransactionHistoryStorage {
         try modelContext.save()
     }
 
+    /// Reopen rows that released clients marked as failed solely because their
+    /// local polling window elapsed. The persisted message was localized, so
+    /// callers provide every bundled translation rather than matching only the
+    /// device's current language.
+    @discardableResult
+    func reopenLegacyClientTimeouts(
+        pubKeyECDSA: String,
+        chainRawValue: String?,
+        timeoutMessages: Set<String>
+    ) throws -> Int {
+        let predicate = #Predicate<TransactionHistoryItem> { item in
+            item.pubKeyECDSA == pubKeyECDSA
+        }
+        let items = try modelContext.fetch(FetchDescriptor(predicate: predicate))
+        let timedOut = items.filter { item in
+            item.statusRawValue == TransactionHistoryStatus.error.rawValue
+                && timeoutMessages.contains(item.errorMessage ?? "")
+                && (chainRawValue == nil || item.chainRawValue == chainRawValue)
+        }
+
+        for item in timedOut {
+            item.statusRawValue = TransactionHistoryStatus.inProgress.rawValue
+            item.errorMessage = nil
+            item.completedAt = nil
+        }
+        if !timedOut.isEmpty {
+            try modelContext.save()
+        }
+        return timedOut.count
+    }
+
     // MARK: - Delete All
 
     /// Remove every stored transaction-history row across ALL vaults. Used by
@@ -253,5 +284,21 @@ final class TransactionHistoryStorage {
         return try modelContext.fetch(descriptor)
             .map { TransactionHistoryData(item: $0) }
             .filter { !$0.swapTrackingUiStatus.isTerminal }
+    }
+}
+
+enum TransactionHistoryLegacyTimeout {
+    static func localizedMessages(in bundle: Bundle = .main) -> Set<String> {
+        var messages: Set<String> = ["timeout".localized, "Timeout"]
+        for localization in bundle.localizations {
+            guard let path = bundle.path(forResource: localization, ofType: "lproj"),
+                  let localizedBundle = Bundle(path: path) else {
+                continue
+            }
+            messages.insert(
+                localizedBundle.localizedString(forKey: "timeout", value: nil, table: nil)
+            )
+        }
+        return messages
     }
 }

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/TransactionHistoryViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/TransactionHistoryViewModel.swift
@@ -76,10 +76,26 @@ class TransactionHistoryViewModel: ObservableObject {
     // MARK: - Loading
 
     func load() {
+        reopenLegacyClientTimeouts()
         fetchRows()
         pollInProgressTransactions()
         resumeSwapTracking()
         loadLimitOrders()
+    }
+
+    private func reopenLegacyClientTimeouts() {
+        do {
+            let reopened = try storage.reopenLegacyClientTimeouts(
+                pubKeyECDSA: pubKeyECDSA,
+                chainRawValue: chainFilter?.rawValue,
+                timeoutMessages: TransactionHistoryLegacyTimeout.localizedMessages()
+            )
+            if reopened > 0 {
+                logger.info("Reopened \(reopened) legacy client-timeout transaction(s)")
+            }
+        } catch {
+            logger.error("Failed to reopen legacy client-timeout transactions: \(error)")
+        }
     }
 
     /// Re-read both tables after the limit tracker observes something.

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/TransactionStatusViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/TransactionStatusViewModel.swift
@@ -108,11 +108,11 @@ class TransactionStatusViewModel: ObservableObject {
                         break
                     }
 
-                    // Check max wait timeout
+                    // The deadline limits this continuous polling session; it
+                    // does not prove the transaction failed. Keep the status
+                    // resumable so a later app launch performs a fresh check.
                     if let start = startTime,
                        Date().timeIntervalSince(start) > config.maxWaitTime {
-                        status = .timeout
-                        saveStatus()
                         break
                     }
 
@@ -123,6 +123,10 @@ class TransactionStatusViewModel: ObservableObject {
                     break
                 } catch {
                     logger.error("Polling error: \(error)")
+                    if let start = startTime,
+                       Date().timeIntervalSince(start) > config.maxWaitTime {
+                        break
+                    }
                     // On error, retry after poll interval
                     try? await Task.sleep(for: .seconds(config.pollInterval))
                 }
@@ -220,7 +224,10 @@ class TransactionStatusViewModel: ObservableObject {
         case "failed":
             return .failed(reason: failureReason ?? "Unknown error")
         case "timeout":
-            return .timeout
+            // Released versions persisted the client polling deadline as a
+            // terminal result. It was never a chain outcome, so reopen it for
+            // one chain-first check on resume.
+            return .pending
         default:
             return .broadcasted(estimatedTime: estimatedTime)
         }

--- a/VultisigApp/VultisigAppTests/Features/TransactionHistory/TransactionStatusPollerTimeoutTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/TransactionHistory/TransactionStatusPollerTimeoutTests.swift
@@ -1,0 +1,235 @@
+//
+//  TransactionStatusPollerTimeoutTests.swift
+//  VultisigAppTests
+//
+
+import SwiftData
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class TransactionStatusPollerTimeoutTests: XCTestCase {
+    func testExpiredTransactionChecksChainBeforeStopping() async {
+        let checker = StubStatusChecker(outcome: .confirmed)
+
+        let action = await TransactionStatusPoller.nextAction(
+            checker: checker,
+            txHash: "confirmed-after-deadline",
+            chain: .ethereum,
+            deadlineReached: true
+        )
+        let callCount = await checker.callCount
+
+        XCTAssertEqual(action, .complete(.successful, nil))
+        XCTAssertEqual(callCount, 1)
+    }
+
+    func testExpiredPendingTransactionStopsWithoutCreatingAnError() async {
+        let checker = StubStatusChecker(outcome: .pending)
+
+        let action = await TransactionStatusPoller.nextAction(
+            checker: checker,
+            txHash: "still-pending",
+            chain: .ethereum,
+            deadlineReached: true
+        )
+
+        XCTAssertEqual(action, .stop)
+    }
+
+    func testExpiredFailedTransactionStillRecordsTheChainFailure() async {
+        let checker = StubStatusChecker(outcome: .failed("rejected by chain"))
+
+        let action = await TransactionStatusPoller.nextAction(
+            checker: checker,
+            txHash: "failed-after-deadline",
+            chain: .ethereum,
+            deadlineReached: true
+        )
+
+        XCTAssertEqual(action, .complete(.error, "rejected by chain"))
+    }
+
+    func testExpiredStatusLookupErrorStopsWithoutCreatingAnError() async {
+        let checker = StubStatusChecker(outcome: .error)
+
+        let action = await TransactionStatusPoller.nextAction(
+            checker: checker,
+            txHash: "lookup-error",
+            chain: .ethereum,
+            deadlineReached: true
+        )
+        let callCount = await checker.callCount
+
+        XCTAssertEqual(action, .stop)
+        XCTAssertEqual(callCount, 1)
+    }
+
+    func testPendingTransactionRetriesBeforeDeadline() async {
+        let checker = StubStatusChecker(outcome: .notFound)
+
+        let action = await TransactionStatusPoller.nextAction(
+            checker: checker,
+            txHash: "not-found-yet",
+            chain: .ethereum,
+            deadlineReached: false
+        )
+
+        XCTAssertEqual(action, .retry)
+    }
+
+    func testLegacyTimeoutRecoveryClearsStaleTerminalFieldsAndPreservesRealErrors() throws {
+        let schema = Schema([TransactionHistoryItem.self, SwapTrackingMetadata.self])
+        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [configuration])
+        let context = container.mainContext
+        let storage = TransactionHistoryStorage(modelContext: context)
+        let legacyTimeout = makeHistoryItem(
+            txHash: "legacy-timeout",
+            vault: "vault-a",
+            chain: .ethereum,
+            errorMessage: "Tiempo de espera agotado"
+        )
+        let realFailure = makeHistoryItem(
+            txHash: "real-failure",
+            vault: "vault-a",
+            chain: .ethereum,
+            errorMessage: "insufficient fee"
+        )
+        let otherChain = makeHistoryItem(
+            txHash: "other-chain",
+            vault: "vault-a",
+            chain: .bitcoin,
+            errorMessage: "Timeout"
+        )
+        let otherVault = makeHistoryItem(
+            txHash: "other-vault",
+            vault: "vault-b",
+            chain: .ethereum,
+            errorMessage: "Timeout"
+        )
+        [legacyTimeout, realFailure, otherChain, otherVault].forEach(context.insert)
+        try context.save()
+
+        let reopened = try storage.reopenLegacyClientTimeouts(
+            pubKeyECDSA: "vault-a",
+            chainRawValue: Chain.ethereum.rawValue,
+            timeoutMessages: TransactionHistoryLegacyTimeout.localizedMessages()
+        )
+
+        XCTAssertEqual(reopened, 1)
+        XCTAssertEqual(legacyTimeout.statusRawValue, TransactionHistoryStatus.inProgress.rawValue)
+        XCTAssertNil(legacyTimeout.errorMessage)
+        XCTAssertNil(legacyTimeout.completedAt)
+        XCTAssertEqual(realFailure.statusRawValue, TransactionHistoryStatus.error.rawValue)
+        XCTAssertEqual(realFailure.errorMessage, "insufficient fee")
+        XCTAssertEqual(otherChain.statusRawValue, TransactionHistoryStatus.error.rawValue)
+        XCTAssertEqual(otherVault.statusRawValue, TransactionHistoryStatus.error.rawValue)
+    }
+
+    func testLegacyTimeoutMessagesIncludeEveryReleasedLocalization() {
+        let messages = TransactionHistoryLegacyTimeout.localizedMessages()
+
+        XCTAssertTrue(messages.isSuperset(of: [
+            "Timeout",
+            "Isteklo vrijeme",
+            "Zeitüberschreitung",
+            "시간 초과",
+            "Tempo scaduto",
+            "超时",
+            "Tempo esgotado",
+            "Tiempo de espera agotado"
+        ]))
+    }
+
+    func testLegacyPendingStorageTimeoutIsResumable() throws {
+        let schema = Schema([StoredPendingTransaction.self])
+        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [configuration])
+        let storage = StoredPendingTransactionStorage(modelContext: container.mainContext)
+        try storage.save(
+            txHash: "legacy-timeout",
+            chain: .ethereum,
+            status: .timeout,
+            pubKeyECDSA: "vault-a"
+        )
+        try storage.save(
+            txHash: "chain-failure",
+            chain: .ethereum,
+            status: .failed(reason: "rejected"),
+            pubKeyECDSA: "vault-a"
+        )
+
+        let resumable = try storage.getAllPending()
+        let transaction = try XCTUnwrap(resumable.first { $0.txHash == "legacy-timeout" })
+        let viewModel = TransactionStatusViewModel(pendingTransaction: transaction)
+
+        XCTAssertEqual(resumable.map(\.txHash), ["legacy-timeout"])
+        XCTAssertEqual(viewModel.status, .pending)
+    }
+
+    private func makeHistoryItem(
+        txHash: String,
+        vault: String,
+        chain: Chain,
+        errorMessage: String
+    ) -> TransactionHistoryItem {
+        TransactionHistoryItem(
+            txHash: txHash,
+            pubKeyECDSA: vault,
+            typeRawValue: TransactionHistoryType.send.rawValue,
+            statusRawValue: TransactionHistoryStatus.error.rawValue,
+            chainRawValue: chain.rawValue,
+            coinTicker: "ETH",
+            coinLogo: "eth",
+            amountCrypto: "1",
+            amountFiat: "1",
+            fromAddress: "from",
+            toAddress: "to",
+            feeCrypto: "0.01",
+            feeFiat: "0.01",
+            network: chain.rawValue,
+            explorerLink: "https://example.com/\(txHash)",
+            completedAt: Date(),
+            errorMessage: errorMessage
+        )
+    }
+}
+
+private actor StubStatusChecker: TransactionStatusChecking {
+    enum Outcome: Sendable {
+        case notFound
+        case pending
+        case confirmed
+        case failed(String)
+        case error
+    }
+
+    private(set) var callCount = 0
+    private let outcome: Outcome
+
+    init(outcome: Outcome) {
+        self.outcome = outcome
+    }
+
+    func checkTransactionStatus(txHash _: String, chain _: Chain) async throws -> TransactionStatusResult {
+        await Task.yield()
+        callCount += 1
+        switch outcome {
+        case .notFound:
+            return TransactionStatusResult(status: .notFound, blockNumber: nil, confirmations: nil)
+        case .pending:
+            return TransactionStatusResult(status: .pending, blockNumber: nil, confirmations: nil)
+        case .confirmed:
+            return TransactionStatusResult(status: .confirmed, blockNumber: 1, confirmations: 1)
+        case let .failed(reason):
+            return TransactionStatusResult(status: .failed(reason: reason), blockNumber: nil, confirmations: nil)
+        case .error:
+            throw StubError.lookupFailed
+        }
+    }
+}
+
+private enum StubError: Error {
+    case lookupFailed
+}


### PR DESCRIPTION
## Description

Treat the client transaction-status polling deadline as a scheduling limit instead of a chain failure.

- Perform one chain lookup before honoring the deadline, including when the app opens after the wait window.
- Keep pending, not-found, and transport-error results resumable rather than persisting `Error / Timeout`.
- Preserve confirmed and genuine failed chain results as terminal.
- Reopen legacy timeout rows in transaction history and pending storage, recognizing all eight bundled timeout translations and clearing stale terminal fields.
- Preserve the existing swap-tracker authority gates.

Fixes #5196

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [x] Sending - Transaction history/status polling; no new broadcast transaction is required for this persistence fix
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature - Please attach tx link here

## Parity

- Android: n/a — repair targets iOS SwiftData records and the iOS polling lifecycle
- Windows + extension: n/a — repair targets iOS SwiftData records and the iOS polling lifecycle
- SDK: n/a — no SDK status persistence or polling behavior changed

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

Not applicable; no UI changes.

## Additional context

Verification:

- Focused timeout recovery suite: 8 tests, 0 failures
- Full `make test`: 6,633 tests, 11 skipped, 0 failures
- Full SwiftLint: 0 serious violations; 26 unrelated pre-existing test warnings
- Changed files: 0 SwiftLint violations

## Agent Metadata (if applicable)
- **Agent**: Codex
- **Issue**: #5196
- **Confidence**: high
- **Needs human review for**: legacy timeout classification using the exact localized values persisted by released builds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transactions that reach the client-side polling deadline remain resumable instead of being marked permanently timed out.
  * Timed-out transactions now receive an additional status check to distinguish temporary polling limits from final blockchain outcomes.
  * Previously affected transactions are automatically reopened and resumed when transaction history loads.
  * Polling errors retry before the deadline and stop cleanly afterward.

* **Tests**
  * Added coverage for timeout recovery, resumed transactions, status outcomes, retry behavior, and localized timeout messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->