### PR TITLE
fix(ton): jetton fee display shows 0.05 but attaches 0.08 TON

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keysign/Services/BlockChainSpecific.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/BlockChainSpecific.swift
@@ -105,8 +105,8 @@ enum BlockChainSpecific: Codable, Hashable {
                 return 0 // We should throw
             }
             return dynamicGas
-        case .Ton:
-            return TonHelper.defaultFee
+        case .Ton(_, _, _, _, let jettonAddress, _):
+            return jettonAddress.isEmpty ? TonHelper.defaultFee : TonHelper.defaultJettonFee
         case .Ripple(_, let gas, _, _, _):
             return gas.description.toBigInt()
         case .Tron(_, _, _, _, _, _, _, _, let gasFeeEstimation):

--- a/VultisigApp/VultisigAppTests/Keysign/TonJettonFeeTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/TonJettonFeeTests.swift
@@ -1,0 +1,41 @@
+//
+//  TonJettonFeeTests.swift
+//  VultisigAppTests
+//
+//  A jetton transfer attaches TonHelper.defaultJettonFee, not the native
+//  defaultFee, so the fee display (which reads BlockChainSpecific.gas/.fee)
+//  must branch on jettonAddress or it under-tells the cost on every jetton send.
+//
+
+import BigInt
+import XCTest
+@testable import VultisigApp
+
+final class TonJettonFeeTests: XCTestCase {
+
+    func testNativeTonGasUsesDefaultFee() {
+        let specific = BlockChainSpecific.Ton(
+            sequenceNumber: 1,
+            expireAt: 0,
+            bounceable: true,
+            sendMaxAmount: false,
+            jettonAddress: "",
+            isActiveDestination: true
+        )
+        XCTAssertEqual(specific.gas, TonHelper.defaultFee)
+        XCTAssertEqual(specific.fee, TonHelper.defaultFee)
+    }
+
+    func testJettonTonGasUsesDefaultJettonFee() {
+        let specific = BlockChainSpecific.Ton(
+            sequenceNumber: 1,
+            expireAt: 0,
+            bounceable: true,
+            sendMaxAmount: false,
+            jettonAddress: "EQD-jettonWalletAddressPlaceholder",
+            isActiveDestination: true
+        )
+        XCTAssertEqual(specific.gas, TonHelper.defaultJettonFee)
+        XCTAssertEqual(specific.fee, TonHelper.defaultJettonFee)
+    }
+}


### PR DESCRIPTION
## Summary
`BlockChainSpecific.gas` returned `TonHelper.defaultFee` (0.05 TON) for every `.Ton` payload, but a jetton send attaches `TonHelper.defaultJettonFee` (0.08 TON, `Ton.swift`). The Verify/keysign fee display (which reads `chainSpecific.gas`) therefore under-told the cost by 0.03 TON on every jetton transfer.

Branch the `.Ton` case on `jettonAddress`: empty → native 0.05 TON, non-empty → jetton 0.08 TON. `fee` delegates to `gas` for `.Ton`, so both display sources are corrected at once.

## Cross-platform safety
Display-only — does not change any signed bytes or payload fields.

## Tests
`TonJettonFeeTests` covers both branches (native + jetton) for `.gas` and `.fee`.

## Verification
Part of the TON S1 hardening set (vultisig-sdk#2181). Verified in a combined local `make test` of all the S1 TON changes (6816 tests); the only failures were 6 pre-existing local snapshot-rendering flakes unrelated to these changes (main CI is green). Cross-model review: Codex (read-only) — no findings on this change.

Closes #5250


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected TON transaction fee calculation to distinguish between native TON and jetton transfers.
  * Native transfers now use the standard fee, while jetton transfers use the appropriate jetton fee.

* **Tests**
  * Added coverage validating gas and fee calculations for both native TON and jetton transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->