### PR TITLE
fix(ton): destination bounceability from tag byte; fix inverted isActiveDestination

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Ton/TonAddressBounceability.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/TonAddressBounceability.swift
@@ -1,0 +1,63 @@
+//
+//  TonAddressBounceability.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// A TON user-friendly address encodes bounce intent in the first byte of its
+/// base64url payload (the "flag" tag byte: 0x11 bounceable / 0x51
+/// non-bounceable on mainnet, +0x80 for testnet). A raw `workchain:hash`
+/// address carries no such byte, so it encodes no bounce intent at all.
+enum TonAddressBounceability {
+
+    private static let addressByteCount = 36
+    private static let nonBounceableFlagBit: UInt8 = 0x40
+    // 0x11/0x51 mainnet, 0x91/0xD1 testnet. A payload of the right length but
+    // any other tag is not a TON friendly address, so its intent is unknown.
+    private static let validTags: Set<UInt8> = [0x11, 0x51, 0x91, 0xD1]
+    private static let addressCharCount = 48
+    private static let urlSafeBase64Chars = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
+
+    /// The bounce flag encoded in a TON user-friendly address, or `nil` when the
+    /// address is raw or is not a canonical friendly address (wrong length,
+    /// non-URL-safe characters, bad tag, or bad checksum).
+    static func isBounceable(_ address: String) -> Bool? {
+        guard !address.contains(":"),
+              address.count == addressCharCount,
+              address.allSatisfy(urlSafeBase64Chars.contains),
+              let data = decodeBase64Url(address),
+              data.count == addressByteCount else {
+            return nil
+        }
+        let bytes = [UInt8](data)
+        guard validTags.contains(bytes[0]) else { return nil }
+        // Bytes 34-35 hold the CRC16-CCITT of the preceding 34; a mismatch means
+        // a corrupted address whose bounce intent can't be trusted.
+        let checksum = UInt16(bytes[34]) << 8 | UInt16(bytes[35])
+        guard crc16(bytes[0..<34]) == checksum else { return nil }
+        return (bytes[0] & nonBounceableFlagBit) == 0
+    }
+
+    private static func crc16(_ bytes: ArraySlice<UInt8>) -> UInt16 {
+        var crc: UInt16 = 0
+        for byte in bytes {
+            crc ^= UInt16(byte) << 8
+            for _ in 0..<8 {
+                crc = (crc & 0x8000) != 0 ? (crc << 1) ^ 0x1021 : crc << 1
+            }
+        }
+        return crc
+    }
+
+    private static func decodeBase64Url(_ string: String) -> Data? {
+        var base64 = string
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = base64.count % 4
+        if remainder > 0 {
+            base64 += String(repeating: "=", count: 4 - remainder)
+        }
+        return Data(base64Encoded: base64)
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
@@ -1027,18 +1027,31 @@ private extension BlockChainService {
 
         case .ton:
             let (seqno, expireAt) = try await ton.getSpecificTransactionInfo(coin)
+            let isSwap = action == .swap
 
-            // Determine if address is bounceable
-            var isBounceable = false
-            if let toAddress = toAddress, !toAddress.isEmpty {
-                // Check if destination wallet is uninitialized
+            let isBounceable: Bool
+            let isActiveDestination: Bool
+            if isSwap {
+                // iOS passes no toAddress for swaps; the deposit lands on a
+                // contract, so force bounceable — a rejection then refunds
+                // instead of the contract absorbing funds it can't process.
+                isBounceable = true
+                isActiveDestination = true
+            } else if let toAddress = toAddress, !toAddress.isEmpty {
                 let walletState = try await ton.getWalletState(toAddress)
-                let isUninitialized = walletState == TON_WALLET_STATE_UNINITIALIZED
-
-                // If wallet is initialized and address starts with "E", it's bounceable
-                if !isUninitialized && toAddress.starts(with: "E") {
-                    isBounceable = true
+                let isInitialized = walletState != TON_WALLET_STATE_UNINITIALIZED
+                if isInitialized {
+                    // Raw/unparseable addresses carry no bounce flag; default
+                    // to bounceable since an initialized account can safely reject.
+                    isBounceable = TonAddressBounceability.isBounceable(toAddress) ?? true
+                } else {
+                    // Not-yet-deployed accounts are only reachable non-bounceable.
+                    isBounceable = false
                 }
+                isActiveDestination = isInitialized
+            } else {
+                isBounceable = false
+                isActiveDestination = false
             }
 
             // For jettons we must send to the SENDER's jetton wallet, never the
@@ -1051,7 +1064,7 @@ private extension BlockChainService {
                 }
                 senderJettonWallet = resolved
             }
-            return .Ton(sequenceNumber: seqno, expireAt: expireAt, bounceable: isBounceable, sendMaxAmount: sendMaxAmount, jettonAddress: senderJettonWallet, isActiveDestination: !isBounceable)
+            return .Ton(sequenceNumber: seqno, expireAt: expireAt, bounceable: isBounceable, sendMaxAmount: sendMaxAmount, jettonAddress: senderJettonWallet, isActiveDestination: isActiveDestination)
         case .ripple:
 
             async let accountTask = ripple.fetchAccountsInfo(for: coin.address)

--- a/VultisigApp/VultisigAppTests/Chains/TonAddressBounceabilityTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/TonAddressBounceabilityTests.swift
@@ -1,0 +1,66 @@
+//
+//  TonAddressBounceabilityTests.swift
+//  VultisigApp
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class TonAddressBounceabilityTests: XCTestCase {
+    // Same underlying account (workchain 0, hash from a real mainnet address
+    // used elsewhere in the test suite), re-encoded with each bounce/network
+    // flag combination so the four cases are directly comparable.
+    private let bounceableMainnet = "EQCIcjES4cQET0z6nRixZ0MdvTB4u3_8triztLSrIIrDkpgJ"
+    private let nonBounceableMainnet = "UQCIcjES4cQET0z6nRixZ0MdvTB4u3_8triztLSrIIrDksXM"
+    private let bounceableTestnet = "kQCIcjES4cQET0z6nRixZ0MdvTB4u3_8triztLSrIIrDkiOD"
+    private let nonBounceableTestnet = "0QCIcjES4cQET0z6nRixZ0MdvTB4u3_8triztLSrIIrDkn5G"
+    private let rawAddress = "0:88723112e1c4044f4cfa9d18b167431dbd3078bb7ffcb6b8b3b4b4ab208ac392"
+
+    func testBounceableMainnetAddressReturnsTrue() {
+        XCTAssertEqual(TonAddressBounceability.isBounceable(bounceableMainnet), true)
+    }
+
+    func testNonBounceableMainnetAddressReturnsFalse() {
+        XCTAssertEqual(TonAddressBounceability.isBounceable(nonBounceableMainnet), false)
+    }
+
+    func testBounceableTestnetAddressReturnsTrue() {
+        XCTAssertEqual(TonAddressBounceability.isBounceable(bounceableTestnet), true)
+    }
+
+    func testNonBounceableTestnetAddressReturnsFalse() {
+        XCTAssertEqual(TonAddressBounceability.isBounceable(nonBounceableTestnet), false)
+    }
+
+    func testRawAddressReturnsNil() {
+        XCTAssertNil(TonAddressBounceability.isBounceable(rawAddress))
+    }
+
+    func testGarbageAddressReturnsNil() {
+        XCTAssertNil(TonAddressBounceability.isBounceable("garbage"))
+    }
+
+    func testEmptyAddressReturnsNil() {
+        XCTAssertNil(TonAddressBounceability.isBounceable(""))
+    }
+
+    func testValidLengthButIllegalTagReturnsNil() {
+        // Right length, but a tag byte outside the four legal TON tags: intent
+        // is unknown, not non-bounceable.
+        let bytes = Data([UInt8](repeating: 0x00, count: 36))
+        XCTAssertNil(TonAddressBounceability.isBounceable(bytes.base64EncodedString()))
+    }
+
+    func testMutatedChecksumReturnsNil() {
+        // A valid address with its final checksum byte flipped must not be trusted.
+        let mutated = String(bounceableMainnet.dropLast()) + "K"
+        XCTAssertNil(TonAddressBounceability.isBounceable(mutated))
+    }
+
+    func testNonCanonicalBase64ReturnsNil() {
+        // The same bytes in standard (non-URL-safe) Base64 is not a canonical
+        // TON friendly address.
+        let standard = bounceableMainnet.replacingOccurrences(of: "_", with: "/")
+        XCTAssertNil(TonAddressBounceability.isBounceable(standard))
+    }
+}


### PR DESCRIPTION
## Summary
Fixes two defects that share one code path — the `.ton` case of `BlockChainService.fetchSpecific`.

**#5248 — bounceability decided by address prefix.** Bounceability was set only when the destination `starts(with: "E")`, so UQ / raw / swap-deposit destinations always went out non-bounceable; a rejecting contract then *absorbs* the transfer instead of refunding it.
- New `TonAddressBounceability` helper decodes the actual bounce **tag byte** from a user-friendly address (mainnet/testnet, bounceable/non-bounceable), returning `nil` for raw or non-canonical inputs.
- Swap deposits go to a contract (and carry no `toAddress`), so they are forced bounceable — mirroring the SDK staking path, so a rejection refunds rather than absorbs.
- Direct sends: honour the address's own flag when the destination is initialized (raw/no-flag initialized → default bounceable); an uninitialized destination stays non-bounceable, which is required to fund a not-yet-deployed recipient wallet.

**#5251 — `isActiveDestination` inverted.** It was set to `!isBounceable`, so an uninitialized destination reported active. It is now derived from the account state (`!= uninit`), matching Android's reference computation (`BlockChainSpecificRepository.kt`). iOS never reads this field, but co-signing devices do (Android uses it for the jetton forward amount).

## Cross-platform safety
Safe to ship independently: `bounceable` and `isActiveDestination` travel **inside** the `KeysignPayload` — computed once by the initiator and read verbatim by co-signers — so this does not change the recomputed signing hash on any peer.

## Maintainer review (HIGH-tier crypto)
Behaviour changes to confirm: raw/initialized destinations now default bounceable (were non-bounceable); UQ addresses now go out non-bounceable per their own flag; swap deposits are forced bounceable.

## Cross-model review (Codex, read-only) — ledger
- **Uninit → non-bounceable (HIGH):** rejected — standard behaviour for funding an undeployed recipient wallet, and matches Android; bounceable-to-uninit would bounce and never arrive.
- **`!= uninit` classification (MED):** rejected — matches Android's own computation verbatim; iOS diverging would desync the co-signer that reads the field.
- **Helper trusted any 36-byte tag (MED):** fixed — helper now accepts only the four legal TON tags (`0x11/0x51/0x91/0xD1`), else `nil`.
- **Decision matrix untested (LOW):** deferred — the network-dependent branch needs a DI seam; the pure tag decoder is table-tested.

## Tests
`TonAddressBounceabilityTests` covers all four tag forms, raw, empty, garbage, and non-canonical-tag inputs.

## Verification
Part of the TON S1 hardening set (vultisig-sdk#2181). Verified in a combined local `make test` of all the S1 TON changes (6816 tests); the only failures were 6 pre-existing local snapshot-rendering flakes unrelated to these changes (main CI is green).

Closes #5248
Closes #5251


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TON transaction handling by independently determining address bounceability and destination activity.
  * Swaps now consistently use bounceable transactions and active destinations.
  * Transfers to initialized, uninitialized, or missing destinations now use appropriate bounceability and activity states.
  * Added validation for TON user-friendly addresses, including encoding, tags, length, and checksum integrity.
  * Invalid, raw, malformed, non-canonical, or unsupported addresses are safely rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->