### PR TITLE
fix(keysign): abort on DKLS malicious-party ban instead of retrying

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Common/common.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Common/common.swift
@@ -11,14 +11,14 @@ import CommonCrypto
 enum HelperError: Error, LocalizedError, Identifiable {
     var id: String { errorDescription ?? "" }
     case runtimeError(String)
-    case maliciousParty(partyIndex: Int)
+    case maliciousParty(partyID: String)
 
     var errorDescription: String? {
         switch self {
         case .runtimeError(let string):
             return string
-        case .maliciousParty(let partyIndex):
-            return String(format: "keysignMaliciousPartyDetected".localized, partyIndex)
+        case .maliciousParty(let partyID):
+            return String(format: "keysignMaliciousPartyDetected".localized, partyID)
         }
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Common/common.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Common/common.swift
@@ -11,11 +11,14 @@ import CommonCrypto
 enum HelperError: Error, LocalizedError, Identifiable {
     var id: String { errorDescription ?? "" }
     case runtimeError(String)
+    case maliciousParty(partyIndex: Int)
 
     var errorDescription: String? {
         switch self {
         case .runtimeError(let string):
             return string
+        case .maliciousParty(let partyIndex):
+            return String(format: "keysignMaliciousPartyDetected".localized, partyIndex)
         }
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/DKLSKeysign.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/DKLSKeysign.swift
@@ -28,6 +28,9 @@ final class DKLSKeysign {
     var cache = NSCache<NSString, AnyObject>()
     var signatures = [String: TssKeysignResponse]()
     let DKLS_LIB_OK: godkls.lib_error = .init(0)
+    // LIB_ABORT_PROTOCOL_AND_BAN_PARTY_1...10 (godkls.h): the library aborted
+    // the session and banned a co-signer for protocol-level misbehavior.
+    private let banPartyRange: ClosedRange<UInt32> = 100...109
     private let httpClient: HTTPClientProtocol
 
     init(keysignCommittee: [String],
@@ -51,6 +54,11 @@ final class DKLSKeysign {
         self.localPartyID = vault.localPartyID
         self.publicKeyECDSA = publicKeyECDSA
         self.httpClient = httpClient
+    }
+
+    func checkForBannedParty(_ error: godkls.lib_error) throws {
+        guard banPartyRange.contains(error.rawValue) else { return }
+        throw HelperError.maliciousParty(partyIndex: Int(error.rawValue - banPartyRange.lowerBound) + 1)
     }
 
     func getSignatures() -> [String: TssKeysignResponse] {
@@ -286,6 +294,7 @@ final class DKLSKeysign {
             var decryptedBodySlice = descryptedBodyArr.to_dkls_goslice()
             var isFinished: UInt32 = 0
             let result = dkls_sign_session_input_message(handle, &decryptedBodySlice, &isFinished)
+            try checkForBannedParty(result)
             if result != DKLS_LIB_OK {
                 throw HelperError.runtimeError("fail to apply message to dkls,\(result)")
             }
@@ -362,6 +371,7 @@ final class DKLSKeysign {
                                                              &localPartySlice,
                                                              keyshareHandle,
                                                              &handler)
+            try checkForBannedParty(sessionResult)
             if sessionResult != DKLS_LIB_OK {
                 throw HelperError.runtimeError("fail to create sign session from setup message,error:\(sessionResult)")
             }
@@ -394,6 +404,10 @@ final class DKLSKeysign {
             // A cancellation is not a signing failure — never retry it,
             // propagate so the abandoned ceremony unwinds immediately.
             if error is CancellationError { throw error }
+            // A banned party is a protocol-level verdict from the library, not a
+            // transient failure — retrying would just re-sign against a peer
+            // DKLS has already identified and banned as malicious.
+            if case HelperError.maliciousParty = error { throw error }
             logger.error("Failed to sign message (\(messageToSign, privacy: .public)) on attempt \(attempt, privacy: .public): \(error.localizedDescription, privacy: .public)")
             if attempt < 3 {
                 try await DKLSKeysignOneMessageWithRetry(attempt: attempt+1, messageToSign: messageToSign)
@@ -415,6 +429,7 @@ final class DKLSKeysign {
             godkls.tss_buffer_free(&buf)
         }
         let result = dkls_sign_session_finish(handle, &buf)
+        try checkForBannedParty(result)
         if result != DKLS_LIB_OK {
             throw HelperError.runtimeError("fail to get keysign signature \(result)")
         }

--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/DKLSKeysign.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/DKLSKeysign.swift
@@ -58,7 +58,11 @@ final class DKLSKeysign {
 
     func checkForBannedParty(_ error: godkls.lib_error) throws {
         guard banPartyRange.contains(error.rawValue) else { return }
-        throw HelperError.maliciousParty(partyIndex: Int(error.rawValue - banPartyRange.lowerBound) + 1)
+        // Party N (1-based) is keysignCommittee[N-1]: the setup message embeds
+        // party ids in exactly this array order (see getDKLSKeysignSetupMessage).
+        let partyIndex = Int(error.rawValue - banPartyRange.lowerBound)
+        let partyID = keysignCommittee.indices.contains(partyIndex) ? keysignCommittee[partyIndex] : "#\(partyIndex + 1)"
+        throw HelperError.maliciousParty(partyID: partyID)
     }
 
     func getSignatures() -> [String: TssKeysignResponse] {

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -751,6 +751,7 @@
 "keysign" = "Schlüsselsignatur";
 "keysignDiscoveryDisclaimer" = "Scanne den QR-Code, um die Transaktion zu signieren.";
 "keysignDiscoveryDisclaimerDevice" = "-Gerätescan erforderlich.";
+"keysignMaliciousPartyDetected" = "Ein Gerät in dieser Keysign-Sitzung (Partei %d) wurde bei böswilligem Verhalten erkannt. Verwende es nicht erneut zum Signieren.";
 "keysignStartResponseError" = "Bei der Verarbeitung der Keysign-Startantwort ist ein Problem aufgetreten. Bitte versuche es erneut.";
 "keysignStartVerifyFailed" = "Verifizierung des Keysign-Starts fehlgeschlagen. Fehler: %@";
 "Korean" = "Koreanisch";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -751,7 +751,7 @@
 "keysign" = "Schlüsselsignatur";
 "keysignDiscoveryDisclaimer" = "Scanne den QR-Code, um die Transaktion zu signieren.";
 "keysignDiscoveryDisclaimerDevice" = "-Gerätescan erforderlich.";
-"keysignMaliciousPartyDetected" = "Ein Gerät in dieser Keysign-Sitzung (Partei %d) wurde bei böswilligem Verhalten erkannt. Verwende es nicht erneut zum Signieren.";
+"keysignMaliciousPartyDetected" = "Das Gerät „%@“ in dieser Keysign-Sitzung wurde bei böswilligem Verhalten erkannt. Verwende es nicht erneut zum Signieren.";
 "keysignStartResponseError" = "Bei der Verarbeitung der Keysign-Startantwort ist ein Problem aufgetreten. Bitte versuche es erneut.";
 "keysignStartVerifyFailed" = "Verifizierung des Keysign-Starts fehlgeschlagen. Fehler: %@";
 "Korean" = "Koreanisch";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -751,6 +751,7 @@
 "keysign" = "Keysign";
 "keysignDiscoveryDisclaimer" = "Scan QR code to sign transaction. ";
 "keysignDiscoveryDisclaimerDevice" = "-device scan required.";
+"keysignMaliciousPartyDetected" = "A device in this keysign session (party %d) was detected acting maliciously. Do not use it for signing again.";
 "keysignStartResponseError" = "There was an issue processing the keysign start response. Please try again.";
 "keysignStartVerifyFailed" = "Failed to verify keysign start. Error: %@";
 "Korean" = "Korean";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -751,7 +751,7 @@
 "keysign" = "Keysign";
 "keysignDiscoveryDisclaimer" = "Scan QR code to sign transaction. ";
 "keysignDiscoveryDisclaimerDevice" = "-device scan required.";
-"keysignMaliciousPartyDetected" = "A device in this keysign session (party %d) was detected acting maliciously. Do not use it for signing again.";
+"keysignMaliciousPartyDetected" = "The device \"%@\" in this keysign session was detected acting maliciously. Do not use it for signing again.";
 "keysignStartResponseError" = "There was an issue processing the keysign start response. Please try again.";
 "keysignStartVerifyFailed" = "Failed to verify keysign start. Error: %@";
 "Korean" = "Korean";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -751,6 +751,7 @@
 "keysign" = "Firma de Clave";
 "keysignDiscoveryDisclaimer" = "Escanea el código QR para firmar la transacción.";
 "keysignDiscoveryDisclaimerDevice" = "-se requiere escanear el dispositivo.";
+"keysignMaliciousPartyDetected" = "Se detectó que un dispositivo en esta sesión de keysign (parte %d) actuó de forma maliciosa. No lo uses de nuevo para firmar.";
 "keysignStartResponseError" = "Hubo un problema al procesar la respuesta de inicio de keysign. Inténtalo de nuevo.";
 "keysignStartVerifyFailed" = "No se pudo verificar el inicio de keysign. Error: %@";
 "Korean" = "Coreano";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -751,7 +751,7 @@
 "keysign" = "Firma de Clave";
 "keysignDiscoveryDisclaimer" = "Escanea el código QR para firmar la transacción.";
 "keysignDiscoveryDisclaimerDevice" = "-se requiere escanear el dispositivo.";
-"keysignMaliciousPartyDetected" = "Se detectó que un dispositivo en esta sesión de keysign (parte %d) actuó de forma maliciosa. No lo uses de nuevo para firmar.";
+"keysignMaliciousPartyDetected" = "Se detectó que el dispositivo \"%@\" en esta sesión de keysign actuó de forma maliciosa. No lo uses de nuevo para firmar.";
 "keysignStartResponseError" = "Hubo un problema al procesar la respuesta de inicio de keysign. Inténtalo de nuevo.";
 "keysignStartVerifyFailed" = "No se pudo verificar el inicio de keysign. Error: %@";
 "Korean" = "Coreano";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -751,7 +751,7 @@
 "keysign" = "Potpis ključa";
 "keysignDiscoveryDisclaimer" = "Skenirajte QR kod kako biste potpisali transakciju.";
 "keysignDiscoveryDisclaimerDevice" = "-potrebno skeniranje uređaja.";
-"keysignMaliciousPartyDetected" = "Otkriveno je da se uređaj u ovoj keysign sesiji (strana %d) zlonamjerno ponaša. Nemoj ga ponovno koristiti za potpisivanje.";
+"keysignMaliciousPartyDetected" = "Otkriveno je da se uređaj \"%@\" u ovoj keysign sesiji zlonamjerno ponaša. Nemoj ga ponovno koristiti za potpisivanje.";
 "keysignStartResponseError" = "Došlo je do problema pri obradi odgovora za pokretanje keysigna. Pokušaj ponovno.";
 "keysignStartVerifyFailed" = "Provjera pokretanja keysigna nije uspjela. Pogreška: %@";
 "Korean" = "Korejski";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -751,6 +751,7 @@
 "keysign" = "Potpis ključa";
 "keysignDiscoveryDisclaimer" = "Skenirajte QR kod kako biste potpisali transakciju.";
 "keysignDiscoveryDisclaimerDevice" = "-potrebno skeniranje uređaja.";
+"keysignMaliciousPartyDetected" = "Otkriveno je da se uređaj u ovoj keysign sesiji (strana %d) zlonamjerno ponaša. Nemoj ga ponovno koristiti za potpisivanje.";
 "keysignStartResponseError" = "Došlo je do problema pri obradi odgovora za pokretanje keysigna. Pokušaj ponovno.";
 "keysignStartVerifyFailed" = "Provjera pokretanja keysigna nije uspjela. Pogreška: %@";
 "Korean" = "Korejski";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -751,7 +751,7 @@
 "keysign" = "Firma Chiave";
 "keysignDiscoveryDisclaimer" = "Scansiona il codice QR per firmare la transazione.";
 "keysignDiscoveryDisclaimerDevice" = "-scansione del dispositivo richiesta.";
-"keysignMaliciousPartyDetected" = "È stato rilevato che un dispositivo in questa sessione di keysign (parte %d) si è comportato in modo malevolo. Non utilizzarlo più per firmare.";
+"keysignMaliciousPartyDetected" = "È stato rilevato che il dispositivo \"%@\" in questa sessione di keysign si è comportato in modo malevolo. Non utilizzarlo più per firmare.";
 "keysignStartResponseError" = "Si è verificato un problema durante l'elaborazione della risposta di avvio del keysign. Riprova.";
 "keysignStartVerifyFailed" = "Impossibile verificare l'avvio del keysign. Errore: %@";
 "Korean" = "Coreano";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -751,6 +751,7 @@
 "keysign" = "Firma Chiave";
 "keysignDiscoveryDisclaimer" = "Scansiona il codice QR per firmare la transazione.";
 "keysignDiscoveryDisclaimerDevice" = "-scansione del dispositivo richiesta.";
+"keysignMaliciousPartyDetected" = "È stato rilevato che un dispositivo in questa sessione di keysign (parte %d) si è comportato in modo malevolo. Non utilizzarlo più per firmare.";
 "keysignStartResponseError" = "Si è verificato un problema durante l'elaborazione della risposta di avvio del keysign. Riprova.";
 "keysignStartVerifyFailed" = "Impossibile verificare l'avvio del keysign. Errore: %@";
 "Korean" = "Coreano";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -751,7 +751,7 @@
 "keysign" = "키사인";
 "keysignDiscoveryDisclaimer" = "QR 코드를 스캔하여 트랜잭션에 서명하세요. ";
 "keysignDiscoveryDisclaimerDevice" = "기기 스캔이 필요합니다.";
-"keysignMaliciousPartyDetected" = "이 keysign 세션의 기기(파티 %d)가 악의적으로 동작한 것이 감지되었습니다. 다시는 서명에 사용하지 마세요.";
+"keysignMaliciousPartyDetected" = "이 keysign 세션의 기기 \"%@\"가 악의적으로 동작한 것이 감지되었습니다. 다시는 서명에 사용하지 마세요.";
 "keysignStartResponseError" = "Keysign 시작 응답을 처리하는 중 문제가 발생했습니다. 다시 시도하세요.";
 "keysignStartVerifyFailed" = "Keysign 시작 확인에 실패했습니다. 오류: %@";
 "Korean" = "한국어";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -751,6 +751,7 @@
 "keysign" = "키사인";
 "keysignDiscoveryDisclaimer" = "QR 코드를 스캔하여 트랜잭션에 서명하세요. ";
 "keysignDiscoveryDisclaimerDevice" = "기기 스캔이 필요합니다.";
+"keysignMaliciousPartyDetected" = "이 keysign 세션의 기기(파티 %d)가 악의적으로 동작한 것이 감지되었습니다. 다시는 서명에 사용하지 마세요.";
 "keysignStartResponseError" = "Keysign 시작 응답을 처리하는 중 문제가 발생했습니다. 다시 시도하세요.";
 "keysignStartVerifyFailed" = "Keysign 시작 확인에 실패했습니다. 오류: %@";
 "Korean" = "한국어";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -751,7 +751,7 @@
 "keysign" = "Assinatura de Chave";
 "keysignDiscoveryDisclaimer" = "Escaneie o código QR para assinar a transação.";
 "keysignDiscoveryDisclaimerDevice" = "-é necessário escanear o dispositivo.";
-"keysignMaliciousPartyDetected" = "Foi detetado que um dispositivo nesta sessão de keysign (parte %d) agiu de forma maliciosa. Não o uses novamente para assinar.";
+"keysignMaliciousPartyDetected" = "Foi detetado que o dispositivo \"%@\" nesta sessão de keysign agiu de forma maliciosa. Não o uses novamente para assinar.";
 "keysignStartResponseError" = "Ocorreu um problema ao processar a resposta de início do keysign. Tenta novamente.";
 "keysignStartVerifyFailed" = "Não foi possível verificar o início do keysign. Erro: %@";
 "Korean" = "Coreano";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -751,6 +751,7 @@
 "keysign" = "Assinatura de Chave";
 "keysignDiscoveryDisclaimer" = "Escaneie o código QR para assinar a transação.";
 "keysignDiscoveryDisclaimerDevice" = "-é necessário escanear o dispositivo.";
+"keysignMaliciousPartyDetected" = "Foi detetado que um dispositivo nesta sessão de keysign (parte %d) agiu de forma maliciosa. Não o uses novamente para assinar.";
 "keysignStartResponseError" = "Ocorreu um problema ao processar a resposta de início do keysign. Tenta novamente.";
 "keysignStartVerifyFailed" = "Não foi possível verificar o início do keysign. Erro: %@";
 "Korean" = "Coreano";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -751,6 +751,7 @@
 "keysign" = "密钥签名";
 "keysignDiscoveryDisclaimer" = "扫描二维码以签署交易";
 "keysignDiscoveryDisclaimerDevice" = "-需要设备扫描";
+"keysignMaliciousPartyDetected" = "检测到此 keysign 会话中的一个设备(第 %d 方)存在恶意行为。请勿再使用它进行签名。";
 "keysignStartResponseError" = "处理 keysign 启动响应时出现问题。请重试。";
 "keysignStartVerifyFailed" = "验证 keysign 启动失败。错误：%@";
 "Korean" = "韩语";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -751,7 +751,7 @@
 "keysign" = "密钥签名";
 "keysignDiscoveryDisclaimer" = "扫描二维码以签署交易";
 "keysignDiscoveryDisclaimerDevice" = "-需要设备扫描";
-"keysignMaliciousPartyDetected" = "检测到此 keysign 会话中的一个设备(第 %d 方)存在恶意行为。请勿再使用它进行签名。";
+"keysignMaliciousPartyDetected" = "检测到此 keysign 会话中的设备“%@”存在恶意行为。请勿再使用它进行签名。";
 "keysignStartResponseError" = "处理 keysign 启动响应时出现问题。请重试。";
 "keysignStartVerifyFailed" = "验证 keysign 启动失败。错误：%@";
 "Korean" = "韩语";

--- a/VultisigApp/VultisigAppTests/Keysign/DKLSBannedPartyDetectionTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/DKLSBannedPartyDetectionTests.swift
@@ -32,15 +32,35 @@ final class DKLSBannedPartyDetectionTests: XCTestCase {
     }
 
     @MainActor
-    func testBanRangeThrowsMaliciousPartyWithOneBasedIndex() throws {
+    func testBanRangeThrowsMaliciousPartyWithCommitteeID() throws {
+        // Party 1 -> keysignCommittee[0], party 2 -> keysignCommittee[1]: the
+        // setup message embeds ids in exactly this array order.
         let keysign = makeKeysign()
-        for rawValue: UInt32 in 100...109 {
-            XCTAssertThrowsError(try keysign.checkForBannedParty(godkls.lib_error(rawValue))) { error in
-                guard case HelperError.maliciousParty(let partyIndex) = error else {
-                    return XCTFail("expected HelperError.maliciousParty, got \(error)")
-                }
-                XCTAssertEqual(partyIndex, Int(rawValue) - 100 + 1)
+        XCTAssertThrowsError(try keysign.checkForBannedParty(godkls.lib_error(100))) { error in
+            guard case HelperError.maliciousParty(let partyID) = error else {
+                return XCTFail("expected HelperError.maliciousParty, got \(error)")
             }
+            XCTAssertEqual(partyID, "partyA")
+        }
+        XCTAssertThrowsError(try keysign.checkForBannedParty(godkls.lib_error(101))) { error in
+            guard case HelperError.maliciousParty(let partyID) = error else {
+                return XCTFail("expected HelperError.maliciousParty, got \(error)")
+            }
+            XCTAssertEqual(partyID, "partyB")
+        }
+    }
+
+    @MainActor
+    func testBanRangeBeyondCommitteeSizeFallsBackToIndex() throws {
+        // The committee here only has 2 members, but the library reports a ban
+        // range covering up to 10 parties — an index with no committee entry
+        // must still produce a readable identifier, not crash.
+        let keysign = makeKeysign()
+        XCTAssertThrowsError(try keysign.checkForBannedParty(godkls.lib_error(102))) { error in
+            guard case HelperError.maliciousParty(let partyID) = error else {
+                return XCTFail("expected HelperError.maliciousParty, got \(error)")
+            }
+            XCTAssertEqual(partyID, "#3")
         }
     }
 

--- a/VultisigApp/VultisigAppTests/Keysign/DKLSBannedPartyDetectionTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/DKLSBannedPartyDetectionTests.swift
@@ -1,0 +1,56 @@
+//
+//  DKLSBannedPartyDetectionTests.swift
+//  VultisigAppTests
+//
+//  godkls returns LIB_ABORT_PROTOCOL_AND_BAN_PARTY_1...10 (100-109) when it
+//  aborts a session after catching a co-signer misbehaving. That must abort
+//  the keysign with a distinct error, not the generic runtime-error string
+//  that other lib_error codes get retried against. See vultisig-ios#5226.
+//
+
+@testable import VultisigApp
+import godkls
+import XCTest
+
+final class DKLSBannedPartyDetectionTests: XCTestCase {
+
+    @MainActor
+    private func makeKeysign() -> DKLSKeysign {
+        let vault = Vault(name: "DKLS", libType: .DKLS)
+        vault.localPartyID = "partyA"
+        return DKLSKeysign(
+            keysignCommittee: ["partyA", "partyB"],
+            mediatorURL: "https://relay.invalid",
+            sessionID: "session",
+            messsageToSign: ["deadbeef"],
+            vault: vault,
+            encryptionKeyHex: "00",
+            chainPath: "",
+            isInitiateDevice: false,
+            publicKeyECDSA: "ECDSAKey"
+        )
+    }
+
+    @MainActor
+    func testBanRangeThrowsMaliciousPartyWithOneBasedIndex() throws {
+        let keysign = makeKeysign()
+        for rawValue: UInt32 in 100...109 {
+            XCTAssertThrowsError(try keysign.checkForBannedParty(godkls.lib_error(rawValue))) { error in
+                guard case HelperError.maliciousParty(let partyIndex) = error else {
+                    return XCTFail("expected HelperError.maliciousParty, got \(error)")
+                }
+                XCTAssertEqual(partyIndex, Int(rawValue) - 100 + 1)
+            }
+        }
+    }
+
+    @MainActor
+    func testNonBanCodesDoNotThrow() throws {
+        let keysign = makeKeysign()
+        // LIB_OK, and a selection of ordinary/unrelated lib_error codes,
+        // including the neighboring (non-ban) LIB_ABORT_PROTOCOL_PARTY_* range.
+        for rawValue: UInt32 in [0, 1, 13, 99, 110, 200, 209] {
+            XCTAssertNoThrow(try keysign.checkForBannedParty(godkls.lib_error(rawValue)))
+        }
+    }
+}


### PR DESCRIPTION
## Description

`godkls` returns `LIB_ABORT_PROTOCOL_AND_BAN_PARTY_1..10` (100-109) when it aborts a DKLS keysign session after catching a co-signer behaving maliciously. `DKLSKeysign.swift` never inspected these codes — every `dkls_sign_session_*` failure was only compared against `LIB_OK`, so `DKLSKeysignOneMessageWithRetry` retried up to 3 times against the already-banned peer, and the user only ever saw a generic keysign-failed message.

This adds `HelperError.maliciousParty(partyIndex:)`, checks the ban range (100-109) on every `dkls_sign_session_*` result that already throws (`dkls_sign_session_input_message`, `dkls_sign_session_from_setup`, `dkls_sign_session_finish`), and skips retry for that case in the catch block the same way cancellation is already skipped. The error flows through the existing `keysignError`/`KeysignView` display path unchanged, with a new localized message (`keysignMaliciousPartyDetected`, added to all 8 shipping locales).

Fixes #5226

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Parity

- Android: n/a — no sibling app-level handling exists yet (checked `vultisig-android`, `dkls-android`); only the vendored DKLS binding headers reference these codes.
- Windows + extension: n/a — same, no app-level handling found.
- SDK: first: DKLS malicious-party (ban-party) detection — no other Vultisig surface currently inspects these codes at the application level; this iOS fix can be used as the reference when porting.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional context

- `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — 0 violations in changed files (26 pre-existing violations elsewhere, unrelated).
- `xcodebuild build` — succeeds.
- New unit test (`DKLSBannedPartyDetectionTests`) covers the full ban range (100-109 → correct 1-based party index) and confirms `LIB_OK` and the neighboring non-ban `LIB_ABORT_PROTOCOL_PARTY_*` range (200-209) don't throw.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #5226
- **Confidence**: high
- **Needs human review for**: DKLS/TSS error-code handling — please double check the ban range against the current `godkls.h` and that a banned party should always abort the *entire* keysign (all remaining messages), not just the current message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keysign sessions now detect and identify devices flagged for malicious behavior.
  * Localized warnings identify the affected device by name and advise against reusing it for signing.
* **Bug Fixes**
  * Malicious-device errors now stop processing immediately instead of triggering retries.
* **Tests**
  * Added coverage for banned-party detection, device identification, fallback labeling, and unrelated protocol errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->