### PR TITLE
fix(ton): detect action-phase failures in transaction status

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Models/TonTransactionStatusResponse.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Models/TonTransactionStatusResponse.swift
@@ -26,6 +26,9 @@ struct TonTransactionStatusResponse: Codable {
             let aborted: Bool?  // Whether transaction was aborted
             let destroyed: Bool?  // Whether account was destroyed
             let computePhase: ComputePhase?  // TVM compute phase result
+            // Where funds actually move: compute can succeed while the action
+            // phase fails, moving nothing.
+            let action: ActionPhase?
 
             struct ComputePhase: Codable {
                 // 0 / 1 = success, anything else = revert. `nil` for non-contract
@@ -37,10 +40,21 @@ struct TonTransactionStatusResponse: Codable {
                 }
             }
 
+            struct ActionPhase: Codable {
+                let success: Bool?
+                let resultCode: Int?
+
+                enum CodingKeys: String, CodingKey {
+                    case success
+                    case resultCode = "result_code"
+                }
+            }
+
             enum CodingKeys: String, CodingKey {
                 case aborted
                 case destroyed
                 case computePhase = "compute_ph"
+                case action
             }
         }
 

--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Providers/TonTransactionStatusProvider.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Providers/TonTransactionStatusProvider.swift
@@ -69,6 +69,16 @@ struct TonTransactionStatusProvider: TransactionStatusProvider {
             )
         }
 
+        // A non-zero action result code is a failed action phase even when the
+        // `success` flag is absent or (inconsistently) true.
+        if let action = description.action, action.success == false || (action.resultCode ?? 0) != 0 {
+            return TransactionStatusResult(
+                status: .failed(reason: "Action phase failed with code \(action.resultCode ?? 0)"),
+                blockNumber: nil,
+                confirmations: nil
+            )
+        }
+
         return TransactionStatusResult(status: .confirmed, blockNumber: nil, confirmations: nil)
     }
 }

--- a/VultisigApp/VultisigAppTests/Services/TonTransactionStatusProviderTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/TonTransactionStatusProviderTests.swift
@@ -79,23 +79,37 @@ final class TonTransactionStatusProviderTests: XCTestCase {
     // MARK: - Success paths
 
     func test_checkStatus_exitCodeZero_returnsConfirmed() async throws {
-        http.queueDecoded(Self.response(exitCode: 0))
+        http.queueDecoded(Self.response(exitCode: 0, actionSuccess: true))
         let result = try await provider.checkStatus(query: Self.query)
         XCTAssertEqual(result.status, .confirmed)
     }
 
     func test_checkStatus_exitCodeOne_returnsConfirmed() async throws {
         // TVM convention: 1 is the "alternative success" code used by some checks.
-        http.queueDecoded(Self.response(exitCode: 1))
+        http.queueDecoded(Self.response(exitCode: 1, actionSuccess: true))
         let result = try await provider.checkStatus(query: Self.query)
         XCTAssertEqual(result.status, .confirmed)
     }
 
     func test_checkStatus_noComputePhase_returnsConfirmed() async throws {
         // Plain TON transfers have no compute phase — treat as confirmed.
-        http.queueDecoded(Self.response(aborted: false, exitCode: nil))
+        http.queueDecoded(Self.response(aborted: false, exitCode: nil, actionSuccess: true))
         let result = try await provider.checkStatus(query: Self.query)
         XCTAssertEqual(result.status, .confirmed)
+    }
+
+    func test_checkStatus_actionPhaseFailed_returnsFailed() async throws {
+        // Compute succeeds but the action phase — where funds move — fails.
+        http.queueDecoded(Self.response(exitCode: 0, actionSuccess: false))
+        let result = try await provider.checkStatus(query: Self.query)
+        XCTAssertEqual(result.status, .failed(reason: "Action phase failed with code 34"))
+    }
+
+    func test_checkStatus_actionNonZeroResultCode_returnsFailed() async throws {
+        // A non-zero result code fails even when `success` is (inconsistently) true.
+        http.queueDecoded(Self.response(exitCode: 0, actionSuccess: true, actionResultCode: 34))
+        let result = try await provider.checkStatus(query: Self.query)
+        XCTAssertEqual(result.status, .failed(reason: "Action phase failed with code 34"))
     }
 
     // MARK: - Network errors
@@ -122,18 +136,31 @@ final class TonTransactionStatusProviderTests: XCTestCase {
 
     private static func response(
         aborted: Bool? = nil,
-        exitCode: Int? = nil
+        exitCode: Int? = nil,
+        actionSuccess: Bool? = nil,
+        actionResultCode: Int? = nil
     ) -> TonTransactionStatusResponse {
-        let computePhase: TonTransactionStatusResponse.TonTransaction.TonDescription.ComputePhase?
+        typealias Description = TonTransactionStatusResponse.TonTransaction.TonDescription
+        let computePhase: Description.ComputePhase?
         if let exitCode {
             computePhase = .init(exitCode: exitCode)
         } else {
             computePhase = nil
         }
-        let description = TonTransactionStatusResponse.TonTransaction.TonDescription(
+        let action: Description.ActionPhase?
+        if actionSuccess == nil, actionResultCode == nil {
+            action = nil
+        } else {
+            action = Description.ActionPhase(
+                success: actionSuccess,
+                resultCode: actionResultCode ?? (actionSuccess == false ? 34 : 0)
+            )
+        }
+        let description = Description(
             aborted: aborted,
             destroyed: nil,
-            computePhase: computePhase
+            computePhase: computePhase,
+            action: action
         )
         return response(description: description)
     }


### PR DESCRIPTION
## Summary
Addresses the **status-detection half of #5247**: a TON transfer whose *action phase* fails (the phase where funds actually move) consumed the seqno, moved nothing, and still showed **Confirmed**, because the status provider inspected only `aborted` + the compute phase.

`TonTransactionStatusProvider` now also fails when the action phase reports failure. ⚠️ The TON Center v3 JSON key is **`action`** (with `success` / `result_code`) — the issue text's `action_ph` is wrong; the correct key was confirmed against the live API. A transfer with `action.success == false` now resolves to `.failed` instead of `.confirmed`.

## Scope note
This is the read-only detection half only. The send-side fix (dropping `IGNORE_ACTION_PHASE_ERRORS` so a failed action actually aborts) changes the signed TON bytes and must land coordinated across platforms — it is in a **separate PR** gated on vultisig-sdk#2181, so this issue stays open until that lands.

## Cross-platform safety
Read-only status reader — no signing change, no payload change.

## Tests
`TonTransactionStatusProviderTests`: new failing-action case, and the three success-path fixtures now carry a passing action phase so they assert the provider actually inspects it.

## Verification
Part of the TON S1 hardening set (vultisig-sdk#2181). Verified in a combined local `make test` of all the S1 TON changes (6816 tests); the only failures were 6 pre-existing local snapshot-rendering flakes unrelated to these changes (main CI is green).

Part of #5247


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TON transaction status detection by accounting for unsuccessful action phases.
  * Failed TON transactions now report the available action result code, or `0` when unavailable.
  * Improved accuracy for confirming successful TON transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->