### PR TITLE
fix(coin-detail): dismiss expanded sheet on pull-down

### DIFF
--- a/VultisigApp/VultisigApp/Features/Wallet/CoinDetail/CoinDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/CoinDetail/CoinDetailScreen.swift
@@ -20,6 +20,7 @@ struct CoinDetailScreen: View {
     /// Where the sheet is resting. Purely presentation state — it never leaves
     /// the view, so it stays here rather than in the view model.
     @State private var detent: PresentationDetent = CoinDetailScreen.initialDetent
+    @State private var hasExpanded = false
 
     @StateObject var viewModel: CoinDetailViewModel
 
@@ -72,10 +73,11 @@ struct CoinDetailScreen: View {
         !isIPadOS && !isMacOS
     }
 
-    /// `.large` stays in the set alongside the partial height so one drag still
-    /// reveals the chart and the market sections.
-    private static var detents: Set<PresentationDetent> {
-        supportsPartialDetent ? [.fraction(partialFraction), .large] : [.large]
+    /// Both detents are available for the first expansion. Once expanded, the
+    /// partial detent is removed so the next pull-down dismisses the sheet
+    /// instead of collapsing it back to its initial resting height.
+    private var detents: Set<PresentationDetent> {
+        Self.supportsPartialDetent && !hasExpanded ? [.fraction(Self.partialFraction), .large] : [.large]
     }
 
     private static var initialDetent: PresentationDetent {
@@ -121,6 +123,10 @@ struct CoinDetailScreen: View {
                 .onChange(of: isPartial) { _, isNowPartial in
                     guard isNowPartial else { return }
                     proxy.scrollTo(Self.topAnchor, anchor: .top)
+                }
+                .onChange(of: detent) { _, newDetent in
+                    guard newDetent == .large else { return }
+                    hasExpanded = true
                 }
         }
     }
@@ -170,10 +176,7 @@ struct CoinDetailScreen: View {
             .showIf(showContractCopiedBanner)
             .zIndex(2)
         )
-        .refreshable {
-            await refresh()
-        }
-        .presentationDetents(Self.detents, selection: $detent)
+        .presentationDetents(detents, selection: $detent)
         .presentationBackground(Theme.colors.bgSurface1)
         .presentationDragIndicator(.visible)
         .background(Theme.colors.bgSurface1)


### PR DESCRIPTION
## Description

Remove pull-to-refresh from the iPhone coin-detail sheet so a downward gesture can dismiss it instead of starting a balance refresh.

Keep the 50% detent for the initial presentation. Once the sheet reaches `.large`, remove the partial detent so the next downward gesture dismisses the sheet rather than collapsing it back to 50%.

Initial loading through `onAppear`, the macOS refresh toolbar button, and Home/Chain Detail pull-to-refresh remain unchanged.

Fixes #5243

## Which feature is affected?

- [ ] Create vault (Secure / Fast)
- [ ] Sending
- [ ] Swap
- [ ] New Chain / Chain related feature
- [x] Wallet / Coin Detail

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

Runtime acceptance was verified directly on iPhone 17 Pro Max / iOS 26.5:

- Sheet initially presented at the half-screen detent.
- After expansion, the native sheet grabber changed its next action from expand to dismiss, confirming no intermediate 50% stop remained.
- Native dismissal returned directly to Chain Detail with no refresh control or spinner.

Full gate: 6,805 tests executed, 11 skipped, 0 failures. Changed-file SwiftLint: 0 violations.

## Screenshots (if applicable)

Not applicable; this changes sheet interaction without changing its visual design.

## Additional context

The first full-suite run had an unrelated signal-kill in `QBTCClaimSecureVaultRoundDriverTests.testRunBtcRoundDoesNotReKickoff()`. A complete rerun passed cleanly. Cross-model Claude review was intentionally skipped at the author's request.

## Agent Metadata (if applicable)

- **Agent**: Codex
- **Issue**: #5243
- **Confidence**: high
- **Needs human review for**: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved the coin detail sheet’s expansion behavior.
  * The sheet now initially supports partial and full-height views, then remains expanded after being opened fully.
  * Updated presentation behavior for supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->