### PR TITLE
feat(home): support permanent banner dismissal

### DIFF
--- a/VultisigApp/VultisigApp/Core/Stores/PromoBannerDismissalStore.swift
+++ b/VultisigApp/VultisigApp/Core/Stores/PromoBannerDismissalStore.swift
@@ -13,8 +13,9 @@ import Foundation
 ///
 /// Two backends, chosen per banner by `BannerDismissalRule`:
 ///
-/// - **TTL banners** persist `dismissalID -> dismissedAt` as JSON in
-///   `UserDefaults`. `isDismissed` is true while `now < dismissedAt + interval`.
+/// - **Permanent and TTL banners** persist `dismissalID -> dismissedAt` as JSON
+///   in `UserDefaults`. Permanent rules treat the record as never-expiring;
+///   TTL rules honor it while `now < dismissedAt + interval`.
 /// - **Session banners** (the backup reminder) route into an in-memory set that
 ///   is never persisted. It starts empty every cold launch, so the banner
 ///   reappears on the next launch while it is still eligible. Hidden for the
@@ -35,18 +36,29 @@ final class PromoBannerDismissalStore: PromoBannerDismissalStoring, @unchecked S
 
     private let defaults: UserDefaults
     private let storageKey: String
+    /// Policy resolution is injected so a future campaign-policy source can
+    /// override the centralized `VaultBannerType.dismissalRule` fallback
+    /// without moving assignments into the carousel or changing persistence.
+    private let ruleProvider: (VaultBannerType) -> BannerDismissalRule
     private let lock = NSLock()
     /// In-memory, process-scoped dismissals for `.session`-ruled banners. Never
     /// written to `defaults`, so it resets on every cold launch.
     private var sessionDismissed: Set<String> = []
 
-    init(defaults: UserDefaults = .standard, storageKey: String = "promoBannerDismissals") {
+    init(
+        defaults: UserDefaults = .standard,
+        storageKey: String = "promoBannerDismissals",
+        ruleProvider: @escaping (VaultBannerType) -> BannerDismissalRule = { $0.dismissalRule }
+    ) {
         self.defaults = defaults
         self.storageKey = storageKey
+        self.ruleProvider = ruleProvider
     }
 
     func isDismissed(_ banner: VaultBannerType, now: Date) -> Bool {
-        switch banner.dismissalRule {
+        switch ruleProvider(banner) {
+        case .permanent:
+            return persistentDismissals()[banner.dismissalID] != nil
         case .session:
             lock.lock()
             defer { lock.unlock() }
@@ -60,12 +72,12 @@ final class PromoBannerDismissalStore: PromoBannerDismissalStoring, @unchecked S
     }
 
     func dismiss(_ banner: VaultBannerType, now: Date) {
-        switch banner.dismissalRule {
+        switch ruleProvider(banner) {
         case .session:
             lock.lock()
             sessionDismissed.insert(banner.dismissalID)
             lock.unlock()
-        case .ttl:
+        case .permanent, .ttl:
             mutatePersistentDismissals { dict in
                 dict[banner.dismissalID] = now
             }
@@ -73,9 +85,10 @@ final class PromoBannerDismissalStore: PromoBannerDismissalStoring, @unchecked S
     }
 
     func migrateLegacyDismissals(legacyAppBanners: [String], legacyVaultBanners: [String], now: Date) {
-        // Only TTL banners carry over. The backup reminder is session-scoped:
-        // per product it should resurface each session while backup is missing,
-        // so its legacy permanent dismissal is intentionally dropped.
+        // Only persistently dismissed banners carry over. The backup reminder
+        // is session-scoped: per product it should resurface each session while
+        // backup is missing, so its legacy permanent dismissal is intentionally
+        // dropped.
         for banner in VaultBannerType.allCases {
             let legacySources: [String]
             switch banner {

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Model/VaultBannerType.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Model/VaultBannerType.swift
@@ -109,6 +109,10 @@ enum VaultBannerType: String, CarouselBannerType, CaseIterable {
 
 /// Per-banner rule governing how long a dismissal suppresses a promo banner.
 enum BannerDismissalRule: Equatable {
+    /// Suppressed forever on this device. Backed by the same persistent,
+    /// app-wide record as TTL dismissals, but the stored timestamp is treated
+    /// only as evidence that the banner was dismissed and never expires.
+    case permanent
     /// Suppressed until `dismissedAt + interval`; reappears once the interval
     /// elapses. Backed by persistent (per-device) storage.
     case ttl(TimeInterval)

--- a/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
@@ -586,6 +586,30 @@ final class VaultDetailViewModelTests: XCTestCase {
         }
     }
 
+    /// A permanent dismissal shares the app-wide persistent store with TTL
+    /// rules, but never consults the timestamp for expiry. A new store instance
+    /// models a cold launch, and a second vault proves the record is not scoped
+    /// to the vault that originated it.
+    func testPermanentRule_staysHiddenAcrossVaultsAndColdLaunches() {
+        let defaults = makeDefaults()
+        let permanentRule: (VaultBannerType) -> BannerDismissalRule = { banner in
+            banner == .buyVult ? .permanent : banner.dismissalRule
+        }
+        let session1 = makeStore(defaults: defaults, ruleProvider: permanentRule)
+        let logic = VaultDetailLogic()
+        let vaultA = makeVault(pubKey: "vault-a", chains: [.bitcoin])
+        let vaultB = makeVault(pubKey: "vault-b", chains: [.solana])
+
+        session1.dismiss(.buyVult, now: fixedNow)
+
+        XCTAssertTrue(session1.isDismissed(.buyVult, now: fixedNow.addingTimeInterval(.days(10_000))))
+        XCTAssertFalse(logic.setupBanners(for: vaultB, store: session1, now: fixedNow).contains(.buyVult))
+
+        let session2 = makeStore(defaults: defaults, ruleProvider: permanentRule)
+        XCTAssertTrue(session2.isDismissed(.buyVult, now: fixedNow.addingTimeInterval(.days(10_000))))
+        XCTAssertFalse(logic.setupBanners(for: vaultA, store: session2, now: fixedNow).contains(.buyVult))
+    }
+
     /// AC: an expired dismissal is ignored and the banner shows again
     /// (eligibility permitting).
     func testExpiredDismissal_showsBannerAgain() {
@@ -710,8 +734,15 @@ final class VaultDetailViewModelTests: XCTestCase {
         return defaults
     }
 
-    private func makeStore(defaults: UserDefaults? = nil) -> PromoBannerDismissalStore {
-        PromoBannerDismissalStore(defaults: defaults ?? makeDefaults(), storageKey: "promoBannerDismissals")
+    private func makeStore(
+        defaults: UserDefaults? = nil,
+        ruleProvider: @escaping (VaultBannerType) -> BannerDismissalRule = { $0.dismissalRule }
+    ) -> PromoBannerDismissalStore {
+        PromoBannerDismissalStore(
+            defaults: defaults ?? makeDefaults(),
+            storageKey: "promoBannerDismissals",
+            ruleProvider: ruleProvider
+        )
     }
 
     /// Build a Vault populated with native coins for the requested chains.


### PR DESCRIPTION
## Summary

- add a permanent/never-return banner dismissal rule alongside TTL and session rules
- persist permanent dismissals globally in the existing dismissal store and never expire them
- keep current per-banner TTL/session assignments centralized in `VaultBannerType.dismissalRule`
- inject policy resolution into the store so a future campaign-policy source can override the local fallback without changing carousel or persistence code
- preserve legacy migration and session-reset behavior

## Remote-policy context

Notification #33 explicitly kept home banners outside the notification system, and notification #34 closed without defining a payload or API. This PR therefore retains the requested hardcoded fallback and provides the integration seam; it does not invent a client-only remote contract.

## Verification

- focused dismissal tests: 33 passed, 0 failed
- permanent dismissal verified across vaults and fresh store instances
- existing TTL expiry and cold-launch session reset tests remain green
- full `make test`: 6,806 tests, 11 skipped, 0 failures
- direct generic simulator build: passed
- SwiftLint on changed files: 0 violations

Fixes #5238

## Agent Metadata

- **Agent**: Codex
- **Issue**: #5238
- **Confidence**: medium
- **Needs human review for**: upstream remote-policy contract remains unavailable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Permanently dismissed banners now remain hidden across vaults, extended time periods, and app sessions.
  * Improved handling of banner dismissal persistence during legacy data migration.
  * Session-only banner dismissals continue to reset as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->