### PR TITLE
fix(solana): scan swap transactions

### DIFF
--- a/VultisigApp/VultisigApp/Core/Security/SecurityScannerTransactionFactory.swift
+++ b/VultisigApp/VultisigApp/Core/Security/SecurityScannerTransactionFactory.swift
@@ -37,6 +37,8 @@ struct SecurityScannerTransactionFactory: SecurityScannerTransactionFactoryProto
         switch chain.chainType {
         case .EVM:
             return try createEVMSecurityScanner(transaction: transaction)
+        case .Solana:
+            return try createSOLSecurityScanner(transaction: transaction)
         default:
             throw SecurityScannerTransactionFactoryError.notSupported(chain: chain)
         }
@@ -217,6 +219,47 @@ private extension SecurityScannerTransactionFactory {
 // MARK: - Swap Transactions
 
 private extension SecurityScannerTransactionFactory {
+    func createSOLSecurityScanner(transaction: SwapTransaction) throws -> SecurityScannerTransaction {
+        guard Base58.decodeNoCheck(string: transaction.fromCoin.address) != nil else {
+            throw SecurityScannerTransactionFactoryError.invalidAddress(transaction.fromCoin.address)
+        }
+        guard let quote = transaction.quote else {
+            throw SecurityScannerTransactionFactoryError.swapProviderNotSupported
+        }
+
+        let base64Transaction: String
+        switch quote {
+        case .lifi(let quote, _, _), .jupiter(let quote, _, _, _):
+            base64Transaction = quote.tx.data
+        case .swapkit(let response, _, _):
+            guard case let .solana(base64) = response.tx else {
+                throw SecurityScannerTransactionFactoryError.swapProviderNotSupported
+            }
+            base64Transaction = base64
+        case .mayachain, .thorchain, .thorchainChainnet, .thorchainStagenet,
+                .oneinch, .kyberswap:
+            throw SecurityScannerTransactionFactoryError.swapProviderNotSupported
+        }
+
+        guard let transactionData = Data(base64Encoded: base64Transaction),
+              !transactionData.isEmpty else {
+            throw SecurityScannerTransactionFactoryError.invalidBlockchainSpecific(
+                "Expected a base64 Solana swap transaction"
+            )
+        }
+
+        // Aggregators and the signer use base64 for the same wire transaction;
+        // Blockaid's Solana request contract requires those bytes as base58.
+        return SecurityScannerTransaction(
+            chain: transaction.fromCoin.chain,
+            type: .swap,
+            from: transaction.fromCoin.address,
+            to: transaction.recipientAddress,
+            amount: .zero,
+            data: Base58.encodeNoCheck(data: transactionData)
+        )
+    }
+
     func createEVMSecurityScanner(transaction: SwapTransaction) throws -> SecurityScannerTransaction {
         // Limit-swap orders are deposits with a memo; the EVM scanner
         // path only handles the routed-swap providers below.

--- a/VultisigApp/VultisigApp/Core/Security/SecurityScannerTransactionFactory.swift
+++ b/VultisigApp/VultisigApp/Core/Security/SecurityScannerTransactionFactory.swift
@@ -220,7 +220,8 @@ private extension SecurityScannerTransactionFactory {
 
 private extension SecurityScannerTransactionFactory {
     func createSOLSecurityScanner(transaction: SwapTransaction) throws -> SecurityScannerTransaction {
-        guard Base58.decodeNoCheck(string: transaction.fromCoin.address) != nil else {
+        guard let decodedAddress = Base58.decodeNoCheck(string: transaction.fromCoin.address),
+              decodedAddress.count == 32 else {
             throw SecurityScannerTransactionFactoryError.invalidAddress(transaction.fromCoin.address)
         }
         guard let quote = transaction.quote else {

--- a/VultisigApp/VultisigApp/Core/ViewModels/SecurityScannerViewModel.swift
+++ b/VultisigApp/VultisigApp/Core/ViewModels/SecurityScannerViewModel.swift
@@ -44,12 +44,12 @@ class SecurityScannerViewModel: ObservableObject {
     }
 
     func scan(transaction: SendTransaction) async {
-        guard isScanningAvailable(for: transaction.coin.chain) else { return }
-        await scan(transactionType: .send(transaction))
+        guard let provider = scanningProvider(for: transaction.coin.chain) else { return }
+        await scan(transactionType: .send(transaction), provider: provider)
     }
 
     func scan(transaction: SwapTransaction) async {
-        guard isScanningAvailable(for: transaction.fromCoin.chain) else {
+        guard let provider = scanningProvider(for: transaction.fromCoin.chain) else {
             // The source-chain swap tx can't be scanned, but an external
             // recipient on a screenable destination chain still must be — fall
             // through to a recipient-only scan instead of returning unscanned.
@@ -58,10 +58,14 @@ class SecurityScannerViewModel: ObservableObject {
             }
             return
         }
-        await scan(transactionType: .swap(transaction))
+        await scan(transactionType: .swap(transaction), provider: provider)
     }
 
-    private func scan(transactionType: SecurityScannerTransactionType) async {
+    private func scan(
+        transactionType: SecurityScannerTransactionType,
+        provider: String
+    ) async {
+        await update(state: .scanning)
         do {
             let tx: SecurityScannerTransaction
             switch transactionType {
@@ -70,8 +74,6 @@ class SecurityScannerViewModel: ObservableObject {
             case .send(let sendTransaction):
                 tx = try await service.createSecurityScannerTransaction(transaction: sendTransaction, vault: sendTransaction.vault)
             }
-            await update(state: .scanning)
-
             var result = try await service.scanTransaction(tx)
 
             // Safety net (HIGH tier): when an external recipient is set, also
@@ -86,11 +88,12 @@ class SecurityScannerViewModel: ObservableObject {
 
             await update(state: .scanned(result))
         } catch {
-            if case let SecurityScannerError.notScanned(provider) = error {
-                await update(state: .notScanned(provider: provider))
+            let failedProvider = if case let SecurityScannerError.notScanned(providerName) = error {
+                providerName
             } else {
-                await update(state: .idle)
+                provider
             }
+            await update(state: .notScanned(provider: failedProvider))
         }
     }
 
@@ -130,14 +133,18 @@ class SecurityScannerViewModel: ObservableObject {
     }
 
     func isScanningAvailable(for chain: Chain) -> Bool {
-        guard service.isSecurityServiceEnabled() else { return false }
+        scanningProvider(for: chain) != nil
+    }
+
+    private func scanningProvider(for chain: Chain) -> String? {
+        guard service.isSecurityServiceEnabled() else { return nil }
         // Check if any provider supports this chain for transaction scanning
         let supportedChains = service.getSupportedChainsByFeature()
-        return supportedChains.contains { support in
+        return supportedChains.first { support in
             support.feature.contains { feature in
                 feature.featureType == .scanTransaction && feature.chains.contains(chain)
             }
-        }
+        }?.provider
     }
 
     private func update(state: SecurityScannerState) async {

--- a/VultisigApp/VultisigAppTests/Security/SecurityScannerSwapTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/SecurityScannerSwapTests.swift
@@ -1,0 +1,231 @@
+//
+//  SecurityScannerSwapTests.swift
+//  VultisigAppTests
+//
+
+import BigInt
+import WalletCore
+import XCTest
+@testable import VultisigApp
+
+final class SecurityScannerSwapTests: XCTestCase {
+    func testJupiterSolanaSwapUsesProviderTransactionBytes() throws {
+        let wire = Data([0, 1, 2, 3, 254, 255])
+        let transaction = makeTransaction(
+            quote: .jupiter(
+                makeSolanaQuote(base64: wire.base64EncodedString()),
+                fee: nil,
+                platformFee: .zero,
+                feeOnInput: false
+            )
+        )
+
+        let scannerTransaction = try SecurityScannerTransactionFactory()
+            .createSecurityScanner(transaction: transaction)
+
+        XCTAssertEqual(scannerTransaction.chain, .solana)
+        XCTAssertEqual(scannerTransaction.type.rawValue, SecurityTransactionType.swap.rawValue)
+        XCTAssertEqual(scannerTransaction.from, transaction.fromCoin.address)
+        XCTAssertEqual(scannerTransaction.to, transaction.recipientAddress)
+        XCTAssertEqual(scannerTransaction.amount, .zero)
+        XCTAssertEqual(scannerTransaction.data, Base58.encodeNoCheck(data: wire))
+    }
+
+    func testLiFiSolanaSwapUsesProviderTransactionBytes() throws {
+        let wire = Data([4, 5, 6, 7])
+        let transaction = makeTransaction(
+            quote: .lifi(
+                makeSolanaQuote(base64: wire.base64EncodedString()),
+                fee: nil,
+                integratorFee: nil
+            )
+        )
+
+        let scannerTransaction = try SecurityScannerTransactionFactory()
+            .createSecurityScanner(transaction: transaction)
+
+        XCTAssertEqual(scannerTransaction.data, Base58.encodeNoCheck(data: wire))
+    }
+
+    func testSwapKitSolanaSwapUsesTypedProviderTransactionBytes() throws {
+        let response = try SwapKitFixtureLoader.decode(
+            SwapKitSwapResponse.self,
+            from: "v3-sol-near-swap-fresh"
+        )
+        guard case let .solana(base64) = response.tx,
+              let wire = Data(base64Encoded: base64) else {
+            return XCTFail("Expected a valid typed Solana transaction fixture")
+        }
+        let transaction = makeTransaction(
+            quote: .swapkit(response, fee: nil, subProvider: "NEAR")
+        )
+
+        let scannerTransaction = try SecurityScannerTransactionFactory()
+            .createSecurityScanner(transaction: transaction)
+
+        XCTAssertEqual(scannerTransaction.data, Base58.encodeNoCheck(data: wire))
+    }
+
+    func testMalformedSolanaSwapPayloadThrowsInsteadOfScanningDifferentBytes() {
+        let transaction = makeTransaction(
+            quote: .jupiter(
+                makeSolanaQuote(base64: "not-base64"),
+                fee: nil,
+                platformFee: .zero,
+                feeOnInput: false
+            )
+        )
+
+        XCTAssertThrowsError(
+            try SecurityScannerTransactionFactory().createSecurityScanner(transaction: transaction)
+        ) { error in
+            guard case SecurityScannerTransactionFactoryError.invalidBlockchainSpecific = error else {
+                return XCTFail("Expected invalid Solana transaction data, got \(error)")
+            }
+        }
+    }
+
+    func testUnsupportedSolanaSwapProviderThrowsInsteadOfScanningPlaceholder() {
+        let transaction = makeTransaction(
+            quote: .oneinch(makeSolanaQuote(base64: Data([1]).base64EncodedString()), fee: nil)
+        )
+
+        XCTAssertThrowsError(
+            try SecurityScannerTransactionFactory().createSecurityScanner(transaction: transaction)
+        ) { error in
+            guard case SecurityScannerTransactionFactoryError.swapProviderNotSupported = error else {
+                return XCTFail("Expected unsupported Solana swap provider, got \(error)")
+            }
+        }
+    }
+
+    func testFactoryFailureEndsInVisibleNotScannedState() async {
+        let service = FailingSecurityScannerService()
+        let viewModel = SecurityScannerViewModel(service: service)
+        let transaction = makeTransaction(
+            quote: .jupiter(
+                makeSolanaQuote(base64: Data([1]).base64EncodedString()),
+                fee: nil,
+                platformFee: .zero,
+                feeOnInput: false
+            )
+        )
+
+        await viewModel.scan(transaction: transaction)
+
+        XCTAssertEqual(viewModel.state, .notScanned(provider: "blockaid"))
+        XCTAssertEqual(service.scanCallCount, 0)
+    }
+}
+
+private extension SecurityScannerSwapTests {
+    func makeTransaction(quote: SwapQuote) -> SwapTransaction {
+        let sol = makeCoin(chain: .solana, ticker: "SOL", decimals: 9, isNative: true)
+        let usdc = makeCoin(chain: .solana, ticker: "USDC", decimals: 6, isNative: false)
+        return SwapTransaction(
+            fromCoin: sol,
+            toCoin: usdc,
+            fromAmount: 1,
+            kind: .market(quote),
+            gas: .zero,
+            gasLimit: .zero,
+            thorchainFee: .zero,
+            vultDiscountBps: 0,
+            referralDiscountBps: 0,
+            feeCoin: sol,
+            advancedSettings: .default
+        )
+    }
+
+    func makeSolanaQuote(base64: String) -> EVMQuote {
+        EVMQuote(
+            dstAmount: "1000000",
+            tx: EVMQuote.Transaction(
+                from: "provider-from",
+                to: "provider-to",
+                data: base64,
+                value: "0",
+                gasPrice: "0",
+                gas: 0
+            )
+        )
+    }
+
+    func makeCoin(
+        chain: Chain,
+        ticker: String,
+        decimals: Int,
+        isNative: Bool
+    ) -> Coin {
+        let meta = CoinMeta.make(
+            chain: chain,
+            ticker: ticker,
+            decimals: decimals,
+            isNativeToken: isNative
+        )
+        return Coin(asset: meta, address: Self.solanaAddress, hexPublicKey: "")
+    }
+
+    static let solanaAddress = "So11111111111111111111111111111111111111112"
+}
+
+private final class FailingSecurityScannerService: SecurityScannerServiceProtocol {
+    private(set) var scanCallCount = 0
+
+    func scanTransaction(
+        _ transaction: SecurityScannerTransaction
+    ) async throws -> SecurityScannerResult {
+        _ = transaction
+        await Task.yield()
+        scanCallCount += 1
+        throw StubError.unused
+    }
+
+    func isSecurityServiceEnabled() -> Bool {
+        true
+    }
+
+    func createSecurityScannerTransaction(
+        transaction: SendTransaction,
+        vault: Vault
+    ) async throws -> SecurityScannerTransaction {
+        _ = transaction
+        _ = vault
+        await Task.yield()
+        throw StubError.unused
+    }
+
+    func createSecurityScannerTransaction(
+        transaction: SwapTransaction
+    ) async throws -> SecurityScannerTransaction {
+        _ = transaction
+        await Task.yield()
+        throw StubError.factoryFailure
+    }
+
+    func createRecipientSecurityScannerTransaction(
+        transaction: SwapTransaction
+    ) throws -> SecurityScannerTransaction {
+        _ = transaction
+        throw StubError.unused
+    }
+
+    func getSupportedChainsByFeature() -> [SecurityScannerSupport] {
+        [
+            SecurityScannerSupport(
+                provider: "blockaid",
+                feature: [
+                    SecurityScannerSupport.Feature(
+                        chains: [.solana],
+                        featureType: .scanTransaction
+                    )
+                ]
+            )
+        ]
+    }
+
+    private enum StubError: Error {
+        case factoryFailure
+        case unused
+    }
+}

--- a/VultisigApp/VultisigAppTests/Security/SecurityScannerSwapTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/SecurityScannerSwapTests.swift
@@ -99,6 +99,26 @@ final class SecurityScannerSwapTests: XCTestCase {
         }
     }
 
+    func testShortBase58SolanaAddressThrowsInsteadOfScanning() {
+        let transaction = makeTransaction(
+            quote: .jupiter(
+                makeSolanaQuote(base64: Data([1]).base64EncodedString()),
+                fee: nil,
+                platformFee: .zero,
+                feeOnInput: false
+            ),
+            fromAddress: "1"
+        )
+
+        XCTAssertThrowsError(
+            try SecurityScannerTransactionFactory().createSecurityScanner(transaction: transaction)
+        ) { error in
+            guard case SecurityScannerTransactionFactoryError.invalidAddress("1") = error else {
+                return XCTFail("Expected invalid Solana source address, got \(error)")
+            }
+        }
+    }
+
     func testFactoryFailureEndsInVisibleNotScannedState() async {
         let service = FailingSecurityScannerService()
         let viewModel = SecurityScannerViewModel(service: service)
@@ -119,9 +139,24 @@ final class SecurityScannerSwapTests: XCTestCase {
 }
 
 private extension SecurityScannerSwapTests {
-    func makeTransaction(quote: SwapQuote) -> SwapTransaction {
-        let sol = makeCoin(chain: .solana, ticker: "SOL", decimals: 9, isNative: true)
-        let usdc = makeCoin(chain: .solana, ticker: "USDC", decimals: 6, isNative: false)
+    func makeTransaction(
+        quote: SwapQuote,
+        fromAddress: String? = nil
+    ) -> SwapTransaction {
+        let sol = makeCoin(
+            chain: .solana,
+            ticker: "SOL",
+            decimals: 9,
+            isNative: true,
+            address: fromAddress ?? Self.solanaAddress
+        )
+        let usdc = makeCoin(
+            chain: .solana,
+            ticker: "USDC",
+            decimals: 6,
+            isNative: false,
+            address: Self.solanaAddress
+        )
         return SwapTransaction(
             fromCoin: sol,
             toCoin: usdc,
@@ -155,7 +190,8 @@ private extension SecurityScannerSwapTests {
         chain: Chain,
         ticker: String,
         decimals: Int,
-        isNative: Bool
+        isNative: Bool,
+        address: String
     ) -> Coin {
         let meta = CoinMeta.make(
             chain: chain,
@@ -163,7 +199,7 @@ private extension SecurityScannerSwapTests {
             decimals: decimals,
             isNativeToken: isNative
         )
-        return Coin(asset: meta, address: Self.solanaAddress, hexPublicKey: "")
+        return Coin(asset: meta, address: address, hexPublicKey: "")
     }
 
     static let solanaAddress = "So11111111111111111111111111111111111111112"


### PR DESCRIPTION
## Problem

Solana-source aggregator swaps advertised Blockaid coverage but never reached the scanner. The swap scanner factory only handled EVM transactions, and the view model collapsed factory/conversion failures back to an empty scanner header.

## Root cause

- `SecurityScannerTransactionFactory` had no Solana branch for provider-built swap transactions.
- Jupiter and LiFi carry the serialized Solana wire transaction as base64 in the quote transaction data, while SwapKit carries it in its typed Solana payload; none was converted to Blockaid's base58 message contract.
- Attempted scan failures other than the provider's explicit `notScanned` error were represented as `.idle`, indistinguishable from a scan that was never available or attempted.

## Fix

- Extract and validate provider-built Solana transactions for Jupiter, LiFi, and typed SwapKit-Solana routes.
- Decode the base64 wire bytes and base58-encode those exact bytes for Blockaid's existing Solana scan request path.
- Validate the source account and reject malformed or unsupported payloads.
- Enter the scanning state before factory work and show the existing provider-specific “not scanned” result for any attempted scan failure; scanner-unavailable chains remain idle.
- Add regression tests for all three providers, malformed/unsupported payloads, payload fidelity, and the visible failure state.

## Verification

- Changed-file SwiftLint: 0 violations.
- Per-commit Claude review: no findings.
- Whole-branch Claude review: all findings triaged; none accepted or deferred.
- Full project gate after `make generate`, using the `make test`-equivalent `xcodebuild test` command with worktree-local DerivedData: `** TEST SUCCEEDED **`, exit 0, 6,811 tests executed, 11 skipped, 0 failures.
- Disk receipts: 14 GiB free immediately before; 39 GiB immediately after; no ENOSPC marker. The 5.1 GiB worktree-local DerivedData was removed after receipts.

## Risk and human verification

Security/funds risk: this closes a pre-signing security-scanner coverage gap. It does not alter provider transaction bytes, signing construction, or MPC behavior, and a “could not scan” result remains user-overridable under the existing policy.

Please verify live Jupiter, LiFi, and SwapKit Solana swaps on device and confirm that Blockaid receives the request and that scanned, unsafe, and unavailable result states render correctly before signing.

Closes #5254


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added security scanning support for Solana swap transactions from supported providers.
  * Scans now retain the selected security provider and report provider-specific results.

* **Bug Fixes**
  * Improved validation for missing, malformed, unsupported, or mismatched swap transaction data.
  * Converted Solana transaction data into the format required for security scanning.

* **Tests**
  * Added coverage for supported providers, invalid payloads, unsupported providers, and failed scan creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->