### PR TITLE
fix: make QBTC claim banner permanently dismissible

### DIFF
--- a/VultisigApp/VultisigApp/Features/Common/Views/Banners/CarouselBannerView.swift
+++ b/VultisigApp/VultisigApp/Features/Common/Views/Banners/CarouselBannerView.swift
@@ -159,7 +159,7 @@ struct CarouselBannerView<Banner: CarouselBannerType>: View {
     }
 }
 
-private struct CarouselBannerCloseButton: View {
+struct CarouselBannerCloseButton: View {
     let action: () -> Void
 
     var body: some View {

--- a/VultisigApp/VultisigApp/Features/QBTCClaim/Components/ClaimQbtcPromoBanner.swift
+++ b/VultisigApp/VultisigApp/Features/QBTCClaim/Components/ClaimQbtcPromoBanner.swift
@@ -31,8 +31,9 @@ struct ClaimQbtcPromoBanner: View {
         )
         .clipShape(Theme.radius.xl.shape)
         .overlay(alignment: .topTrailing) {
-            dismissButton
+            CarouselBannerCloseButton(action: onDismiss)
                 .padding(8)
+                .accessibilityLabel("close".localized)
         }
     }
 
@@ -105,16 +106,6 @@ struct ClaimQbtcPromoBanner: View {
             .fixedSize()
         }
         .padding(24)
-    }
-
-    private var dismissButton: some View {
-        Button(action: onDismiss) {
-            Icon(.crossSmall, color: Theme.colors.textPrimary, size: 16)
-                .frame(width: 40, height: 40)
-                .contentShape(Circle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("close".localized)
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/QBTCClaim/Components/ClaimQbtcPromoBanner.swift
+++ b/VultisigApp/VultisigApp/Features/QBTCClaim/Components/ClaimQbtcPromoBanner.swift
@@ -7,19 +7,20 @@
 //  Figma `Chain Detail Page - Default` banner (node 75201:107954):
 //  a centered text block on a `bgSurface2` card, a radial blue glow,
 //  scattered/rotated BTC coin decorations, and a primary "Claim Now"
-//  pill. No close button — the banner self-hides once the vault has a
-//  QBTC chain (host gates visibility on `!hasQbtcChain`).
+//  pill, plus a close control that lets the host dismiss the banner.
 //
 
 import SwiftUI
 
 struct ClaimQbtcPromoBanner: View {
     let onClaim: () -> Void
+    let onDismiss: () -> Void
 
     var body: some View {
         ZStack {
             backgroundGlow
             decorativeCoins
+                .accessibilityHidden(true)
             foreground
         }
         .frame(height: 156)
@@ -29,7 +30,10 @@ struct ClaimQbtcPromoBanner: View {
                 .fill(Theme.colors.bgSurface2)
         )
         .clipShape(Theme.radius.xl.shape)
-        .accessibilityElement(children: .combine)
+        .overlay(alignment: .topTrailing) {
+            dismissButton
+                .padding(8)
+        }
     }
 
     private var backgroundGlow: some View {
@@ -102,10 +106,20 @@ struct ClaimQbtcPromoBanner: View {
         }
         .padding(24)
     }
+
+    private var dismissButton: some View {
+        Button(action: onDismiss) {
+            Icon(.crossSmall, color: Theme.colors.textPrimary, size: 16)
+                .frame(width: 40, height: 40)
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("close".localized)
+    }
 }
 
 #Preview {
-    ClaimQbtcPromoBanner(onClaim: {})
+    ClaimQbtcPromoBanner(onClaim: {}, onDismiss: {})
         .padding()
         .background(Theme.colors.bgPrimary)
 }

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
@@ -43,6 +43,8 @@ struct ChainDetailScreen: View {
     @StateObject private var trustLineActivation = RippleTrustLineActivationViewModel()
 
     private let scrollReferenceId = "chainDetailScreenBottomContentId"
+    private let topContentSpacing: CGFloat = 32
+    private let qbtcClaimBannerHeight: CGFloat = 156
 
     @EnvironmentObject var coinSelectionViewModel: CoinSelectionViewModel
     @Environment(\.dismiss) var dismiss
@@ -241,7 +243,7 @@ struct ChainDetailScreen: View {
     }
 
     var topContentSection: some View {
-        VStack(spacing: 32) {
+        VStack(spacing: 0) {
             ChainDetailHeaderView(
                 vault: vault,
                 nativeCoin: nativeCoin,
@@ -252,13 +254,9 @@ struct ChainDetailScreen: View {
                 actions: viewModel.availableActions,
                 onAction: onAction
             )
+            .padding(.top, topContentSpacing)
 
-            ClaimQbtcPromoBanner(
-                onClaim: onClaimBannerTapped,
-                onDismiss: dismissQbtcClaimBanner
-            )
-            .transition(.verticalGrowAndFade)
-            .showIf(showsQbtcBanner)
+            qbtcClaimBannerSection
 
             TronResourcesCardView(
                 availableBandwidth: viewModel.tronLoader?.availableBandwidth ?? 0,
@@ -266,9 +264,29 @@ struct ChainDetailScreen: View {
                 availableEnergy: viewModel.tronLoader?.availableEnergy ?? 0,
                 totalEnergy: viewModel.tronLoader?.totalEnergy ?? 0,
                 isLoading: viewModel.tronLoader?.isLoading ?? false
-            ).showIf(viewModel.isTron)
+            )
+            .padding(.top, topContentSpacing)
+            .showIf(viewModel.isTron)
         }
-        .animation(.interpolatingSpring(duration: 0.25), value: isQbtcClaimBannerDismissed)
+    }
+
+    var qbtcClaimBannerSection: some View {
+        VStack(spacing: 0) {
+            ClaimQbtcPromoBanner(
+                onClaim: onClaimBannerTapped,
+                onDismiss: dismissQbtcClaimBanner
+            )
+            .padding(.top, topContentSpacing)
+        }
+        .frame(
+            height: showsQbtcBanner ? qbtcClaimBannerHeight + topContentSpacing : 0,
+            alignment: .top
+        )
+        .opacity(showsQbtcBanner ? 1 : 0)
+        .clipped()
+        .allowsHitTesting(showsQbtcBanner)
+        .accessibilityHidden(!showsQbtcBanner)
+        .animation(.interpolatingSpring(duration: 0.25), value: showsQbtcBanner)
     }
 
     var bottomContentSection: some View {

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
@@ -257,6 +257,7 @@ struct ChainDetailScreen: View {
                 onClaim: onClaimBannerTapped,
                 onDismiss: dismissQbtcClaimBanner
             )
+            .transition(.verticalGrowAndFade)
             .showIf(showsQbtcBanner)
 
             TronResourcesCardView(

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
@@ -268,6 +268,7 @@ struct ChainDetailScreen: View {
                 isLoading: viewModel.tronLoader?.isLoading ?? false
             ).showIf(viewModel.isTron)
         }
+        .animation(.interpolatingSpring(duration: 0.25), value: isQbtcClaimBannerDismissed)
     }
 
     var bottomContentSection: some View {

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
@@ -44,7 +44,6 @@ struct ChainDetailScreen: View {
 
     private let scrollReferenceId = "chainDetailScreenBottomContentId"
     private let topContentSpacing: CGFloat = 32
-    private let qbtcClaimBannerHeight: CGFloat = 156
 
     @EnvironmentObject var coinSelectionViewModel: CoinSelectionViewModel
     @Environment(\.dismiss) var dismiss
@@ -129,7 +128,9 @@ struct ChainDetailScreen: View {
                     topContentSection
                         .padding(.top, isMacOS ? 60 : 0)
                     bottomContentSection
+                        .geometryGroup()
                 }
+                .animation(.interpolatingSpring(duration: 0.25), value: showsQbtcBanner)
                 .padding(.bottom, showsQbtcClaimButton ? claimButtonReservedHeight : 0)
                 .padding(.horizontal, 16)
                 .padding(.bottom, isMacOS ? 120 : 0)
@@ -278,15 +279,10 @@ struct ChainDetailScreen: View {
             )
             .padding(.top, topContentSpacing)
         }
-        .frame(
-            height: showsQbtcBanner ? qbtcClaimBannerHeight + topContentSpacing : 0,
-            alignment: .top
-        )
-        .opacity(showsQbtcBanner ? 1 : 0)
-        .clipped()
         .allowsHitTesting(showsQbtcBanner)
         .accessibilityHidden(!showsQbtcBanner)
-        .animation(.interpolatingSpring(duration: 0.25), value: showsQbtcBanner)
+        .transition(.verticalGrowAndFade)
+        .showIf(showsQbtcBanner)
     }
 
     var bottomContentSection: some View {

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
@@ -30,6 +30,8 @@ struct ChainDetailScreen: View {
     /// key — pickup happens once `qbtcQuantumKeygenCompleted` fires so the
     /// user lands back here with QBTC already added to the vault.
     @State private var pendingQbtcAddAfterKeygen: Bool = false
+    @AppStorage("isQbtcClaimBannerDismissed")
+    private var isQbtcClaimBannerDismissed: Bool = false
     @State private var addressCopyTask: Task<Void, Never>?
     @State private var coinDetailTask: Task<Void, Never>?
 
@@ -67,6 +69,7 @@ struct ChainDetailScreen: View {
         QBTCConfig.isFeatureEnabled
             && nativeCoin.chain == .bitcoin
             && qbtcEligibility.hasClaimableUtxos
+            && !isQbtcClaimBannerDismissed
     }
 
     /// QBTC chain detail's Claim button mirrors the same predicate: only
@@ -250,8 +253,11 @@ struct ChainDetailScreen: View {
                 onAction: onAction
             )
 
-            ClaimQbtcPromoBanner(onClaim: onClaimBannerTapped)
-                .showIf(showsQbtcBanner)
+            ClaimQbtcPromoBanner(
+                onClaim: onClaimBannerTapped,
+                onDismiss: dismissQbtcClaimBanner
+            )
+            .showIf(showsQbtcBanner)
 
             TronResourcesCardView(
                 availableBandwidth: viewModel.tronLoader?.availableBandwidth ?? 0,
@@ -480,6 +486,12 @@ private extension ChainDetailScreen {
         } else {
             pendingQbtcAddAfterKeygen = true
             router.navigate(to: KeygenRoute.quantumSecurityIntro(vault: vault))
+        }
+    }
+
+    func dismissQbtcClaimBanner() {
+        withAnimation {
+            isQbtcClaimBannerDismissed = true
         }
     }
 


### PR DESCRIPTION
## Summary

- add a close control to the QBTC claim banner on Bitcoin chain detail using `CarouselBannerCloseButton`
- remove the banner with `verticalGrowAndFade` and animate the complete scroll-content stack for that visibility change
- isolate the moving lower section with `geometryGroup()` so its layout position interpolates instead of jumping
- persist dismissal across screen recreation and app relaunches with a dedicated app-storage flag
- keep the behavior independent from the home promo-banner dismissal system

## Verification

- Changed-file SwiftLint: 0 violations
- Runtime layout harness: banner-only and parent-only variants jumped in 2 geometry samples; the geometry-grouped variant moved across 51 intermediate samples
- Full `make test`: 6,833 tests executed, 11 skipped, 0 failures (`** TEST SUCCEEDED **`)

Closes #5246


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dismiss button to the QBTC claim promotional banner.
  * Banner dismissal is remembered, so the banner stays hidden after being closed.
  * Improved accessibility labels and support for assistive technologies.

* **UI Improvements**
  * Refined banner layout, spacing, transitions, and dismissal animation.
  * Decorative elements are excluded from accessibility navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->