### PR TITLE
fix(thorchain): gate App Layer staking while WASM is halted

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainMainnetAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainMainnetAPI.swift
@@ -39,10 +39,13 @@ struct ThorchainMainnetAPI: TargetType {
         case accountNumber(address: String)
         case denomMetadata(denom: String)
         case allDenomMetadata
+        case wasmContractInfo(address: String)
+        case wasmCodeInfo(codeID: String)
 
         // MARK: THORChain-specific endpoints (thornode)
         case networkInfo
         case inboundAddresses
+        case lastBlock
         /// `/thorchain/mimir/key/<KEY>` — a single network mimir value as a bare
         /// integer body (e.g. the `EnableAdvSwapQueue` limit-swap availability
         /// gate). Parsed from raw bytes by the caller, not JSON-decoded.
@@ -101,7 +104,8 @@ struct ThorchainMainnetAPI: TargetType {
     var baseURL: URL {
         switch endpoint {
         case .balances, .accountNumber, .denomMetadata, .allDenomMetadata,
-             .networkInfo, .inboundAddresses, .mimir, .poolInfo, .pools,
+             .wasmContractInfo, .wasmCodeInfo,
+             .networkInfo, .inboundAddresses, .lastBlock, .mimir, .poolInfo, .pools,
              .securedAssets, .poolLiquidityProvider, .swapQuote, .tcyStaker,
              .limitSwapQueue, .transaction,
              .tcyAutoCompoundStatus:
@@ -136,10 +140,16 @@ struct ThorchainMainnetAPI: TargetType {
             return "/cosmos/bank/v1beta1/denoms_metadata/\(encodedDenom)"
         case .allDenomMetadata:
             return "/cosmos/bank/v1beta1/denoms_metadata"
+        case .wasmContractInfo(let address):
+            return "/cosmwasm/wasm/v1/contract/\(address)"
+        case .wasmCodeInfo(let codeID):
+            return "/cosmwasm/wasm/v1/code/\(codeID)"
         case .networkInfo:
             return "/thorchain/network"
         case .inboundAddresses:
             return "/thorchain/inbound_addresses"
+        case .lastBlock:
+            return "/thorchain/lastblock"
         case .mimir(let key):
             // Mimir keys are stored uppercase on THORNode (matching the
             // CHURNINTERVAL convention). Uppercase defensively.
@@ -183,8 +193,9 @@ struct ThorchainMainnetAPI: TargetType {
 
     var task: HTTPTask {
         switch endpoint {
-        case .balances, .accountNumber, .denomMetadata, .networkInfo,
-             .inboundAddresses, .mimir, .poolInfo, .pools, .securedAssets,
+        case .balances, .accountNumber, .denomMetadata, .wasmContractInfo,
+             .wasmCodeInfo, .networkInfo, .inboundAddresses, .lastBlock, .mimir,
+             .poolInfo, .pools, .securedAssets,
              .poolLiquidityProvider, .tcyStaker, .networkStatus,
              .tcyAutoCompoundStatus, .resolveTNS, .transaction:
             return .requestPlain
@@ -220,8 +231,9 @@ struct ThorchainMainnetAPI: TargetType {
     var headers: [String: String]? {
         var base: [String: String] = ["Content-Type": "application/json"]
         switch endpoint {
-        case .balances, .accountNumber, .swapQuote, .poolInfo, .pools,
-             .securedAssets, .poolLiquidityProvider, .inboundAddresses, .mimir:
+        case .balances, .accountNumber, .wasmContractInfo, .wasmCodeInfo,
+             .swapQuote, .poolInfo, .pools, .securedAssets, .poolLiquidityProvider,
+             .inboundAddresses, .lastBlock, .mimir:
             // Endpoints that the legacy code marked with X-Client-ID via
             // get9RRequest(). Kept for 9Realms partner attribution.
             base["X-Client-ID"] = "vultisig"

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService+WasmExecutionAvailability.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService+WasmExecutionAvailability.swift
@@ -1,0 +1,215 @@
+//
+//  ThorchainService+WasmExecutionAvailability.swift
+//  VultisigApp
+//
+
+import Foundation
+import OSLog
+
+enum THORChainWasmExecutionAvailability: Equatable, Sendable {
+    case available
+    case halted
+    case unavailable
+}
+
+protocol THORChainWasmExecutionAvailabilityProviding {
+    func fetchWasmExecutionAvailabilities(
+        for contractAddresses: Set<String>
+    ) async -> [String: THORChainWasmExecutionAvailability]
+}
+
+extension ThorchainService: THORChainWasmExecutionAvailabilityProviding {
+    /// Mirrors `WasmMgr.ExecuteContract` in thornode: global WASM, contract-address suffix,
+    /// then code-checksum halts. Deployer halts intentionally do not participate here; thornode
+    /// applies those only when storing or instantiating code, not when executing an existing app.
+    func fetchWasmExecutionAvailabilities(
+        for contractAddresses: Set<String>
+    ) async -> [String: THORChainWasmExecutionAvailability] {
+        guard !contractAddresses.isEmpty else { return [:] }
+
+        let currentHeight: Int64
+        let globalHaltHeight: Int64
+        do {
+            async let height = fetchWasmPolicyBlockHeight()
+            async let globalHalt = fetchWasmMimirHeight(key: Self.wasmGlobalHaltMimirKey)
+            (currentHeight, globalHaltHeight) = try await (height, globalHalt)
+        } catch {
+            logger.warning("Could not verify THORChain global WASM availability: \(error.localizedDescription)")
+            return contractAddresses.reduce(into: [:]) { result, address in
+                result[address] = .unavailable
+            }
+        }
+
+        if Self.isWasmHaltActive(globalHaltHeight, at: currentHeight) {
+            return contractAddresses.reduce(into: [:]) { result, address in
+                result[address] = .halted
+            }
+        }
+
+        return await withTaskGroup(
+            of: (String, THORChainWasmExecutionAvailability).self,
+            returning: [String: THORChainWasmExecutionAvailability].self
+        ) { group in
+            for address in contractAddresses {
+                group.addTask {
+                    do {
+                        let availability = try await self.fetchWasmContractExecutionAvailability(
+                            address: address,
+                            currentHeight: currentHeight
+                        )
+                        return (address, availability)
+                    } catch {
+                        self.logger.warning(
+                            "Could not verify THORChain WASM availability for \(address, privacy: .private): \(error.localizedDescription)"
+                        )
+                        return (address, .unavailable)
+                    }
+                }
+            }
+
+            var result: [String: THORChainWasmExecutionAvailability] = [:]
+            for await (address, availability) in group {
+                result[address] = availability
+            }
+            return result
+        }
+    }
+}
+
+extension ThorchainService {
+    static let wasmGlobalHaltMimirKey = "HaltWasmGlobal"
+
+    static func wasmContractHaltMimirKey(address: String) -> String? {
+        guard address.count >= 6 else { return nil }
+        return "HaltWasmContract-\(address.suffix(6))"
+    }
+
+    static func wasmChecksumHaltMimirKey(dataHash: String) -> String? {
+        guard let checksum = Data(hexString: dataHash), checksum.count == 32 else { return nil }
+        return "HaltWasmCs-\(base32MimirReference(checksum))"
+    }
+
+    static func isWasmHaltActive(_ haltHeight: Int64, at currentHeight: Int64) -> Bool {
+        haltHeight > 0 && currentHeight > haltHeight
+    }
+
+    static func parseWasmMimirHeight(_ data: Data) -> Int64? {
+        guard let raw = String(data: data, encoding: .utf8) else { return nil }
+        return Int64(raw.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    /// RFC 4648 base32 without trailing `=` padding. THORNode derives checksum Mimir keys with
+    /// Go's `base32.StdEncoding` and trims that padding to fit the 64-character Mimir key limit.
+    static func base32MimirReference(_ data: Data) -> String {
+        let alphabet = Array("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567")
+        var accumulator = 0
+        var bitCount = 0
+        var output = ""
+
+        for byte in data {
+            accumulator = (accumulator << 8) | Int(byte)
+            bitCount += 8
+            while bitCount >= 5 {
+                bitCount -= 5
+                output.append(alphabet[(accumulator >> bitCount) & 0x1F])
+            }
+            accumulator &= (1 << bitCount) - 1
+        }
+
+        if bitCount > 0 {
+            output.append(alphabet[(accumulator << (5 - bitCount)) & 0x1F])
+        }
+        return output
+    }
+}
+
+private extension ThorchainService {
+    enum WasmAvailabilityError: Error {
+        case invalidBlockHeight
+        case invalidContractAddress
+        case invalidDataHash
+        case invalidMimir
+    }
+
+    struct WasmContractInfoResponse: Decodable {
+        struct ContractInfo: Decodable {
+            let codeID: String
+
+            enum CodingKeys: String, CodingKey {
+                case codeID = "code_id"
+            }
+        }
+
+        let contractInfo: ContractInfo
+
+        enum CodingKeys: String, CodingKey {
+            case contractInfo = "contract_info"
+        }
+    }
+
+    struct WasmCodeInfoResponse: Decodable {
+        struct CodeInfo: Decodable {
+            let dataHash: String
+
+            enum CodingKeys: String, CodingKey {
+                case dataHash = "data_hash"
+            }
+        }
+
+        let codeInfo: CodeInfo
+
+        enum CodingKeys: String, CodingKey {
+            case codeInfo = "code_info"
+        }
+    }
+
+    func fetchWasmContractExecutionAvailability(
+        address: String,
+        currentHeight: Int64
+    ) async throws -> THORChainWasmExecutionAvailability {
+        guard let contractMimirKey = Self.wasmContractHaltMimirKey(address: address) else {
+            throw WasmAvailabilityError.invalidContractAddress
+        }
+
+        async let contractHalt = fetchWasmMimirHeight(key: contractMimirKey)
+        let contractInfoResponse = try await httpClient.request(
+            mainnet(.wasmContractInfo(address: address)),
+            responseType: WasmContractInfoResponse.self
+        )
+        let codeInfoResponse = try await httpClient.request(
+            mainnet(.wasmCodeInfo(codeID: contractInfoResponse.data.contractInfo.codeID)),
+            responseType: WasmCodeInfoResponse.self
+        )
+        guard let checksumMimirKey = Self.wasmChecksumHaltMimirKey(
+            dataHash: codeInfoResponse.data.codeInfo.dataHash
+        ) else {
+            throw WasmAvailabilityError.invalidDataHash
+        }
+
+        async let checksumHalt = fetchWasmMimirHeight(key: checksumMimirKey)
+        let (contractHaltHeight, checksumHaltHeight) = try await (contractHalt, checksumHalt)
+        let halted = Self.isWasmHaltActive(contractHaltHeight, at: currentHeight) ||
+            Self.isWasmHaltActive(checksumHaltHeight, at: currentHeight)
+        return halted ? .halted : .available
+    }
+
+    func fetchWasmPolicyBlockHeight() async throws -> Int64 {
+        let response = try await httpClient.request(
+            mainnet(.lastBlock),
+            responseType: [LastBlockResponse].self
+        )
+        guard let height = response.data.first?.thorchain,
+              let blockHeight = Int64(exactly: height) else {
+            throw WasmAvailabilityError.invalidBlockHeight
+        }
+        return blockHeight
+    }
+
+    func fetchWasmMimirHeight(key: String) async throws -> Int64 {
+        let response = try await httpClient.request(mainnet(.mimir(key: key)))
+        guard let height = Self.parseWasmMimirHeight(response.data) else {
+            throw WasmAvailabilityError.invalidMimir
+        }
+        return height
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -887,8 +887,6 @@
 "maxTotalFee" = "Max. Gesamtgebühr";
 "mayaCacaoStakingHaltedWarning" = "CACAO-Staking ist vorübergehend nicht verfügbar, da MAYAChain angehalten wurde. Bitte versuche es erneut, sobald das Netzwerk wieder aktiv ist.";
 "mayaCacaoStakingUnavailableWarning" = "Die Verfügbarkeit von MAYAChain-Staking konnte nicht überprüft werden. Bitte versuche es später erneut.";
-"thorchainWasmStakingHaltedWarning" = "THORChain-App-Layer-Staking ist vorübergehend nicht verfügbar, da die Vertragsausführung pausiert ist. Bitte versuche es erneut, sobald sie fortgesetzt wird.";
-"thorchainWasmStakingUnavailableWarning" = "Die Verfügbarkeit von THORChain-App-Layer-Staking konnte nicht überprüft werden. Bitte versuche es später erneut.";
 "memo" = "Memo";
 "memoLabel" = "Memo";
 "mergeCoins" = "Coins zusammenführen";
@@ -1548,6 +1546,8 @@
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
 "thorchainCustomTokenInvalidFormat" = "Ungültiges THORChain-Token-Format. Verwende THOR.{SYMBOL}, z. B. THOR.LQDY.";
 "thorChainNotEnabledForLP" = "THORChain ist in diesem Tresor nicht aktiviert. Bitte aktiviere THORChain, um diese Funktion zu nutzen.";
+"thorchainWasmStakingHaltedWarning" = "THORChain-App-Layer-Staking ist vorübergehend nicht verfügbar, da die Vertragsausführung pausiert ist. Bitte versuche es erneut, sobald sie fortgesetzt wird.";
+"thorchainWasmStakingUnavailableWarning" = "Die Verfügbarkeit von THORChain-App-Layer-Staking konnte nicht überprüft werden. Bitte versuche es später erneut.";
 "thresholdNotReachedMessage" = "Schwelle nicht erreicht.\nEs fehlen genügend Anfangsgeräte.";
 "timeout" = "Zeitüberschreitung";
 "title" = "Titel";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -887,6 +887,8 @@
 "maxTotalFee" = "Max. Gesamtgebühr";
 "mayaCacaoStakingHaltedWarning" = "CACAO-Staking ist vorübergehend nicht verfügbar, da MAYAChain angehalten wurde. Bitte versuche es erneut, sobald das Netzwerk wieder aktiv ist.";
 "mayaCacaoStakingUnavailableWarning" = "Die Verfügbarkeit von MAYAChain-Staking konnte nicht überprüft werden. Bitte versuche es später erneut.";
+"thorchainWasmStakingHaltedWarning" = "THORChain-App-Layer-Staking ist vorübergehend nicht verfügbar, da die Vertragsausführung pausiert ist. Bitte versuche es erneut, sobald sie fortgesetzt wird.";
+"thorchainWasmStakingUnavailableWarning" = "Die Verfügbarkeit von THORChain-App-Layer-Staking konnte nicht überprüft werden. Bitte versuche es später erneut.";
 "memo" = "Memo";
 "memoLabel" = "Memo";
 "mergeCoins" = "Coins zusammenführen";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -887,8 +887,6 @@
 "maxTotalFee" = "Max. Total Fee";
 "mayaCacaoStakingHaltedWarning" = "CACAO staking is temporarily unavailable because MAYAChain is halted. Please try again when the network resumes.";
 "mayaCacaoStakingUnavailableWarning" = "Unable to verify MAYAChain staking availability. Please try again later.";
-"thorchainWasmStakingHaltedWarning" = "THORChain App Layer staking is temporarily unavailable because contract execution is paused. Please try again when it resumes.";
-"thorchainWasmStakingUnavailableWarning" = "Unable to verify THORChain App Layer staking availability. Please try again later.";
 "memo" = "Memo";
 "memoLabel" = "Memo";
 "mergeCoins" = "Merge Coins";
@@ -1548,6 +1546,8 @@
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
 "thorchainCustomTokenInvalidFormat" = "Invalid THORChain token format. Use THOR.{SYMBOL}, e.g. THOR.LQDY.";
 "thorChainNotEnabledForLP" = "THORChain is not enabled on this vault. Please enable THORChain to use this feature.";
+"thorchainWasmStakingHaltedWarning" = "THORChain App Layer staking is temporarily unavailable because contract execution is paused. Please try again when it resumes.";
+"thorchainWasmStakingUnavailableWarning" = "Unable to verify THORChain App Layer staking availability. Please try again later.";
 "thresholdNotReachedMessage" = "Threshold not reached.\nMissing enough initial devices.";
 "timeout" = "Timeout";
 "title" = "Title";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -887,6 +887,8 @@
 "maxTotalFee" = "Max. Total Fee";
 "mayaCacaoStakingHaltedWarning" = "CACAO staking is temporarily unavailable because MAYAChain is halted. Please try again when the network resumes.";
 "mayaCacaoStakingUnavailableWarning" = "Unable to verify MAYAChain staking availability. Please try again later.";
+"thorchainWasmStakingHaltedWarning" = "THORChain App Layer staking is temporarily unavailable because contract execution is paused. Please try again when it resumes.";
+"thorchainWasmStakingUnavailableWarning" = "Unable to verify THORChain App Layer staking availability. Please try again later.";
 "memo" = "Memo";
 "memoLabel" = "Memo";
 "mergeCoins" = "Merge Coins";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -887,8 +887,6 @@
 "maxTotalFee" = "Tarifa total máx.";
 "mayaCacaoStakingHaltedWarning" = "El staking de CACAO no está disponible temporalmente porque MAYAChain está detenida. Inténtalo de nuevo cuando la red se reanude.";
 "mayaCacaoStakingUnavailableWarning" = "No se pudo verificar la disponibilidad del staking de MAYAChain. Inténtalo de nuevo más tarde.";
-"thorchainWasmStakingHaltedWarning" = "El staking de la App Layer de THORChain no está disponible temporalmente porque la ejecución de contratos está pausada. Inténtalo de nuevo cuando se reanude.";
-"thorchainWasmStakingUnavailableWarning" = "No se pudo verificar la disponibilidad del staking de la App Layer de THORChain. Inténtalo de nuevo más tarde.";
 "memo" = "Memorándum";
 "memoLabel" = "Memo";
 "mergeCoins" = "Fusionar monedas";
@@ -1548,6 +1546,8 @@
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
 "thorchainCustomTokenInvalidFormat" = "Formato de token de THORChain no válido. Usa THOR.{SYMBOL}, p. ej. THOR.LQDY.";
 "thorChainNotEnabledForLP" = "THORChain no está habilitado en esta bóveda. Por favor, habilita THORChain para usar esta función.";
+"thorchainWasmStakingHaltedWarning" = "El staking de la App Layer de THORChain no está disponible temporalmente porque la ejecución de contratos está pausada. Inténtalo de nuevo cuando se reanude.";
+"thorchainWasmStakingUnavailableWarning" = "No se pudo verificar la disponibilidad del staking de la App Layer de THORChain. Inténtalo de nuevo más tarde.";
 "thresholdNotReachedMessage" = "Umbral no alcanzado.\nFaltan suficientes dispositivos iniciales.";
 "timeout" = "Tiempo de espera agotado";
 "title" = "Título";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -887,6 +887,8 @@
 "maxTotalFee" = "Tarifa total máx.";
 "mayaCacaoStakingHaltedWarning" = "El staking de CACAO no está disponible temporalmente porque MAYAChain está detenida. Inténtalo de nuevo cuando la red se reanude.";
 "mayaCacaoStakingUnavailableWarning" = "No se pudo verificar la disponibilidad del staking de MAYAChain. Inténtalo de nuevo más tarde.";
+"thorchainWasmStakingHaltedWarning" = "El staking de la App Layer de THORChain no está disponible temporalmente porque la ejecución de contratos está pausada. Inténtalo de nuevo cuando se reanude.";
+"thorchainWasmStakingUnavailableWarning" = "No se pudo verificar la disponibilidad del staking de la App Layer de THORChain. Inténtalo de nuevo más tarde.";
 "memo" = "Memorándum";
 "memoLabel" = "Memo";
 "mergeCoins" = "Fusionar monedas";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -887,8 +887,6 @@
 "maxTotalFee" = "Maks. ukupna naknada";
 "mayaCacaoStakingHaltedWarning" = "CACAO staking privremeno nije dostupan jer je MAYAChain zaustavljen. Pokušajte ponovno kada se mreža nastavi.";
 "mayaCacaoStakingUnavailableWarning" = "Nije moguće provjeriti dostupnost MAYAChain stakinga. Pokušajte ponovno kasnije.";
-"thorchainWasmStakingHaltedWarning" = "THORChain App Layer staking privremeno nije dostupan jer je izvršavanje ugovora pauzirano. Pokušajte ponovno kada se nastavi.";
-"thorchainWasmStakingUnavailableWarning" = "Nije moguće provjeriti dostupnost THORChain App Layer stakinga. Pokušajte ponovno kasnije.";
 "memo" = "Bilješka";
 "memoLabel" = "Memo";
 "mergeCoins" = "Spoji novčiće";
@@ -1548,6 +1546,8 @@
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
 "thorchainCustomTokenInvalidFormat" = "Neispravan format THORChain tokena. Koristite THOR.{SYMBOL}, npr. THOR.LQDY.";
 "thorChainNotEnabledForLP" = "THORChain nije omogućen na ovom vaultu. Molimo omogućite THORChain da biste koristili ovu značajku.";
+"thorchainWasmStakingHaltedWarning" = "THORChain App Layer staking privremeno nije dostupan jer je izvršavanje ugovora pauzirano. Pokušajte ponovno kada se nastavi.";
+"thorchainWasmStakingUnavailableWarning" = "Nije moguće provjeriti dostupnost THORChain App Layer stakinga. Pokušajte ponovno kasnije.";
 "thresholdNotReachedMessage" = "Prag nije dosegnut.\nNedostaje dovoljno početnih uređaja.";
 "timeout" = "Isteklo vrijeme";
 "title" = "Naslov";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -887,6 +887,8 @@
 "maxTotalFee" = "Maks. ukupna naknada";
 "mayaCacaoStakingHaltedWarning" = "CACAO staking privremeno nije dostupan jer je MAYAChain zaustavljen. Pokušajte ponovno kada se mreža nastavi.";
 "mayaCacaoStakingUnavailableWarning" = "Nije moguće provjeriti dostupnost MAYAChain stakinga. Pokušajte ponovno kasnije.";
+"thorchainWasmStakingHaltedWarning" = "THORChain App Layer staking privremeno nije dostupan jer je izvršavanje ugovora pauzirano. Pokušajte ponovno kada se nastavi.";
+"thorchainWasmStakingUnavailableWarning" = "Nije moguće provjeriti dostupnost THORChain App Layer stakinga. Pokušajte ponovno kasnije.";
 "memo" = "Bilješka";
 "memoLabel" = "Memo";
 "mergeCoins" = "Spoji novčiće";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -887,6 +887,8 @@
 "maxTotalFee" = "Commissione totale max.";
 "mayaCacaoStakingHaltedWarning" = "Lo staking di CACAO non è temporaneamente disponibile perché MAYAChain è sospesa. Riprova quando la rete riprenderà.";
 "mayaCacaoStakingUnavailableWarning" = "Impossibile verificare la disponibilità dello staking su MAYAChain. Riprova più tardi.";
+"thorchainWasmStakingHaltedWarning" = "Lo staking dell'App Layer di THORChain non è temporaneamente disponibile perché l'esecuzione dei contratti è sospesa. Riprova quando riprenderà.";
+"thorchainWasmStakingUnavailableWarning" = "Impossibile verificare la disponibilità dello staking dell'App Layer di THORChain. Riprova più tardi.";
 "memo" = "Memo";
 "memoLabel" = "Memo";
 "mergeCoins" = "Unisci monete";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -887,8 +887,6 @@
 "maxTotalFee" = "Commissione totale max.";
 "mayaCacaoStakingHaltedWarning" = "Lo staking di CACAO non è temporaneamente disponibile perché MAYAChain è sospesa. Riprova quando la rete riprenderà.";
 "mayaCacaoStakingUnavailableWarning" = "Impossibile verificare la disponibilità dello staking su MAYAChain. Riprova più tardi.";
-"thorchainWasmStakingHaltedWarning" = "Lo staking dell'App Layer di THORChain non è temporaneamente disponibile perché l'esecuzione dei contratti è sospesa. Riprova quando riprenderà.";
-"thorchainWasmStakingUnavailableWarning" = "Impossibile verificare la disponibilità dello staking dell'App Layer di THORChain. Riprova più tardi.";
 "memo" = "Memo";
 "memoLabel" = "Memo";
 "mergeCoins" = "Unisci monete";
@@ -1548,6 +1546,8 @@
 "thorAddressNotFound" = "Indirizzo THORChain non trovato nel vault. Assicurati di avere RUNE nel tuo vault.";
 "thorchainCustomTokenInvalidFormat" = "Formato del token THORChain non valido. Usa THOR.{SYMBOL}, ad es. THOR.LQDY.";
 "thorChainNotEnabledForLP" = "THORChain non è abilitato su questo caveau. Abilita THORChain per utilizzare questa funzione.";
+"thorchainWasmStakingHaltedWarning" = "Lo staking dell'App Layer di THORChain non è temporaneamente disponibile perché l'esecuzione dei contratti è sospesa. Riprova quando riprenderà.";
+"thorchainWasmStakingUnavailableWarning" = "Impossibile verificare la disponibilità dello staking dell'App Layer di THORChain. Riprova più tardi.";
 "thresholdNotReachedMessage" = "Soglia non raggiunta.\nMancano dispositivi iniziali sufficienti.";
 "timeout" = "Tempo scaduto";
 "title" = "Titolo";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -887,8 +887,6 @@
 "maxTotalFee" = "최대 총 수수료";
 "mayaCacaoStakingHaltedWarning" = "MAYAChain이 중단되어 CACAO 스테이킹을 일시적으로 사용할 수 없습니다. 네트워크가 재개되면 다시 시도해 주세요.";
 "mayaCacaoStakingUnavailableWarning" = "MAYAChain 스테이킹 가능 여부를 확인할 수 없습니다. 나중에 다시 시도해 주세요.";
-"thorchainWasmStakingHaltedWarning" = "컨트랙트 실행이 일시 중지되어 THORChain App Layer 스테이킹을 일시적으로 사용할 수 없습니다. 실행이 재개되면 다시 시도해 주세요.";
-"thorchainWasmStakingUnavailableWarning" = "THORChain App Layer 스테이킹 가능 여부를 확인할 수 없습니다. 나중에 다시 시도해 주세요.";
 "memo" = "메모";
 "memoLabel" = "메모";
 "mergeCoins" = "코인 병합";
@@ -1548,6 +1546,8 @@
 "thorAddressNotFound" = "볼트에서 THORChain 주소를 찾을 수 없습니다. RUNE이 볼트에 있는지 확인하세요.";
 "thorchainCustomTokenInvalidFormat" = "잘못된 THORChain 토큰 형식입니다. THOR.{SYMBOL} 형식을 사용하세요. 예: THOR.LQDY.";
 "thorChainNotEnabledForLP" = "이 볼트에서 THORChain이 활성화되어 있지 않습니다. 이 기능을 사용하려면 THORChain을 활성화하세요.";
+"thorchainWasmStakingHaltedWarning" = "컨트랙트 실행이 일시 중지되어 THORChain App Layer 스테이킹을 일시적으로 사용할 수 없습니다. 실행이 재개되면 다시 시도해 주세요.";
+"thorchainWasmStakingUnavailableWarning" = "THORChain App Layer 스테이킹 가능 여부를 확인할 수 없습니다. 나중에 다시 시도해 주세요.";
 "thresholdNotReachedMessage" = "임계값에 도달하지 않았습니다.\n초기 기기가 충분하지 않습니다.";
 "timeout" = "시간 초과";
 "title" = "제목";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -887,6 +887,8 @@
 "maxTotalFee" = "최대 총 수수료";
 "mayaCacaoStakingHaltedWarning" = "MAYAChain이 중단되어 CACAO 스테이킹을 일시적으로 사용할 수 없습니다. 네트워크가 재개되면 다시 시도해 주세요.";
 "mayaCacaoStakingUnavailableWarning" = "MAYAChain 스테이킹 가능 여부를 확인할 수 없습니다. 나중에 다시 시도해 주세요.";
+"thorchainWasmStakingHaltedWarning" = "컨트랙트 실행이 일시 중지되어 THORChain App Layer 스테이킹을 일시적으로 사용할 수 없습니다. 실행이 재개되면 다시 시도해 주세요.";
+"thorchainWasmStakingUnavailableWarning" = "THORChain App Layer 스테이킹 가능 여부를 확인할 수 없습니다. 나중에 다시 시도해 주세요.";
 "memo" = "메모";
 "memoLabel" = "메모";
 "mergeCoins" = "코인 병합";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -887,8 +887,6 @@
 "maxTotalFee" = "Taxa total máx.";
 "mayaCacaoStakingHaltedWarning" = "O staking de CACAO está temporariamente indisponível porque a MAYAChain está pausada. Tente novamente quando a rede for retomada.";
 "mayaCacaoStakingUnavailableWarning" = "Não foi possível verificar a disponibilidade do staking na MAYAChain. Tente novamente mais tarde.";
-"thorchainWasmStakingHaltedWarning" = "O staking da App Layer da THORChain está temporariamente indisponível porque a execução de contratos está pausada. Tente novamente quando ela for retomada.";
-"thorchainWasmStakingUnavailableWarning" = "Não foi possível verificar a disponibilidade do staking da App Layer da THORChain. Tente novamente mais tarde.";
 "memo" = "Memorando";
 "memoLabel" = "Memo";
 "mergeCoins" = "Mesclar moedas";
@@ -1548,6 +1546,8 @@
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
 "thorchainCustomTokenInvalidFormat" = "Formato de token THORChain inválido. Use THOR.{SYMBOL}, ex.: THOR.LQDY.";
 "thorChainNotEnabledForLP" = "THORChain não está habilitado neste cofre. Por favor, habilite THORChain para usar este recurso.";
+"thorchainWasmStakingHaltedWarning" = "O staking da App Layer da THORChain está temporariamente indisponível porque a execução de contratos está pausada. Tente novamente quando ela for retomada.";
+"thorchainWasmStakingUnavailableWarning" = "Não foi possível verificar a disponibilidade do staking da App Layer da THORChain. Tente novamente mais tarde.";
 "thresholdNotReachedMessage" = "Limite não alcançado.\nFaltam dispositivos iniciais suficientes.";
 "timeout" = "Tempo esgotado";
 "title" = "Título";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -887,6 +887,8 @@
 "maxTotalFee" = "Taxa total máx.";
 "mayaCacaoStakingHaltedWarning" = "O staking de CACAO está temporariamente indisponível porque a MAYAChain está pausada. Tente novamente quando a rede for retomada.";
 "mayaCacaoStakingUnavailableWarning" = "Não foi possível verificar a disponibilidade do staking na MAYAChain. Tente novamente mais tarde.";
+"thorchainWasmStakingHaltedWarning" = "O staking da App Layer da THORChain está temporariamente indisponível porque a execução de contratos está pausada. Tente novamente quando ela for retomada.";
+"thorchainWasmStakingUnavailableWarning" = "Não foi possível verificar a disponibilidade do staking da App Layer da THORChain. Tente novamente mais tarde.";
 "memo" = "Memorando";
 "memoLabel" = "Memo";
 "mergeCoins" = "Mesclar moedas";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -887,6 +887,8 @@
 "maxTotalFee" = "最大总费用";
 "mayaCacaoStakingHaltedWarning" = "由于 MAYAChain 已暂停，CACAO 质押暂时不可用。请在网络恢复后重试。";
 "mayaCacaoStakingUnavailableWarning" = "无法验证 MAYAChain 质押是否可用。请稍后重试。";
+"thorchainWasmStakingHaltedWarning" = "由于合约执行已暂停，THORChain App Layer 质押暂时不可用。请在恢复后重试。";
+"thorchainWasmStakingUnavailableWarning" = "无法验证 THORChain App Layer 质押是否可用。请稍后重试。";
 "memo" = "备忘录";
 "memoLabel" = "备注";
 "mergeCoins" = "合并代币";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -887,8 +887,6 @@
 "maxTotalFee" = "最大总费用";
 "mayaCacaoStakingHaltedWarning" = "由于 MAYAChain 已暂停，CACAO 质押暂时不可用。请在网络恢复后重试。";
 "mayaCacaoStakingUnavailableWarning" = "无法验证 MAYAChain 质押是否可用。请稍后重试。";
-"thorchainWasmStakingHaltedWarning" = "由于合约执行已暂停，THORChain App Layer 质押暂时不可用。请在恢复后重试。";
-"thorchainWasmStakingUnavailableWarning" = "无法验证 THORChain App Layer 质押是否可用。请稍后重试。";
 "memo" = "备忘录";
 "memoLabel" = "备注";
 "mergeCoins" = "合并代币";
@@ -1548,6 +1546,8 @@
 "thorAddressNotFound" = "保险库中未找到 THORChain 地址。请确保您的保险库中有 RUNE。";
 "thorchainCustomTokenInvalidFormat" = "THORChain 代币格式无效。请使用 THOR.{SYMBOL}，例如 THOR.LQDY。";
 "thorChainNotEnabledForLP" = "此保险库未启用 THORChain。请启用 THORChain 以使用此功能。";
+"thorchainWasmStakingHaltedWarning" = "由于合约执行已暂停，THORChain App Layer 质押暂时不可用。请在恢复后重试。";
+"thorchainWasmStakingUnavailableWarning" = "无法验证 THORChain App Layer 质押是否可用。请稍后重试。";
 "thresholdNotReachedMessage" = "未达到阈值。\n缺少足够的初始设备";
 "timeout" = "超时";
 "title" = "标题";

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/MayaChainStakeInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/MayaChainStakeInteractor.swift
@@ -23,13 +23,18 @@ struct MayaChainStakeInteractor: StakeInteractor {
         self.mayaChainAPIService = mayaChainAPIService
     }
 
-    func fetchActionAvailability() async -> StakeActionAvailability {
+    func fetchActionAvailabilities(for coins: [CoinMeta]) async -> StakeActionAvailabilities {
+        let availability: StakeActionAvailability
         do {
-            let availability = try await mayaChainAPIService.getNativeDepositAvailability(shouldCache: false)
-            return availability == .available ? .available : .halted
+            let nativeDepositAvailability = try await mayaChainAPIService.getNativeDepositAvailability(shouldCache: false)
+            availability = nativeDepositAvailability == .available ? .available : .halted
         } catch {
             logger.error("Could not verify Maya CACAO staking availability: \(error.localizedDescription, privacy: .private)")
-            return .unavailable
+            availability = .unavailable
+        }
+
+        return coins.reduce(into: [:]) { result, coin in
+            result[coin] = availability
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/StakeInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/StakeInteractor.swift
@@ -14,30 +14,26 @@ enum StakeActionAvailability: Equatable, Sendable {
     var disablesActions: Bool {
         self != .available
     }
-
-    var warningLocalizationKey: String? {
-        switch self {
-        case .checking, .available:
-            nil
-        case .halted:
-            "mayaCacaoStakingHaltedWarning"
-        case .unavailable:
-            "mayaCacaoStakingUnavailableWarning"
-        }
-    }
 }
+
+typealias StakeActionAvailabilities = [CoinMeta: StakeActionAvailability]
 
 protocol StakeInteractor {
     /// Returns one DTO per coin that was successfully fetched. Per-coin failures are silently
     /// omitted — storage upserts only what's returned, so the persisted row keeps its last good
     /// value until the next refresh.
     func fetchStakePositions(vault: Vault) async -> [StakePositionData]
-    func fetchActionAvailability() async -> StakeActionAvailability
+    /// Returns availability overrides keyed by the concrete position coin. Missing coins use the
+    /// presentation default (`available`), which lets mixed chains gate contract positions without
+    /// disabling unrelated native-module actions.
+    func fetchActionAvailabilities(for coins: [CoinMeta]) async -> StakeActionAvailabilities
 }
 
 extension StakeInteractor {
     // swiftlint:disable:next async_without_await
-    func fetchActionAvailability() async -> StakeActionAvailability {
-        .available
+    func fetchActionAvailabilities(for coins: [CoinMeta]) async -> StakeActionAvailabilities {
+        coins.reduce(into: [:]) { result, coin in
+            result[coin] = .available
+        }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/THORChainStakeInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/THORChainStakeInteractor.swift
@@ -11,9 +11,14 @@ private let logger = Log.defi.interactor
 
 struct THORChainStakeInteractor: StakeInteractor {
     private let stakingService: THORChainStakingProviding
+    private let wasmAvailabilityProvider: THORChainWasmExecutionAvailabilityProviding
 
-    init(stakingService: THORChainStakingProviding = THORChainStakingService.shared) {
+    init(
+        stakingService: THORChainStakingProviding = THORChainStakingService.shared,
+        wasmAvailabilityProvider: THORChainWasmExecutionAvailabilityProviding = ThorchainService.shared
+    ) {
         self.stakingService = stakingService
+        self.wasmAvailabilityProvider = wasmAvailabilityProvider
     }
 
     static func scaledAmount(rawAmount: Decimal, decimals: Int) -> Decimal {
@@ -31,6 +36,42 @@ struct THORChainStakeInteractor: StakeInteractor {
             dtos.append(contentsOf: await positions(for: snapshot, runeMeta: runeMeta))
         }
         return dtos
+    }
+
+    func fetchActionAvailabilities(for coins: [CoinMeta]) async -> StakeActionAvailabilities {
+        let contractAddresses = Set(coins.flatMap { Self.wasmContractAddresses(for: $0) })
+        let contractAvailabilities = await wasmAvailabilityProvider.fetchWasmExecutionAvailabilities(
+            for: contractAddresses
+        )
+
+        return coins.reduce(into: [:]) { result, coin in
+            let addresses = Self.wasmContractAddresses(for: coin)
+            let availabilities = addresses.map { contractAvailabilities[$0] ?? .unavailable }
+            if availabilities.contains(.halted) {
+                result[coin] = .halted
+            } else if availabilities.contains(.unavailable) {
+                result[coin] = .unavailable
+            } else {
+                result[coin] = .available
+            }
+        }
+    }
+
+    static func wasmContractAddresses(for coin: CoinMeta) -> [String] {
+        switch coin.ticker.uppercased() {
+        case "RUJI", "SRUJI":
+            return [RUJIStakingConstants.contract]
+        case "STCY":
+            return [TCYAutoCompoundConstants.contract]
+        case "YBRUNE":
+            return [BRUNEStakingConstants.contract]
+        case "YRUNE":
+            return [YVaultConstants.affiliateContractAddress, YVaultConstants.contracts["rune"]].compactMap { $0 }
+        case "YTCY":
+            return [YVaultConstants.affiliateContractAddress, YVaultConstants.contracts["tcy"]].compactMap { $0 }
+        default:
+            return []
+        }
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedPositionView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedPositionView.swift
@@ -55,16 +55,27 @@ struct DefiChainStakedPositionView: View {
     var unstakeDisabled: Bool { actionAvailability.disablesActions || !position.canUnstake }
     var stakeDisabled: Bool { actionAvailability.disablesActions || !position.canStake }
     var actionWarningMessage: String? {
-        guard position.coin.chain == .mayaChain else {
+        switch position.coin.chain {
+        case .mayaChain:
+            switch actionAvailability {
+            case .checking, .available:
+                return nil
+            case .halted:
+                return "mayaCacaoStakingHaltedWarning".localized
+            case .unavailable:
+                return "mayaCacaoStakingUnavailableWarning".localized
+            }
+        case .thorChain:
+            switch actionAvailability {
+            case .checking, .available:
+                return nil
+            case .halted:
+                return "thorchainWasmStakingHaltedWarning".localized
+            case .unavailable:
+                return "thorchainWasmStakingUnavailableWarning".localized
+            }
+        default:
             return nil
-        }
-        switch actionAvailability {
-        case .checking, .available:
-            return nil
-        case .halted:
-            return "mayaCacaoStakingHaltedWarning".localized
-        case .unavailable:
-            return "mayaCacaoStakingUnavailableWarning".localized
         }
     }
     var canWithdraw: Bool {

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedPositionView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedPositionView.swift
@@ -55,11 +55,17 @@ struct DefiChainStakedPositionView: View {
     var unstakeDisabled: Bool { actionAvailability.disablesActions || !position.canUnstake }
     var stakeDisabled: Bool { actionAvailability.disablesActions || !position.canStake }
     var actionWarningMessage: String? {
-        guard position.coin.chain == .mayaChain,
-              let key = actionAvailability.warningLocalizationKey else {
+        guard position.coin.chain == .mayaChain else {
             return nil
         }
-        return key.localized
+        switch actionAvailability {
+        case .checking, .available:
+            return nil
+        case .halted:
+            return "mayaCacaoStakingHaltedWarning".localized
+        case .unavailable:
+            return "mayaCacaoStakingUnavailableWarning".localized
+        }
     }
     var canWithdraw: Bool {
         guard let rewards = position.rewards else { return false }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedView.swift
@@ -45,7 +45,7 @@ struct DefiChainStakedView<EmptyStateView: View>: View {
                     DefiChainStakedPositionView(
                         position: position,
                         fiatAmount: fiatAmount,
-                        actionAvailability: viewModel.actionAvailability,
+                        actionAvailability: viewModel.actionAvailability(for: position),
                         onStake: { onStake(position) },
                         onUnstake: { onUnstake(position) },
                         onWithdraw: { onWithdraw(position) },

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainStakeViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainStakeViewModel.swift
@@ -14,7 +14,7 @@ private let logger = Log.defi.viewModel
 final class DefiChainStakeViewModel: ObservableObject {
     @Published private(set) var vault: Vault
     @Published private(set) var initialLoadingDone: Bool
-    @Published private(set) var actionAvailability: StakeActionAvailability
+    @Published private(set) var actionAvailabilities: StakeActionAvailabilities
 
     private let chain: Chain
     private let interactor: StakeInteractor?
@@ -35,6 +35,10 @@ final class DefiChainStakeViewModel: ObservableObject {
 
     var vaultStakePositions: [CoinMeta] {
         vault.defiPositions.first { $0.chain == chain }?.staking ?? []
+    }
+
+    func actionAvailability(for position: StakePosition) -> StakeActionAvailability {
+        actionAvailabilities[position.coin] ?? .available
     }
 
     /// Whether a persisted position should be shown for this chain. TON nominator
@@ -58,7 +62,10 @@ final class DefiChainStakeViewModel: ObservableObject {
         self.chain = chain
         self.interactor = interactor ?? DefiInteractorResolver.stakeInteractor(for: chain)
         self.storage = storage
-        self.actionAvailability = chain == .mayaChain ? .checking : .available
+        self.actionAvailabilities = Self.initialActionAvailabilities(
+            for: vault.defiPositions.first { $0.chain == chain }?.staking ?? [],
+            chain: chain
+        )
         // Mirror the per-chain visibility rule: TON shows any persisted stake
         // ungated; other chains require the per-coin opt-in.
         if chain == .ton {
@@ -75,20 +82,42 @@ final class DefiChainStakeViewModel: ObservableObject {
 
     func refresh() async {
         guard let interactor else {
-            actionAvailability = chain == .mayaChain ? .unavailable : .available
+            actionAvailabilities = Self.resolvedActionAvailabilities(
+                for: vaultStakePositions,
+                availability: chain == .mayaChain ? .unavailable : .available
+            )
             initialLoadingDone = true
             return
         }
 
+        let enabledCoins = vaultStakePositions
         async let positions = interactor.fetchStakePositions(vault: vault)
-        async let availability = interactor.fetchActionAvailability()
-        let (dtos, resolvedAvailability) = await (positions, availability)
-        actionAvailability = resolvedAvailability
+        async let availabilities = interactor.fetchActionAvailabilities(for: enabledCoins)
+        let (dtos, resolvedAvailabilities) = await (positions, availabilities)
+        actionAvailabilities = resolvedAvailabilities
         do {
             try storage.upsert(stake: dtos, for: vault)
         } catch {
             logger.error("Failed to persist stake positions for chain \(self.chain.rawValue, privacy: .public): \(error.localizedDescription, privacy: .private)")
         }
         initialLoadingDone = true
+    }
+}
+
+private extension DefiChainStakeViewModel {
+    static func initialActionAvailabilities(for coins: [CoinMeta], chain: Chain) -> StakeActionAvailabilities {
+        resolvedActionAvailabilities(
+            for: coins,
+            availability: chain == .mayaChain ? .checking : .available
+        )
+    }
+
+    static func resolvedActionAvailabilities(
+        for coins: [CoinMeta],
+        availability: StakeActionAvailability
+    ) -> StakeActionAvailabilities {
+        coins.reduce(into: [:]) { result, coin in
+            result[coin] = availability
+        }
     }
 }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Common/Service/THORChainWasmExecutionPreflight.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Common/Service/THORChainWasmExecutionPreflight.swift
@@ -1,0 +1,49 @@
+//
+//  THORChainWasmExecutionPreflight.swift
+//  VultisigApp
+//
+//  Fresh signing-boundary availability check for THORChain WASM transactions.
+//
+
+enum THORChainWasmExecutionPreflightError: Error, Equatable {
+    case halted
+    case unavailable
+
+    var localizationKey: String {
+        switch self {
+        case .halted:
+            "thorchainWasmStakingHaltedWarning"
+        case .unavailable:
+            "thorchainWasmStakingUnavailableWarning"
+        }
+    }
+}
+
+struct THORChainWasmExecutionPreflight {
+    private let availabilityProvider: THORChainWasmExecutionAvailabilityProviding
+
+    init(
+        availabilityProvider: THORChainWasmExecutionAvailabilityProviding = ThorchainService.shared
+    ) {
+        self.availabilityProvider = availabilityProvider
+    }
+
+    func validate(_ transactionBuilder: TransactionBuilder) async throws {
+        guard transactionBuilder.coin.chain == .thorChain else { return }
+
+        let contractAddresses = transactionBuilder.wasmContractAddressesForPreflight
+        guard !contractAddresses.isEmpty else { return }
+
+        let availabilities = await availabilityProvider.fetchWasmExecutionAvailabilities(
+            for: contractAddresses
+        )
+        let states = contractAddresses.map { availabilities[$0] ?? .unavailable }
+
+        if states.contains(.halted) {
+            throw THORChainWasmExecutionPreflightError.halted
+        }
+        if states.contains(.unavailable) {
+            throw THORChainWasmExecutionPreflightError.unavailable
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
@@ -15,6 +15,7 @@ struct FunctionTransactionScreen: View {
     let vault: Vault
     let transactionType: FunctionTransactionType
     private let mayaCacaoStakingPreflight = MayaCacaoStakingPreflight()
+    private let thorchainWasmExecutionPreflight = THORChainWasmExecutionPreflight()
 
     @State private var isLoading: Bool = false
     @State private var preflightErrorToast: String?
@@ -318,11 +319,17 @@ struct FunctionTransactionScreen: View {
 
             do {
                 try await mayaCacaoStakingPreflight.validate(transactionBuilder)
+                try await thorchainWasmExecutionPreflight.validate(transactionBuilder)
             } catch let error as MayaCacaoStakingPreflightError {
                 preflightErrorToast = error.localizationKey.localized
                 return
+            } catch let error as THORChainWasmExecutionPreflightError {
+                preflightErrorToast = error.localizationKey.localized
+                return
             } catch {
-                preflightErrorToast = "mayaCacaoStakingUnavailableWarning".localized
+                preflightErrorToast = transactionBuilder.coin.chain == .thorChain
+                    ? "thorchainWasmStakingUnavailableWarning".localized
+                    : "mayaCacaoStakingUnavailableWarning".localized
                 return
             }
 

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Mint/MintTransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Mint/MintTransactionBuilder.swift
@@ -49,6 +49,14 @@ struct MintTransactionBuilder: TransactionBuilder {
         )
     }
 
+    var wasmContractAddressesForPreflight: Set<String> {
+        var addresses = Set([YVaultConstants.affiliateContractAddress])
+        if let targetContract = YVaultConstants.contracts[coin.ticker.lowercased()] {
+            addresses.insert(targetContract)
+        }
+        return addresses
+    }
+
     private func buildExecuteMsg() -> String {
         let denom = coin.ticker.lowercased()
         let targetContract = YVaultConstants.contracts[denom] ?? ""

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Mint/RedeemTransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Mint/RedeemTransactionBuilder.swift
@@ -49,6 +49,14 @@ struct RedeemTransactionBuilder: TransactionBuilder {
         )
     }
 
+    var wasmContractAddressesForPreflight: Set<String> {
+        var addresses = Set([YVaultConstants.affiliateContractAddress])
+        if let targetContract = YVaultConstants.contracts[coin.ticker.lowercased()] {
+            addresses.insert(targetContract)
+        }
+        return addresses
+    }
+
     private func buildExecuteMsg() -> String {
         let denom = coin.ticker.lowercased()
         let targetContract = YVaultConstants.contracts[denom] ?? ""

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/TransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/TransactionBuilder.swift
@@ -15,6 +15,10 @@ protocol TransactionBuilder {
     var memoFunctionDictionary: ThreadSafeDictionary<String, String> { get }
     var transactionType: VSTransactionType { get }
     var wasmContractPayload: WasmExecuteContractPayload? { get }
+    /// Every THORChain WASM contract whose execution must remain available for
+    /// this transaction. Most builders execute only the payload contract; proxy
+    /// builders can add the downstream contract they invoke.
+    var wasmContractAddressesForPreflight: Set<String> { get }
     var toAddress: String { get }
     /// Cosmos-SDK staking / distribution operation intent. Populated only by
     /// the per-flow Cosmos staking builders (delegate, undelegate, redelegate,
@@ -34,6 +38,11 @@ protocol TransactionBuilder {
 }
 
 extension TransactionBuilder {
+    var wasmContractAddressesForPreflight: Set<String> {
+        guard let address = wasmContractPayload?.contractAddress else { return [] }
+        return [address]
+    }
+
     /// Default — only Cosmos staking builders override this. Keeping the
     /// requirement defaulted means every existing `TransactionBuilder`
     /// conformer compiles unchanged.

--- a/VultisigApp/VultisigAppTests/Defi/DefiChainStakeViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/DefiChainStakeViewModelTests.swift
@@ -71,15 +71,31 @@ final class DefiChainStakeViewModelTests: XCTestCase {
     func testMayaRefreshPublishesHaltedActionAvailability() async {
         let cacao = TokensStore.cacao
         vault.defiPositions = [DefiPositions(chain: .mayaChain, bonds: [], staking: [cacao], lps: [])]
-        interactor.actionAvailabilityStub = .halted
+        interactor.actionAvailabilitiesStub = [cacao: .halted]
         let viewModel = DefiChainStakeViewModel(vault: vault, chain: .mayaChain, interactor: interactor)
 
-        XCTAssertEqual(viewModel.actionAvailability, .checking)
+        let position = StakePosition(coin: cacao, type: .stake, amount: 10, vault: vault)
+        XCTAssertEqual(viewModel.actionAvailability(for: position), .checking)
 
         await viewModel.refresh()
 
-        XCTAssertEqual(viewModel.actionAvailability, .halted)
+        XCTAssertEqual(viewModel.actionAvailability(for: position), .halted)
         XCTAssertEqual(interactor.actionAvailabilityCallCount, 1)
+    }
+
+    func testRefreshPublishesAvailabilityPerPosition() async {
+        let tcy = CoinMeta.make(chain: .thorChain, ticker: "TCY")
+        let ruji = CoinMeta.make(chain: .thorChain, ticker: "RUJI")
+        vault.defiPositions = [DefiPositions(chain: .thorChain, bonds: [], staking: [tcy, ruji], lps: [])]
+        interactor.actionAvailabilitiesStub = [tcy: .available, ruji: .halted]
+        let viewModel = makeViewModel()
+
+        await viewModel.refresh()
+
+        let tcyPosition = StakePosition(coin: tcy, type: .stake, amount: 10, vault: vault)
+        let rujiPosition = StakePosition(coin: ruji, type: .stake, amount: 10, vault: vault)
+        XCTAssertEqual(viewModel.actionAvailability(for: tcyPosition), .available)
+        XCTAssertEqual(viewModel.actionAvailability(for: rujiPosition), .halted)
     }
 
     /// Refresh that returns no DTOs (e.g. all per-coin fetches failed) must not flicker the list

--- a/VultisigApp/VultisigAppTests/Defi/Helpers/MockInteractors.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Helpers/MockInteractors.swift
@@ -15,7 +15,7 @@ import Foundation
 
 final class MockStakeInteractor: StakeInteractor, @unchecked Sendable {
     var stub: [StakePositionData] = []
-    var actionAvailabilityStub: StakeActionAvailability = .available
+    var actionAvailabilitiesStub: StakeActionAvailabilities = [:]
     private(set) var callCount = 0
     private(set) var actionAvailabilityCallCount = 0
 
@@ -24,9 +24,13 @@ final class MockStakeInteractor: StakeInteractor, @unchecked Sendable {
         return stub
     }
 
-    func fetchActionAvailability() async -> StakeActionAvailability {
+    func fetchActionAvailabilities(for coins: [CoinMeta]) async -> StakeActionAvailabilities {
         actionAvailabilityCallCount += 1
-        return actionAvailabilityStub
+        return coins.reduce(into: actionAvailabilitiesStub) { result, coin in
+            if result[coin] == nil {
+                result[coin] = .available
+            }
+        }
     }
 }
 

--- a/VultisigApp/VultisigAppTests/Defi/THORChainWasmStakingAvailabilityTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/THORChainWasmStakingAvailabilityTests.swift
@@ -1,0 +1,197 @@
+//
+//  THORChainWasmStakingAvailabilityTests.swift
+//  VultisigAppTests
+//
+
+import Foundation
+@testable import VultisigApp
+import XCTest
+
+final class THORChainWasmStakingAvailabilityTests: XCTestCase {
+    private let contractAddress = "thor1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqabcdef"
+    private let dataHash = "9F3A872C75AB4413DD37936F720B81A051062B1B96554C9CB46C7CCDB4FD017E"
+    private let checksumReference = "T45IOLDVVNCBHXJXSNXXEC4BUBIQMKY3SZKUZHFUNR6M3NH5AF7A"
+
+    func testHaltHeightStartsAfterConfiguredBlock() {
+        XCTAssertFalse(ThorchainService.isWasmHaltActive(-1, at: 100))
+        XCTAssertFalse(ThorchainService.isWasmHaltActive(0, at: 100))
+        XCTAssertFalse(ThorchainService.isWasmHaltActive(100, at: 100))
+        XCTAssertFalse(ThorchainService.isWasmHaltActive(101, at: 100))
+        XCTAssertTrue(ThorchainService.isWasmHaltActive(100, at: 101))
+    }
+
+    func testChecksumKeyUsesThornodeBase32WithoutPadding() {
+        XCTAssertEqual(ThorchainService.base32MimirReference(Data("foo".utf8)), "MZXW6")
+        XCTAssertEqual(
+            ThorchainService.wasmChecksumHaltMimirKey(dataHash: dataHash),
+            "HaltWasmCs-\(checksumReference)"
+        )
+        XCTAssertNil(ThorchainService.wasmChecksumHaltMimirKey(dataHash: "not-hex"))
+    }
+
+    func testContractKeyUsesLastSixAddressCharacters() {
+        XCTAssertEqual(
+            ThorchainService.wasmContractHaltMimirKey(address: contractAddress),
+            "HaltWasmContract-abcdef"
+        )
+        XCTAssertNil(ThorchainService.wasmContractHaltMimirKey(address: "short"))
+    }
+
+    func testChecksumHaltDisablesContractAfterConfiguredHeight() async {
+        let client = makeClient(currentHeight: 101, global: -1, contract: -1, checksum: 100)
+        let service = ThorchainService(resolver: NoTHORChainRPCOverride(), httpClient: client)
+
+        let availability = await service.fetchWasmExecutionAvailabilities(for: [contractAddress])
+
+        XCTAssertEqual(availability[contractAddress], .halted)
+    }
+
+    func testChecksumHaltDoesNotStartAtConfiguredHeight() async {
+        let client = makeClient(currentHeight: 100, global: -1, contract: -1, checksum: 100)
+        let service = ThorchainService(resolver: NoTHORChainRPCOverride(), httpClient: client)
+
+        let availability = await service.fetchWasmExecutionAvailabilities(for: [contractAddress])
+
+        XCTAssertEqual(availability[contractAddress], .available)
+    }
+
+    func testContractHaltDisablesContractAfterConfiguredHeight() async {
+        let client = makeClient(currentHeight: 101, global: -1, contract: 100, checksum: -1)
+        let service = ThorchainService(resolver: NoTHORChainRPCOverride(), httpClient: client)
+
+        let availability = await service.fetchWasmExecutionAvailabilities(for: [contractAddress])
+
+        XCTAssertEqual(availability[contractAddress], .halted)
+    }
+
+    func testGlobalHaltDisablesWithoutContractMetadataRequests() async {
+        let client = THORChainWasmAvailabilityHTTPClient(
+            responses: [
+                "/thorchain/lastblock": [lastBlockJSON(height: 101)],
+                "/thorchain/mimir/key/HALTWASMGLOBAL": [Data("100".utf8)]
+            ]
+        )
+        let service = ThorchainService(resolver: NoTHORChainRPCOverride(), httpClient: client)
+
+        let availability = await service.fetchWasmExecutionAvailabilities(for: [contractAddress])
+        let contractInfoRequests = await client.requestCount(for: "/cosmwasm/wasm/v1/contract/\(contractAddress)")
+
+        XCTAssertEqual(availability[contractAddress], .halted)
+        XCTAssertEqual(contractInfoRequests, 0)
+    }
+
+    func testMetadataFailureFailsOnlyThatContractClosed() async {
+        let client = THORChainWasmAvailabilityHTTPClient(
+            responses: [
+                "/thorchain/lastblock": [lastBlockJSON(height: 101)],
+                "/thorchain/mimir/key/HALTWASMGLOBAL": [Data("-1".utf8)],
+                "/thorchain/mimir/key/HALTWASMCONTRACT-ABCDEF": [Data("-1".utf8)]
+            ]
+        )
+        let service = ThorchainService(resolver: NoTHORChainRPCOverride(), httpClient: client)
+
+        let availability = await service.fetchWasmExecutionAvailabilities(for: [contractAddress])
+
+        XCTAssertEqual(availability[contractAddress], .unavailable)
+    }
+
+    func testInteractorGatesRujiWithoutDisablingNativeTcy() async {
+        let ruji = TokensStore.ruji
+        let tcy = TokensStore.tcy
+        let provider = StubWasmAvailabilityProvider(
+            availabilities: [RUJIStakingConstants.contract: .halted]
+        )
+        let interactor = THORChainStakeInteractor(wasmAvailabilityProvider: provider)
+
+        let availability = await interactor.fetchActionAvailabilities(for: [ruji, tcy])
+
+        XCTAssertEqual(availability[ruji], .halted)
+        XCTAssertEqual(availability[tcy], .available)
+    }
+
+    func testInteractorFailsRujiClosedWhenProviderOmitsContract() async {
+        let provider = StubWasmAvailabilityProvider(availabilities: [:])
+        let interactor = THORChainStakeInteractor(wasmAvailabilityProvider: provider)
+
+        let availability = await interactor.fetchActionAvailabilities(for: [TokensStore.ruji])
+
+        XCTAssertEqual(availability[TokensStore.ruji], .unavailable)
+    }
+
+    private func makeClient(
+        currentHeight: UInt64,
+        global: Int64,
+        contract: Int64,
+        checksum: Int64
+    ) -> THORChainWasmAvailabilityHTTPClient {
+        THORChainWasmAvailabilityHTTPClient(
+            responses: [
+                "/thorchain/lastblock": [lastBlockJSON(height: currentHeight)],
+                "/thorchain/mimir/key/HALTWASMGLOBAL": [Data(String(global).utf8)],
+                "/thorchain/mimir/key/HALTWASMCONTRACT-ABCDEF": [Data(String(contract).utf8)],
+                "/cosmwasm/wasm/v1/contract/\(contractAddress)": [contractInfoJSON(codeID: "43")],
+                "/cosmwasm/wasm/v1/code/43": [codeInfoJSON(dataHash: dataHash)],
+                "/thorchain/mimir/key/HALTWASMCS-\(checksumReference)": [Data(String(checksum).utf8)]
+            ]
+        )
+    }
+
+    private func lastBlockJSON(height: UInt64) -> Data {
+        Data("[{\"thorchain\":\(height)}]".utf8)
+    }
+
+    private func contractInfoJSON(codeID: String) -> Data {
+        Data("{\"contract_info\":{\"code_id\":\"\(codeID)\"}}".utf8)
+    }
+
+    private func codeInfoJSON(dataHash: String) -> Data {
+        Data("{\"code_info\":{\"data_hash\":\"\(dataHash)\"}}".utf8)
+    }
+}
+
+private struct NoTHORChainRPCOverride: RPCEndpointResolving {
+    func url(for _: Chain) -> String? { nil }
+}
+
+private struct StubWasmAvailabilityProvider: THORChainWasmExecutionAvailabilityProviding {
+    let availabilities: [String: THORChainWasmExecutionAvailability]
+
+    // swiftlint:disable async_without_await
+    func fetchWasmExecutionAvailabilities(
+        for contractAddresses: Set<String>
+    ) async -> [String: THORChainWasmExecutionAvailability] {
+        availabilities.filter { contractAddresses.contains($0.key) }
+    }
+    // swiftlint:enable async_without_await
+}
+
+private actor THORChainWasmAvailabilityHTTPClient: HTTPClientProtocol {
+    private var responses: [String: [Data]]
+    private var counts: [String: Int] = [:]
+
+    init(responses: [String: [Data]]) {
+        self.responses = responses
+    }
+
+    func requestCount(for path: String) -> Int {
+        counts[path, default: 0]
+    }
+
+    // swiftlint:disable:next async_without_await
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        let path = target.path
+        counts[path, default: 0] += 1
+        guard var queued = responses[path], !queued.isEmpty else {
+            throw HTTPError.statusCode(501, nil)
+        }
+        let data = queued.removeFirst()
+        responses[path] = queued
+        let response = HTTPURLResponse(
+            url: target.baseURL.appendingPathComponent(path),
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return HTTPResponse(data: data, response: response)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Defi/THORChainWasmStakingPresentationTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/THORChainWasmStakingPresentationTests.swift
@@ -1,0 +1,70 @@
+//
+//  THORChainWasmStakingPresentationTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class THORChainWasmStakingPresentationTests: XCTestCase {
+    private var storeToken: TestContextToken!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        storeToken = try TestStore.installInMemoryContainer()
+    }
+
+    override func tearDown() async throws {
+        TestStore.restore(storeToken)
+        storeToken = nil
+        try await super.tearDown()
+    }
+
+    func testHaltDisablesRujiActionsAndShowsAppLayerWarning() {
+        let view = makeView(coin: TokensStore.ruji, availability: .halted)
+
+        XCTAssertTrue(view.stakeDisabled)
+        XCTAssertTrue(view.unstakeDisabled)
+        XCTAssertEqual(view.actionWarningMessage, "thorchainWasmStakingHaltedWarning".localized)
+    }
+
+    func testUnavailablePolicyDisablesRujiActionsAndShowsVerificationWarning() {
+        let view = makeView(coin: TokensStore.ruji, availability: .unavailable)
+
+        XCTAssertTrue(view.stakeDisabled)
+        XCTAssertTrue(view.unstakeDisabled)
+        XCTAssertEqual(view.actionWarningMessage, "thorchainWasmStakingUnavailableWarning".localized)
+    }
+
+    func testAvailableNativeTcyHasNoAppLayerWarning() {
+        let view = makeView(coin: TokensStore.tcy, availability: .available)
+
+        XCTAssertFalse(view.stakeDisabled)
+        XCTAssertFalse(view.unstakeDisabled)
+        XCTAssertNil(view.actionWarningMessage)
+    }
+
+    private func makeView(
+        coin: CoinMeta,
+        availability: StakeActionAvailability
+    ) -> DefiChainStakedPositionView {
+        let vault = TestStore.makeVault()
+        let position = StakePosition(
+            coin: coin,
+            type: .stake,
+            amount: 10,
+            availableToUnstake: 10,
+            vault: vault
+        )
+        return DefiChainStakedPositionView(
+            position: position,
+            fiatAmount: "$10.00",
+            actionAvailability: availability,
+            onStake: {},
+            onUnstake: {},
+            onWithdraw: {},
+            onTransfer: {}
+        )
+    }
+}

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/THORChainWasmExecutionPreflightTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/THORChainWasmExecutionPreflightTests.swift
@@ -1,0 +1,126 @@
+//
+//  THORChainWasmExecutionPreflightTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class THORChainWasmExecutionPreflightTests: XCTestCase {
+    func testHaltedNetworkBlocksRujiStake() async {
+        let provider = SequencedWasmAvailabilityProvider(states: [.halted])
+        let preflight = THORChainWasmExecutionPreflight(availabilityProvider: provider)
+
+        do {
+            try await preflight.validate(makeRujiStakeBuilder())
+            XCTFail("A halted THORChain WASM runtime must block RUJI staking.")
+        } catch let error as THORChainWasmExecutionPreflightError {
+            XCTAssertEqual(error, .halted)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testUnavailableOrMissingStateFailsClosed() async {
+        for state in [THORChainWasmExecutionAvailability.unavailable, nil] {
+            let provider = SequencedWasmAvailabilityProvider(states: [state])
+            let preflight = THORChainWasmExecutionPreflight(availabilityProvider: provider)
+
+            do {
+                try await preflight.validate(makeRujiStakeBuilder())
+                XCTFail("An unverifiable WASM policy must block RUJI staking.")
+            } catch let error as THORChainWasmExecutionPreflightError {
+                XCTAssertEqual(error, .unavailable)
+            } catch {
+                XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testPreflightReadsFreshStateOnEveryAttempt() async {
+        let provider = SequencedWasmAvailabilityProvider(states: [.available, .halted])
+        let preflight = THORChainWasmExecutionPreflight(availabilityProvider: provider)
+        let builder = makeRujiStakeBuilder()
+
+        try? await preflight.validate(builder)
+        try? await preflight.validate(builder)
+
+        let requestCount = await provider.requestCount
+        XCTAssertEqual(requestCount, 2)
+    }
+
+    func testNativeThorchainTransactionSkipsWasmRequest() async throws {
+        let provider = SequencedWasmAvailabilityProvider(states: [.halted])
+        let preflight = THORChainWasmExecutionPreflight(availabilityProvider: provider)
+        let builder = CustomMemoTransactionBuilder(
+            coin: makeCoin(asset: TokensStore.tcy),
+            customMemo: "tcy+:thor1address",
+            customAmount: 1
+        )
+
+        try await preflight.validate(builder)
+
+        let requestCount = await provider.requestCount
+        XCTAssertEqual(requestCount, 0)
+    }
+
+    func testYVaultPreflightIncludesProxyAndTargetContracts() {
+        let mint = MintTransactionBuilder(
+            coin: makeCoin(asset: TokensStore.rune),
+            amount: "1",
+            sendMaxAmount: false
+        )
+        let redeem = RedeemTransactionBuilder(
+            coin: makeCoin(asset: TokensStore.yrune),
+            amount: "1",
+            sendMaxAmount: false,
+            slippage: 0.01
+        )
+        let expected: Set<String> = [
+            YVaultConstants.affiliateContractAddress,
+            YVaultConstants.contracts["rune"]!
+        ]
+
+        XCTAssertEqual(mint.wasmContractAddressesForPreflight, expected)
+        XCTAssertEqual(redeem.wasmContractAddressesForPreflight, expected)
+    }
+
+    private func makeRujiStakeBuilder() -> RUJIStakeTransactionBuilder {
+        RUJIStakeTransactionBuilder(
+            coin: makeCoin(asset: TokensStore.ruji),
+            amount: "1",
+            sendMaxAmount: false
+        )
+    }
+
+    private func makeCoin(asset: CoinMeta) -> Coin {
+        Coin(
+            asset: asset,
+            address: "thor1fixtureaddress000000000000000000000000000",
+            hexPublicKey: "02" + String(repeating: "00", count: 32)
+        )
+    }
+}
+
+// swiftlint:disable async_without_await
+private actor SequencedWasmAvailabilityProvider: THORChainWasmExecutionAvailabilityProviding {
+    private var states: [THORChainWasmExecutionAvailability?]
+    private(set) var requestCount = 0
+
+    init(states: [THORChainWasmExecutionAvailability?]) {
+        self.states = states
+    }
+
+    func fetchWasmExecutionAvailabilities(
+        for contractAddresses: Set<String>
+    ) async -> [String: THORChainWasmExecutionAvailability] {
+        requestCount += 1
+        let state = states.isEmpty ? nil : states.removeFirst()
+        guard let state else { return [:] }
+        return contractAddresses.reduce(into: [:]) { result, address in
+            result[address] = state
+        }
+    }
+}
+// swiftlint:enable async_without_await


### PR DESCRIPTION
## Summary

- scope staking availability per DeFi position while preserving the CACAO halt behavior from the base PR
- mirror THORNode's global, contract-suffix, and code-checksum WASM execution halt policy
- disable RUJI and other THORChain App Layer staking actions without disabling native TCY staking
- repeat a fresh, fail-closed WASM policy check immediately before Verify
- add localized warnings and focused unit coverage

## Root cause

The reported RUJI transaction used the expected staking contract and execute payload. THORChain mainnet had `HaltWasmGlobal = 1`, so THORNode rejected contract execution with `wasm halted: unauthorized`.

## Stack

This PR is stacked on #5233 and should be reviewed after that PR.

## Verification

- focused staking, presentation, CACAO regression, and preflight tests pass
- changed-file SwiftLint passes with zero violations
- full SwiftLint completes with the existing 26-warning baseline and zero serious violations
- full unit suite was executed with the pinned package graph; six unrelated tests failed initially, five passed on isolated rerun, and the pre-existing `QBTCClaimSecureVaultRoundDriverTests.testRunBtcRoundDoesNotReKickoff()` failure remained reproducible

The cross-model review was skipped at the request of the author.
