### PR TITLE
fix(solana): surface execution errors before finality

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Models/SolanaTransactionStatusResponse.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Models/SolanaTransactionStatusResponse.swift
@@ -7,26 +7,22 @@
 
 import Foundation
 
-struct SolanaTransactionStatusResponse: Codable {
+struct SolanaTransactionStatusResponse: Decodable {
     let result: SolanaResult?
 
-    struct SolanaResult: Codable {
+    struct SolanaResult: Decodable {
         let value: [SolanaStatusValue?]
     }
 
-    struct SolanaStatusValue: Codable {
+    struct SolanaStatusValue: Decodable {
         let slot: Int?
         let confirmationStatus: String?
-        let err: SolanaError?
+        let err: SolanaRPCJSONValue?
 
         enum CodingKeys: String, CodingKey {
             case slot
             case confirmationStatus
             case err
         }
-    }
-
-    struct SolanaError: Codable {
-        // Can be various types, just capture as dictionary
     }
 }

--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Providers/SolanaTransactionStatusProvider.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Providers/SolanaTransactionStatusProvider.swift
@@ -20,8 +20,8 @@ struct SolanaTransactionStatusProvider: TransactionStatusProvider {
             responseType: SolanaTransactionStatusResponse.self
         )
 
-        guard let result = response.data.result,
-              let statusValue = result.value.first as? SolanaTransactionStatusResponse.SolanaStatusValue else {
+        guard let firstValue = response.data.result?.value.first,
+              let statusValue = firstValue else {
             // Transaction not found
             return TransactionStatusResult(
                 status: .notFound,
@@ -30,47 +30,27 @@ struct SolanaTransactionStatusProvider: TransactionStatusProvider {
             )
         }
 
-        // Check confirmationStatus
-        if let confirmationStatus = statusValue.confirmationStatus {
-            switch confirmationStatus {
-            case "finalized":
-                // Check for errors
-                if let _ = statusValue.err {
-                    return TransactionStatusResult(
-                        status: .failed(reason: "Transaction error"),
-                        blockNumber: nil,
-                        confirmations: nil
-                    )
-                }
-
-                return TransactionStatusResult(
-                    status: .confirmed,
-                    blockNumber: statusValue.slot,
-                    confirmations: nil
-                )
-
-            case "confirmed", "processed":
-                // Still pending finalization
-                return TransactionStatusResult(
-                    status: .pending,
-                    blockNumber: nil,
-                    confirmations: nil
-                )
-
-            default:
-                return TransactionStatusResult(
-                    status: .pending,
-                    blockNumber: nil,
-                    confirmations: nil
-                )
-            }
+        if statusValue.err != nil {
+            return TransactionStatusResult(
+                status: .failed(reason: "Transaction error"),
+                blockNumber: nil,
+                confirmations: nil
+            )
         }
 
-        // No status = not found
-        return TransactionStatusResult(
-            status: .notFound,
-            blockNumber: nil,
-            confirmations: nil
-        )
+        switch statusValue.confirmationStatus {
+        case "confirmed", "finalized":
+            return TransactionStatusResult(
+                status: .confirmed,
+                blockNumber: statusValue.slot,
+                confirmations: nil
+            )
+        default:
+            return TransactionStatusResult(
+                status: .pending,
+                blockNumber: nil,
+                confirmations: nil
+            )
+        }
     }
 }

--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Providers/SolanaTransactionStatusProvider.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Providers/SolanaTransactionStatusProvider.swift
@@ -32,7 +32,7 @@ struct SolanaTransactionStatusProvider: TransactionStatusProvider {
 
         if statusValue.err != nil {
             return TransactionStatusResult(
-                status: .failed(reason: "Transaction error"),
+                status: .failed(reason: "transactionFailed".localized),
                 blockNumber: nil,
                 confirmations: nil
             )

--- a/VultisigApp/VultisigAppTests/Services/SolanaTransactionStatusProviderTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/SolanaTransactionStatusProviderTests.swift
@@ -1,0 +1,105 @@
+//
+//  SolanaTransactionStatusProviderTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class SolanaTransactionStatusProviderTests: XCTestCase {
+
+    private static let query = TransactionStatusQuery(txHash: "signature", chain: .solana)
+
+    func testConfirmedObjectErrorReturnsFailed() async throws {
+        let result = try await checkStatus(
+            status: "confirmed",
+            errorJSON: #"{"InstructionError":[0,{"Custom":6001}]}"#
+        )
+
+        XCTAssertEqual(result.status, .failed(reason: "Transaction error"))
+    }
+
+    func testProcessedStringErrorReturnsFailed() async throws {
+        let result = try await checkStatus(
+            status: "processed",
+            errorJSON: #""AccountInUse""#
+        )
+
+        XCTAssertEqual(result.status, .failed(reason: "Transaction error"))
+    }
+
+    func testErrorWithoutConfirmationStatusReturnsFailed() async throws {
+        let result = try await checkStatus(
+            status: nil,
+            errorJSON: #""BlockhashNotFound""#
+        )
+
+        XCTAssertEqual(result.status, .failed(reason: "Transaction error"))
+    }
+
+    func testConfirmedWithoutErrorReturnsConfirmed() async throws {
+        let result = try await checkStatus(status: "confirmed")
+
+        XCTAssertEqual(result.status, .confirmed)
+        XCTAssertEqual(result.blockNumber, 42)
+    }
+
+    func testFinalizedWithoutErrorReturnsConfirmed() async throws {
+        let result = try await checkStatus(status: "finalized")
+
+        XCTAssertEqual(result.status, .confirmed)
+        XCTAssertEqual(result.blockNumber, 42)
+    }
+
+    func testProcessedWithoutErrorReturnsPending() async throws {
+        let result = try await checkStatus(status: "processed")
+
+        XCTAssertEqual(result.status, .pending)
+    }
+
+    func testKnownSignatureWithoutConfirmationStatusReturnsPending() async throws {
+        let result = try await checkStatus(status: nil)
+
+        XCTAssertEqual(result.status, .pending)
+    }
+
+    func testNullSignatureReturnsNotFound() async throws {
+        let client = SolanaStatusHTTPClient(json: #"{"result":{"value":[null]}}"#)
+        let provider = SolanaTransactionStatusProvider(httpClient: client)
+
+        let result = try await provider.checkStatus(query: Self.query)
+
+        XCTAssertEqual(result.status, .notFound)
+    }
+
+    private func checkStatus(
+        status: String?,
+        errorJSON: String = "null"
+    ) async throws -> TransactionStatusResult {
+        let statusJSON = status.map { #""\#($0)""# } ?? "null"
+        let json = #"{"result":{"value":[{"slot":42,"err":\#(errorJSON),"confirmationStatus":\#(statusJSON)}]}}"#
+        let client = SolanaStatusHTTPClient(json: json)
+        let provider = SolanaTransactionStatusProvider(httpClient: client)
+
+        return try await provider.checkStatus(query: Self.query)
+    }
+}
+
+private final class SolanaStatusHTTPClient: HTTPClientProtocol, @unchecked Sendable {
+    private let data: Data
+
+    init(json: String) {
+        self.data = Data(json.utf8)
+    }
+
+    // swiftlint:disable:next async_without_await
+    func request(_: TargetType) async throws -> HTTPResponse<Data> {
+        let response = HTTPURLResponse(
+            url: URL(string: "https://test.local")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return HTTPResponse(data: data, response: response)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Services/SolanaTransactionStatusProviderTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/SolanaTransactionStatusProviderTests.swift
@@ -16,7 +16,7 @@ final class SolanaTransactionStatusProviderTests: XCTestCase {
             errorJSON: #"{"InstructionError":[0,{"Custom":6001}]}"#
         )
 
-        XCTAssertEqual(result.status, .failed(reason: "Transaction error"))
+        XCTAssertEqual(result.status, .failed(reason: "transactionFailed".localized))
     }
 
     func testProcessedStringErrorReturnsFailed() async throws {
@@ -25,7 +25,7 @@ final class SolanaTransactionStatusProviderTests: XCTestCase {
             errorJSON: #""AccountInUse""#
         )
 
-        XCTAssertEqual(result.status, .failed(reason: "Transaction error"))
+        XCTAssertEqual(result.status, .failed(reason: "transactionFailed".localized))
     }
 
     func testErrorWithoutConfirmationStatusReturnsFailed() async throws {
@@ -34,7 +34,7 @@ final class SolanaTransactionStatusProviderTests: XCTestCase {
             errorJSON: #""BlockhashNotFound""#
         )
 
-        XCTAssertEqual(result.status, .failed(reason: "Transaction error"))
+        XCTAssertEqual(result.status, .failed(reason: "transactionFailed".localized))
     }
 
     func testConfirmedWithoutErrorReturnsConfirmed() async throws {


### PR DESCRIPTION
## Problem

Solana `getSignatureStatuses` can report an execution error before finalization. The iOS provider only inspected `err` inside the `finalized` branch, so a reverted transaction at `confirmed` or `processed` mapped to `.pending`. The keysign rebroadcast safety check deliberately treats `.pending` as positive on-chain evidence, which could therefore treat a failed transaction as landed.

## Root cause

- `SolanaTransactionStatusProvider` branched on commitment before inspecting `err`.
- The response model represented `err` as an empty object-only type even though Solana RPC permits both object and string error payloads.
- Non-error `confirmed` responses were kept pending even though confirmed commitment is the intended user-facing success threshold for this flow.

## Fix

- Decode the polymorphic Solana RPC error with the existing JSON-value model so object and string errors are both recognized.
- Check `err` before commitment and return `.failed` whenever it is non-null.
- Treat non-error `confirmed` and `finalized` statuses as confirmed; keep `processed`, missing, and unknown commitment states pending.
- Add raw-RPC provider coverage for structured/string errors, each successful commitment, processed pending, missing commitment, and a null signature.

## Verification

- Whole-branch cross-model review: no actionable findings.
- SwiftLint on touched files: 0 violations.
- Full `VultisigApp` unit-test suite: 6,813 tests, 11 skipped, 0 failures — `** TEST SUCCEEDED **`.
- New `SolanaTransactionStatusProviderTests`: 8 tests, 0 failures.

## Review focus

This is a Solana funds/reliability path. Please verify the error-first mapping and the `confirmed` success threshold in particular.

Closes #5255


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solana transaction status handling for failed, confirmed, finalized, pending, and incomplete transactions.
  * Added support for both object-based and string-based transaction errors.
  * Correctly handles missing or null transaction signatures and confirmation statuses.

* **Tests**
  * Added coverage for the updated Solana transaction status scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->