### PR TITLE
test(keysign): add missing sei.json golden fixture

### DIFF
--- a/VultisigApp/VultisigAppTests/Chains/ChainHelperTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/ChainHelperTests.swift
@@ -122,6 +122,7 @@ enum ChainHelperFixture: String, CaseIterable {
     case mayaswap
     case pol
     case qbtc
+    case sei
     case solana
     case solanaSignData = "solana-sign-data"
     case sui
@@ -162,6 +163,7 @@ enum ChainHelperFixture: String, CaseIterable {
         case .mayaswap: return 2
         case .pol: return 1
         case .qbtc: return 1
+        case .sei: return 2
         case .solana: return 4
         case .solanaSignData: return 1
         case .sui: return 1
@@ -219,6 +221,7 @@ final class ChainHelperTests: XCTestCase {
     func testMayaswapFixture() throws { try runFixture(.mayaswap) }
     func testPolFixture() throws { try runFixture(.pol) }
     func testQbtcFixture() throws { try runFixture(.qbtc) }
+    func testSeiFixture() throws { try runFixture(.sei) }
     func testSolanaFixture() throws { try runFixture(.solana) }
     func testSolanaSignDataFixture() throws { try runFixture(.solanaSignData) }
     func testSuiFixture() throws { try runFixture(.sui) }
@@ -483,7 +486,7 @@ final class ChainHelperTests: XCTestCase {
             let imageHash = try utxoHelper.getPreSignedImageHash(keysignPayload: keysignPayload)
             result += imageHash
         case .ethereum, .arbitrum, .optimism, .polygon, .base, .bscChain, .avalanche, .mantle,
-             .blast, .cronosChain, .zksync, .hyperliquid:
+             .blast, .cronosChain, .zksync, .hyperliquid, .sei:
             let chain = keysignPayload.coin.chain
             if keysignPayload.coin.contractAddress.isEmpty {
                 let evmHelper = EVMHelper.getHelper(coin: keysignPayload.coin)

--- a/VultisigApp/VultisigAppTests/TestData/sei.json
+++ b/VultisigApp/VultisigAppTests/TestData/sei.json
@@ -1,0 +1,68 @@
+[
+    {
+        "name": "Send SEI",
+        "keysign_payload": {
+            "coin": {
+                "chain": "Sei",
+                "ticker": "SEI",
+                "address": "0x07773707BdA78aC4052f736544928b15dD31c5cc",
+                "decimals": 18,
+                "price_provider_id": "sei-network",
+                "is_native_token": true,
+                "hex_public_key": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+                "contract_address": "",
+                "logo": "sei"
+            },
+            "to_address": "0xe5F238C95142be312852e864B830daADB9B7D290",
+            "to_amount": "100000000000000000",
+            "BlockchainSpecific": {
+                "EthereumSpecific": {
+                    "max_fee_per_gas_wei": "1000000000",
+                    "priority_fee": "1000000000",
+                    "nonce": 1,
+                    "gas_limit": "21000"
+                }
+            },
+            "utxo_info": [],
+            "SwapPayload": null,
+            "vault_public_key_ecdsa": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+            "lib_type": "DKLS"
+        },
+        "expected_image_hash": [
+            "09d6110cf12c44513622e239605f2ef6d62abd33f66ed07a22b176f84cd5bb90"
+        ]
+    },
+    {
+        "name": "Send SEI ERC20 USDC",
+        "keysign_payload": {
+            "coin": {
+                "chain": "Sei",
+                "ticker": "USDC",
+                "address": "0x07773707BdA78aC4052f736544928b15dD31c5cc",
+                "decimals": 6,
+                "price_provider_id": "usd-coin",
+                "is_native_token": false,
+                "hex_public_key": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+                "contract_address": "0x3894085Ef7Ff0f0AeDf52E2A2704928d1eC074F1",
+                "logo": "usdc"
+            },
+            "to_address": "0xe5F238C95142be312852e864B830daADB9B7D290",
+            "to_amount": "1000000",
+            "BlockchainSpecific": {
+                "EthereumSpecific": {
+                    "max_fee_per_gas_wei": "1000000000",
+                    "priority_fee": "1000000000",
+                    "nonce": 1,
+                    "gas_limit": "21000"
+                }
+            },
+            "utxo_info": [],
+            "SwapPayload": null,
+            "vault_public_key_ecdsa": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+            "lib_type": "DKLS"
+        },
+        "expected_image_hash": [
+            "3b8f59a295989ea8df77181996d4d07c2e05bdb8687fcfdc59750a033d7a8a45"
+        ]
+    }
+]


### PR DESCRIPTION
## Description

Closes the Sei portion of #5242. That issue claimed 5 golden signing-vector cases were missing from `cosmos.json`/`solana.json`/`thorchain.json`, plus a wholly missing `sei.json`. On inspection, 4 of the 5 named cases already exist — they just live in dedicated fixture files (`cosmos-sdk-sign-amino.json`, `cosmos-sdk-sign-direct.json`, `solana-sign-data.json`) rather than the filenames the issue named, and are already registered in `ChainHelperFixture` with correct `expectedCaseCount`s. Only Sei was a genuine gap: no `sei.json`, no `.sei` case in the fixture registry, and — discovered while wiring it up — no `.sei` entry in `ChainHelperTests`'s own EVM dispatch switch, so a Sei test case would have failed with "Unsupported chain" even with the fixture in place.

This PR:
- Adds `VultisigAppTests/TestData/sei.json` with 2 cases (native `Send SEI`, ERC20 `Send SEI ERC20 USDC`), matching vultisig-sdk#2148's fixture shape/payloads. The native-send `expected_image_hash` (`09d6110c...`) is cross-checked against vultisig-android PR #5677's `evm-chain-matrix.json` entry, which computed the identical hash for the same payload — the ERC20 case has no second-signer corroboration yet (same caveat already flagged in this file for the THORChain-memo Amino case).
- Registers `.sei` in `ChainHelperFixture` (`expectedCaseCount = 2`) with `testSeiFixture()`.
- Adds `.sei` to the EVM chain-type case in `computeDirectImageHashes` — Sei is already fully wired in the production signing path (`evm.swift`, `EvmService.swift`), this switch just hadn't caught up.

Fixes #5242 (Sei portion only — filed a follow-up comment on the issue about the stale filenames for the other 4 cases).

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

Test-only change: no production code touched, so none of the above apply.

## Parity

- Android: linked vultisig-android#5677 (source of the native-send hash; Android folded Sei into its `evm-chain-matrix.json` as 1 case rather than a standalone file)
- Windows + extension: n/a — test fixture only
- SDK: linked vultisig-sdk#2148 (source of both fixture payloads/hashes)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional context

Ran `swiftlint lint` (0 violations) and `xcodebuild test -only-testing:VultisigAppTests/ChainHelperTests` locally — all 34 tests pass, including `testSeiFixture`, `testAllRegisteredFixturesExecute`, and `testEveryBundledFixtureIsRegistered`.

## Agent Metadata
- **Agent**: Claude Code
- **Issue**: #5242
- **Confidence**: high
- **Needs human review for**: whether the SEI ERC20 USDC fixture's uncorroborated hash (only one signer has produced it) is acceptable to merge as-is, per this file's existing precedent for the THORChain-memo case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added golden-vector coverage for Sei transactions.
  * Added validation fixtures for native SEI and ERC20 USDC transfers.
  * Added EVM signing coverage and expected transaction image-hash checks for Sei.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->