### PR TITLE
fix(solana): reject off-curve recipients

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleDestinationReserveValidator.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleDestinationReserveValidator.swift
@@ -37,7 +37,7 @@ struct RippleDestinationReserveValidator: SendAmountValidator {
         input.chain == .ripple
             && input.isNativeToken
             && !input.toAddress.isEmpty
-            && AddressService.validateAddress(address: input.toAddress, chain: input.chain)
+            && AddressService.validateRecipientAddress(address: input.toAddress, chain: input.chain)
             && !input.amount.isEmpty
             && !input.amountDecimal.isZero
     }

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Models/SolanaProgramDerivedAddress.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Models/SolanaProgramDerivedAddress.swift
@@ -58,6 +58,12 @@ enum SolanaProgramDerivedAddress {
 
     private static let fieldModulus = BigInt(2).power(255) - 19
 
+    /// Whether a base58 Solana address is an ordinary ed25519 public key.
+    static func isOnEd25519Curve(_ address: String) -> Bool {
+        guard let bytes = Base58.decodeNoCheck(string: address) else { return false }
+        return isOnEd25519Curve(bytes)
+    }
+
     /// Whether these 32 bytes decompress to a point on the ed25519 curve — i.e.
     /// whether they are a possible public key rather than a program address.
     ///

--- a/VultisigApp/VultisigApp/Components/Validators/AddressValidator.swift
+++ b/VultisigApp/VultisigApp/Components/Validators/AddressValidator.swift
@@ -10,7 +10,7 @@ struct AddressValidator: FormFieldValidator {
 
     func validate(value: String) throws {
         guard value.isNotEmpty else { return }
-        guard AddressService.validateAddress(address: value, chain: chain) else {
+        guard AddressService.validateRecipientAddress(address: value, chain: chain) else {
             throw HelperError.runtimeError("validAddressError".localized)
         }
     }

--- a/VultisigApp/VultisigApp/Core/Services/AddressService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/AddressService.swift
@@ -67,9 +67,9 @@ struct AddressService {
 
         // Iterate through all WalletCore CoinTypes to find matching address
         for coinType in CoinType.allCases {
-            guard coinType.validate(address: address) else { continue }
             // Map CoinType to Vultisig Chain
             guard let chain = Chain.allCases.first(where: { $0.coinType == coinType }) else { continue }
+            guard validateAddress(address: address, chain: chain) else { continue }
             // Only return if chain exists in vault with native token
             if vault.coins.contains(where: { $0.chain == chain && $0.isNativeToken }) {
                 return chain
@@ -137,7 +137,7 @@ struct AddressService {
             }
         }
 
-        if chain.coinType.validate(address: input) {
+        if validateAddress(address: input, chain: chain) {
             return input
         }
 
@@ -172,6 +172,11 @@ struct AddressService {
 
         if chain == .bittensor {
             return BittensorHelper.isValidAddress(address)
+        }
+
+        if chain == .solana {
+            return chain.coinType.validate(address: address)
+                && SolanaProgramDerivedAddress.isOnEd25519Curve(address)
         }
 
         return chain.coinType.validate(address: address)

--- a/VultisigApp/VultisigApp/Core/Services/AddressService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/AddressService.swift
@@ -15,7 +15,7 @@ struct AddressService {
     /// Returns the detected chain if found and it exists in the vault, or nil otherwise
     static func detectChain(from address: String, vault: Vault, currentChain: Chain) -> Chain? {
         // First check if address is valid for current chain
-        if validateAddress(address: address, chain: currentChain) {
+        if validateRecipientAddress(address: address, chain: currentChain) {
             return nil // Already on correct chain
         }
 
@@ -69,7 +69,7 @@ struct AddressService {
         for coinType in CoinType.allCases {
             // Map CoinType to Vultisig Chain
             guard let chain = Chain.allCases.first(where: { $0.coinType == coinType }) else { continue }
-            guard validateAddress(address: address, chain: chain) else { continue }
+            guard validateRecipientAddress(address: address, chain: chain) else { continue }
             // Only return if chain exists in vault with native token
             if vault.coins.contains(where: { $0.chain == chain && $0.isNativeToken }) {
                 return chain
@@ -137,7 +137,7 @@ struct AddressService {
             }
         }
 
-        if validateAddress(address: input, chain: chain) {
+        if validateRecipientAddress(address: input, chain: chain) {
             return input
         }
 
@@ -174,12 +174,13 @@ struct AddressService {
             return BittensorHelper.isValidAddress(address)
         }
 
-        if chain == .solana {
-            return chain.coinType.validate(address: address)
-                && SolanaProgramDerivedAddress.isOnEd25519Curve(address)
-        }
-
         return chain.coinType.validate(address: address)
+    }
+
+    static func validateRecipientAddress(address: String, chain: Chain) -> Bool {
+        guard validateAddress(address: address, chain: chain) else { return false }
+        guard chain == .solana else { return true }
+        return SolanaProgramDerivedAddress.isOnEd25519Curve(address)
     }
 
 }
@@ -192,7 +193,7 @@ private extension AddressService {
 
     static func resolveAndValidate(_ resolution: @autoclosure () async throws -> String, chain: Chain) async throws -> String {
         let resolved = try await resolution()
-        guard validateAddress(address: resolved, chain: chain) else {
+        guard validateRecipientAddress(address: resolved, chain: chain) else {
             throw Errors.invalidAddress
         }
         return resolved

--- a/VultisigApp/VultisigApp/Core/Services/AddressService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/AddressService.swift
@@ -185,11 +185,14 @@ struct AddressService {
 
 }
 
-private extension AddressService {
+extension AddressService {
 
-    enum Errors: Error {
+    enum Errors: Error, Equatable {
         case invalidAddress
     }
+}
+
+private extension AddressService {
 
     static func resolveAndValidate(_ resolution: @autoclosure () async throws -> String, chain: Chain) async throws -> String {
         let resolved = try await resolution()

--- a/VultisigApp/VultisigApp/Features/AddressBook/Views/AddAddressBookScreen.swift
+++ b/VultisigApp/VultisigApp/Features/AddressBook/Views/AddAddressBookScreen.swift
@@ -115,7 +115,7 @@ struct AddAddressBookScreen: View {
             return
         }
 
-        guard AddressService.validateAddress(address: address, chain: selectedChain.chain) else {
+        guard AddressService.validateRecipientAddress(address: address, chain: selectedChain.chain) else {
             toggleAlertInvalidAddress()
             return
         }

--- a/VultisigApp/VultisigApp/Features/AddressBook/Views/EditAddressBookScreen.swift
+++ b/VultisigApp/VultisigApp/Features/AddressBook/Views/EditAddressBookScreen.swift
@@ -103,7 +103,7 @@ struct EditAddressBookScreen: View {
             return
         }
 
-        guard AddressService.validateAddress(address: address, chain: selectedChain.chain) else {
+        guard AddressService.validateRecipientAddress(address: address, chain: selectedChain.chain) else {
             toggleAlertInvalidAddress()
             return
         }

--- a/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
@@ -571,7 +571,7 @@ extension HomeScreen {
                     break
                 }
             } else {
-                let isValid = chain.coinType.validate(address: address)
+                let isValid = AddressService.validateRecipientAddress(address: address, chain: chain)
                 if isValid {
                     chainToUse = chain
                     break

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -552,7 +552,7 @@ final class SendDetailsViewModel {
     /// definitive verdict.
     func markInvalidRecipientIfUnresolvable() {
         guard !toAddress.isEmpty else { return }
-        guard !AddressService.validateAddress(address: toAddress, chain: coin.chain) else { return }
+        guard !AddressService.validateRecipientAddress(address: toAddress, chain: coin.chain) else { return }
         guard !toAddress.isENSNameService() else { return }
         let resolvesNames: Set<Chain> = [.thorChain, .thorChainChainnet, .thorChainStagenet]
         guard !resolvesNames.contains(coin.chain) else { return }
@@ -614,7 +614,7 @@ final class SendDetailsViewModel {
     func isValidAddressFormat() -> Bool {
         guard !toAddress.isEmpty else { return false }
         normalizeRippleXAddressIfNeeded()
-        let isValid = AddressService.validateAddress(address: toAddress, chain: coin.chain)
+        let isValid = AddressService.validateRecipientAddress(address: toAddress, chain: coin.chain)
         if isValid {
             showAddressAlert = false
             errorMessage = nil

--- a/VultisigApp/VultisigAppTests/Services/AddressServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/AddressServiceTests.swift
@@ -212,8 +212,10 @@ final class AddressServiceTests: XCTestCase {
         do {
             _ = try await AddressService.resolveInput(tokenAccount, chain: .solana)
             XCTFail("Expected an associated token account to be rejected as a recipient")
+        } catch let error as AddressService.Errors {
+            XCTAssertEqual(error, .invalidAddress)
         } catch {
-            // Expected: off-curve accounts are not wallet recipients.
+            XCTFail("Expected invalidAddress, got \(error)")
         }
     }
 

--- a/VultisigApp/VultisigAppTests/Services/AddressServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/AddressServiceTests.swift
@@ -191,13 +191,19 @@ final class AddressServiceTests: XCTestCase {
 
     func testSolanaWalletAddressValidates() {
         XCTAssertTrue(AddressService.validateAddress(address: solanaWalletAddress, chain: .solana))
+        XCTAssertTrue(AddressService.validateRecipientAddress(address: solanaWalletAddress, chain: .solana))
     }
 
     func testSolanaAssociatedTokenAccountIsRejectedEvenThoughWalletCoreAcceptsIt() throws {
         let tokenAccount = try makeSolanaAssociatedTokenAccount()
 
         XCTAssertTrue(Chain.solana.coinType.validate(address: tokenAccount))
-        XCTAssertFalse(AddressService.validateAddress(address: tokenAccount, chain: .solana))
+        XCTAssertTrue(AddressService.validateAddress(address: tokenAccount, chain: .solana))
+        XCTAssertFalse(AddressService.validateRecipientAddress(address: tokenAccount, chain: .solana))
+    }
+
+    func testSolanaMintStillPassesGenericAddressValidation() {
+        XCTAssertTrue(AddressService.validateAddress(address: solanaMintAddress, chain: .solana))
     }
 
     func testSolanaAssociatedTokenAccountIsRejectedByResolution() async throws {

--- a/VultisigApp/VultisigAppTests/Services/AddressServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/AddressServiceTests.swift
@@ -25,6 +25,8 @@ final class AddressServiceTests: XCTestCase {
     /// Generic Substrate SS58 address (prefix 42), which is what Bittensor uses.
     private let bittensorAddress = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
     private let evmAddress = "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+    private let solanaWalletAddress = "6BTaMq25LcNDTVhheUe9UyvwWgayqFv77njymVnG8SNy"
+    private let solanaMintAddress = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
 
     // MARK: - Coin builders
 
@@ -185,6 +187,43 @@ final class AddressServiceTests: XCTestCase {
         XCTAssertNil(detected)
     }
 
+    // MARK: - Solana curve membership
+
+    func testSolanaWalletAddressValidates() {
+        XCTAssertTrue(AddressService.validateAddress(address: solanaWalletAddress, chain: .solana))
+    }
+
+    func testSolanaAssociatedTokenAccountIsRejectedEvenThoughWalletCoreAcceptsIt() throws {
+        let tokenAccount = try makeSolanaAssociatedTokenAccount()
+
+        XCTAssertTrue(Chain.solana.coinType.validate(address: tokenAccount))
+        XCTAssertFalse(AddressService.validateAddress(address: tokenAccount, chain: .solana))
+    }
+
+    func testSolanaAssociatedTokenAccountIsRejectedByResolution() async throws {
+        let tokenAccount = try makeSolanaAssociatedTokenAccount()
+
+        do {
+            _ = try await AddressService.resolveInput(tokenAccount, chain: .solana)
+            XCTFail("Expected an associated token account to be rejected as a recipient")
+        } catch {
+            // Expected: off-curve accounts are not wallet recipients.
+        }
+    }
+
+    func testSolanaAssociatedTokenAccountDoesNotSwitchToSolana() throws {
+        let sol = SendFormFixture.makeCoin(.solana, ticker: "SOL", decimals: 9, isNative: true)
+        let vault = SendFormFixture.makeVault(coins: [sol])
+
+        let detected = AddressService.detectChain(
+            from: try makeSolanaAssociatedTokenAccount(),
+            vault: vault,
+            currentChain: .bitcoin
+        )
+
+        XCTAssertNil(detected)
+    }
+
     // MARK: - EVM
 
     /// From a non-EVM chain, land in the EVM family rather than leaving the
@@ -234,5 +273,15 @@ final class AddressServiceTests: XCTestCase {
         let detected = AddressService.detectChain(from: btcAddress, vault: vault, currentChain: .litecoin)
 
         XCTAssertNil(detected)
+    }
+
+    private func makeSolanaAssociatedTokenAccount() throws -> String {
+        try XCTUnwrap(
+            SolanaAssociatedTokenAccount.derive(
+                owner: solanaWalletAddress,
+                mint: solanaMintAddress,
+                tokenProgram: .token
+            )
+        )
     }
 }


### PR DESCRIPTION
## Problem

Solana token accounts and program-derived addresses pass WalletCore's syntax validation even though they are off the ed25519 curve. Accepting one as an SPL recipient causes the app to derive an associated token account from an address nobody controls, putting funds at risk.

## Root cause

Recipient entry points used generic Solana address validation. That check is intentionally syntax-only because the same API also validates legitimate off-curve mint and program addresses.

## Fix

- Add a base58 address-shaped wrapper around the existing ed25519 curve-membership implementation.
- Keep generic Solana address validation unchanged for mints/contracts.
- Add recipient-only validation and use it across send, resolution, chain detection, address book, swap/function validation, Ripple reserve validation, and Home deep links.
- Add regression coverage for normal wallets, ATAs, resolution, chain detection, and generic mint validation.

## Verification

- Focused `AddressServiceTests`: 26 passed, 0 failed.
- Full iOS unit-test gate: 6,810 passed, 11 skipped, 0 failed (`TEST SUCCEEDED`).
- SwiftLint: no new warnings relative to the 26-warning baseline.
- Two-round per-step Claude review and whole-branch review completed; no actionable findings remain.

## Manual review requested

This changes fund-safety validation. Please verify native SOL and SPL sends on device with a normal wallet recipient, an ATA, a PDA, and a custom token mint before release.

Closes #5252


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recipient address validation across sending, address book, deep links, and chain detection.
  * Solana addresses are now checked against the Ed25519 curve.
  * Invalid Solana addresses, token accounts, and malformed Base58 input are rejected more reliably.
  * Prevented unintended chain switching during address validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->