### PR TITLE
fix(maya): gate CACAO staking while chain is halted

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Maya/API/MayaChainAPIService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Maya/API/MayaChainAPIService.swift
@@ -64,9 +64,9 @@ struct MayaChainAPIService {
         return data
     }
 
-    func getMimir() async throws -> MayaMimir {
+    func getMimir(shouldCache: Bool = true) async throws -> MayaMimir {
         // Check cache first
-        if let cached = await cache.getCachedMimir() {
+        if shouldCache, let cached = await cache.getCachedMimir() {
             return cached
         }
 
@@ -79,6 +79,42 @@ struct MayaChainAPIService {
 
         return data
     }
+
+    func getLastBlock() async throws -> Int64 {
+        let response = try await httpClient.request(
+            MayaChainBondsAPI.getLastBlock,
+            responseType: [MayaLastBlockResponse].self
+        )
+        guard let height = response.data.first?.mayachain else {
+            throw MayaChainAPIError.invalidResponse
+        }
+        return height
+    }
+
+    /// Whether MAYANode will currently admit a native MAYAChain `MsgDeposit`.
+    /// MAYANode's last-block endpoint supplies a height coherent with its Mimir
+    /// values. Callers at a signing boundary pass `shouldCache: false` so a halt
+    /// that began after the DeFi card loaded cannot slip through on a stale Mimir.
+    func getNativeDepositAvailability(
+        shouldCache: Bool = true
+    ) async throws -> MayaNativeDepositAvailability {
+        async let currentHeight = getLastBlock()
+        async let mimir = getMimir(shouldCache: shouldCache)
+        let (resolvedHeight, resolvedMimir) = try await (currentHeight, mimir)
+
+        return resolvedMimir.isNativeDepositHalted(at: resolvedHeight)
+            ? .halted
+            : .available
+    }
+}
+
+private struct MayaLastBlockResponse: Decodable {
+    let mayachain: Int64
+}
+
+enum MayaNativeDepositAvailability: Equatable, Sendable {
+    case available
+    case halted
 }
 
 // MARK: - Cache

--- a/VultisigApp/VultisigApp/Blockchain/Maya/API/Models/Common/MayaMimir.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Maya/API/Models/Common/MayaMimir.swift
@@ -12,12 +12,21 @@ struct MayaMimir: Codable {
     let minimumBondInRune: Int64?
     let maxBondProviders: Int?
     let pauseBond: Int64?
+    let haltChainGlobal: Int64?
+    let nodePauseChainGlobal: Int64?
+    let haltMayaChain: Int64?
+    let solvencyHaltMayaChain: Int64?
 
     enum CodingKeys: String, CodingKey {
         case cacaoPoolDepositMaturityBlocks = "CACAOPOOLDEPOSITMATURITYBLOCKS"
         case minimumBondInRune = "MINIMUMBONDINRUNE"
         case maxBondProviders = "MAXBONDPROVIDERS"
         case pauseBond = "PAUSEBOND"
+        case haltChainGlobal = "HALTCHAINGLOBAL"
+        case nodePauseChainGlobal = "NODEPAUSECHAINGLOBAL"
+        // MAYANode's native BASEChain identifier is MAYA.
+        case haltMayaChain = "HALTMAYACHAIN"
+        case solvencyHaltMayaChain = "SOLVENCYHALTMAYACHAIN"
     }
 
     /// Minimum bond requirement in CACAO (converted from base units)
@@ -34,5 +43,26 @@ struct MayaMimir: Codable {
     /// Maximum number of bond providers allowed per node
     var maxProviders: Int {
         maxBondProviders ?? 8
+    }
+
+    /// Mirrors MAYANode's `IsChainHalted(ctx, common.BASEChain)` decision for
+    /// native `MsgDeposit`. Most halt Mimirs store the block height at which the
+    /// halt begins; `NodePauseChainGlobal` instead stores the height through
+    /// which a node-operator pause remains active.
+    func isNativeDepositHalted(at currentHeight: Int64) -> Bool {
+        Self.haltStarted(haltChainGlobal, at: currentHeight)
+            || Self.nodePauseActive(nodePauseChainGlobal, at: currentHeight)
+            || Self.haltStarted(haltMayaChain, at: currentHeight)
+            || Self.haltStarted(solvencyHaltMayaChain, at: currentHeight)
+    }
+
+    private static func haltStarted(_ value: Int64?, at currentHeight: Int64) -> Bool {
+        guard let value else { return false }
+        return value > 0 && value < currentHeight
+    }
+
+    private static func nodePauseActive(_ value: Int64?, at currentHeight: Int64) -> Bool {
+        guard let value else { return false }
+        return value > currentHeight
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Maya/API/TargetType/MayaChainBondsAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Maya/API/TargetType/MayaChainBondsAPI.swift
@@ -13,10 +13,11 @@ enum MayaChainBondsAPI: TargetType {
     case getHealth
     case getNetwork
     case getMimir
+    case getLastBlock
 
     var baseURL: URL {
         switch self {
-        case .getAllNodes, .getNodeDetails, .getMimir:
+        case .getAllNodes, .getNodeDetails, .getMimir, .getLastBlock:
             return URL(string: "https://mayanode.mayachain.info")!
         case .getHealth:
             return URL(string: "https://midgard.mayachain.info/v2")!
@@ -37,26 +38,28 @@ enum MayaChainBondsAPI: TargetType {
             return "/network"
         case .getMimir:
             return "/mayachain/mimir"
+        case .getLastBlock:
+            return "/mayachain/lastblock"
         }
     }
 
     var method: HTTPMethod {
         switch self {
-        case .getAllNodes, .getNodeDetails, .getHealth, .getNetwork, .getMimir:
+        case .getAllNodes, .getNodeDetails, .getHealth, .getNetwork, .getMimir, .getLastBlock:
             return .get
         }
     }
 
     var task: HTTPTask {
         switch self {
-        case .getAllNodes, .getNodeDetails, .getHealth, .getNetwork, .getMimir:
+        case .getAllNodes, .getNodeDetails, .getHealth, .getNetwork, .getMimir, .getLastBlock:
             return .requestPlain
         }
     }
 
     var headers: [String: String]? {
         switch self {
-        case .getAllNodes, .getNodeDetails, .getHealth, .getNetwork, .getMimir:
+        case .getAllNodes, .getNodeDetails, .getHealth, .getNetwork, .getMimir, .getLastBlock:
             return ["X-Client-ID": "vultisig"]
         }
     }

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainMainnetAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainMainnetAPI.swift
@@ -39,10 +39,13 @@ struct ThorchainMainnetAPI: TargetType {
         case accountNumber(address: String)
         case denomMetadata(denom: String)
         case allDenomMetadata
+        case wasmContractInfo(address: String)
+        case wasmCodeInfo(codeID: String)
 
         // MARK: THORChain-specific endpoints (thornode)
         case networkInfo
         case inboundAddresses
+        case lastBlock
         /// `/thorchain/mimir/key/<KEY>` — a single network mimir value as a bare
         /// integer body (e.g. the `EnableAdvSwapQueue` limit-swap availability
         /// gate). Parsed from raw bytes by the caller, not JSON-decoded.
@@ -101,7 +104,8 @@ struct ThorchainMainnetAPI: TargetType {
     var baseURL: URL {
         switch endpoint {
         case .balances, .accountNumber, .denomMetadata, .allDenomMetadata,
-             .networkInfo, .inboundAddresses, .mimir, .poolInfo, .pools,
+             .wasmContractInfo, .wasmCodeInfo,
+             .networkInfo, .inboundAddresses, .lastBlock, .mimir, .poolInfo, .pools,
              .securedAssets, .poolLiquidityProvider, .swapQuote, .tcyStaker,
              .limitSwapQueue, .transaction,
              .tcyAutoCompoundStatus:
@@ -136,10 +140,16 @@ struct ThorchainMainnetAPI: TargetType {
             return "/cosmos/bank/v1beta1/denoms_metadata/\(encodedDenom)"
         case .allDenomMetadata:
             return "/cosmos/bank/v1beta1/denoms_metadata"
+        case .wasmContractInfo(let address):
+            return "/cosmwasm/wasm/v1/contract/\(address)"
+        case .wasmCodeInfo(let codeID):
+            return "/cosmwasm/wasm/v1/code/\(codeID)"
         case .networkInfo:
             return "/thorchain/network"
         case .inboundAddresses:
             return "/thorchain/inbound_addresses"
+        case .lastBlock:
+            return "/thorchain/lastblock"
         case .mimir(let key):
             // Mimir keys are stored uppercase on THORNode (matching the
             // CHURNINTERVAL convention). Uppercase defensively.
@@ -183,8 +193,9 @@ struct ThorchainMainnetAPI: TargetType {
 
     var task: HTTPTask {
         switch endpoint {
-        case .balances, .accountNumber, .denomMetadata, .networkInfo,
-             .inboundAddresses, .mimir, .poolInfo, .pools, .securedAssets,
+        case .balances, .accountNumber, .denomMetadata, .wasmContractInfo,
+             .wasmCodeInfo, .networkInfo, .inboundAddresses, .lastBlock, .mimir,
+             .poolInfo, .pools, .securedAssets,
              .poolLiquidityProvider, .tcyStaker, .networkStatus,
              .tcyAutoCompoundStatus, .resolveTNS, .transaction:
             return .requestPlain
@@ -220,8 +231,9 @@ struct ThorchainMainnetAPI: TargetType {
     var headers: [String: String]? {
         var base: [String: String] = ["Content-Type": "application/json"]
         switch endpoint {
-        case .balances, .accountNumber, .swapQuote, .poolInfo, .pools,
-             .securedAssets, .poolLiquidityProvider, .inboundAddresses, .mimir:
+        case .balances, .accountNumber, .wasmContractInfo, .wasmCodeInfo,
+             .swapQuote, .poolInfo, .pools, .securedAssets, .poolLiquidityProvider,
+             .inboundAddresses, .lastBlock, .mimir:
             // Endpoints that the legacy code marked with X-Client-ID via
             // get9RRequest(). Kept for 9Realms partner attribution.
             base["X-Client-ID"] = "vultisig"

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService+WasmExecutionAvailability.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService+WasmExecutionAvailability.swift
@@ -1,0 +1,215 @@
+//
+//  ThorchainService+WasmExecutionAvailability.swift
+//  VultisigApp
+//
+
+import Foundation
+import OSLog
+
+enum THORChainWasmExecutionAvailability: Equatable, Sendable {
+    case available
+    case halted
+    case unavailable
+}
+
+protocol THORChainWasmExecutionAvailabilityProviding {
+    func fetchWasmExecutionAvailabilities(
+        for contractAddresses: Set<String>
+    ) async -> [String: THORChainWasmExecutionAvailability]
+}
+
+extension ThorchainService: THORChainWasmExecutionAvailabilityProviding {
+    /// Mirrors `WasmMgr.ExecuteContract` in thornode: global WASM, contract-address suffix,
+    /// then code-checksum halts. Deployer halts intentionally do not participate here; thornode
+    /// applies those only when storing or instantiating code, not when executing an existing app.
+    func fetchWasmExecutionAvailabilities(
+        for contractAddresses: Set<String>
+    ) async -> [String: THORChainWasmExecutionAvailability] {
+        guard !contractAddresses.isEmpty else { return [:] }
+
+        let currentHeight: Int64
+        let globalHaltHeight: Int64
+        do {
+            async let height = fetchWasmPolicyBlockHeight()
+            async let globalHalt = fetchWasmMimirHeight(key: Self.wasmGlobalHaltMimirKey)
+            (currentHeight, globalHaltHeight) = try await (height, globalHalt)
+        } catch {
+            logger.warning("Could not verify THORChain global WASM availability: \(error.localizedDescription)")
+            return contractAddresses.reduce(into: [:]) { result, address in
+                result[address] = .unavailable
+            }
+        }
+
+        if Self.isWasmHaltActive(globalHaltHeight, at: currentHeight) {
+            return contractAddresses.reduce(into: [:]) { result, address in
+                result[address] = .halted
+            }
+        }
+
+        return await withTaskGroup(
+            of: (String, THORChainWasmExecutionAvailability).self,
+            returning: [String: THORChainWasmExecutionAvailability].self
+        ) { group in
+            for address in contractAddresses {
+                group.addTask {
+                    do {
+                        let availability = try await self.fetchWasmContractExecutionAvailability(
+                            address: address,
+                            currentHeight: currentHeight
+                        )
+                        return (address, availability)
+                    } catch {
+                        self.logger.warning(
+                            "Could not verify THORChain WASM availability for \(address, privacy: .private): \(error.localizedDescription)"
+                        )
+                        return (address, .unavailable)
+                    }
+                }
+            }
+
+            var result: [String: THORChainWasmExecutionAvailability] = [:]
+            for await (address, availability) in group {
+                result[address] = availability
+            }
+            return result
+        }
+    }
+}
+
+extension ThorchainService {
+    static let wasmGlobalHaltMimirKey = "HaltWasmGlobal"
+
+    static func wasmContractHaltMimirKey(address: String) -> String? {
+        guard address.count >= 6 else { return nil }
+        return "HaltWasmContract-\(address.suffix(6))"
+    }
+
+    static func wasmChecksumHaltMimirKey(dataHash: String) -> String? {
+        guard let checksum = Data(hexString: dataHash), checksum.count == 32 else { return nil }
+        return "HaltWasmCs-\(base32MimirReference(checksum))"
+    }
+
+    static func isWasmHaltActive(_ haltHeight: Int64, at currentHeight: Int64) -> Bool {
+        haltHeight > 0 && currentHeight > haltHeight
+    }
+
+    static func parseWasmMimirHeight(_ data: Data) -> Int64? {
+        guard let raw = String(data: data, encoding: .utf8) else { return nil }
+        return Int64(raw.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    /// RFC 4648 base32 without trailing `=` padding. THORNode derives checksum Mimir keys with
+    /// Go's `base32.StdEncoding` and trims that padding to fit the 64-character Mimir key limit.
+    static func base32MimirReference(_ data: Data) -> String {
+        let alphabet = Array("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567")
+        var accumulator = 0
+        var bitCount = 0
+        var output = ""
+
+        for byte in data {
+            accumulator = (accumulator << 8) | Int(byte)
+            bitCount += 8
+            while bitCount >= 5 {
+                bitCount -= 5
+                output.append(alphabet[(accumulator >> bitCount) & 0x1F])
+            }
+            accumulator &= (1 << bitCount) - 1
+        }
+
+        if bitCount > 0 {
+            output.append(alphabet[(accumulator << (5 - bitCount)) & 0x1F])
+        }
+        return output
+    }
+}
+
+private extension ThorchainService {
+    enum WasmAvailabilityError: Error {
+        case invalidBlockHeight
+        case invalidContractAddress
+        case invalidDataHash
+        case invalidMimir
+    }
+
+    struct WasmContractInfoResponse: Decodable {
+        struct ContractInfo: Decodable {
+            let codeID: String
+
+            enum CodingKeys: String, CodingKey {
+                case codeID = "code_id"
+            }
+        }
+
+        let contractInfo: ContractInfo
+
+        enum CodingKeys: String, CodingKey {
+            case contractInfo = "contract_info"
+        }
+    }
+
+    struct WasmCodeInfoResponse: Decodable {
+        struct CodeInfo: Decodable {
+            let dataHash: String
+
+            enum CodingKeys: String, CodingKey {
+                case dataHash = "data_hash"
+            }
+        }
+
+        let codeInfo: CodeInfo
+
+        enum CodingKeys: String, CodingKey {
+            case codeInfo = "code_info"
+        }
+    }
+
+    func fetchWasmContractExecutionAvailability(
+        address: String,
+        currentHeight: Int64
+    ) async throws -> THORChainWasmExecutionAvailability {
+        guard let contractMimirKey = Self.wasmContractHaltMimirKey(address: address) else {
+            throw WasmAvailabilityError.invalidContractAddress
+        }
+
+        async let contractHalt = fetchWasmMimirHeight(key: contractMimirKey)
+        let contractInfoResponse = try await httpClient.request(
+            mainnet(.wasmContractInfo(address: address)),
+            responseType: WasmContractInfoResponse.self
+        )
+        let codeInfoResponse = try await httpClient.request(
+            mainnet(.wasmCodeInfo(codeID: contractInfoResponse.data.contractInfo.codeID)),
+            responseType: WasmCodeInfoResponse.self
+        )
+        guard let checksumMimirKey = Self.wasmChecksumHaltMimirKey(
+            dataHash: codeInfoResponse.data.codeInfo.dataHash
+        ) else {
+            throw WasmAvailabilityError.invalidDataHash
+        }
+
+        async let checksumHalt = fetchWasmMimirHeight(key: checksumMimirKey)
+        let (contractHaltHeight, checksumHaltHeight) = try await (contractHalt, checksumHalt)
+        let halted = Self.isWasmHaltActive(contractHaltHeight, at: currentHeight) ||
+            Self.isWasmHaltActive(checksumHaltHeight, at: currentHeight)
+        return halted ? .halted : .available
+    }
+
+    func fetchWasmPolicyBlockHeight() async throws -> Int64 {
+        let response = try await httpClient.request(
+            mainnet(.lastBlock),
+            responseType: [LastBlockResponse].self
+        )
+        guard let height = response.data.first?.thorchain,
+              let blockHeight = Int64(exactly: height) else {
+            throw WasmAvailabilityError.invalidBlockHeight
+        }
+        return blockHeight
+    }
+
+    func fetchWasmMimirHeight(key: String) async throws -> Int64 {
+        let response = try await httpClient.request(mainnet(.mimir(key: key)))
+        guard let height = Self.parseWasmMimirHeight(response.data) else {
+            throw WasmAvailabilityError.invalidMimir
+        }
+        return height
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1546,6 +1546,8 @@
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
 "thorchainCustomTokenInvalidFormat" = "Ungültiges THORChain-Token-Format. Verwende THOR.{SYMBOL}, z. B. THOR.LQDY.";
 "thorChainNotEnabledForLP" = "THORChain ist in diesem Tresor nicht aktiviert. Bitte aktiviere THORChain, um diese Funktion zu nutzen.";
+"thorchainWasmStakingHaltedWarning" = "THORChain-App-Layer-Staking ist vorübergehend nicht verfügbar, da die Vertragsausführung pausiert ist. Bitte versuche es erneut, sobald sie fortgesetzt wird.";
+"thorchainWasmStakingUnavailableWarning" = "Die Verfügbarkeit von THORChain-App-Layer-Staking konnte nicht überprüft werden. Bitte versuche es später erneut.";
 "thresholdNotReachedMessage" = "Schwelle nicht erreicht.\nEs fehlen genügend Anfangsgeräte.";
 "timeout" = "Zeitüberschreitung";
 "title" = "Titel";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -885,6 +885,8 @@
 "maxSendPlanChangedError" = "Dein verfügbares Guthaben hat sich während der Überprüfung geändert, daher würde diese Transaktion nicht mehr den angezeigten Betrag senden. Geh zurück und prüfe den aktualisierten Betrag.";
 "maxSupply" = "Maximale Menge";
 "maxTotalFee" = "Max. Gesamtgebühr";
+"mayaCacaoStakingHaltedWarning" = "CACAO-Staking ist vorübergehend nicht verfügbar, da MAYAChain angehalten wurde. Bitte versuche es erneut, sobald das Netzwerk wieder aktiv ist.";
+"mayaCacaoStakingUnavailableWarning" = "Die Verfügbarkeit von MAYAChain-Staking konnte nicht überprüft werden. Bitte versuche es später erneut.";
 "memo" = "Memo";
 "memoLabel" = "Memo";
 "mergeCoins" = "Coins zusammenführen";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -885,6 +885,8 @@
 "maxSendPlanChangedError" = "Your available funds changed while you were reviewing, so this transaction would no longer send the amount shown. Go back and review the updated amount.";
 "maxSupply" = "Max Supply";
 "maxTotalFee" = "Max. Total Fee";
+"mayaCacaoStakingHaltedWarning" = "CACAO staking is temporarily unavailable because MAYAChain is halted. Please try again when the network resumes.";
+"mayaCacaoStakingUnavailableWarning" = "Unable to verify MAYAChain staking availability. Please try again later.";
 "memo" = "Memo";
 "memoLabel" = "Memo";
 "mergeCoins" = "Merge Coins";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1546,6 +1546,8 @@
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
 "thorchainCustomTokenInvalidFormat" = "Invalid THORChain token format. Use THOR.{SYMBOL}, e.g. THOR.LQDY.";
 "thorChainNotEnabledForLP" = "THORChain is not enabled on this vault. Please enable THORChain to use this feature.";
+"thorchainWasmStakingHaltedWarning" = "THORChain App Layer staking is temporarily unavailable because contract execution is paused. Please try again when it resumes.";
+"thorchainWasmStakingUnavailableWarning" = "Unable to verify THORChain App Layer staking availability. Please try again later.";
 "thresholdNotReachedMessage" = "Threshold not reached.\nMissing enough initial devices.";
 "timeout" = "Timeout";
 "title" = "Title";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -885,6 +885,8 @@
 "maxSendPlanChangedError" = "Tus fondos disponibles cambiaron mientras revisabas, por lo que esta transacción ya no enviaría la cantidad mostrada. Vuelve atrás y revisa la cantidad actualizada.";
 "maxSupply" = "Suministro máximo";
 "maxTotalFee" = "Tarifa total máx.";
+"mayaCacaoStakingHaltedWarning" = "El staking de CACAO no está disponible temporalmente porque MAYAChain está detenida. Inténtalo de nuevo cuando la red se reanude.";
+"mayaCacaoStakingUnavailableWarning" = "No se pudo verificar la disponibilidad del staking de MAYAChain. Inténtalo de nuevo más tarde.";
 "memo" = "Memorándum";
 "memoLabel" = "Memo";
 "mergeCoins" = "Fusionar monedas";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1546,6 +1546,8 @@
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
 "thorchainCustomTokenInvalidFormat" = "Formato de token de THORChain no válido. Usa THOR.{SYMBOL}, p. ej. THOR.LQDY.";
 "thorChainNotEnabledForLP" = "THORChain no está habilitado en esta bóveda. Por favor, habilita THORChain para usar esta función.";
+"thorchainWasmStakingHaltedWarning" = "El staking de la App Layer de THORChain no está disponible temporalmente porque la ejecución de contratos está pausada. Inténtalo de nuevo cuando se reanude.";
+"thorchainWasmStakingUnavailableWarning" = "No se pudo verificar la disponibilidad del staking de la App Layer de THORChain. Inténtalo de nuevo más tarde.";
 "thresholdNotReachedMessage" = "Umbral no alcanzado.\nFaltan suficientes dispositivos iniciales.";
 "timeout" = "Tiempo de espera agotado";
 "title" = "Título";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -885,6 +885,8 @@
 "maxSendPlanChangedError" = "Vaša raspoloživa sredstva promijenila su se dok ste pregledavali, pa ova transakcija više ne bi poslala prikazani iznos. Vratite se i pregledajte ažurirani iznos.";
 "maxSupply" = "Maksimalna ponuda";
 "maxTotalFee" = "Maks. ukupna naknada";
+"mayaCacaoStakingHaltedWarning" = "CACAO staking privremeno nije dostupan jer je MAYAChain zaustavljen. Pokušajte ponovno kada se mreža nastavi.";
+"mayaCacaoStakingUnavailableWarning" = "Nije moguće provjeriti dostupnost MAYAChain stakinga. Pokušajte ponovno kasnije.";
 "memo" = "Bilješka";
 "memoLabel" = "Memo";
 "mergeCoins" = "Spoji novčiće";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1546,6 +1546,8 @@
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
 "thorchainCustomTokenInvalidFormat" = "Neispravan format THORChain tokena. Koristite THOR.{SYMBOL}, npr. THOR.LQDY.";
 "thorChainNotEnabledForLP" = "THORChain nije omogućen na ovom vaultu. Molimo omogućite THORChain da biste koristili ovu značajku.";
+"thorchainWasmStakingHaltedWarning" = "THORChain App Layer staking privremeno nije dostupan jer je izvršavanje ugovora pauzirano. Pokušajte ponovno kada se nastavi.";
+"thorchainWasmStakingUnavailableWarning" = "Nije moguće provjeriti dostupnost THORChain App Layer stakinga. Pokušajte ponovno kasnije.";
 "thresholdNotReachedMessage" = "Prag nije dosegnut.\nNedostaje dovoljno početnih uređaja.";
 "timeout" = "Isteklo vrijeme";
 "title" = "Naslov";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -885,6 +885,8 @@
 "maxSendPlanChangedError" = "I tuoi fondi disponibili sono cambiati durante la verifica, quindi questa transazione non invierebbe più l'importo mostrato. Torna indietro e controlla l'importo aggiornato.";
 "maxSupply" = "Offerta massima";
 "maxTotalFee" = "Commissione totale max.";
+"mayaCacaoStakingHaltedWarning" = "Lo staking di CACAO non è temporaneamente disponibile perché MAYAChain è sospesa. Riprova quando la rete riprenderà.";
+"mayaCacaoStakingUnavailableWarning" = "Impossibile verificare la disponibilità dello staking su MAYAChain. Riprova più tardi.";
 "memo" = "Memo";
 "memoLabel" = "Memo";
 "mergeCoins" = "Unisci monete";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1546,6 +1546,8 @@
 "thorAddressNotFound" = "Indirizzo THORChain non trovato nel vault. Assicurati di avere RUNE nel tuo vault.";
 "thorchainCustomTokenInvalidFormat" = "Formato del token THORChain non valido. Usa THOR.{SYMBOL}, ad es. THOR.LQDY.";
 "thorChainNotEnabledForLP" = "THORChain non è abilitato su questo caveau. Abilita THORChain per utilizzare questa funzione.";
+"thorchainWasmStakingHaltedWarning" = "Lo staking dell'App Layer di THORChain non è temporaneamente disponibile perché l'esecuzione dei contratti è sospesa. Riprova quando riprenderà.";
+"thorchainWasmStakingUnavailableWarning" = "Impossibile verificare la disponibilità dello staking dell'App Layer di THORChain. Riprova più tardi.";
 "thresholdNotReachedMessage" = "Soglia non raggiunta.\nMancano dispositivi iniziali sufficienti.";
 "timeout" = "Tempo scaduto";
 "title" = "Titolo";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1546,6 +1546,8 @@
 "thorAddressNotFound" = "볼트에서 THORChain 주소를 찾을 수 없습니다. RUNE이 볼트에 있는지 확인하세요.";
 "thorchainCustomTokenInvalidFormat" = "잘못된 THORChain 토큰 형식입니다. THOR.{SYMBOL} 형식을 사용하세요. 예: THOR.LQDY.";
 "thorChainNotEnabledForLP" = "이 볼트에서 THORChain이 활성화되어 있지 않습니다. 이 기능을 사용하려면 THORChain을 활성화하세요.";
+"thorchainWasmStakingHaltedWarning" = "컨트랙트 실행이 일시 중지되어 THORChain App Layer 스테이킹을 일시적으로 사용할 수 없습니다. 실행이 재개되면 다시 시도해 주세요.";
+"thorchainWasmStakingUnavailableWarning" = "THORChain App Layer 스테이킹 가능 여부를 확인할 수 없습니다. 나중에 다시 시도해 주세요.";
 "thresholdNotReachedMessage" = "임계값에 도달하지 않았습니다.\n초기 기기가 충분하지 않습니다.";
 "timeout" = "시간 초과";
 "title" = "제목";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -885,6 +885,8 @@
 "maxSendPlanChangedError" = "확인하는 동안 사용 가능한 잔액이 변경되어 이 트랜잭션은 표시된 금액을 전송하지 않습니다. 돌아가서 업데이트된 금액을 확인하세요.";
 "maxSupply" = "최대 공급량";
 "maxTotalFee" = "최대 총 수수료";
+"mayaCacaoStakingHaltedWarning" = "MAYAChain이 중단되어 CACAO 스테이킹을 일시적으로 사용할 수 없습니다. 네트워크가 재개되면 다시 시도해 주세요.";
+"mayaCacaoStakingUnavailableWarning" = "MAYAChain 스테이킹 가능 여부를 확인할 수 없습니다. 나중에 다시 시도해 주세요.";
 "memo" = "메모";
 "memoLabel" = "메모";
 "mergeCoins" = "코인 병합";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1546,6 +1546,8 @@
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
 "thorchainCustomTokenInvalidFormat" = "Formato de token THORChain inválido. Use THOR.{SYMBOL}, ex.: THOR.LQDY.";
 "thorChainNotEnabledForLP" = "THORChain não está habilitado neste cofre. Por favor, habilite THORChain para usar este recurso.";
+"thorchainWasmStakingHaltedWarning" = "O staking da App Layer da THORChain está temporariamente indisponível porque a execução de contratos está pausada. Tente novamente quando ela for retomada.";
+"thorchainWasmStakingUnavailableWarning" = "Não foi possível verificar a disponibilidade do staking da App Layer da THORChain. Tente novamente mais tarde.";
 "thresholdNotReachedMessage" = "Limite não alcançado.\nFaltam dispositivos iniciais suficientes.";
 "timeout" = "Tempo esgotado";
 "title" = "Título";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -885,6 +885,8 @@
 "maxSendPlanChangedError" = "Seus fundos disponíveis mudaram enquanto você revisava, então esta transação não enviaria mais o valor exibido. Volte e revise o valor atualizado.";
 "maxSupply" = "Fornecimento máximo";
 "maxTotalFee" = "Taxa total máx.";
+"mayaCacaoStakingHaltedWarning" = "O staking de CACAO está temporariamente indisponível porque a MAYAChain está pausada. Tente novamente quando a rede for retomada.";
+"mayaCacaoStakingUnavailableWarning" = "Não foi possível verificar a disponibilidade do staking na MAYAChain. Tente novamente mais tarde.";
 "memo" = "Memorando";
 "memoLabel" = "Memo";
 "mergeCoins" = "Mesclar moedas";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -885,6 +885,8 @@
 "maxSendPlanChangedError" = "在您确认期间可用余额发生了变化，此交易将不再发送所显示的金额。请返回并查看更新后的金额";
 "maxSupply" = "最大供应量";
 "maxTotalFee" = "最大总费用";
+"mayaCacaoStakingHaltedWarning" = "由于 MAYAChain 已暂停，CACAO 质押暂时不可用。请在网络恢复后重试。";
+"mayaCacaoStakingUnavailableWarning" = "无法验证 MAYAChain 质押是否可用。请稍后重试。";
 "memo" = "备忘录";
 "memoLabel" = "备注";
 "mergeCoins" = "合并代币";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1546,6 +1546,8 @@
 "thorAddressNotFound" = "保险库中未找到 THORChain 地址。请确保您的保险库中有 RUNE。";
 "thorchainCustomTokenInvalidFormat" = "THORChain 代币格式无效。请使用 THOR.{SYMBOL}，例如 THOR.LQDY。";
 "thorChainNotEnabledForLP" = "此保险库未启用 THORChain。请启用 THORChain 以使用此功能。";
+"thorchainWasmStakingHaltedWarning" = "由于合约执行已暂停，THORChain App Layer 质押暂时不可用。请在恢复后重试。";
+"thorchainWasmStakingUnavailableWarning" = "无法验证 THORChain App Layer 质押是否可用。请稍后重试。";
 "thresholdNotReachedMessage" = "未达到阈值。\n缺少足够的初始设备";
 "timeout" = "超时";
 "title" = "标题";

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/MayaChainStakeInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/MayaChainStakeInteractor.swift
@@ -17,7 +17,21 @@ private struct CacaoSnapshot {
 }
 
 struct MayaChainStakeInteractor: StakeInteractor {
-    private let mayaChainAPIService = MayaChainAPIService()
+    private let mayaChainAPIService: MayaChainAPIService
+
+    init(mayaChainAPIService: MayaChainAPIService = MayaChainAPIService()) {
+        self.mayaChainAPIService = mayaChainAPIService
+    }
+
+    func fetchActionAvailability() async -> StakeActionAvailability {
+        do {
+            let availability = try await mayaChainAPIService.getNativeDepositAvailability(shouldCache: false)
+            return availability == .available ? .available : .halted
+        } catch {
+            logger.error("Could not verify Maya CACAO staking availability: \(error.localizedDescription, privacy: .private)")
+            return .unavailable
+        }
+    }
 
     func fetchStakePositions(vault: Vault) async -> [StakePositionData] {
         guard let cacao = await cacaoSnapshot(in: vault) else { return [] }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/MayaChainStakeInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/MayaChainStakeInteractor.swift
@@ -23,13 +23,18 @@ struct MayaChainStakeInteractor: StakeInteractor {
         self.mayaChainAPIService = mayaChainAPIService
     }
 
-    func fetchActionAvailability() async -> StakeActionAvailability {
+    func fetchActionAvailabilities(for coins: [CoinMeta]) async -> StakeActionAvailabilities {
+        let availability: StakeActionAvailability
         do {
-            let availability = try await mayaChainAPIService.getNativeDepositAvailability(shouldCache: false)
-            return availability == .available ? .available : .halted
+            let nativeDepositAvailability = try await mayaChainAPIService.getNativeDepositAvailability(shouldCache: false)
+            availability = nativeDepositAvailability == .available ? .available : .halted
         } catch {
             logger.error("Could not verify Maya CACAO staking availability: \(error.localizedDescription, privacy: .private)")
-            return .unavailable
+            availability = .unavailable
+        }
+
+        return coins.reduce(into: [:]) { result, coin in
+            result[coin] = availability
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/StakeInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/StakeInteractor.swift
@@ -5,9 +5,39 @@
 //  Created by Gaston Mazzeo on 21/11/2025.
 //
 
+enum StakeActionAvailability: Equatable, Sendable {
+    case checking
+    case available
+    case halted
+    case unavailable
+
+    var disablesActions: Bool {
+        self != .available
+    }
+
+    var warningLocalizationKey: String? {
+        switch self {
+        case .checking, .available:
+            nil
+        case .halted:
+            "mayaCacaoStakingHaltedWarning"
+        case .unavailable:
+            "mayaCacaoStakingUnavailableWarning"
+        }
+    }
+}
+
 protocol StakeInteractor {
     /// Returns one DTO per coin that was successfully fetched. Per-coin failures are silently
     /// omitted — storage upserts only what's returned, so the persisted row keeps its last good
     /// value until the next refresh.
     func fetchStakePositions(vault: Vault) async -> [StakePositionData]
+    func fetchActionAvailability() async -> StakeActionAvailability
+}
+
+extension StakeInteractor {
+    // swiftlint:disable:next async_without_await
+    func fetchActionAvailability() async -> StakeActionAvailability {
+        .available
+    }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/StakeInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/StakeInteractor.swift
@@ -14,30 +14,26 @@ enum StakeActionAvailability: Equatable, Sendable {
     var disablesActions: Bool {
         self != .available
     }
-
-    var warningLocalizationKey: String? {
-        switch self {
-        case .checking, .available:
-            nil
-        case .halted:
-            "mayaCacaoStakingHaltedWarning"
-        case .unavailable:
-            "mayaCacaoStakingUnavailableWarning"
-        }
-    }
 }
+
+typealias StakeActionAvailabilities = [CoinMeta: StakeActionAvailability]
 
 protocol StakeInteractor {
     /// Returns one DTO per coin that was successfully fetched. Per-coin failures are silently
     /// omitted — storage upserts only what's returned, so the persisted row keeps its last good
     /// value until the next refresh.
     func fetchStakePositions(vault: Vault) async -> [StakePositionData]
-    func fetchActionAvailability() async -> StakeActionAvailability
+    /// Returns availability overrides keyed by the concrete position coin. Missing coins use the
+    /// presentation default (`available`), which lets mixed chains gate contract positions without
+    /// disabling unrelated native-module actions.
+    func fetchActionAvailabilities(for coins: [CoinMeta]) async -> StakeActionAvailabilities
 }
 
 extension StakeInteractor {
     // swiftlint:disable:next async_without_await
-    func fetchActionAvailability() async -> StakeActionAvailability {
-        .available
+    func fetchActionAvailabilities(for coins: [CoinMeta]) async -> StakeActionAvailabilities {
+        coins.reduce(into: [:]) { result, coin in
+            result[coin] = .available
+        }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/THORChainStakeInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/THORChainStakeInteractor.swift
@@ -11,9 +11,14 @@ private let logger = Log.defi.interactor
 
 struct THORChainStakeInteractor: StakeInteractor {
     private let stakingService: THORChainStakingProviding
+    private let wasmAvailabilityProvider: THORChainWasmExecutionAvailabilityProviding
 
-    init(stakingService: THORChainStakingProviding = THORChainStakingService.shared) {
+    init(
+        stakingService: THORChainStakingProviding = THORChainStakingService.shared,
+        wasmAvailabilityProvider: THORChainWasmExecutionAvailabilityProviding = ThorchainService.shared
+    ) {
         self.stakingService = stakingService
+        self.wasmAvailabilityProvider = wasmAvailabilityProvider
     }
 
     static func scaledAmount(rawAmount: Decimal, decimals: Int) -> Decimal {
@@ -31,6 +36,42 @@ struct THORChainStakeInteractor: StakeInteractor {
             dtos.append(contentsOf: await positions(for: snapshot, runeMeta: runeMeta))
         }
         return dtos
+    }
+
+    func fetchActionAvailabilities(for coins: [CoinMeta]) async -> StakeActionAvailabilities {
+        let contractAddresses = Set(coins.flatMap { Self.wasmContractAddresses(for: $0) })
+        let contractAvailabilities = await wasmAvailabilityProvider.fetchWasmExecutionAvailabilities(
+            for: contractAddresses
+        )
+
+        return coins.reduce(into: [:]) { result, coin in
+            let addresses = Self.wasmContractAddresses(for: coin)
+            let availabilities = addresses.map { contractAvailabilities[$0] ?? .unavailable }
+            if availabilities.contains(.halted) {
+                result[coin] = .halted
+            } else if availabilities.contains(.unavailable) {
+                result[coin] = .unavailable
+            } else {
+                result[coin] = .available
+            }
+        }
+    }
+
+    static func wasmContractAddresses(for coin: CoinMeta) -> [String] {
+        switch coin.ticker.uppercased() {
+        case "RUJI", "SRUJI":
+            return [RUJIStakingConstants.contract]
+        case "STCY":
+            return [TCYAutoCompoundConstants.contract]
+        case "YBRUNE":
+            return [BRUNEStakingConstants.contract]
+        case "YRUNE":
+            return [YVaultConstants.affiliateContractAddress, YVaultConstants.contracts["rune"]].compactMap { $0 }
+        case "YTCY":
+            return [YVaultConstants.affiliateContractAddress, YVaultConstants.contracts["tcy"]].compactMap { $0 }
+        default:
+            return []
+        }
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedPositionView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedPositionView.swift
@@ -12,6 +12,7 @@ struct DefiChainStakedPositionView: View {
 
     let position: StakePosition
     let fiatAmount: String
+    var actionAvailability: StakeActionAvailability = .available
     var onStake: () -> Void
     var onUnstake: () -> Void
     var onWithdraw: () -> Void
@@ -51,8 +52,15 @@ struct DefiChainStakedPositionView: View {
         return CustomDateFormatter.formatMonthDayYear(nextPayout)
     }
 
-    var unstakeDisabled: Bool { !position.canUnstake }
-    var stakeDisabled: Bool { !position.canStake }
+    var unstakeDisabled: Bool { actionAvailability.disablesActions || !position.canUnstake }
+    var stakeDisabled: Bool { actionAvailability.disablesActions || !position.canStake }
+    var actionWarningMessage: String? {
+        guard position.coin.chain == .mayaChain,
+              let key = actionAvailability.warningLocalizationKey else {
+            return nil
+        }
+        return key.localized
+    }
     var canWithdraw: Bool {
         guard let rewards = position.rewards else { return false }
         return rewards > 0
@@ -193,6 +201,13 @@ struct DefiChainStakedPositionView: View {
             VStack(alignment: .leading, spacing: 16) {
                 PrimaryButton(title: withdrawTitle, action: onWithdraw)
                     .showIf(canWithdraw)
+                if let actionWarningMessage {
+                    InfoBannerView(
+                        description: actionWarningMessage,
+                        type: .warning,
+                        leadingIcon: .triangleWarning
+                    )
+                }
                 defaultButtonsView
 
                 if let unstakeMessage = position.unstakeMessage {

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedPositionView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedPositionView.swift
@@ -55,11 +55,28 @@ struct DefiChainStakedPositionView: View {
     var unstakeDisabled: Bool { actionAvailability.disablesActions || !position.canUnstake }
     var stakeDisabled: Bool { actionAvailability.disablesActions || !position.canStake }
     var actionWarningMessage: String? {
-        guard position.coin.chain == .mayaChain,
-              let key = actionAvailability.warningLocalizationKey else {
+        switch position.coin.chain {
+        case .mayaChain:
+            switch actionAvailability {
+            case .checking, .available:
+                return nil
+            case .halted:
+                return "mayaCacaoStakingHaltedWarning".localized
+            case .unavailable:
+                return "mayaCacaoStakingUnavailableWarning".localized
+            }
+        case .thorChain:
+            switch actionAvailability {
+            case .checking, .available:
+                return nil
+            case .halted:
+                return "thorchainWasmStakingHaltedWarning".localized
+            case .unavailable:
+                return "thorchainWasmStakingUnavailableWarning".localized
+            }
+        default:
             return nil
         }
-        return key.localized
     }
     var canWithdraw: Bool {
         guard let rewards = position.rewards else { return false }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedView.swift
@@ -45,6 +45,7 @@ struct DefiChainStakedView<EmptyStateView: View>: View {
                     DefiChainStakedPositionView(
                         position: position,
                         fiatAmount: fiatAmount,
+                        actionAvailability: viewModel.actionAvailability,
                         onStake: { onStake(position) },
                         onUnstake: { onUnstake(position) },
                         onWithdraw: { onWithdraw(position) },

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedView.swift
@@ -45,7 +45,7 @@ struct DefiChainStakedView<EmptyStateView: View>: View {
                     DefiChainStakedPositionView(
                         position: position,
                         fiatAmount: fiatAmount,
-                        actionAvailability: viewModel.actionAvailability,
+                        actionAvailability: viewModel.actionAvailability(for: position),
                         onStake: { onStake(position) },
                         onUnstake: { onUnstake(position) },
                         onWithdraw: { onWithdraw(position) },

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainStakeViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainStakeViewModel.swift
@@ -14,6 +14,7 @@ private let logger = Log.defi.viewModel
 final class DefiChainStakeViewModel: ObservableObject {
     @Published private(set) var vault: Vault
     @Published private(set) var initialLoadingDone: Bool
+    @Published private(set) var actionAvailability: StakeActionAvailability
 
     private let chain: Chain
     private let interactor: StakeInteractor?
@@ -57,6 +58,7 @@ final class DefiChainStakeViewModel: ObservableObject {
         self.chain = chain
         self.interactor = interactor ?? DefiInteractorResolver.stakeInteractor(for: chain)
         self.storage = storage
+        self.actionAvailability = chain == .mayaChain ? .checking : .available
         // Mirror the per-chain visibility rule: TON shows any persisted stake
         // ungated; other chains require the per-coin opt-in.
         if chain == .ton {
@@ -73,11 +75,15 @@ final class DefiChainStakeViewModel: ObservableObject {
 
     func refresh() async {
         guard let interactor else {
+            actionAvailability = chain == .mayaChain ? .unavailable : .available
             initialLoadingDone = true
             return
         }
 
-        let dtos = await interactor.fetchStakePositions(vault: vault)
+        async let positions = interactor.fetchStakePositions(vault: vault)
+        async let availability = interactor.fetchActionAvailability()
+        let (dtos, resolvedAvailability) = await (positions, availability)
+        actionAvailability = resolvedAvailability
         do {
             try storage.upsert(stake: dtos, for: vault)
         } catch {

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainStakeViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainStakeViewModel.swift
@@ -14,7 +14,7 @@ private let logger = Log.defi.viewModel
 final class DefiChainStakeViewModel: ObservableObject {
     @Published private(set) var vault: Vault
     @Published private(set) var initialLoadingDone: Bool
-    @Published private(set) var actionAvailability: StakeActionAvailability
+    @Published private(set) var actionAvailabilities: StakeActionAvailabilities
 
     private let chain: Chain
     private let interactor: StakeInteractor?
@@ -35,6 +35,10 @@ final class DefiChainStakeViewModel: ObservableObject {
 
     var vaultStakePositions: [CoinMeta] {
         vault.defiPositions.first { $0.chain == chain }?.staking ?? []
+    }
+
+    func actionAvailability(for position: StakePosition) -> StakeActionAvailability {
+        actionAvailabilities[position.coin] ?? .available
     }
 
     /// Whether a persisted position should be shown for this chain. TON nominator
@@ -58,7 +62,10 @@ final class DefiChainStakeViewModel: ObservableObject {
         self.chain = chain
         self.interactor = interactor ?? DefiInteractorResolver.stakeInteractor(for: chain)
         self.storage = storage
-        self.actionAvailability = chain == .mayaChain ? .checking : .available
+        self.actionAvailabilities = Self.initialActionAvailabilities(
+            for: vault.defiPositions.first { $0.chain == chain }?.staking ?? [],
+            chain: chain
+        )
         // Mirror the per-chain visibility rule: TON shows any persisted stake
         // ungated; other chains require the per-coin opt-in.
         if chain == .ton {
@@ -75,20 +82,42 @@ final class DefiChainStakeViewModel: ObservableObject {
 
     func refresh() async {
         guard let interactor else {
-            actionAvailability = chain == .mayaChain ? .unavailable : .available
+            actionAvailabilities = Self.resolvedActionAvailabilities(
+                for: vaultStakePositions,
+                availability: chain == .mayaChain ? .unavailable : .available
+            )
             initialLoadingDone = true
             return
         }
 
+        let enabledCoins = vaultStakePositions
         async let positions = interactor.fetchStakePositions(vault: vault)
-        async let availability = interactor.fetchActionAvailability()
-        let (dtos, resolvedAvailability) = await (positions, availability)
-        actionAvailability = resolvedAvailability
+        async let availabilities = interactor.fetchActionAvailabilities(for: enabledCoins)
+        let (dtos, resolvedAvailabilities) = await (positions, availabilities)
+        actionAvailabilities = resolvedAvailabilities
         do {
             try storage.upsert(stake: dtos, for: vault)
         } catch {
             logger.error("Failed to persist stake positions for chain \(self.chain.rawValue, privacy: .public): \(error.localizedDescription, privacy: .private)")
         }
         initialLoadingDone = true
+    }
+}
+
+private extension DefiChainStakeViewModel {
+    static func initialActionAvailabilities(for coins: [CoinMeta], chain: Chain) -> StakeActionAvailabilities {
+        resolvedActionAvailabilities(
+            for: coins,
+            availability: chain == .mayaChain ? .checking : .available
+        )
+    }
+
+    static func resolvedActionAvailabilities(
+        for coins: [CoinMeta],
+        availability: StakeActionAvailability
+    ) -> StakeActionAvailabilities {
+        coins.reduce(into: [:]) { result, coin in
+            result[coin] = availability
+        }
     }
 }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Common/Service/MayaCacaoStakingPreflight.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Common/Service/MayaCacaoStakingPreflight.swift
@@ -1,0 +1,51 @@
+//
+//  MayaCacaoStakingPreflight.swift
+//  VultisigApp
+//
+//  Fresh signing-boundary availability check for CACAO pool transactions.
+//
+
+enum MayaCacaoStakingPreflightError: Error, Equatable {
+    case halted
+    case unavailable
+
+    var localizationKey: String {
+        switch self {
+        case .halted:
+            "mayaCacaoStakingHaltedWarning"
+        case .unavailable:
+            "mayaCacaoStakingUnavailableWarning"
+        }
+    }
+}
+
+struct MayaCacaoStakingPreflight {
+    typealias AvailabilityReader = () async throws -> MayaNativeDepositAvailability
+
+    private let readAvailability: AvailabilityReader
+
+    init(
+        readAvailability: @escaping AvailabilityReader = {
+            try await MayaChainAPIService().getNativeDepositAvailability(shouldCache: false)
+        }
+    ) {
+        self.readAvailability = readAvailability
+    }
+
+    func validate(_ transactionBuilder: TransactionBuilder) async throws {
+        guard transactionBuilder is CacaoStakeTransactionBuilder
+                || transactionBuilder is CacaoUnstakeTransactionBuilder else {
+            return
+        }
+
+        do {
+            guard try await readAvailability() == .available else {
+                throw MayaCacaoStakingPreflightError.halted
+            }
+        } catch let error as MayaCacaoStakingPreflightError {
+            throw error
+        } catch {
+            throw MayaCacaoStakingPreflightError.unavailable
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Common/Service/THORChainWasmExecutionPreflight.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Common/Service/THORChainWasmExecutionPreflight.swift
@@ -1,0 +1,49 @@
+//
+//  THORChainWasmExecutionPreflight.swift
+//  VultisigApp
+//
+//  Fresh signing-boundary availability check for THORChain WASM transactions.
+//
+
+enum THORChainWasmExecutionPreflightError: Error, Equatable {
+    case halted
+    case unavailable
+
+    var localizationKey: String {
+        switch self {
+        case .halted:
+            "thorchainWasmStakingHaltedWarning"
+        case .unavailable:
+            "thorchainWasmStakingUnavailableWarning"
+        }
+    }
+}
+
+struct THORChainWasmExecutionPreflight {
+    private let availabilityProvider: THORChainWasmExecutionAvailabilityProviding
+
+    init(
+        availabilityProvider: THORChainWasmExecutionAvailabilityProviding = ThorchainService.shared
+    ) {
+        self.availabilityProvider = availabilityProvider
+    }
+
+    func validate(_ transactionBuilder: TransactionBuilder) async throws {
+        guard transactionBuilder.coin.chain == .thorChain else { return }
+
+        let contractAddresses = transactionBuilder.wasmContractAddressesForPreflight
+        guard !contractAddresses.isEmpty else { return }
+
+        let availabilities = await availabilityProvider.fetchWasmExecutionAvailabilities(
+            for: contractAddresses
+        )
+        let states = contractAddresses.map { availabilities[$0] ?? .unavailable }
+
+        if states.contains(.halted) {
+            throw THORChainWasmExecutionPreflightError.halted
+        }
+        if states.contains(.unavailable) {
+            throw THORChainWasmExecutionPreflightError.unavailable
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
@@ -15,6 +15,7 @@ struct FunctionTransactionScreen: View {
     let vault: Vault
     let transactionType: FunctionTransactionType
     private let mayaCacaoStakingPreflight = MayaCacaoStakingPreflight()
+    private let thorchainWasmExecutionPreflight = THORChainWasmExecutionPreflight()
 
     @State private var isLoading: Bool = false
     @State private var preflightErrorToast: String?
@@ -318,11 +319,17 @@ struct FunctionTransactionScreen: View {
 
             do {
                 try await mayaCacaoStakingPreflight.validate(transactionBuilder)
+                try await thorchainWasmExecutionPreflight.validate(transactionBuilder)
             } catch let error as MayaCacaoStakingPreflightError {
                 preflightErrorToast = error.localizationKey.localized
                 return
+            } catch let error as THORChainWasmExecutionPreflightError {
+                preflightErrorToast = error.localizationKey.localized
+                return
             } catch {
-                preflightErrorToast = "mayaCacaoStakingUnavailableWarning".localized
+                preflightErrorToast = transactionBuilder.coin.chain == .thorChain
+                    ? "thorchainWasmStakingUnavailableWarning".localized
+                    : "mayaCacaoStakingUnavailableWarning".localized
                 return
             }
 

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
@@ -14,8 +14,10 @@ struct FunctionTransactionScreen: View {
     @Environment(\.router) var router
     let vault: Vault
     let transactionType: FunctionTransactionType
+    private let mayaCacaoStakingPreflight = MayaCacaoStakingPreflight()
 
     @State private var isLoading: Bool = false
+    @State private var preflightErrorToast: String?
 
     @Environment(\.dismiss) var dismiss
 
@@ -306,17 +308,30 @@ struct FunctionTransactionScreen: View {
             }
         }
         .withLoading(isLoading: $isLoading)
+        .withBanner(text: $preflightErrorToast, style: .error)
     }
 
     func onVerify(_ transactionBuilder: TransactionBuilder) {
         Task { @MainActor in
+            isLoading = true
+            defer { isLoading = false }
+
+            do {
+                try await mayaCacaoStakingPreflight.validate(transactionBuilder)
+            } catch let error as MayaCacaoStakingPreflightError {
+                preflightErrorToast = error.localizationKey.localized
+                return
+            } catch {
+                preflightErrorToast = "mayaCacaoStakingUnavailableWarning".localized
+                return
+            }
+
             // Cosmos staking flows bypass the legacy `FunctionCallForm`
             // round-trip — the SignDoc payload travels via
             // `SendTransaction.cosmosStakingPayload`, which `fromForm(_:)`
             // would drop. Skip directly to the immutable struct so the
             // Verify → KeysignPayload resolver sees the staking intent.
             if let stakingPayload = transactionBuilder.cosmosStakingPayload {
-                isLoading = true
                 var immutableTx = transactionBuilder.buildSendTransaction(vault: vault)
                 // `buildSendTransaction` defaults gas to .zero and the staking
                 // flow never fetches chain-specific gas (the SignDoc resolver
@@ -347,13 +362,9 @@ struct FunctionTransactionScreen: View {
                         "Failed to derive staking display fee: \(error.localizedDescription, privacy: .public)"
                     )
                 }
-                isLoading = false
                 router.navigate(to: FunctionTransactionRoute.verify(tx: immutableTx, vault: vault))
                 return
             }
-
-            isLoading = true
-            defer { isLoading = false }
 
             // Priced before it is disclosed. Nothing downstream re-resolves the
             // fee for display, so this figure is the one the user approves.

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Mint/MintTransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Mint/MintTransactionBuilder.swift
@@ -49,6 +49,14 @@ struct MintTransactionBuilder: TransactionBuilder {
         )
     }
 
+    var wasmContractAddressesForPreflight: Set<String> {
+        var addresses = Set([YVaultConstants.affiliateContractAddress])
+        if let targetContract = YVaultConstants.contracts[coin.ticker.lowercased()] {
+            addresses.insert(targetContract)
+        }
+        return addresses
+    }
+
     private func buildExecuteMsg() -> String {
         let denom = coin.ticker.lowercased()
         let targetContract = YVaultConstants.contracts[denom] ?? ""

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Mint/RedeemTransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Mint/RedeemTransactionBuilder.swift
@@ -49,6 +49,14 @@ struct RedeemTransactionBuilder: TransactionBuilder {
         )
     }
 
+    var wasmContractAddressesForPreflight: Set<String> {
+        var addresses = Set([YVaultConstants.affiliateContractAddress])
+        if let targetContract = YVaultConstants.contracts[coin.ticker.lowercased()] {
+            addresses.insert(targetContract)
+        }
+        return addresses
+    }
+
     private func buildExecuteMsg() -> String {
         let denom = coin.ticker.lowercased()
         let targetContract = YVaultConstants.contracts[denom] ?? ""

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/TransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/TransactionBuilder.swift
@@ -15,6 +15,10 @@ protocol TransactionBuilder {
     var memoFunctionDictionary: ThreadSafeDictionary<String, String> { get }
     var transactionType: VSTransactionType { get }
     var wasmContractPayload: WasmExecuteContractPayload? { get }
+    /// Every THORChain WASM contract whose execution must remain available for
+    /// this transaction. Most builders execute only the payload contract; proxy
+    /// builders can add the downstream contract they invoke.
+    var wasmContractAddressesForPreflight: Set<String> { get }
     var toAddress: String { get }
     /// Cosmos-SDK staking / distribution operation intent. Populated only by
     /// the per-flow Cosmos staking builders (delegate, undelegate, redelegate,
@@ -34,6 +38,11 @@ protocol TransactionBuilder {
 }
 
 extension TransactionBuilder {
+    var wasmContractAddressesForPreflight: Set<String> {
+        guard let address = wasmContractPayload?.contractAddress else { return [] }
+        return [address]
+    }
+
     /// Default — only Cosmos staking builders override this. Keeping the
     /// requirement defaulted means every existing `TransactionBuilder`
     /// conformer compiles unchanged.

--- a/VultisigApp/VultisigAppTests/Defi/DefiChainStakeViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/DefiChainStakeViewModelTests.swift
@@ -71,15 +71,31 @@ final class DefiChainStakeViewModelTests: XCTestCase {
     func testMayaRefreshPublishesHaltedActionAvailability() async {
         let cacao = TokensStore.cacao
         vault.defiPositions = [DefiPositions(chain: .mayaChain, bonds: [], staking: [cacao], lps: [])]
-        interactor.actionAvailabilityStub = .halted
+        interactor.actionAvailabilitiesStub = [cacao: .halted]
         let viewModel = DefiChainStakeViewModel(vault: vault, chain: .mayaChain, interactor: interactor)
 
-        XCTAssertEqual(viewModel.actionAvailability, .checking)
+        let position = StakePosition(coin: cacao, type: .stake, amount: 10, vault: vault)
+        XCTAssertEqual(viewModel.actionAvailability(for: position), .checking)
 
         await viewModel.refresh()
 
-        XCTAssertEqual(viewModel.actionAvailability, .halted)
+        XCTAssertEqual(viewModel.actionAvailability(for: position), .halted)
         XCTAssertEqual(interactor.actionAvailabilityCallCount, 1)
+    }
+
+    func testRefreshPublishesAvailabilityPerPosition() async {
+        let tcy = CoinMeta.make(chain: .thorChain, ticker: "TCY")
+        let ruji = CoinMeta.make(chain: .thorChain, ticker: "RUJI")
+        vault.defiPositions = [DefiPositions(chain: .thorChain, bonds: [], staking: [tcy, ruji], lps: [])]
+        interactor.actionAvailabilitiesStub = [tcy: .available, ruji: .halted]
+        let viewModel = makeViewModel()
+
+        await viewModel.refresh()
+
+        let tcyPosition = StakePosition(coin: tcy, type: .stake, amount: 10, vault: vault)
+        let rujiPosition = StakePosition(coin: ruji, type: .stake, amount: 10, vault: vault)
+        XCTAssertEqual(viewModel.actionAvailability(for: tcyPosition), .available)
+        XCTAssertEqual(viewModel.actionAvailability(for: rujiPosition), .halted)
     }
 
     /// Refresh that returns no DTOs (e.g. all per-coin fetches failed) must not flicker the list

--- a/VultisigApp/VultisigAppTests/Defi/DefiChainStakeViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/DefiChainStakeViewModelTests.swift
@@ -68,6 +68,20 @@ final class DefiChainStakeViewModelTests: XCTestCase {
         XCTAssertTrue(vm.initialLoadingDone)
     }
 
+    func testMayaRefreshPublishesHaltedActionAvailability() async {
+        let cacao = TokensStore.cacao
+        vault.defiPositions = [DefiPositions(chain: .mayaChain, bonds: [], staking: [cacao], lps: [])]
+        interactor.actionAvailabilityStub = .halted
+        let viewModel = DefiChainStakeViewModel(vault: vault, chain: .mayaChain, interactor: interactor)
+
+        XCTAssertEqual(viewModel.actionAvailability, .checking)
+
+        await viewModel.refresh()
+
+        XCTAssertEqual(viewModel.actionAvailability, .halted)
+        XCTAssertEqual(interactor.actionAvailabilityCallCount, 1)
+    }
+
     /// Refresh that returns no DTOs (e.g. all per-coin fetches failed) must not flicker the list
     /// to empty — persisted rows stay visible.
     func testRefreshEmptyPreservesPersistedState() async throws {

--- a/VultisigApp/VultisigAppTests/Defi/Helpers/MockInteractors.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Helpers/MockInteractors.swift
@@ -15,11 +15,18 @@ import Foundation
 
 final class MockStakeInteractor: StakeInteractor, @unchecked Sendable {
     var stub: [StakePositionData] = []
+    var actionAvailabilityStub: StakeActionAvailability = .available
     private(set) var callCount = 0
+    private(set) var actionAvailabilityCallCount = 0
 
     func fetchStakePositions(vault: Vault) async -> [StakePositionData] {
         callCount += 1
         return stub
+    }
+
+    func fetchActionAvailability() async -> StakeActionAvailability {
+        actionAvailabilityCallCount += 1
+        return actionAvailabilityStub
     }
 }
 

--- a/VultisigApp/VultisigAppTests/Defi/Helpers/MockInteractors.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Helpers/MockInteractors.swift
@@ -15,7 +15,7 @@ import Foundation
 
 final class MockStakeInteractor: StakeInteractor, @unchecked Sendable {
     var stub: [StakePositionData] = []
-    var actionAvailabilityStub: StakeActionAvailability = .available
+    var actionAvailabilitiesStub: StakeActionAvailabilities = [:]
     private(set) var callCount = 0
     private(set) var actionAvailabilityCallCount = 0
 
@@ -24,9 +24,13 @@ final class MockStakeInteractor: StakeInteractor, @unchecked Sendable {
         return stub
     }
 
-    func fetchActionAvailability() async -> StakeActionAvailability {
+    func fetchActionAvailabilities(for coins: [CoinMeta]) async -> StakeActionAvailabilities {
         actionAvailabilityCallCount += 1
-        return actionAvailabilityStub
+        return coins.reduce(into: actionAvailabilitiesStub) { result, coin in
+            if result[coin] == nil {
+                result[coin] = .available
+            }
+        }
     }
 }
 

--- a/VultisigApp/VultisigAppTests/Defi/MayaCacaoStakingAvailabilityTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/MayaCacaoStakingAvailabilityTests.swift
@@ -1,0 +1,172 @@
+//
+//  MayaCacaoStakingAvailabilityTests.swift
+//  VultisigAppTests
+//
+//  Native MsgDeposit availability for CACAO pool Add / Remove.
+//
+
+import Foundation
+@testable import VultisigApp
+import XCTest
+
+final class MayaCacaoStakingAvailabilityTests: XCTestCase {
+
+    func testMimirDecodesEveryNativeDepositHaltInput() throws {
+        let mimir = try decodeMimir(
+            haltChainGlobal: 1,
+            nodePauseChainGlobal: 200,
+            haltMayaChain: 2,
+            solvencyHaltMayaChain: 3
+        )
+
+        XCTAssertEqual(mimir.haltChainGlobal, 1)
+        XCTAssertEqual(mimir.nodePauseChainGlobal, 200)
+        XCTAssertEqual(mimir.haltMayaChain, 2)
+        XCTAssertEqual(mimir.solvencyHaltMayaChain, 3)
+    }
+
+    func testMimirDecodesNativeHaltKeysFromLivePayloadShape() throws {
+        let data = Data("""
+        {
+          "CACAOPOOLDEPOSITMATURITYBLOCKS": 302400,
+          "HALTCHAINGLOBAL": 1,
+          "NODEPAUSECHAINGLOBAL": 16576652,
+          "HALTMAYACHAIN": -1,
+          "SOLVENCYHALTMAYACHAIN": -1
+        }
+        """.utf8)
+
+        let mimir = try JSONDecoder().decode(MayaMimir.self, from: data)
+
+        XCTAssertEqual(mimir.haltChainGlobal, 1)
+        XCTAssertEqual(mimir.nodePauseChainGlobal, 16_576_652)
+        XCTAssertEqual(mimir.haltMayaChain, -1)
+        XCTAssertEqual(mimir.solvencyHaltMayaChain, -1)
+    }
+
+    func testGlobalAndMayaHaltsStartAfterTheirConfiguredHeight() throws {
+        for key in ["HALTCHAINGLOBAL", "HALTMAYACHAIN", "SOLVENCYHALTMAYACHAIN"] {
+            XCTAssertFalse(try decodeMimir(extra: [key: 100]).isNativeDepositHalted(at: 100))
+            XCTAssertTrue(try decodeMimir(extra: [key: 100]).isNativeDepositHalted(at: 101))
+        }
+    }
+
+    func testNodePauseIsActiveOnlyBeforeItsResumeHeight() throws {
+        let mimir = try decodeMimir(nodePauseChainGlobal: 200)
+
+        XCTAssertTrue(mimir.isNativeDepositHalted(at: 199))
+        XCTAssertFalse(mimir.isNativeDepositHalted(at: 200))
+        XCTAssertFalse(mimir.isNativeDepositHalted(at: 201))
+    }
+
+    func testMissingZeroNegativeAndFutureAdminHaltsAreAvailable() throws {
+        XCTAssertFalse(try decodeMimir().isNativeDepositHalted(at: 100))
+        XCTAssertFalse(try decodeMimir(haltChainGlobal: 0).isNativeDepositHalted(at: 100))
+        XCTAssertFalse(try decodeMimir(haltChainGlobal: -1).isNativeDepositHalted(at: 100))
+        XCTAssertFalse(try decodeMimir(haltChainGlobal: 101).isNativeDepositHalted(at: 100))
+    }
+
+    func testAvailabilityCacheCanBeBypassedForSigningBoundary() async throws {
+        let client = MayaAvailabilityHTTPClient(
+            responses: [
+                "/mayachain/lastblock": [
+                    lastBlockJSON(height: 100),
+                    lastBlockJSON(height: 100),
+                    lastBlockJSON(height: 101)
+                ],
+                "/mayachain/mimir": [mimirJSON(haltChainGlobal: 0), mimirJSON(haltChainGlobal: 1)]
+            ]
+        )
+        let service = MayaChainAPIService(httpClient: client)
+
+        let initialAvailability = try await service.getNativeDepositAvailability()
+        let cachedAvailability = try await service.getNativeDepositAvailability()
+        let refreshedAvailability = try await service.getNativeDepositAvailability(shouldCache: false)
+        let lastBlockRequestCount = await client.requestCount(for: "/mayachain/lastblock")
+        let mimirRequestCount = await client.requestCount(for: "/mayachain/mimir")
+
+        XCTAssertEqual(initialAvailability, .available)
+        XCTAssertEqual(
+            cachedAvailability,
+            .available,
+            "The ordinary UI read may reuse its five-minute snapshot."
+        )
+        XCTAssertEqual(
+            refreshedAvailability,
+            .halted,
+            "The signing-boundary read must observe a halt that began after the card loaded."
+        )
+        XCTAssertEqual(lastBlockRequestCount, 3)
+        XCTAssertEqual(mimirRequestCount, 2)
+    }
+
+    private func decodeMimir(
+        haltChainGlobal: Int64? = nil,
+        nodePauseChainGlobal: Int64? = nil,
+        haltMayaChain: Int64? = nil,
+        solvencyHaltMayaChain: Int64? = nil
+    ) throws -> MayaMimir {
+        var extra: [String: Int64] = [:]
+        extra["HALTCHAINGLOBAL"] = haltChainGlobal
+        extra["NODEPAUSECHAINGLOBAL"] = nodePauseChainGlobal
+        extra["HALTMAYACHAIN"] = haltMayaChain
+        extra["SOLVENCYHALTMAYACHAIN"] = solvencyHaltMayaChain
+        return try decodeMimir(extra: extra)
+    }
+
+    private func decodeMimir(extra: [String: Int64]) throws -> MayaMimir {
+        try JSONDecoder().decode(MayaMimir.self, from: mimirJSON(extra: extra))
+    }
+
+    private func mimirJSON(haltChainGlobal: Int64) -> Data {
+        mimirJSON(extra: ["HALTCHAINGLOBAL": haltChainGlobal])
+    }
+
+    private func mimirJSON(extra: [String: Int64]) -> Data {
+        var values = extra
+        values["CACAOPOOLDEPOSITMATURITYBLOCKS"] = 302_400
+        let fields = values
+            .sorted { $0.key < $1.key }
+            .map { "\"\($0.key)\":\($0.value)" }
+            .joined(separator: ",")
+        return Data("{\(fields)}".utf8)
+    }
+
+    private func lastBlockJSON(height: Int64) -> Data {
+        Data("""
+        [{"chain":"THOR","last_observed_in":27477640,"last_signed_out":17978543,"mayachain":\(height)}]
+        """.utf8)
+    }
+}
+
+private actor MayaAvailabilityHTTPClient: HTTPClientProtocol {
+    private var responses: [String: [Data]]
+    private var counts: [String: Int] = [:]
+
+    init(responses: [String: [Data]]) {
+        self.responses = responses
+    }
+
+    func requestCount(for path: String) -> Int {
+        counts[path, default: 0]
+    }
+
+    // swiftlint:disable:next async_without_await
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        let path = target.path
+        counts[path, default: 0] += 1
+        guard var queued = responses[path], !queued.isEmpty else {
+            throw HTTPError.statusCode(501, nil)
+        }
+        let data = queued.removeFirst()
+        responses[path] = queued
+
+        let response = HTTPURLResponse(
+            url: target.baseURL.appendingPathComponent(path),
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return HTTPResponse(data: data, response: response)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Defi/MayaCacaoStakingPresentationTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/MayaCacaoStakingPresentationTests.swift
@@ -1,0 +1,67 @@
+//
+//  MayaCacaoStakingPresentationTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class MayaCacaoStakingPresentationTests: XCTestCase {
+    private var storeToken: TestContextToken!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        storeToken = try TestStore.installInMemoryContainer()
+    }
+
+    override func tearDown() async throws {
+        TestStore.restore(storeToken)
+        storeToken = nil
+        try await super.tearDown()
+    }
+
+    func testHaltDisablesBothCacaoActionsAndShowsWarning() {
+        let view = makeView(availability: .halted)
+
+        XCTAssertTrue(view.stakeDisabled)
+        XCTAssertTrue(view.unstakeDisabled)
+        XCTAssertEqual(view.actionWarningMessage, "mayaCacaoStakingHaltedWarning".localized)
+    }
+
+    func testAvailableNetworkLeavesBothCacaoActionsEnabled() {
+        let view = makeView(availability: .available)
+
+        XCTAssertFalse(view.stakeDisabled)
+        XCTAssertFalse(view.unstakeDisabled)
+        XCTAssertNil(view.actionWarningMessage)
+    }
+
+    func testUnknownNetworkStateFailsClosedWithWarning() {
+        let view = makeView(availability: .unavailable)
+
+        XCTAssertTrue(view.stakeDisabled)
+        XCTAssertTrue(view.unstakeDisabled)
+        XCTAssertEqual(view.actionWarningMessage, "mayaCacaoStakingUnavailableWarning".localized)
+    }
+
+    private func makeView(availability: StakeActionAvailability) -> DefiChainStakedPositionView {
+        let vault = TestStore.makeVault()
+        let position = StakePosition(
+            coin: TokensStore.cacao,
+            type: .stake,
+            amount: 10,
+            availableToUnstake: 10,
+            vault: vault
+        )
+        return DefiChainStakedPositionView(
+            position: position,
+            fiatAmount: "$10.00",
+            actionAvailability: availability,
+            onStake: {},
+            onUnstake: {},
+            onWithdraw: {},
+            onTransfer: {}
+        )
+    }
+}

--- a/VultisigApp/VultisigAppTests/Defi/THORChainWasmStakingAvailabilityTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/THORChainWasmStakingAvailabilityTests.swift
@@ -1,0 +1,197 @@
+//
+//  THORChainWasmStakingAvailabilityTests.swift
+//  VultisigAppTests
+//
+
+import Foundation
+@testable import VultisigApp
+import XCTest
+
+final class THORChainWasmStakingAvailabilityTests: XCTestCase {
+    private let contractAddress = "thor1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqabcdef"
+    private let dataHash = "9F3A872C75AB4413DD37936F720B81A051062B1B96554C9CB46C7CCDB4FD017E"
+    private let checksumReference = "T45IOLDVVNCBHXJXSNXXEC4BUBIQMKY3SZKUZHFUNR6M3NH5AF7A"
+
+    func testHaltHeightStartsAfterConfiguredBlock() {
+        XCTAssertFalse(ThorchainService.isWasmHaltActive(-1, at: 100))
+        XCTAssertFalse(ThorchainService.isWasmHaltActive(0, at: 100))
+        XCTAssertFalse(ThorchainService.isWasmHaltActive(100, at: 100))
+        XCTAssertFalse(ThorchainService.isWasmHaltActive(101, at: 100))
+        XCTAssertTrue(ThorchainService.isWasmHaltActive(100, at: 101))
+    }
+
+    func testChecksumKeyUsesThornodeBase32WithoutPadding() {
+        XCTAssertEqual(ThorchainService.base32MimirReference(Data("foo".utf8)), "MZXW6")
+        XCTAssertEqual(
+            ThorchainService.wasmChecksumHaltMimirKey(dataHash: dataHash),
+            "HaltWasmCs-\(checksumReference)"
+        )
+        XCTAssertNil(ThorchainService.wasmChecksumHaltMimirKey(dataHash: "not-hex"))
+    }
+
+    func testContractKeyUsesLastSixAddressCharacters() {
+        XCTAssertEqual(
+            ThorchainService.wasmContractHaltMimirKey(address: contractAddress),
+            "HaltWasmContract-abcdef"
+        )
+        XCTAssertNil(ThorchainService.wasmContractHaltMimirKey(address: "short"))
+    }
+
+    func testChecksumHaltDisablesContractAfterConfiguredHeight() async {
+        let client = makeClient(currentHeight: 101, global: -1, contract: -1, checksum: 100)
+        let service = ThorchainService(resolver: NoTHORChainRPCOverride(), httpClient: client)
+
+        let availability = await service.fetchWasmExecutionAvailabilities(for: [contractAddress])
+
+        XCTAssertEqual(availability[contractAddress], .halted)
+    }
+
+    func testChecksumHaltDoesNotStartAtConfiguredHeight() async {
+        let client = makeClient(currentHeight: 100, global: -1, contract: -1, checksum: 100)
+        let service = ThorchainService(resolver: NoTHORChainRPCOverride(), httpClient: client)
+
+        let availability = await service.fetchWasmExecutionAvailabilities(for: [contractAddress])
+
+        XCTAssertEqual(availability[contractAddress], .available)
+    }
+
+    func testContractHaltDisablesContractAfterConfiguredHeight() async {
+        let client = makeClient(currentHeight: 101, global: -1, contract: 100, checksum: -1)
+        let service = ThorchainService(resolver: NoTHORChainRPCOverride(), httpClient: client)
+
+        let availability = await service.fetchWasmExecutionAvailabilities(for: [contractAddress])
+
+        XCTAssertEqual(availability[contractAddress], .halted)
+    }
+
+    func testGlobalHaltDisablesWithoutContractMetadataRequests() async {
+        let client = THORChainWasmAvailabilityHTTPClient(
+            responses: [
+                "/thorchain/lastblock": [lastBlockJSON(height: 101)],
+                "/thorchain/mimir/key/HALTWASMGLOBAL": [Data("100".utf8)]
+            ]
+        )
+        let service = ThorchainService(resolver: NoTHORChainRPCOverride(), httpClient: client)
+
+        let availability = await service.fetchWasmExecutionAvailabilities(for: [contractAddress])
+        let contractInfoRequests = await client.requestCount(for: "/cosmwasm/wasm/v1/contract/\(contractAddress)")
+
+        XCTAssertEqual(availability[contractAddress], .halted)
+        XCTAssertEqual(contractInfoRequests, 0)
+    }
+
+    func testMetadataFailureFailsOnlyThatContractClosed() async {
+        let client = THORChainWasmAvailabilityHTTPClient(
+            responses: [
+                "/thorchain/lastblock": [lastBlockJSON(height: 101)],
+                "/thorchain/mimir/key/HALTWASMGLOBAL": [Data("-1".utf8)],
+                "/thorchain/mimir/key/HALTWASMCONTRACT-ABCDEF": [Data("-1".utf8)]
+            ]
+        )
+        let service = ThorchainService(resolver: NoTHORChainRPCOverride(), httpClient: client)
+
+        let availability = await service.fetchWasmExecutionAvailabilities(for: [contractAddress])
+
+        XCTAssertEqual(availability[contractAddress], .unavailable)
+    }
+
+    func testInteractorGatesRujiWithoutDisablingNativeTcy() async {
+        let ruji = TokensStore.ruji
+        let tcy = TokensStore.tcy
+        let provider = StubWasmAvailabilityProvider(
+            availabilities: [RUJIStakingConstants.contract: .halted]
+        )
+        let interactor = THORChainStakeInteractor(wasmAvailabilityProvider: provider)
+
+        let availability = await interactor.fetchActionAvailabilities(for: [ruji, tcy])
+
+        XCTAssertEqual(availability[ruji], .halted)
+        XCTAssertEqual(availability[tcy], .available)
+    }
+
+    func testInteractorFailsRujiClosedWhenProviderOmitsContract() async {
+        let provider = StubWasmAvailabilityProvider(availabilities: [:])
+        let interactor = THORChainStakeInteractor(wasmAvailabilityProvider: provider)
+
+        let availability = await interactor.fetchActionAvailabilities(for: [TokensStore.ruji])
+
+        XCTAssertEqual(availability[TokensStore.ruji], .unavailable)
+    }
+
+    private func makeClient(
+        currentHeight: UInt64,
+        global: Int64,
+        contract: Int64,
+        checksum: Int64
+    ) -> THORChainWasmAvailabilityHTTPClient {
+        THORChainWasmAvailabilityHTTPClient(
+            responses: [
+                "/thorchain/lastblock": [lastBlockJSON(height: currentHeight)],
+                "/thorchain/mimir/key/HALTWASMGLOBAL": [Data(String(global).utf8)],
+                "/thorchain/mimir/key/HALTWASMCONTRACT-ABCDEF": [Data(String(contract).utf8)],
+                "/cosmwasm/wasm/v1/contract/\(contractAddress)": [contractInfoJSON(codeID: "43")],
+                "/cosmwasm/wasm/v1/code/43": [codeInfoJSON(dataHash: dataHash)],
+                "/thorchain/mimir/key/HALTWASMCS-\(checksumReference)": [Data(String(checksum).utf8)]
+            ]
+        )
+    }
+
+    private func lastBlockJSON(height: UInt64) -> Data {
+        Data("[{\"thorchain\":\(height)}]".utf8)
+    }
+
+    private func contractInfoJSON(codeID: String) -> Data {
+        Data("{\"contract_info\":{\"code_id\":\"\(codeID)\"}}".utf8)
+    }
+
+    private func codeInfoJSON(dataHash: String) -> Data {
+        Data("{\"code_info\":{\"data_hash\":\"\(dataHash)\"}}".utf8)
+    }
+}
+
+private struct NoTHORChainRPCOverride: RPCEndpointResolving {
+    func url(for _: Chain) -> String? { nil }
+}
+
+private struct StubWasmAvailabilityProvider: THORChainWasmExecutionAvailabilityProviding {
+    let availabilities: [String: THORChainWasmExecutionAvailability]
+
+    // swiftlint:disable async_without_await
+    func fetchWasmExecutionAvailabilities(
+        for contractAddresses: Set<String>
+    ) async -> [String: THORChainWasmExecutionAvailability] {
+        availabilities.filter { contractAddresses.contains($0.key) }
+    }
+    // swiftlint:enable async_without_await
+}
+
+private actor THORChainWasmAvailabilityHTTPClient: HTTPClientProtocol {
+    private var responses: [String: [Data]]
+    private var counts: [String: Int] = [:]
+
+    init(responses: [String: [Data]]) {
+        self.responses = responses
+    }
+
+    func requestCount(for path: String) -> Int {
+        counts[path, default: 0]
+    }
+
+    // swiftlint:disable:next async_without_await
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        let path = target.path
+        counts[path, default: 0] += 1
+        guard var queued = responses[path], !queued.isEmpty else {
+            throw HTTPError.statusCode(501, nil)
+        }
+        let data = queued.removeFirst()
+        responses[path] = queued
+        let response = HTTPURLResponse(
+            url: target.baseURL.appendingPathComponent(path),
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return HTTPResponse(data: data, response: response)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Defi/THORChainWasmStakingPresentationTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/THORChainWasmStakingPresentationTests.swift
@@ -1,0 +1,70 @@
+//
+//  THORChainWasmStakingPresentationTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class THORChainWasmStakingPresentationTests: XCTestCase {
+    private var storeToken: TestContextToken!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        storeToken = try TestStore.installInMemoryContainer()
+    }
+
+    override func tearDown() async throws {
+        TestStore.restore(storeToken)
+        storeToken = nil
+        try await super.tearDown()
+    }
+
+    func testHaltDisablesRujiActionsAndShowsAppLayerWarning() {
+        let view = makeView(coin: TokensStore.ruji, availability: .halted)
+
+        XCTAssertTrue(view.stakeDisabled)
+        XCTAssertTrue(view.unstakeDisabled)
+        XCTAssertEqual(view.actionWarningMessage, "thorchainWasmStakingHaltedWarning".localized)
+    }
+
+    func testUnavailablePolicyDisablesRujiActionsAndShowsVerificationWarning() {
+        let view = makeView(coin: TokensStore.ruji, availability: .unavailable)
+
+        XCTAssertTrue(view.stakeDisabled)
+        XCTAssertTrue(view.unstakeDisabled)
+        XCTAssertEqual(view.actionWarningMessage, "thorchainWasmStakingUnavailableWarning".localized)
+    }
+
+    func testAvailableNativeTcyHasNoAppLayerWarning() {
+        let view = makeView(coin: TokensStore.tcy, availability: .available)
+
+        XCTAssertFalse(view.stakeDisabled)
+        XCTAssertFalse(view.unstakeDisabled)
+        XCTAssertNil(view.actionWarningMessage)
+    }
+
+    private func makeView(
+        coin: CoinMeta,
+        availability: StakeActionAvailability
+    ) -> DefiChainStakedPositionView {
+        let vault = TestStore.makeVault()
+        let position = StakePosition(
+            coin: coin,
+            type: .stake,
+            amount: 10,
+            availableToUnstake: 10,
+            vault: vault
+        )
+        return DefiChainStakedPositionView(
+            position: position,
+            fiatAmount: "$10.00",
+            actionAvailability: availability,
+            onStake: {},
+            onUnstake: {},
+            onWithdraw: {},
+            onTransfer: {}
+        )
+    }
+}

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/MayaCacaoStakingPreflightTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/MayaCacaoStakingPreflightTests.swift
@@ -1,0 +1,70 @@
+//
+//  MayaCacaoStakingPreflightTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class MayaCacaoStakingPreflightTests: XCTestCase {
+    func testHaltedNetworkBlocksStakeAndUnstake() async {
+        let preflight = MayaCacaoStakingPreflight { .halted }
+        let builders: [TransactionBuilder] = [
+            CacaoStakeTransactionBuilder(coin: .example, amount: "1"),
+            CacaoUnstakeTransactionBuilder(coin: .example, bps: 5_000)
+        ]
+
+        for builder in builders {
+            do {
+                try await preflight.validate(builder)
+                XCTFail("A halted MAYAChain must block every CACAO pool action.")
+            } catch let error as MayaCacaoStakingPreflightError {
+                XCTAssertEqual(error, .halted)
+            } catch {
+                XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testAvailableNetworkAllowsStakeAndUnstake() async throws {
+        let preflight = MayaCacaoStakingPreflight { .available }
+
+        try await preflight.validate(CacaoStakeTransactionBuilder(coin: .example, amount: "1"))
+        try await preflight.validate(CacaoUnstakeTransactionBuilder(coin: .example, bps: 5_000))
+    }
+
+    func testAvailabilityFailureBlocksSigningAsUnavailable() async {
+        let preflight = MayaCacaoStakingPreflight { throw StubError.unreachable }
+
+        do {
+            try await preflight.validate(CacaoStakeTransactionBuilder(coin: .example, amount: "1"))
+            XCTFail("An unverifiable network state must fail closed.")
+        } catch let error as MayaCacaoStakingPreflightError {
+            XCTAssertEqual(error, .unavailable)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testUnrelatedTransactionSkipsAvailabilityRequest() async throws {
+        var requestCount = 0
+        let preflight = MayaCacaoStakingPreflight {
+            requestCount += 1
+            return .halted
+        }
+        let builder = CustomMemoTransactionBuilder(
+            coin: .example,
+            customMemo: "memo",
+            customAmount: 0
+        )
+
+        try await preflight.validate(builder)
+
+        XCTAssertEqual(requestCount, 0)
+    }
+}
+
+private enum StubError: Error {
+    case unreachable
+}

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/THORChainWasmExecutionPreflightTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/THORChainWasmExecutionPreflightTests.swift
@@ -1,0 +1,126 @@
+//
+//  THORChainWasmExecutionPreflightTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class THORChainWasmExecutionPreflightTests: XCTestCase {
+    func testHaltedNetworkBlocksRujiStake() async {
+        let provider = SequencedWasmAvailabilityProvider(states: [.halted])
+        let preflight = THORChainWasmExecutionPreflight(availabilityProvider: provider)
+
+        do {
+            try await preflight.validate(makeRujiStakeBuilder())
+            XCTFail("A halted THORChain WASM runtime must block RUJI staking.")
+        } catch let error as THORChainWasmExecutionPreflightError {
+            XCTAssertEqual(error, .halted)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testUnavailableOrMissingStateFailsClosed() async {
+        for state in [THORChainWasmExecutionAvailability.unavailable, nil] {
+            let provider = SequencedWasmAvailabilityProvider(states: [state])
+            let preflight = THORChainWasmExecutionPreflight(availabilityProvider: provider)
+
+            do {
+                try await preflight.validate(makeRujiStakeBuilder())
+                XCTFail("An unverifiable WASM policy must block RUJI staking.")
+            } catch let error as THORChainWasmExecutionPreflightError {
+                XCTAssertEqual(error, .unavailable)
+            } catch {
+                XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testPreflightReadsFreshStateOnEveryAttempt() async {
+        let provider = SequencedWasmAvailabilityProvider(states: [.available, .halted])
+        let preflight = THORChainWasmExecutionPreflight(availabilityProvider: provider)
+        let builder = makeRujiStakeBuilder()
+
+        try? await preflight.validate(builder)
+        try? await preflight.validate(builder)
+
+        let requestCount = await provider.requestCount
+        XCTAssertEqual(requestCount, 2)
+    }
+
+    func testNativeThorchainTransactionSkipsWasmRequest() async throws {
+        let provider = SequencedWasmAvailabilityProvider(states: [.halted])
+        let preflight = THORChainWasmExecutionPreflight(availabilityProvider: provider)
+        let builder = CustomMemoTransactionBuilder(
+            coin: makeCoin(asset: TokensStore.tcy),
+            customMemo: "tcy+:thor1address",
+            customAmount: 1
+        )
+
+        try await preflight.validate(builder)
+
+        let requestCount = await provider.requestCount
+        XCTAssertEqual(requestCount, 0)
+    }
+
+    func testYVaultPreflightIncludesProxyAndTargetContracts() {
+        let mint = MintTransactionBuilder(
+            coin: makeCoin(asset: TokensStore.rune),
+            amount: "1",
+            sendMaxAmount: false
+        )
+        let redeem = RedeemTransactionBuilder(
+            coin: makeCoin(asset: TokensStore.yrune),
+            amount: "1",
+            sendMaxAmount: false,
+            slippage: 0.01
+        )
+        let expected: Set<String> = [
+            YVaultConstants.affiliateContractAddress,
+            YVaultConstants.contracts["rune"]!
+        ]
+
+        XCTAssertEqual(mint.wasmContractAddressesForPreflight, expected)
+        XCTAssertEqual(redeem.wasmContractAddressesForPreflight, expected)
+    }
+
+    private func makeRujiStakeBuilder() -> RUJIStakeTransactionBuilder {
+        RUJIStakeTransactionBuilder(
+            coin: makeCoin(asset: TokensStore.ruji),
+            amount: "1",
+            sendMaxAmount: false
+        )
+    }
+
+    private func makeCoin(asset: CoinMeta) -> Coin {
+        Coin(
+            asset: asset,
+            address: "thor1fixtureaddress000000000000000000000000000",
+            hexPublicKey: "02" + String(repeating: "00", count: 32)
+        )
+    }
+}
+
+// swiftlint:disable async_without_await
+private actor SequencedWasmAvailabilityProvider: THORChainWasmExecutionAvailabilityProviding {
+    private var states: [THORChainWasmExecutionAvailability?]
+    private(set) var requestCount = 0
+
+    init(states: [THORChainWasmExecutionAvailability?]) {
+        self.states = states
+    }
+
+    func fetchWasmExecutionAvailabilities(
+        for contractAddresses: Set<String>
+    ) async -> [String: THORChainWasmExecutionAvailability] {
+        requestCount += 1
+        let state = states.isEmpty ? nil : states.removeFirst()
+        guard let state else { return [:] }
+        return contractAddresses.reduce(into: [:]) { result, address in
+            result[address] = state
+        }
+    }
+}
+// swiftlint:enable async_without_await


### PR DESCRIPTION
## Summary

- decode MAYANode native-deposit halt Mimirs against a coherent MAYANode block height
- disable CACAO Add and Remove actions with a localized warning while deposits are halted or availability cannot be verified
- re-check uncached availability immediately before Verify so stale screen state cannot proceed to signing

## Context

The reported CACAO staking transaction failed with `unable to use MsgDeposit while chain is halted`:
https://www.explorer.mayachain.info/tx/E7C36752551F5648B46FB7B4131DD9D9D319005D83E29A616B768FC39ACCA806

## Testing

- `make test` — 6,639 tests, 11 skipped, 0 failures
- `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — 26 existing warnings, 0 serious violations
- focused CACAO halt availability, presentation, preflight, and view-model tests — 21 passed, 0 failures


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added MAYAChain CACAO staking availability checks based on current network status.
  - Stake and unstake actions are disabled when staking is halted or availability cannot be verified.
  - Added warning messages for halted and unavailable staking states.
  - Added localized messages in English, German, Spanish, Croatian, Italian, Korean, Portuguese, and Simplified Chinese.

- **Bug Fixes**
  - Prevented staking transactions from proceeding when MAYAChain is halted or unavailable.
  - Added clear error feedback during transaction verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->