### PR TITLE
feat(swap): add Robinhood and HyperEVM SwapKit routing

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapCoinsResolver.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapCoinsResolver.swift
@@ -22,9 +22,10 @@ struct SwapCoinsResolver {
     }
 
     static func resolveToCoins(fromCoin: Coin, allCoins: [Coin], selectedToCoin: Coin) -> (coins: [Coin], selected: Coin) {
-        let fromProviders = fromCoin.swapProviders
         let coins = allCoins
-            .filter { $0.swapProviders.contains(where: fromProviders.contains) }
+            .filter {
+                !resolveAllProviders(fromCoin: fromCoin, toCoin: $0).isEmpty
+            }
             .filter { $0 != fromCoin }
             .sorted()
 
@@ -37,6 +38,10 @@ struct SwapCoinsResolver {
         let fromProviders = fromCoin.swapProviders
         let toProviders = toCoin.swapProviders
         var commonProviders = fromProviders.filter { toProviders.contains($0) }
+
+        if !SwapKitCapability.canQuote(from: fromCoin.chain) {
+            commonProviders.removeAll { $0 == .swapkit }
+        }
 
         // If either coin is thorchain stagenet, remove mainnet thorchain provider to avoid mixing networks
         if toCoin.chain == .thorChainChainnet || fromCoin.chain == .thorChainChainnet {

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -781,6 +781,10 @@ private extension SwapService {
             sourceAddress: fromCoin.address,
             destinationAddress: destination
         )
+        try SwapKitService.validateSigningCapability(
+            response: response,
+            fromChain: fromCoin.chain
+        )
         return .swapkit(
             response,
             fee: service.inboundFee(from: response, fromCoin: fromCoin),

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -736,6 +736,9 @@ private extension SwapService {
         slippageBps: Int?,
         recipientAddress: String?
     ) async throws -> SwapQuote {
+        guard SwapKitCapability.canQuote(from: fromCoin.chain) else {
+            throw SwapKitError.providerNotEnabled
+        }
         // Provider-cache gate — refuse to call `/v3/quote` for a chain SwapKit
         // doesn't enable. Fails CLOSED on the no-snapshot edge (throws
         // `providerNotEnabled`) rather than offering routes that fail

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitAssetCatalog.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitAssetCatalog.swift
@@ -1,0 +1,227 @@
+//
+//  SwapKitAssetCatalog.swift
+//  VultisigApp
+//
+//  Shared SwapKit token-catalog cache. The picker consumes its CoinMeta
+//  buckets while the quote path consumes the exact upstream identifiers.
+//
+
+import Foundation
+import OSLog
+
+private let logger = Log.swap.store
+
+struct SwapKitAssetKey: Hashable, Sendable {
+    let chain: Chain
+    let contractAddress: String
+
+    init(chain: Chain, contractAddress: String, isNativeToken: Bool) {
+        self.chain = chain
+        if isNativeToken || contractAddress.isEmpty {
+            self.contractAddress = ""
+        } else if chain.chainType == .EVM {
+            self.contractAddress = contractAddress.lowercased()
+        } else {
+            self.contractAddress = contractAddress
+        }
+    }
+
+    init(coin: Coin) {
+        self.init(
+            chain: coin.chain,
+            contractAddress: coin.contractAddress,
+            isNativeToken: coin.isNativeToken
+        )
+    }
+
+    init(coinMeta: CoinMeta) {
+        self.init(
+            chain: coinMeta.chain,
+            contractAddress: coinMeta.contractAddress,
+            isNativeToken: coinMeta.isNativeToken
+        )
+    }
+}
+
+struct SwapKitAssetCatalogSnapshot: Sendable {
+    let buckets: [Chain: DestinationTokenBucket]
+    let identifiers: [SwapKitAssetKey: Set<String>]
+}
+
+actor SwapKitAssetCatalog {
+    static let shared = SwapKitAssetCatalog()
+
+    private let httpClient: HTTPClientProtocol
+    private let providerCache: SwapKitProviderCache
+    private var snapshot: Snapshot?
+    private var inFlight: Task<SwapKitAssetCatalogSnapshot?, Never>?
+
+    private struct Snapshot: Sendable {
+        let catalog: SwapKitAssetCatalogSnapshot
+        let fetchedAt: Date
+    }
+
+    init(
+        httpClient: HTTPClientProtocol = HTTPClient(),
+        providerCache: SwapKitProviderCache = .shared
+    ) {
+        self.httpClient = httpClient
+        self.providerCache = providerCache
+    }
+
+    func tokens(
+        for chain: Chain,
+        forceRefresh: Bool = false,
+        now: Date = Date()
+    ) async -> DestinationTokenBucket {
+        guard SwapKitConfig.isFeatureEnabled else {
+            return .empty(chain: chain)
+        }
+        let catalog = await ensureSnapshot(now: now, forceRefresh: forceRefresh)
+        return catalog?.buckets[chain] ?? .empty(chain: chain)
+    }
+
+    func identifier(
+        for key: SwapKitAssetKey,
+        forceRefresh: Bool = false,
+        now: Date = Date()
+    ) async -> String? {
+        guard SwapKitConfig.isFeatureEnabled else { return nil }
+        guard let identifiers = await ensureSnapshot(
+            now: now,
+            forceRefresh: forceRefresh
+        )?.identifiers[key], identifiers.count == 1 else {
+            return nil
+        }
+        return identifiers.first
+    }
+
+    func setSnapshot(
+        _ catalog: SwapKitAssetCatalogSnapshot,
+        fetchedAt: Date = Date()
+    ) {
+        snapshot = Snapshot(catalog: catalog, fetchedAt: fetchedAt)
+    }
+
+    func clearCache() {
+        snapshot = nil
+        inFlight?.cancel()
+        inFlight = nil
+    }
+
+    private func ensureSnapshot(
+        now: Date,
+        forceRefresh: Bool
+    ) async -> SwapKitAssetCatalogSnapshot? {
+        if !forceRefresh,
+           let snapshot,
+           now.timeIntervalSince(snapshot.fetchedAt) < SwapKitConfig.tokensCacheTTL {
+            return snapshot.catalog
+        }
+        if let inFlight {
+            return await inFlight.value
+        }
+
+        let task = Task { [providerCache, httpClient] in
+            await Self.fetchAll(
+                providerCache: providerCache,
+                httpClient: httpClient,
+                now: now
+            )
+        }
+        inFlight = task
+        let result = await task.value
+        inFlight = nil
+        if let result {
+            snapshot = Snapshot(catalog: result, fetchedAt: now)
+        }
+        return result ?? snapshot?.catalog
+    }
+
+    private static func fetchAll(
+        providerCache: SwapKitProviderCache,
+        httpClient: HTTPClientProtocol,
+        now: Date
+    ) async -> SwapKitAssetCatalogSnapshot? {
+        guard let allProviders = await providerCache.providers(now: now) else {
+            logger.info("[swapkit-tokens] no provider snapshot available — skipping fetch")
+            return nil
+        }
+
+        let providerNames = Set(allProviders.map { $0.provider.uppercased() })
+            .filter { !SwapKitConfig.filteredProviders.contains($0) }
+            .sorted()
+        guard !providerNames.isEmpty else {
+            logger.info("[swapkit-tokens] no eligible providers after THORChain/Maya filter")
+            return SwapKitAssetCatalogSnapshot(buckets: [:], identifiers: [:])
+        }
+
+        let fetched = await withTaskGroup(of: SwapKitTokensResponse?.self) { group in
+            for name in providerNames {
+                group.addTask {
+                    await fetchTokens(provider: name, httpClient: httpClient)
+                }
+            }
+            var collected: [SwapKitTokensResponse] = []
+            for await response in group {
+                if let response {
+                    collected.append(response)
+                }
+            }
+            return collected
+        }
+        return buildSnapshot(responses: fetched)
+    }
+
+    private static func fetchTokens(
+        provider: String,
+        httpClient: HTTPClientProtocol
+    ) async -> SwapKitTokensResponse? {
+        do {
+            let response = try await httpClient.request(
+                SwapKitAPI.tokens(provider: provider),
+                responseType: SwapKitTokensResponse.self
+            )
+            return response.data
+        } catch {
+            logger.warning("[swapkit-tokens] failed to fetch \(provider, privacy: .public): \(String(describing: error), privacy: .public)")
+            return nil
+        }
+    }
+
+    nonisolated static func buildSnapshot(
+        responses: [SwapKitTokensResponse]
+    ) -> SwapKitAssetCatalogSnapshot {
+        var byChainTokens: [Chain: [CoinMeta]] = [:]
+        var byChainIdentifiers: [Chain: Set<String>] = [:]
+        var assetIdentifiers: [SwapKitAssetKey: Set<String>] = [:]
+
+        for response in responses {
+            for token in response.tokens {
+                guard let coinMeta = token.toCoinMeta() else { continue }
+                let key = SwapKitAssetKey(coinMeta: coinMeta)
+                assetIdentifiers[key, default: []].insert(token.identifier)
+
+                let chain = coinMeta.chain
+                var seen = byChainIdentifiers[chain] ?? []
+                guard !seen.contains(token.identifier) else { continue }
+                seen.insert(token.identifier)
+                byChainIdentifiers[chain] = seen
+                byChainTokens[chain, default: []].append(coinMeta)
+            }
+        }
+
+        var buckets: [Chain: DestinationTokenBucket] = [:]
+        for (chain, tokens) in byChainTokens {
+            buckets[chain] = DestinationTokenBucket(
+                chain: chain,
+                tokens: tokens,
+                uniqueIds: Set(tokens.map(\.uniqueId))
+            )
+        }
+        return SwapKitAssetCatalogSnapshot(
+            buckets: buckets,
+            identifiers: assetIdentifiers
+        )
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitAssetCatalog.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitAssetCatalog.swift
@@ -86,10 +86,10 @@ actor SwapKitAssetCatalog {
         guard let identifiers = await ensureSnapshot(
             now: now,
             forceRefresh: forceRefresh
-        )?.identifiers[key], identifiers.count == 1 else {
+        )?.identifiers[key] else {
             return nil
         }
-        return identifiers.first
+        return Self.preferredIdentifier(from: identifiers, for: key)
     }
 
     func setSnapshot(
@@ -219,5 +219,25 @@ actor SwapKitAssetCatalog {
             buckets: buckets,
             identifiers: assetIdentifiers
         )
+    }
+
+    /// Provider catalogues do not agree on EVM address casing inside an
+    /// otherwise identical identifier. Treat case-only variants as the same
+    /// asset and prefer a spelling whose contract suffix matches the
+    /// lowercased lookup key. Distinct identifiers remain ambiguous and fail
+    /// closed instead of guessing between symbols that share a contract key.
+    nonisolated private static func preferredIdentifier(
+        from identifiers: Set<String>,
+        for key: SwapKitAssetKey
+    ) -> String? {
+        guard !identifiers.isEmpty else { return nil }
+        guard Set(identifiers.map { $0.lowercased() }).count == 1 else {
+            return nil
+        }
+
+        let sorted = identifiers.sorted()
+        guard !key.contractAddress.isEmpty else { return sorted.first }
+        let canonicalSuffix = "-\(key.contractAddress)"
+        return sorted.first(where: { $0.hasSuffix(canonicalSuffix) }) ?? sorted.first
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitAssetCatalog.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitAssetCatalog.swift
@@ -74,9 +74,6 @@ actor SwapKitAssetCatalog {
         forceRefresh: Bool = false,
         now: Date = Date()
     ) async -> DestinationTokenBucket {
-        guard SwapKitConfig.isFeatureEnabled else {
-            return .empty(chain: chain)
-        }
         let catalog = await ensureSnapshot(now: now, forceRefresh: forceRefresh)
         return catalog?.buckets[chain] ?? .empty(chain: chain)
     }
@@ -86,7 +83,6 @@ actor SwapKitAssetCatalog {
         forceRefresh: Bool = false,
         now: Date = Date()
     ) async -> String? {
-        guard SwapKitConfig.isFeatureEnabled else { return nil }
         guard let identifiers = await ensureSnapshot(
             now: now,
             forceRefresh: forceRefresh

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitCapability.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitCapability.swift
@@ -41,4 +41,30 @@ enum SwapKitCapability {
         }
         return true
     }
+
+    /// The `/swap` payload must match the source chain's implemented signer.
+    /// A typed payload for the wrong chain is as unsafe as an unknown payload:
+    /// both are rejected before the quote can enter ranking.
+    static func canSign(_ tx: SwapKitTx, from chain: Chain) -> Bool {
+        switch (chain, tx) {
+        case (_, .evm) where chain.chainType == .EVM:
+            return true
+        case (.solana, .solana),
+             (.bitcoin, .psbt),
+             (.litecoin, .psbt),
+             (.dogecoin, .dogecoinPsbt),
+             (.bitcoinCash, .bitcoinCashPsbt),
+             (.dash, .dashPsbt),
+             (.zcash, .zcashPsbt),
+             (.ton, .ton),
+             (.cardano, .cardano),
+             (.cardano, .cardanoPrebuilt),
+             (.sui, .sui),
+             (.tron, .tron),
+             (.ripple, .rippleDepositOnly):
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitCapability.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitCapability.swift
@@ -1,0 +1,44 @@
+//
+//  SwapKitCapability.swift
+//  VultisigApp
+//
+
+enum SwapKitCapability {
+    /// The app can hold a destination asset on these chains. Exact token
+    /// support is still decided by the live SwapKit catalogue.
+    static func canReceive(on chain: Chain) -> Bool {
+        if chain.chainType == .EVM {
+            return chain.isSwapAvailable
+        }
+
+        switch chain {
+        case .bitcoin,
+             .bitcoinCash,
+             .cardano,
+             .dash,
+             .dogecoin,
+             .litecoin,
+             .ripple,
+             .solana,
+             .sui,
+             .ton,
+             .tron,
+             .zcash:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Source-side eligibility is directional. EVM SwapKit transactions must
+    /// be reputation-checked before signing, so only networks with a known
+    /// Blockaid identifier can originate a route. This deliberately keeps
+    /// Robinhood destination-only until Blockaid supports chain 4663.
+    static func canQuote(from chain: Chain) -> Bool {
+        guard canReceive(on: chain) else { return false }
+        if chain.chainType == .EVM {
+            return BlockaidChainIdentifier.name(for: chain) != nil
+        }
+        return true
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitChainIdentifier.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitChainIdentifier.swift
@@ -3,13 +3,8 @@
 //  VultisigApp
 //
 //  Translation from the Vultisig `Chain` enum to the chainId string SwapKit's
-//  `/track` endpoint expects. The table mirrors the canonical chain table in
-//  `swapkit-spike/api-contract.md` — EVM chains use the decimal chainId,
+//  `/track` endpoint expects. EVM chains use their decimal chainId directly;
 //  non-EVM chains use SwapKit's slug.
-//
-//  Kept separate from `SwapKitService.chainPrefix` because that function maps
-//  to the *asset prefix* (e.g. `ETH`, `ARB`, `BTC`) — `/track` needs the
-//  numeric/slug chainId instead, which only overlaps for a couple of chains.
 //
 
 import Foundation

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitChainIdentifier.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitChainIdentifier.swift
@@ -20,59 +20,7 @@ enum SwapKitChainIdentifier {
     /// `nil` is the signal to skip tracking — the caller surfaces a deep-link
     /// fallback rather than attempting polling against an unknown chain.
     static func chainId(for chain: Chain) -> String? {
-        switch chain {
-        case .ethereum:
-            return "1"
-        case .arbitrum:
-            return "42161"
-        case .avalanche:
-            return "43114"
-        case .base:
-            return "8453"
-        case .bscChain:
-            return "56"
-        case .polygon, .polygonV2:
-            return "137"
-        case .optimism:
-            return "10"
-        case .blast:
-            return "81457"
-        case .zksync:
-            return "324"
-        case .tron:
-            return "728126428"
-        case .cardano:
-            return "cardano"
-        case .ton:
-            return "ton"
-        case .solana:
-            return "solana"
-        case .bitcoin:
-            return "bitcoin"
-        case .bitcoinCash:
-            return "bitcoincash"
-        case .litecoin:
-            return "litecoin"
-        case .ripple:
-            return "ripple"
-        case .gaiaChain:
-            return "cosmoshub-4"
-        case .dash:
-            return "dash"
-        case .zcash:
-            return "zcash"
-        case .sui:
-            return "sui"
-        case .dogecoin:
-            return "dogecoin"
-        case .kujira:
-            return "kaiyo-1"
-        case .mayaChain:
-            return "mayachain-mainnet-v1"
-        case .thorChain, .thorChainChainnet, .thorChainStagenet:
-            return "thorchain-1"
-        default:
-            return nil
-        }
+        let chainId = SwapKitChainIDMapper.swapKitChainId(for: chain)
+        return chainId.isEmpty ? nil : chainId
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitConfig.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitConfig.swift
@@ -68,13 +68,4 @@ enum SwapKitConfig {
         "MAYACHAIN",
         "MAYACHAIN_STREAMING"
     ]
-
-    /// Gates SwapKit across the app — `swapProviders` list inclusion and
-    /// `SwapKitService.fetchBestRoute`. SwapKit has shipped and is always
-    /// enabled; the former Settings → Advanced opt-out toggle has been
-    /// removed. The property is kept as a single source of truth so the
-    /// call sites retain one gate if we ever need to dark-launch a change.
-    static var isFeatureEnabled: Bool {
-        true
-    }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitProviderCache.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitProviderCache.swift
@@ -157,20 +157,16 @@ actor SwapKitProviderCache {
     }
 }
 
-/// Maps Vultisig's `Chain` enum to SwapKit's chainId string (per
-/// `api-contract.md` canonical chain table). Returns `""` when the chain has
-/// no SwapKit-side identifier — that maps to "definitely not enabled" in the
-/// cache predicate, which is what we want.
+/// Maps Vultisig's `Chain` enum to SwapKit's chainId string. EVM chains use
+/// their decimal chain id directly so a newly supported EVM network does not
+/// require another client allowlist entry just to try a quote.
 enum SwapKitChainIDMapper {
     static func swapKitChainId(for chain: Chain) -> String {
+        if chain.chainType == .EVM, let chainId = chain.chainID {
+            return String(chainId)
+        }
+
         switch chain {
-        case .ethereum: return "1"
-        case .arbitrum: return "42161"
-        case .avalanche: return "43114"
-        case .base: return "8453"
-        case .bscChain: return "56"
-        case .polygon, .polygonV2: return "137"
-        case .optimism: return "10"
         case .solana: return "solana"
         case .bitcoin: return "bitcoin"
         case .bitcoinCash: return "bitcoincash"
@@ -191,15 +187,30 @@ enum SwapKitChainIDMapper {
         }
     }
 
-    /// Reverse map for the per-token `chain` field in `/tokens` responses
-    /// (uppercase ticker-style key, e.g. `"ETH"`, `"BSC"`, `"NEAR"`, `"BTC"`).
+    /// Reverse map for a `/tokens` entry. Numeric EVM `chainId` is
+    /// authoritative, which distinguishes Robinhood (`4663`) from Ethereum
+    /// even though both native assets use the ETH ticker. The `chain` key is
+    /// retained for non-EVM slugs and legacy responses without `chainId`.
     /// Returns `nil` for chains Vultisig has no wallet support for — those
     /// tokens can't be receive destinations so they're dropped at decode.
     /// Note: SwapKit's per-token `chain` is unique per Vultisig chain (Base
     /// ETH appears as `"BASE"`, OP ETH as `"OP"`, not as `"ETH"`), so the
     /// reverse map is many-to-one only for legacy aliases (e.g. `"POL"` and
     /// `"MATIC"` both reaching `.polygon`).
-    static func chain(forSwapKitChain swapKitChain: String) -> Chain? {
+    static func chain(
+        forSwapKitChain swapKitChain: String,
+        chainId: String? = nil
+    ) -> Chain? {
+        if let chainId,
+           let numericChainId = Int(chainId),
+           let evmChain = Chain.allCases.first(where: {
+               $0.chainType == .EVM && $0.chainID == numericChainId
+           }) {
+            // PolygonV2 shares 137 with Polygon. SwapKit's catalogue models
+            // the network as one chain, so keep the canonical wallet chain.
+            return evmChain == .polygonV2 ? .polygon : evmChain
+        }
+
         switch swapKitChain.uppercased() {
         case "ETH": return .ethereum
         case "BSC", "BNB": return .bscChain
@@ -222,6 +233,11 @@ enum SwapKitChainIDMapper {
         case "XRP": return .ripple
         case "ATOM": return .gaiaChain
         case "KUJI": return .kujira
+        case "HOOD": return .robinhood
+        case "HYPEREVM": return .hyperliquid
+        // HyperCore is a separate venue and is deliberately out of scope.
+        // Never infer the EVM wallet chain from its `HYPE` catalogue key.
+        case "HYPE": return nil
         // Chains SwapKit lists tokens on but Vultisig doesn't hold wallets
         // for — caller drops the token. Enumerated for grep-discoverability
         // rather than relying on the default arm.

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
@@ -19,13 +19,16 @@ struct SwapKitService {
 
     private let httpClient: HTTPClientProtocol
     private let providerCache: SwapKitProviderCache
+    private let assetCatalog: SwapKitAssetCatalog
 
     init(
         httpClient: HTTPClientProtocol = HTTPClient(),
-        providerCache: SwapKitProviderCache = .shared
+        providerCache: SwapKitProviderCache = .shared,
+        assetCatalog: SwapKitAssetCatalog = .shared
     ) {
         self.httpClient = httpClient
         self.providerCache = providerCache
+        self.assetCatalog = assetCatalog
     }
 
     /// Fetch all candidate routes for a (from, to) pair, drop the ones we
@@ -74,9 +77,20 @@ struct SwapKitService {
         // (when set) is passed here so SwapKit AML-screens it at quote time and
         // discovers routes that can deliver to it.
         let resolvedDestination = destinationAddress ?? toCoin.address
+        guard
+            let sellAsset = await assetCatalog.identifier(
+                for: SwapKitAssetKey(coin: fromCoin)
+            ),
+            let buyAsset = await assetCatalog.identifier(
+                for: SwapKitAssetKey(coin: toCoin)
+            )
+        else {
+            logger.info("[swapkit] exact catalogue identifier unavailable — skipping quote")
+            return nil
+        }
         let request = SwapKitQuoteRequest(
-            sellAsset: assetIdentifier(for: fromCoin),
-            buyAsset: assetIdentifier(for: toCoin),
+            sellAsset: sellAsset,
+            buyAsset: buyAsset,
             sellAmount: Self.formatSellAmount(amount),
             sourceAddress: fromCoin.address.isEmpty ? nil : fromCoin.address,
             destinationAddress: resolvedDestination.isEmpty ? nil : resolvedDestination,
@@ -251,9 +265,13 @@ extension SwapKitService {
     }
 
     private func inboundFeeFromWire(response: SwapKitSwapResponse, fromCoin: Coin) -> BigInt? {
-        let prefix = chainPrefix(for: fromCoin.chain, fallback: fromCoin.ticker)
+        guard let prefix = response.sellAsset.split(separator: ".").first.map(String.init) else {
+            return nil
+        }
         guard
-            let inbound = response.fees.first(where: { $0.type == "inbound" && $0.chain == prefix }),
+            let inbound = response.fees.first(where: {
+                $0.type == "inbound" && $0.chain.caseInsensitiveCompare(prefix) == .orderedSame
+            }),
             let amount = Decimal(string: inbound.amount)
         else {
             return nil
@@ -271,90 +289,7 @@ extension SwapKitService {
     }
 }
 
-extension SwapKitService {
-    /// SwapKit asset identifier format: `Chain.Ticker` for native tokens,
-    /// `Chain.Ticker-Contract` for tokens with an on-chain contract address.
-    /// See `api-contract.md` for the canonical chain prefix table.
-    ///
-    /// SwapKit tracks display renames, so there is no new-to-old mapping to
-    /// apply here. The native TON coin is `TON.GRAM`, not `TON.TON`: the
-    /// Toncoin → Gram rename has landed on their side too, and quoting the
-    /// pre-rename identifier now fails with `tokenPriceUnavailable`. Re-check
-    /// the exact identifier before assuming otherwise — the list is public and
-    /// unauthenticated:
-    ///
-    ///     GET https://api.vultisig.com/swapkit/tokens?provider=NEAR
-    ///
-    /// (bare host, no `/v3` — see `SwapKitAPI.baseURL`). Match on `identifier`;
-    /// `price` is null for every entry on that endpoint, so a null price says
-    /// nothing about whether an asset is quotable.
-    func assetIdentifier(for coin: Coin) -> String {
-        let prefix = chainPrefix(for: coin.chain, fallback: coin.ticker)
-        let symbol = canonicalSymbol(for: coin)
-        if coin.isNativeToken || coin.contractAddress.isEmpty {
-            return "\(prefix).\(symbol)"
-        }
-        return "\(prefix).\(symbol)-\(coin.contractAddress)"
-    }
-}
-
 private extension SwapKitService {
-    /// The symbol to quote the coin under: its own ticker, except that a NATIVE
-    /// coin defers to the curated `TokensStore` entry for its chain.
-    ///
-    /// That normalises a *stale persisted* ticker forward to the name the asset
-    /// trades under today. The launch migration rewrites `vault.coins`, but a
-    /// vault restored from a pre-rebrand backup lands after it has already run
-    /// and still holds a `TON`-ticker'd native, which would quote as the dead
-    /// `TON.TON`.
-    ///
-    /// Note the direction — this maps stale local data onto the CURRENT
-    /// canonical symbol, and reads that symbol from the store rather than
-    /// hardcoding it, so a future rename needs no change here. The reverse
-    /// (rewriting a current ticker back to a legacy one to accommodate a
-    /// lagging counterparty) is exactly what broke TON swaps and must not be
-    /// reintroduced without re-checking the live list first.
-    func canonicalSymbol(for coin: Coin) -> String {
-        guard coin.isNativeToken else { return coin.ticker }
-        let curated = TokensStore.TokenSelectionAssets
-            .first { $0.chain == coin.chain && $0.isNativeToken }
-        return curated?.ticker ?? coin.ticker
-    }
-
-    func chainPrefix(for chain: Chain, fallback: String) -> String {
-        // Canonical prefixes verified empirically against
-        // `/v3/tokens?provider=NEAR` — SwapKit uses chain-specific tickers
-        // for EVM L2s and BSC, not the gas-token tickers Vultisig stores in
-        // `coin.ticker`. Mismatches surface as `helpers_invalid_asset_identifier`
-        // 500s from the proxy at quote time.
-        switch chain {
-        case .ethereum: return "ETH"
-        case .base: return "BASE"
-        case .optimism: return "OP"
-        case .arbitrum: return "ARB"
-        case .avalanche: return "AVAX"
-        case .bscChain: return "BSC"
-        case .polygon, .polygonV2: return "POL"
-        case .solana: return "SOL"
-        case .bitcoin: return "BTC"
-        case .bitcoinCash: return "BCH"
-        case .litecoin: return "LTC"
-        case .dogecoin: return "DOGE"
-        case .tron: return "TRON"
-        case .ton: return "TON"
-        case .cardano: return "ADA"
-        case .sui: return "SUI"
-        case .ripple: return "XRP"
-        case .dash: return "DASH"
-        case .zcash: return "ZEC"
-        case .gaiaChain: return "ATOM"
-        case .kujira: return "KUJI"
-        case .thorChain, .thorChainChainnet, .thorChainStagenet: return "THOR"
-        case .mayaChain: return "MAYA"
-        default: return fallback
-        }
-    }
-
     /// Decimals to scale the inbound fee by. The fee is always denominated in the source chain's
     /// native gas coin, so a native-source coin already carries the right decimals; for an ERC-20 /
     /// SPL token source we look up the chain's native coin (whose decimals differ from the token's)

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
@@ -192,6 +192,20 @@ struct SwapKitService {
         return ranked.max(by: { $0.1 < $1.1 })?.0
     }
 
+    static func validateSigningCapability(
+        response: SwapKitSwapResponse,
+        fromChain: Chain
+    ) throws {
+        if case let .unsupported(txType, _) = response.tx {
+            throw SwapKitError.unsupportedTxType(txType)
+        }
+        guard SwapKitCapability.canSign(response.tx, from: fromChain) else {
+            throw SwapKitError.unsupportedTxType(
+                "\(response.meta.txType)/\(fromChain.ticker)"
+            )
+        }
+    }
+
     /// Format an amount as a dot-separated decimal string suitable for
     /// `SwapKitQuoteRequest.sellAmount`. SwapKit interprets the value as the
     /// human-readable amount of the source asset (e.g. "0.0086" BNB), NOT

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
@@ -45,19 +45,6 @@ struct SwapKitService {
         slippagePercent: Double? = nil,
         affiliateFeeBps: Int
     ) async throws -> SwapKitRoute? {
-        // Opt-in feature flag (Settings → Advanced → "SwapKit"). When the
-        // flag is off, short-circuit even if `Coin+Swaps.swapProviders`
-        // already filtered `.swapkit` out — defense in depth so a future
-        // call site that bypasses the provider list can't accidentally
-        // light SwapKit up. The Vultisig proxy
-        // (`api.vultisig.com/swapkit/`) attaches the partner API key
-        // server-side; this flag exists to control client-side visibility
-        // during smoke testing.
-        guard SwapKitConfig.isFeatureEnabled else {
-            logger.info("[swapkit] feature flag disabled — skipping fetch")
-            return nil
-        }
-
         // `sellAmount` must be a decimal-with-dot string (e.g. "0.0086"),
         // NOT raw base units. Per the SwapKit API contract:
         //   "Amount in basic units (decimals separated with a dot)"

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
@@ -251,6 +251,9 @@ extension SwapKitService {
     /// and TRON fixtures all report the real native miner/network fee there as
     /// a decimal native amount (e.g. "0.000005" SOL).
     func inboundFee(from response: SwapKitSwapResponse, fromCoin: Coin) -> BigInt? {
+        guard SwapKitCapability.canSign(response.tx, from: fromCoin.chain) else {
+            return nil
+        }
         if case let .evm(tx) = response.tx {
             return evmNetworkFee(from: tx, isNativeSource: fromCoin.isNativeToken)
         }

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitToken.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitToken.swift
@@ -21,8 +21,8 @@ import Foundation
 ///    empty string for NEAR's `NEAR.NEAR` gas token, sometimes a NEAR
 ///    intent identifier like `zec.omft.near` for cross-chain entries).
 ///  - `chainId` — SwapKit's per-chain identifier (`"1"` for EVM, `"solana"`,
-///    `"bitcoin"`, etc.). Not used by the adapter; the `chain` string is the
-///    canonical key.
+///    `"bitcoin"`, etc.). Numeric EVM ids are authoritative because the
+///    display `chain` key can otherwise collide or refer to HyperCore.
 struct SwapKitToken: Codable, Hashable {
     let chain: String
     let chainId: String?
@@ -54,7 +54,10 @@ extension SwapKitToken {
     ///    its chain (NEAR cross-chain wrappers like `NEAR.ZEC-zec.omft.near`
     ///    aren't holdable on Vultisig).
     func toCoinMeta() -> CoinMeta? {
-        guard let chain = SwapKitChainIDMapper.chain(forSwapKitChain: self.chain) else {
+        guard let chain = SwapKitChainIDMapper.chain(
+            forSwapKitChain: self.chain,
+            chainId: chainId
+        ) else {
             return nil
         }
 

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitTokensCache.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitTokensCache.swift
@@ -2,214 +2,72 @@
 //  SwapKitTokensCache.swift
 //  VultisigApp
 //
-//  Fans out `GET /tokens?provider=<NAME>` against the providers currently
-//  enabled in the cached `/v3/providers` snapshot, dedupes by `identifier`,
-//  buckets by reverse-mapped Vultisig `Chain`, and caches the result in
-//  memory with a 5-minute TTL. The destination coin picker resolves SwapKit
-//  destinations via `DestinationTokenRegistry`, which calls
-//  `tokens(for: chain)` here.
-//
-//  Storage decision: in-memory only. SwapKit publishes a `timestamp` per
-//  response and the list changes rarely; offline = no swap anyway, so
-//  SwiftData persistence would buy nothing for the migration / Sendable
-//  cost. See `wiki/.../swapkit-integration/tokens-picker-plan.md` §D2.
+//  Main-actor token-provider facade over the shared SwapKit asset catalogue.
 //
 
 import Foundation
-import OSLog
-
-private let logger = Log.swap.store
 
 @MainActor
 final class SwapKitTokensCache: DestinationTokenProvider {
-    static let shared = SwapKitTokensCache()
+    static let shared = SwapKitTokensCache(catalog: .shared)
 
     let kind: String = "swapKit"
-    // Long-tail cross-chain destinations: coingeckoId presence is only a weak
-    // proxy, so SwapKit tokens are the weakest trust tier. They still populate
-    // the swap destination picker (all destinations are swappable); the wallet
-    // search catalog gates them out via verification-to-surface.
     let verification: TokenVerification = .unverified
 
-    private let httpClient: HTTPClientProtocol
-    private let providerCache: SwapKitProviderCache
-    private var snapshot: Snapshot?
-    private var inFlight: Task<[Chain: DestinationTokenBucket]?, Never>?
-
-    private struct Snapshot {
-        let buckets: [Chain: DestinationTokenBucket]
-        let fetchedAt: Date
-    }
+    private let catalog: SwapKitAssetCatalog
 
     init(
         httpClient: HTTPClientProtocol = HTTPClient(),
-        providerCache: SwapKitProviderCache = .shared
+        providerCache: SwapKitProviderCache = .shared,
+        catalog: SwapKitAssetCatalog? = nil
     ) {
-        self.httpClient = httpClient
-        self.providerCache = providerCache
+        self.catalog = catalog ?? SwapKitAssetCatalog(
+            httpClient: httpClient,
+            providerCache: providerCache
+        )
     }
 
-    /// Tokens unlocked by SwapKit on `chain`, fetched + cached on first call.
-    /// Returns an empty bucket (rather than nil) when:
-    ///  - The feature flag is OFF (defensive — callers should already gate
-    ///    on `SwapKitConfig.isFeatureEnabled`, but the cache fails closed).
-    ///  - The cache fetch fails entirely and we have no prior snapshot.
-    ///  - SwapKit has no tokens on this chain (cache built, bucket missing).
-    /// The picker treats "empty bucket" identically to "no SwapKit unlock"
-    /// and falls back to the curated + 1inch + Jupiter list it has today.
-    func tokens(for chain: Chain, forceRefresh: Bool) async -> DestinationTokenBucket {
-        await tokens(for: chain, forceRefresh: forceRefresh, now: Date())
+    func tokens(
+        for chain: Chain,
+        forceRefresh: Bool
+    ) async -> DestinationTokenBucket {
+        await catalog.tokens(for: chain, forceRefresh: forceRefresh)
     }
 
-    /// Date-injectable variant used by tests / TTL-sensitive callers.
-    func tokens(for chain: Chain, forceRefresh: Bool = false, now: Date) async -> DestinationTokenBucket {
-        guard SwapKitConfig.isFeatureEnabled else {
-            return .empty(chain: chain)
-        }
-        let buckets = await ensureSnapshot(now: now, forceRefresh: forceRefresh)
-        return buckets?[chain] ?? .empty(chain: chain)
-    }
-
-    /// Coalescing fetch — concurrent callers share one in-flight Task to
-    /// avoid stampeding the proxy on first picker open. Returns the cached
-    /// snapshot when fresh; otherwise refreshes.
-    ///
-    /// `forceRefresh` skips the TTL-fresh early-return so the caller always
-    /// triggers a re-fetch, but still rides the `inFlight` coalescing (so
-    /// concurrent force-refreshes share one request) and the last-good
-    /// fallback (so a failed forced fetch keeps the prior snapshot on screen).
-    private func ensureSnapshot(now: Date, forceRefresh: Bool) async -> [Chain: DestinationTokenBucket]? {
-        if !forceRefresh,
-           let snapshot,
-           now.timeIntervalSince(snapshot.fetchedAt) < SwapKitConfig.tokensCacheTTL {
-            return snapshot.buckets
-        }
-        if let inFlight {
-            return await inFlight.value
-        }
-        let task = Task { [providerCache, httpClient] () -> [Chain: DestinationTokenBucket]? in
-            await Self.fetchAll(providerCache: providerCache, httpClient: httpClient, now: now)
-        }
-        inFlight = task
-        let result = await task.value
-        inFlight = nil
-        if let result {
-            snapshot = Snapshot(buckets: result, fetchedAt: now)
-        }
-        return result ?? snapshot?.buckets
-    }
-
-    /// Replace the snapshot — exposed for tests so they don't need a fake
-    /// `HTTPClient`. Mirrors the affordance `SwapKitProviderCache.setSnapshot`
-    /// gives provider-cache tests.
-    func setSnapshot(buckets: [Chain: DestinationTokenBucket], fetchedAt: Date = Date()) {
-        snapshot = Snapshot(buckets: buckets, fetchedAt: fetchedAt)
-    }
-
-    /// Drop the cached snapshot + in-flight task. Next `tokens(for:)` call
-    /// refetches against the proxy regardless of TTL. Exposed for the
-    /// Settings → Advanced "Clear SwapKit tokens cache" debug action so
-    /// testers can pick up upstream catalog changes without waiting for
-    /// the 5-minute TTL or app relaunch.
-    func clearCache() {
-        snapshot = nil
-        inFlight?.cancel()
-        inFlight = nil
-    }
-
-    // MARK: - Fan-out + merge
-
-    private static func fetchAll(
-        providerCache: SwapKitProviderCache,
-        httpClient: HTTPClientProtocol,
+    func tokens(
+        for chain: Chain,
+        forceRefresh: Bool = false,
         now: Date
-    ) async -> [Chain: DestinationTokenBucket]? {
-        guard let allProviders = await providerCache.providers(now: now) else {
-            logger.info("[swapkit-tokens] no provider snapshot available — skipping fetch")
-            return nil
-        }
-        // Fan out by `provider.provider` (the canonical API identifier), not
-        // `provider.name`. `SwapKitProviderCache.chainEnabled` filters
-        // THORChain/Maya by `provider.provider.uppercased()` against
-        // `SwapKitConfig.filteredProviders`, and the same identifier is the
-        // one `/tokens?provider=` accepts. Using `.name` here can both let
-        // filtered providers through (when name and identifier diverge) and
-        // request `/tokens` with a non-canonical value.
-        let providerNames = allProviders
-            .map { $0.provider.uppercased() }
-            .filter { !SwapKitConfig.filteredProviders.contains($0) }
-
-        guard !providerNames.isEmpty else {
-            logger.info("[swapkit-tokens] no eligible providers after THORChain/Maya filter")
-            return [:]
-        }
-
-        let fetched: [SwapKitTokensResponse] = await withTaskGroup(of: SwapKitTokensResponse?.self) { group in
-            for name in providerNames {
-                group.addTask {
-                    await fetchTokens(provider: name, httpClient: httpClient)
-                }
-            }
-            var collected: [SwapKitTokensResponse] = []
-            for await response in group {
-                if let response { collected.append(response) }
-            }
-            return collected
-        }
-
-        return mergeByChain(responses: fetched)
+    ) async -> DestinationTokenBucket {
+        await catalog.tokens(
+            for: chain,
+            forceRefresh: forceRefresh,
+            now: now
+        )
     }
 
-    private static func fetchTokens(
-        provider: String,
-        httpClient: HTTPClientProtocol
-    ) async -> SwapKitTokensResponse? {
-        do {
-            let response = try await httpClient.request(
-                SwapKitAPI.tokens(provider: provider),
-                responseType: SwapKitTokensResponse.self
-            )
-            return response.data
-        } catch {
-            logger.warning("[swapkit-tokens] failed to fetch \(provider, privacy: .public): \(String(describing: error), privacy: .public)")
-            return nil
+    func setSnapshot(
+        buckets: [Chain: DestinationTokenBucket],
+        fetchedAt: Date = Date()
+    ) async {
+        await catalog.setSnapshot(
+            SwapKitAssetCatalogSnapshot(
+                buckets: buckets,
+                identifiers: [:]
+            ),
+            fetchedAt: fetchedAt
+        )
+    }
+
+    func clearCache() {
+        Task {
+            await catalog.clearCache()
         }
     }
 
-    /// Dedup + bucket. Exposed as a static so tests can drive it from
-    /// fixture data without standing up the cache + HTTPClient.
-    /// `nonisolated` since the body touches no instance state and the
-    /// inputs/outputs are value types — keeps test callers off MainActor.
-    ///
-    /// Dedup priority within a chain: a token already seen (by SwapKit
-    /// `identifier`) wins over a later one. SwapKit responses are stable
-    /// within a provider; cross-provider collisions are typically USDC
-    /// variants where the first hit is correct. Insertion order of the
-    /// resulting `tokens` array follows the order tokens were first
-    /// observed across the merged responses.
-    nonisolated static func mergeByChain(responses: [SwapKitTokensResponse]) -> [Chain: DestinationTokenBucket] {
-        var byChainTokens: [Chain: [CoinMeta]] = [:]
-        var byChainIdentifiers: [Chain: Set<String>] = [:]
-        for response in responses {
-            for token in response.tokens {
-                guard let coinMeta = token.toCoinMeta() else { continue }
-                let chain = coinMeta.chain
-                var seen = byChainIdentifiers[chain] ?? []
-                guard !seen.contains(token.identifier) else { continue }
-                seen.insert(token.identifier)
-                byChainIdentifiers[chain] = seen
-                byChainTokens[chain, default: []].append(coinMeta)
-            }
-        }
-        var buckets: [Chain: DestinationTokenBucket] = [:]
-        for (chain, tokens) in byChainTokens {
-            let uniqueIds = Set(tokens.map { $0.uniqueId })
-            buckets[chain] = DestinationTokenBucket(
-                chain: chain,
-                tokens: tokens,
-                uniqueIds: uniqueIds
-            )
-        }
-        return buckets
+    nonisolated static func mergeByChain(
+        responses: [SwapKitTokensResponse]
+    ) -> [Chain: DestinationTokenBucket] {
+        SwapKitAssetCatalog.buildSnapshot(responses: responses).buckets
     }
 }

--- a/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidChainIdentifier.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidChainIdentifier.swift
@@ -1,0 +1,24 @@
+//
+//  BlockaidChainIdentifier.swift
+//  VultisigApp
+//
+
+enum BlockaidChainIdentifier {
+    static func name(for chain: Chain) -> String? {
+        switch chain {
+        case .arbitrum: return "arbitrum"
+        case .avalanche: return "avalanche"
+        case .base: return "base"
+        case .blast: return "blast"
+        case .bscChain: return "bsc"
+        case .bitcoin: return "bitcoin"
+        case .ethereum: return "ethereum"
+        case .hyperliquid: return "hyperevm"
+        case .optimism: return "optimism"
+        case .polygon, .polygonV2: return "polygon"
+        case .solana: return "solana"
+        case .sui: return "sui"
+        default: return nil
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidRpcClient.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidRpcClient.swift
@@ -36,7 +36,7 @@ struct BlockaidRpcClient: BlockaidRpcClientProtocol {
         amount: String,
         data: String
     ) async throws -> BlockaidTransactionScanResponseJson {
-        let request = buildEthereumScanRequest(
+        let request = try buildEthereumScanRequest(
             chain: chain,
             from: from,
             to: to,
@@ -57,7 +57,7 @@ struct BlockaidRpcClient: BlockaidRpcClientProtocol {
         amount: String,
         data: String
     ) async throws -> BlockaidEvmSimulationResponseJson {
-        let request = buildEthereumSimulateRequest(
+        let request = try buildEthereumSimulateRequest(
             chain: chain,
             from: from,
             to: to,
@@ -117,7 +117,7 @@ private extension BlockaidRpcClient {
         serializedTransaction: String
     ) -> BitcoinScanTransactionRequestJson {
         return BitcoinScanTransactionRequestJson(
-            chain: Chain.bitcoin.toBlockaidName(),
+            chain: BlockaidChainIdentifier.name(for: .bitcoin) ?? "bitcoin",
             metadata: CommonMetadataJson(url: BlockaidConstants.vultisigDomain),
             options: ["validation"],
             accountAddress: address,
@@ -131,9 +131,15 @@ private extension BlockaidRpcClient {
         to: String,
         data: String,
         amount: String
-    ) -> EthereumScanTransactionRequestJson {
+    ) throws -> EthereumScanTransactionRequestJson {
+        guard let blockaidChain = BlockaidChainIdentifier.name(for: chain) else {
+            throw BlockaidScannerError.scannerError(
+                "Chain \(chain) is not supported",
+                payload: nil
+            )
+        }
         return EthereumScanTransactionRequestJson(
-            chain: chain.toBlockaidName(),
+            chain: blockaidChain,
             metadata: EthereumScanTransactionRequestJson.MetadataJson(
                 domain: BlockaidConstants.vultisigDomain
             ),
@@ -155,7 +161,13 @@ private extension BlockaidRpcClient {
         to: String,
         data: String,
         amount: String
-    ) -> EthereumSimulateTransactionRequestJson {
+    ) throws -> EthereumSimulateTransactionRequestJson {
+        guard let blockaidChain = BlockaidChainIdentifier.name(for: chain) else {
+            throw BlockaidScannerError.scannerError(
+                "Chain \(chain) is not supported",
+                payload: nil
+            )
+        }
         return EthereumSimulateTransactionRequestJson(
             data: EthereumSimulateTransactionRequestJson.DataJson(
                 method: "eth_sendTransaction",
@@ -168,7 +180,7 @@ private extension BlockaidRpcClient {
                     )
                 ]
             ),
-            chain: chain.toBlockaidName(),
+            chain: blockaidChain,
             metadata: EthereumSimulateTransactionRequestJson.MetadataJson(
                 domain: BlockaidConstants.vultisigDomain
             ),
@@ -220,38 +232,5 @@ private extension BlockaidRpcClient {
             accountAddress: address,
             transaction: serializedTransaction
         )
-    }
-}
-
-// MARK: - Chain Extension
-
-private extension Chain {
-    func toBlockaidName() -> String {
-        switch self {
-        case .arbitrum:
-            return "arbitrum"
-        case .avalanche:
-            return "avalanche"
-        case .base:
-            return "base"
-        case .blast:
-            return "blast"
-        case .bscChain:
-            return "bsc"
-        case .bitcoin:
-            return "bitcoin"
-        case .ethereum:
-            return "ethereum"
-        case .optimism:
-            return "optimism"
-        case .polygon, .polygonV2:
-            return "polygon"
-        case .sui:
-            return "sui"
-        case .solana:
-            return "solana"
-        default:
-            return .empty
-        }
     }
 }

--- a/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidScannerService.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidScannerService.swift
@@ -22,7 +22,8 @@ class BlockaidScannerService: BlockaidScannerServiceProtocol {
         let chain = transaction.chain
 
         switch chain {
-        case .arbitrum, .avalanche, .base, .blast, .bscChain, .ethereum, .optimism, .polygon, .polygonV2:
+        case .arbitrum, .avalanche, .base, .blast, .bscChain, .ethereum,
+             .hyperliquid, .optimism, .polygon, .polygonV2:
             return try await scanEvmTransaction(transaction)
         case .bitcoin:
             return try await scanBitcoinTransaction(transaction)
@@ -123,6 +124,7 @@ private extension BlockaidScannerService {
             .blast,
             .bscChain,
             .ethereum,
+            .hyperliquid,
             .optimism,
             .polygon,
             .polygonV2,

--- a/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidSimulationService.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidSimulationService.swift
@@ -168,7 +168,8 @@ actor BlockaidSimulationService {
         init?(payload: KeysignPayload) {
             switch payload.coin.chainType {
             case .EVM:
-                guard let memo = payload.memo?.lowercased(),
+                guard BlockaidChainIdentifier.name(for: payload.coin.chain) != nil,
+                      let memo = payload.memo?.lowercased(),
                       memo.hasPrefix("0x"),
                       memo.count > 2 else { return nil }
                 self = .evm(chain: payload.coin.chain, memo: memo)

--- a/VultisigApp/VultisigApp/Core/Services/Actions/Coin+Swaps.swift
+++ b/VultisigApp/VultisigApp/Core/Services/Actions/Coin+Swaps.swift
@@ -36,26 +36,16 @@ extension Coin {
         return applyProviderGates(providers)
     }
 
-    /// Applies the SwapKit feature flag + the debug forced-provider gate to a
-    /// raw natural-provider list.
+    /// Applies the debug forced-provider gate to a raw natural-provider list.
     private func applyProviderGates(_ raw: [SwapProvider]) -> [SwapProvider] {
-        // SwapKit is opt-in behind the Settings → Advanced → "SwapKit" toggle.
-        let afterSwapKitGate = SwapKitConfig.isFeatureEnabled
-            ? raw
-            : raw.filter { $0 != .swapkit }
-
         // Debug-only: Settings → Advanced → "Force swap provider" lets a
         // tester pin every quote to a single provider so the chosen
         // signing path is exercised in isolation (ranking ties don't
         // matter). Empty UserDefaults value = no force = production
-        // ranking across all providers. The forced-provider gate runs
-        // AFTER the SwapKit feature flag — if SwapKit is off and the
-        // forced provider is "swapkit", the result is empty and the swap
-        // UI surfaces "no providers available" rather than silently
-        // re-enabling SwapKit.
+        // ranking across all providers.
         let forced = UserDefaults.standard.string(forKey: "forcedSwapProvider") ?? ""
-        guard !forced.isEmpty else { return afterSwapKitGate }
-        return afterSwapKitGate.filter { matchesForcedProvider($0, forced: forced) }
+        guard !forced.isEmpty else { return raw }
+        return raw.filter { matchesForcedProvider($0, forced: forced) }
     }
 
     private func matchesForcedProvider(_ provider: SwapProvider, forced: String) -> Bool {
@@ -81,8 +71,8 @@ extension Coin {
         }
     }
 
-    /// The natural swap-provider list for a coin's chain, before the SwapKit
-    /// feature flag + forced-provider gates (`applyProviderGates`).
+    /// The natural swap-provider list for a coin's chain, before the
+    /// forced-provider gate (`applyProviderGates`).
     ///
     /// THORChain / MayaChain are offered at the **chain** level — every token on
     /// a supported EVM chain carries the native provider, and the live quote

--- a/VultisigApp/VultisigApp/Core/Services/Actions/Coin+Swaps.swift
+++ b/VultisigApp/VultisigApp/Core/Services/Actions/Coin+Swaps.swift
@@ -29,13 +29,11 @@ extension Coin {
     }
 
     var swapProviders: [SwapProvider] {
-        // SwapKit is opt-in behind the Settings → Advanced → "SwapKit"
-        // toggle. When the flag is off, drop `.swapkit` from every chain's
-        // provider list — ranking falls back to the other providers exactly
-        // as before the SwapKit integration shipped. Single point of
-        // gating: every chain's switch arm below carries `.swapkit` as if
-        // unconditionally enabled, and this filter prunes when needed.
-        return applyProviderGates(naturalSwapProviders)
+        var providers = naturalSwapProviders
+        if SwapKitCapability.canReceive(on: chain) {
+            providers.append(.swapkit)
+        }
+        return applyProviderGates(providers)
     }
 
     /// Applies the SwapKit feature flag + the debug forced-provider gate to a
@@ -97,34 +95,34 @@ extension Coin {
         case .mayaChain, .kujira:
             return [.mayachain]
         case .dash:
-            // Tier 1 L1 source — `.swapkit` enables DASH↔EVM / DASH↔SOL routes
+            // Tier 1 L1 source — SwapKit enables DASH↔EVM / DASH↔SOL routes
             // via NEAR Intents. Wire shape mirrors DOGE (legacy P2PKH PSBT,
             // no segwit); signed through `SwapKitDashSigner` riding
             // WalletCore's `CoinType.dash` end-to-end. MayaChain stays as
             // a provider — both rank against each other per quote.
-            return [.mayachain, .swapkit]
+            return [.mayachain]
         case .ethereum:
-            return [.thorchain, .mayachain, .oneinch(chain), .lifi, .kyberswap(chain), .swapkit]
+            return [.thorchain, .mayachain, .oneinch(chain), .lifi, .kyberswap(chain)]
         case .bscChain:
-            return [.thorchain, .oneinch(chain), .lifi, .kyberswap(chain), .swapkit]
+            return [.thorchain, .oneinch(chain), .lifi, .kyberswap(chain)]
         case .avalanche:
-            return [.thorchain, .oneinch(chain), .lifi, .kyberswap(chain), .swapkit]
+            return [.thorchain, .oneinch(chain), .lifi, .kyberswap(chain)]
         case .arbitrum:
-            return [.mayachain, .oneinch(chain), .lifi, .kyberswap(chain), .swapkit]
+            return [.mayachain, .oneinch(chain), .lifi, .kyberswap(chain)]
         case .base:
-            return [.thorchain, .oneinch(chain), .lifi, .kyberswap(chain), .swapkit]
+            return [.thorchain, .oneinch(chain), .lifi, .kyberswap(chain)]
         case .optimism, .polygon, .polygonV2:
-            return [.lifi, .oneinch(chain), .kyberswap(chain), .swapkit] // KyberSwap supported
+            return [.lifi, .oneinch(chain), .kyberswap(chain)] // KyberSwap supported
         case .mantle:
-            // `.swapkit` is included unconditionally — eligibility per chain
+            // SwapKit is included centrally — eligibility per chain
             // is gated dynamically by `SwapKitProviderCache.isEnabled`
             // against the cached `/v3/providers.enabledChainIds`. If
             // SwapKit lights up Mantle later, no iOS release needed.
-            return [.lifi, .oneinch(chain), .kyberswap(chain), .swapkit]
+            return [.lifi, .oneinch(chain), .kyberswap(chain)]
         case .zksync:
-            return [.oneinch(chain), .lifi, .swapkit] // KyberSwap not supported on zkSync
+            return [.oneinch(chain), .lifi] // KyberSwap not supported on zkSync
         case .blast:
-            return [.lifi, .swapkit] // KyberSwap not supported on Blast
+            return [.lifi] // KyberSwap not supported on Blast
         case .thorChain:
             return [.thorchain, .mayachain]
         case .thorChainChainnet:
@@ -132,22 +130,22 @@ extension Coin {
         case .thorChainStagenet:
             return [.thorchainStagenet]
         case .bitcoin:
-            // Phase 2 chain — `.swapkit` enables BTC↔EVM / BTC↔SOL / BTC↔TON
+            // Phase 2 chain — SwapKit enables BTC↔EVM / BTC↔SOL / BTC↔TON
             // / BTC↔SUI / BTC↔ADA routes via NEAR Intents / Chainflip /
             // Garden / Flashnet / Harbor. SwapKit returns a pre-built base64
             // PSBT and we sign it through the same UTXO helper path
             // THORChain BTC swaps already use.
-            return [.thorchain, .mayachain, .swapkit]
+            return [.thorchain, .mayachain]
         case .dogecoin:
             // Tier 1 L1 source — `.swapkit` enables DOGE↔EVM / DOGE↔SOL routes
             // via NEAR Intents. Wire shape matches BTC (`meta.txType: "PSBT"`)
             // but inputs are legacy P2PKH; signed through `SwapKitDogeSigner`
             // riding WalletCore's `CoinType.dogecoin` end-to-end.
-            return [.thorchain, .swapkit]
+            return [.thorchain]
         case .bitcoinCash:
             // Tier 1 L1 source — same shape as DOGE (legacy P2PKH PSBT).
             // BCH adds SIGHASH_FORKID natively via WalletCore.
-            return [.thorchain, .swapkit]
+            return [.thorchain]
         case .litecoin:
             // Tier 1 L1 source — flag-flip-ready. LTC reuses the existing
             // `SwapKitBTCSigner` (segwit-compatible — LTC addresses are
@@ -157,7 +155,7 @@ extension Coin {
             // Despite this, `/v3/quote` serves LTC routes via NEAR — the gate
             // is overly conservative. Shipping the flip pre-emptively so the
             // gate flip is the only diff when upstream lights up.
-            return [.thorchain, .swapkit]
+            return [.thorchain]
         case .gaiaChain:
             return [.thorchain]
         case .solana:
@@ -166,7 +164,7 @@ extension Coin {
             // SPL↔SPL). Jupiter is Solana-only and same-chain — cross-chain
             // pairs drop it automatically via the `SwapCoinsResolver` from∩to
             // intersection, and THORChain stays for SPL↔other-chain routes.
-            return [.thorchain, .jupiter, .lifi, .swapkit]
+            return [.thorchain, .jupiter, .lifi]
         case .hyperliquid:
             return [.lifi]
         case .cronosChain:
@@ -177,7 +175,7 @@ extension Coin {
             // (Vultisig can't manage shielded keys). Sapling-v4 PSBT signed
             // through `SwapKitZcashSigner` with ZIP-243 sighash via
             // WalletCore `CoinType.zcash`.
-            return [.mayachain, .swapkit]
+            return [.mayachain]
         case .ripple:
             // Tier 1 L1 source — `.swapkit` enables XRP↔EVM / XRP↔SOL routes
             // via NEAR Intents. Deposit-only flow: SwapKit returns a per-route
@@ -186,15 +184,15 @@ extension Coin {
             // is defensive — NEAR's ephemeral deposit pattern doesn't need
             // tags, but a future Chainflip shared-vault flip would silently
             // misroute funds without it.
-            return [.thorchain, .swapkit]
+            return [.thorchain]
         case .tron:
-            return [.thorchain, .swapkit]
+            return [.thorchain]
         case .ton, .cardano, .sui:
-            return [.swapkit]
+            return []
         case .robinhood:
             // 1inch live-confirmed on 4663: /quote and /swap return executable
             // calldata to its deployed router (0x5a70…89c7).
-            return [.oneinch(chain), .lifi, .kyberswap(chain), .swapkit]
+            return [.oneinch(chain), .lifi, .kyberswap(chain)]
         case .polkadot, .dydx, .osmosis, .terra, .terraClassic, .noble, .akash, .ethereumSepolia, .sei, .qbtc, .bittensor:
             return []
         }

--- a/VultisigApp/VultisigAppTests/Model/ChainSwapAvailabilityTests.swift
+++ b/VultisigApp/VultisigAppTests/Model/ChainSwapAvailabilityTests.swift
@@ -188,9 +188,8 @@ final class ChainSwapAvailabilityTests: XCTestCase {
     //
     // `isSwapAvailable == true` alone would still pass if Robinhood lost a
     // provider or gained one it shouldn't route. Pin the exact contract:
-    // 1inch + LiFi + Kyber (all live-confirmed on 4663), SwapKit follows
-    // its feature gate, and no native (Thor/Maya) or Solana-only provider
-    // leaks in.
+    // 1inch + LiFi + Kyber (all live-confirmed on 4663), plus SwapKit, and no
+    // native (Thor/Maya) or Solana-only provider leaks in.
     @MainActor
     func testRobinhoodProviderContract() {
         let meta = CoinMeta.make(chain: .robinhood, ticker: "ETH", decimals: 18, isNativeToken: true)
@@ -200,11 +199,7 @@ final class ChainSwapAvailabilityTests: XCTestCase {
         XCTAssertTrue(providers.contains(.oneinch(.robinhood)), "1inch must route Robinhood: \(providers)")
         XCTAssertTrue(providers.contains(.lifi), "LiFi must route Robinhood: \(providers)")
         XCTAssertTrue(providers.contains(.kyberswap(.robinhood)), "Kyber must route Robinhood: \(providers)")
-        XCTAssertEqual(
-            providers.contains(.swapkit),
-            SwapKitConfig.isFeatureEnabled,
-            "SwapKit presence must follow its feature gate: \(providers)"
-        )
+        XCTAssertTrue(providers.contains(.swapkit), "SwapKit must route Robinhood: \(providers)")
         XCTAssertFalse(providers.contains(.thorchain), "THORChain must not route Robinhood: \(providers)")
         XCTAssertFalse(providers.contains(.mayachain), "Maya must not route Robinhood: \(providers)")
         XCTAssertFalse(providers.contains(.jupiter), "Jupiter is Solana-only: \(providers)")

--- a/VultisigApp/VultisigAppTests/Services/BlockaidChainIdentifierTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/BlockaidChainIdentifierTests.swift
@@ -1,0 +1,30 @@
+//
+//  BlockaidChainIdentifierTests.swift
+//  VultisigAppTests
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class BlockaidChainIdentifierTests: XCTestCase {
+    func testHyperEvmUsesBlockaidHyperevmIdentifier() {
+        XCTAssertEqual(
+            BlockaidChainIdentifier.name(for: .hyperliquid),
+            "hyperevm"
+        )
+    }
+
+    func testRobinhoodHasNoBlockaidIdentifier() {
+        XCTAssertNil(BlockaidChainIdentifier.name(for: .robinhood))
+    }
+
+    func testScannerSupportsHyperEvmButNotRobinhood() {
+        let scanner = BlockaidScannerService(
+            blockaidRpcClient: MockBlockaidRpcClient()
+        )
+        let supported = scanner.getSupportedChains()[.scanTransaction] ?? []
+
+        XCTAssertTrue(supported.contains(.hyperliquid))
+        XCTAssertFalse(supported.contains(.robinhood))
+    }
+}

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitChainIdentifierTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitChainIdentifierTests.swift
@@ -21,6 +21,8 @@ final class SwapKitChainIdentifierTests: XCTestCase {
         XCTAssertEqual(SwapKitChainIdentifier.chainId(for: .polygon), "137")
         XCTAssertEqual(SwapKitChainIdentifier.chainId(for: .polygonV2), "137")
         XCTAssertEqual(SwapKitChainIdentifier.chainId(for: .optimism), "10")
+        XCTAssertEqual(SwapKitChainIdentifier.chainId(for: .hyperliquid), "999")
+        XCTAssertEqual(SwapKitChainIdentifier.chainId(for: .robinhood), "4663")
     }
 
     func testTronUsesNumericChainIdNotName() {

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitFeatureFlagTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitFeatureFlagTests.swift
@@ -58,6 +58,56 @@ final class SwapKitFeatureFlagTests: XCTestCase {
         XCTAssertTrue(providers.contains(.thorchain))
     }
 
+    func testSwapkitIsAddedCentrallyToHyperEvmAndOtherHeldEvmChains() {
+        XCTAssertTrue(makeCoin(chain: .hyperliquid, ticker: "HYPE").swapProviders.contains(.swapkit))
+        XCTAssertTrue(makeCoin(chain: .cronosChain, ticker: "CRO").swapProviders.contains(.swapkit))
+    }
+
+    func testRobinhoodIsSwapKitDestinationOnly() {
+        let ethereum = makeCoin(chain: .ethereum, ticker: "ETH")
+        let robinhood = makeCoin(chain: .robinhood, ticker: "ETH")
+
+        XCTAssertTrue(
+            SwapCoinsResolver.resolveAllProviders(
+                fromCoin: ethereum,
+                toCoin: robinhood
+            ).contains(.swapkit)
+        )
+        XCTAssertFalse(
+            SwapCoinsResolver.resolveAllProviders(
+                fromCoin: robinhood,
+                toCoin: ethereum
+            ).contains(.swapkit)
+        )
+    }
+
+    func testHyperEvmCanOriginateSwapKitQuotes() {
+        let hyperEvm = makeCoin(chain: .hyperliquid, ticker: "HYPE")
+        let ethereum = makeCoin(chain: .ethereum, ticker: "ETH")
+
+        XCTAssertTrue(
+            SwapCoinsResolver.resolveAllProviders(
+                fromCoin: hyperEvm,
+                toCoin: ethereum
+            ).contains(.swapkit)
+        )
+    }
+
+    func testDestinationResolverDropsSwapKitOnlyCoinFromRobinhoodSource() {
+        let robinhood = makeCoin(chain: .robinhood, ticker: "ETH")
+        let ton = makeCoin(chain: .ton, ticker: "GRAM")
+        let ethereum = makeCoin(chain: .ethereum, ticker: "ETH")
+
+        let resolved = SwapCoinsResolver.resolveToCoins(
+            fromCoin: robinhood,
+            allCoins: [ton, ethereum],
+            selectedToCoin: ton
+        )
+
+        XCTAssertEqual(resolved.coins, [ethereum])
+        XCTAssertEqual(resolved.selected, ethereum)
+    }
+
     // MARK: - Forced swap provider (debug picker)
 
     func testForcedProviderDefaultPreservesAllProviders() {
@@ -106,7 +156,7 @@ final class SwapKitFeatureFlagTests: XCTestCase {
     }
 
     func testForcedProviderNotEligibleForChainReturnsEmpty() {
-        // Ripple has only [.thorchain] naturally. Forcing 1inch produces
+        // Ripple has no 1inch route. Forcing 1inch produces
         // an empty list — Vultisig won't route through a provider that
         // doesn't support the chain at all.
         UserDefaults.standard.set("oneInch", forKey: forcedKey)

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitFeatureFlagTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitFeatureFlagTests.swift
@@ -2,10 +2,8 @@
 //  SwapKitFeatureFlagTests.swift
 //  VultisigAppTests
 //
-//  Locks the shipped behaviour for SwapKit: the integration is enabled for
-//  everyone now that the former Settings → Advanced opt-out toggle has been
-//  removed. `Coin+Swaps.swapProviders` is the single point of gating, and
-//  the `forcedSwapProvider` debug picker still narrows the provider list.
+//  Locks SwapKit provider availability and verifies that the
+//  `forcedSwapProvider` debug picker still narrows the provider list.
 //
 
 import XCTest
@@ -29,16 +27,7 @@ final class SwapKitFeatureFlagTests: XCTestCase {
         }
     }
 
-    // MARK: - isFeatureEnabled
-
-    func testFeatureFlagIsAlwaysEnabled() {
-        XCTAssertTrue(
-            SwapKitConfig.isFeatureEnabled,
-            "SwapKit has shipped — the feature is always enabled"
-        )
-    }
-
-    // MARK: - Coin+Swaps gating
+    // MARK: - Coin+Swaps availability
 
     func testSwapkitPresentInEthereumProviders() {
         let providers = makeCoin(chain: .ethereum, ticker: "ETH").swapProviders

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitProviderCacheTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitProviderCacheTests.swift
@@ -84,6 +84,38 @@ final class SwapKitProviderCacheTests: XCTestCase {
         XCTAssertTrue(SwapKitProviderCache.chainEnabled(.ripple, in: providers))
     }
 
+    func testLiveProviderShapeEnablesRobinhoodAndHyperEvm() {
+        let liveShape = [
+            SwapKitProvider(
+                name: "FLASHNET",
+                provider: "FLASHNET",
+                displayName: "Flashnet",
+                displayNameLong: nil,
+                count: nil,
+                enabledChainIds: ["4663", "999"],
+                supportedChainIds: nil,
+                supportedActions: ["swap"]
+            )
+        ]
+
+        XCTAssertTrue(SwapKitProviderCache.chainEnabled(.robinhood, in: liveShape))
+        XCTAssertTrue(SwapKitProviderCache.chainEnabled(.hyperliquid, in: liveShape))
+        XCTAssertTrue(
+            SwapKitProviderCache.pairEnabled(
+                fromChain: .robinhood,
+                toChain: .hyperliquid,
+                in: liveShape
+            )
+        )
+    }
+
+    func testFutureEvmChainUsesItsNumericChainIdWithoutMapperRow() {
+        XCTAssertEqual(
+            SwapKitChainIDMapper.swapKitChainId(for: .mantle),
+            String(Chain.mantle.chainID ?? 0)
+        )
+    }
+
     /// LTC is currently NOT in any provider's `enabledChainIds`, so the
     /// cache reads it as "not enabled" and `Coin+Swaps.swift`'s `.litecoin`
     /// arm (which lists `.swapkit`) is silently filtered out at the

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitQuoteDecodingTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitQuoteDecodingTests.swift
@@ -150,6 +150,42 @@ final class SwapKitQuoteDecodingTests: XCTestCase {
             return XCTFail("Expected unsupported tx variant for unknown txType")
         }
         XCTAssertEqual(txType, "FUTURE_CHAIN")
+        XCTAssertThrowsError(
+            try SwapKitService.validateSigningCapability(
+                response: response,
+                fromChain: .ethereum
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? SwapKitError,
+                .unsupportedTxType("FUTURE_CHAIN")
+            )
+        }
+    }
+
+    func testTypedTxMustMatchSourceChainBeforeRanking() throws {
+        let response = try SwapKitFixtureLoader.decode(
+            SwapKitSwapResponse.self,
+            from: "v3-erc20-erc20-swap"
+        )
+
+        XCTAssertNoThrow(
+            try SwapKitService.validateSigningCapability(
+                response: response,
+                fromChain: .hyperliquid
+            )
+        )
+        XCTAssertThrowsError(
+            try SwapKitService.validateSigningCapability(
+                response: response,
+                fromChain: .solana
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? SwapKitError,
+                .unsupportedTxType("EVM/SOL")
+            )
+        }
     }
 
     func testProvidersFixtureDecodesEnabledChainIds() throws {

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitServiceTests.swift
@@ -116,12 +116,21 @@ final class SwapKitServiceTests: XCTestCase {
         let data = try XCTUnwrap(body.data(using: .utf8))
         let client = NoRoutesHTTPClient(payload: data)
         let cache = await Self.makeCacheWithSupportedPair(fromChain: .bitcoinCash, toChain: .ethereum)
-        let service = SwapKitService(httpClient: client, providerCache: cache)
+        let fromCoin = Self.makeNativeCoin(.bitcoinCash, ticker: "BCH", decimals: 8)
+        let toCoin = Self.makeNativeCoin(.ethereum, ticker: "ETH", decimals: 18)
+        let catalog = await Self.makeCatalog(
+            entries: [(fromCoin, "BCH.BCH"), (toCoin, "ETH.ETH")]
+        )
+        let service = SwapKitService(
+            httpClient: client,
+            providerCache: cache,
+            assetCatalog: catalog
+        )
 
         do {
             _ = try await service.fetchBestRoute(
-                fromCoin: Self.makeNativeCoin(.bitcoinCash, ticker: "BCH", decimals: 8),
-                toCoin: Self.makeNativeCoin(.ethereum, ticker: "ETH", decimals: 18),
+                fromCoin: fromCoin,
+                toCoin: toCoin,
                 amount: Decimal(string: "0.0115") ?? .zero,
                 affiliateFeeBps: 50
             )
@@ -156,12 +165,21 @@ final class SwapKitServiceTests: XCTestCase {
             ],
             fetchedAt: Date()
         ))
-        let service = SwapKitService(httpClient: client, providerCache: cache)
+        let fromCoin = Self.makeNativeCoin(.bitcoinCash, ticker: "BCH", decimals: 8)
+        let toCoin = Self.makeNativeCoin(.ethereum, ticker: "ETH", decimals: 18)
+        let catalog = await Self.makeCatalog(
+            entries: [(fromCoin, "BCH.BCH"), (toCoin, "ETH.ETH")]
+        )
+        let service = SwapKitService(
+            httpClient: client,
+            providerCache: cache,
+            assetCatalog: catalog
+        )
 
         do {
             _ = try await service.fetchBestRoute(
-                fromCoin: Self.makeNativeCoin(.bitcoinCash, ticker: "BCH", decimals: 8),
-                toCoin: Self.makeNativeCoin(.ethereum, ticker: "ETH", decimals: 18),
+                fromCoin: fromCoin,
+                toCoin: toCoin,
                 amount: Decimal(string: "0.5") ?? .zero,
                 affiliateFeeBps: 50
             )
@@ -178,12 +196,21 @@ final class SwapKitServiceTests: XCTestCase {
         let data = try XCTUnwrap(body.data(using: .utf8))
         let client = NoRoutesHTTPClient(payload: data)
         let cache = await Self.makeCacheWithSupportedPair(fromChain: .bitcoinCash, toChain: .ethereum)
-        let service = SwapKitService(httpClient: client, providerCache: cache)
+        let fromCoin = Self.makeNativeCoin(.bitcoinCash, ticker: "BCH", decimals: 8)
+        let toCoin = Self.makeNativeCoin(.ethereum, ticker: "ETH", decimals: 18)
+        let catalog = await Self.makeCatalog(
+            entries: [(fromCoin, "BCH.BCH"), (toCoin, "ETH.ETH")]
+        )
+        let service = SwapKitService(
+            httpClient: client,
+            providerCache: cache,
+            assetCatalog: catalog
+        )
 
         do {
             _ = try await service.fetchBestRoute(
-                fromCoin: Self.makeNativeCoin(.bitcoinCash, ticker: "BCH", decimals: 8),
-                toCoin: Self.makeNativeCoin(.ethereum, ticker: "ETH", decimals: 18),
+                fromCoin: fromCoin,
+                toCoin: toCoin,
                 amount: Decimal(string: "0.5") ?? .zero,
                 affiliateFeeBps: 50
             )
@@ -191,6 +218,25 @@ final class SwapKitServiceTests: XCTestCase {
         } catch let error as SwapKitError {
             XCTAssertEqual(error, .apiKeyInvalid)
         }
+    }
+
+    func testFetchBestRouteCatalogMissSkipsNetwork() async throws {
+        let client = RequestCountingHTTPClient()
+        let catalog = SwapKitAssetCatalog()
+        await catalog.setSnapshot(
+            SwapKitAssetCatalogSnapshot(buckets: [:], identifiers: [:])
+        )
+        let service = SwapKitService(httpClient: client, assetCatalog: catalog)
+
+        let route = try await service.fetchBestRoute(
+            fromCoin: Self.makeNativeCoin(.ethereum, ticker: "ETH", decimals: 18),
+            toCoin: Self.makeNativeCoin(.robinhood, ticker: "ETH", decimals: 18),
+            amount: 1,
+            affiliateFeeBps: 50
+        )
+
+        XCTAssertNil(route)
+        XCTAssertEqual(client.requestCount, 0)
     }
 
     // MARK: - Fixtures
@@ -222,6 +268,19 @@ final class SwapKitServiceTests: XCTestCase {
         )
         await cache.setSnapshot(snapshot)
         return cache
+    }
+
+    private static func makeCatalog(
+        entries: [(Coin, String)]
+    ) async -> SwapKitAssetCatalog {
+        let identifiers = Dictionary(uniqueKeysWithValues: entries.map { coin, identifier in
+            (SwapKitAssetKey(coin: coin), Set([identifier]))
+        })
+        let catalog = SwapKitAssetCatalog()
+        await catalog.setSnapshot(
+            SwapKitAssetCatalogSnapshot(buckets: [:], identifiers: identifiers)
+        )
+        return catalog
     }
 
     private func makeRoute(
@@ -277,5 +336,22 @@ private final class NoRoutesHTTPClient: HTTPClientProtocol, @unchecked Sendable 
         _ = responseType
         await Task.yield()
         throw HTTPError.statusCode(404, payload)
+    }
+}
+
+private final class RequestCountingHTTPClient: HTTPClientProtocol, @unchecked Sendable {
+    private enum TestError: Error { case unexpectedRequest }
+
+    private let lock = NSLock()
+    private var count = 0
+
+    var requestCount: Int {
+        lock.withLock { count }
+    }
+
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        _ = target
+        lock.withLock { count += 1 }
+        throw TestError.unexpectedRequest
     }
 }

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensCacheTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensCacheTests.swift
@@ -88,7 +88,10 @@ final class SwapKitTokensCacheTests: XCTestCase {
             httpClient: failingClient,
             providerCache: SwapKitProviderCache(httpClient: failingClient)
         )
-        cache.setSnapshot(buckets: [.ethereum: bucket], fetchedAt: Date(timeIntervalSince1970: 0))
+        await cache.setSnapshot(
+            buckets: [.ethereum: bucket],
+            fetchedAt: Date(timeIntervalSince1970: 0)
+        )
 
         // Force a refresh well past the TTL — the snapshot is stale, the fetch
         // fails (no provider snapshot), so last-good must be served.

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensDecodingTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensDecodingTests.swift
@@ -108,6 +108,100 @@ final class SwapKitTokensDecodingTests: XCTestCase {
         XCTAssertNil(nearGas.toCoinMeta())
     }
 
+    func testRobinhoodAndHyperEvmTokensUseNumericChainIds() throws {
+        let robinhood = SwapKitToken(
+            chain: "HOOD",
+            chainId: "4663",
+            address: "",
+            ticker: "ETH",
+            identifier: "HOOD.ETH",
+            name: "Ether",
+            decimals: 18,
+            logoURI: nil,
+            coingeckoId: "ethereum"
+        )
+        let hyperEvm = SwapKitToken(
+            chain: "HYPEREVM",
+            chainId: "999",
+            address: "",
+            ticker: "HYPE",
+            identifier: "HYPEREVM.HYPE",
+            name: "HYPE",
+            decimals: 18,
+            logoURI: nil,
+            coingeckoId: "hyperliquid"
+        )
+
+        XCTAssertEqual(try XCTUnwrap(robinhood.toCoinMeta()).chain, .robinhood)
+        XCTAssertEqual(try XCTUnwrap(hyperEvm.toCoinMeta()).chain, .hyperliquid)
+    }
+
+    func testHyperCoreTokenIsNotReverseMappedToHyperEvm() {
+        let hyperCore = SwapKitToken(
+            chain: "HYPE",
+            chainId: "hype",
+            address: "",
+            ticker: "HYPE",
+            identifier: "HYPE.HYPE",
+            name: "HYPE",
+            decimals: 8,
+            logoURI: nil,
+            coingeckoId: "hyperliquid"
+        )
+
+        XCTAssertNil(hyperCore.toCoinMeta())
+    }
+
+    func testCatalogPinsExactNewChainIdentifiers() async throws {
+        let usdcContract = "0xb88339CB7199b77E23DB6E890353E22632Ba630f"
+        let tokens = [
+            SwapKitToken(
+                chain: "HOOD",
+                chainId: "4663",
+                address: "",
+                ticker: "ETH",
+                identifier: "HOOD.ETH",
+                name: "Ether",
+                decimals: 18,
+                logoURI: nil,
+                coingeckoId: "ethereum"
+            ),
+            SwapKitToken(
+                chain: "HYPEREVM",
+                chainId: "999",
+                address: usdcContract,
+                ticker: "USDC",
+                identifier: "HYPEREVM.USDC-\(usdcContract)",
+                name: "USD Coin",
+                decimals: 6,
+                logoURI: nil,
+                coingeckoId: "usd-coin"
+            )
+        ]
+        let catalog = SwapKitAssetCatalog()
+        await catalog.setSnapshot(
+            SwapKitAssetCatalog.buildSnapshot(
+                responses: [
+                    SwapKitTokensResponse(provider: "FLASHNET", count: tokens.count, tokens: tokens)
+                ]
+            )
+        )
+
+        let hoodIdentifier = await catalog.identifier(
+            for: SwapKitAssetKey(chain: .robinhood, contractAddress: "", isNativeToken: true)
+        )
+        let hyperIdentifier = await catalog.identifier(
+            for: SwapKitAssetKey(
+                chain: .hyperliquid,
+                contractAddress: usdcContract.lowercased(),
+                isNativeToken: false
+            )
+        )
+
+        XCTAssertEqual(hoodIdentifier, "HOOD.ETH")
+        XCTAssertEqual(hyperIdentifier, "HYPEREVM.USDC-\(usdcContract)")
+    }
+
     func testMergeByChainDedupesByIdentifier() throws {
         // Two responses both list ETH.USDT — merged bucket has one entry.
         let payload = """

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensPickerFlagTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensPickerFlagTests.swift
@@ -119,6 +119,50 @@ final class SwapKitTokensPickerFlagTests: XCTestCase {
         XCTAssertNil(identifier)
     }
 
+    func testCatalogCollapsesEvmIdentifierAddressCasing() async {
+        let catalog = SwapKitAssetCatalog()
+        let lowercased = SwapKitToken(
+            chain: "ETH",
+            chainId: "1",
+            address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            ticker: "USDC",
+            identifier: "ETH.USDC-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            name: "USD Coin",
+            decimals: 6,
+            logoURI: nil,
+            coingeckoId: "usd-coin"
+        )
+        let checksummed = SwapKitToken(
+            chain: "ETH",
+            chainId: "1",
+            address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            ticker: "USDC",
+            identifier: "ETH.USDC-0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            name: "USD Coin",
+            decimals: 6,
+            logoURI: nil,
+            coingeckoId: "usd-coin"
+        )
+        await catalog.setSnapshot(
+            SwapKitAssetCatalog.buildSnapshot(
+                responses: [
+                    SwapKitTokensResponse(provider: "LOWER", count: 1, tokens: [lowercased]),
+                    SwapKitTokensResponse(provider: "CHECKSUM", count: 1, tokens: [checksummed])
+                ]
+            )
+        )
+        let coin = makeCoin(
+            chain: .ethereum,
+            ticker: "USDC",
+            contractAddress: lowercased.address ?? "",
+            isNativeToken: false
+        )
+
+        let identifier = await catalog.identifier(for: SwapKitAssetKey(coin: coin))
+
+        XCTAssertEqual(identifier, lowercased.identifier)
+    }
+
     @MainActor
     func testCacheSeededSnapshotReturnsBuckets() async {
         let novel = CoinMeta(chain: .arbitrum, ticker: "NOVL", logo: "", decimals: 18, priceProviderId: "", contractAddress: "0x000000000000000000000000000000000000000A", isNativeToken: false)

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensPickerFlagTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensPickerFlagTests.swift
@@ -88,51 +88,35 @@ final class SwapKitTokensPickerFlagTests: XCTestCase {
         return Coin(asset: meta, address: "addr", hexPublicKey: "pub")
     }
 
-    /// The native TON asset is `TON.GRAM` on the wire. SwapKit tracked the
-    /// Toncoin → Gram rename, so the pre-rename `TON.TON` no longer resolves —
-    /// quoting it fails with `tokenPriceUnavailable`. Verifiable against
-    /// `GET https://api.vultisig.com/swapkit/tokens?provider=NEAR` (bare host,
-    /// no `/v3`), which lists `TON.GRAM` and no `TON.TON` at all.
-    func testAssetIdentifierUsesGramForTheNativeTonCoin() {
-        let gram = makeCoin(chain: .ton, ticker: "GRAM", isNativeToken: true)
-
-        XCTAssertEqual(SwapKitService().assetIdentifier(for: gram), "TON.GRAM")
-    }
-
-    /// A jetton keeps its own ticker and appends its contract — the native case
-    /// must not bleed into it. Matches SwapKit's listed
-    /// `TON.USDT-EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs`.
-    func testAssetIdentifierKeepsTheJettonTickerAndContract() {
-        let contract = "EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs"
-        let usdt = makeCoin(chain: .ton, ticker: "USDT", contractAddress: contract, isNativeToken: false)
-
-        XCTAssertEqual(SwapKitService().assetIdentifier(for: usdt), "TON.USDT-\(contract)")
-    }
-
-    /// A vault restored from a pre-rebrand backup still holds a `TON`-ticker'd
-    /// native: the launch migration rewrites `vault.coins`, but an import lands
-    /// after it has already run. Canonicalising against the curated store keeps
-    /// that vault quotable instead of sending the dead `TON.TON`.
-    func testAssetIdentifierCanonicalisesAnUnmigratedNativeTonCoin() {
+    func testCatalogUsesExactIdentifierForLegacyNativeTicker() async {
+        let catalog = SwapKitAssetCatalog()
+        let token = SwapKitToken(
+            chain: "TON",
+            chainId: "ton",
+            address: "",
+            ticker: "GRAM",
+            identifier: "TON.GRAM",
+            name: "Gram",
+            decimals: 9,
+            logoURI: nil,
+            coingeckoId: "the-open-network"
+        )
+        await catalog.setSnapshot(Self.snapshot(tokens: [token]))
         let legacy = makeCoin(chain: .ton, ticker: "TON", isNativeToken: true)
 
-        XCTAssertEqual(SwapKitService().assetIdentifier(for: legacy), "TON.GRAM")
+        let identifier = await catalog.identifier(for: SwapKitAssetKey(coin: legacy))
+
+        XCTAssertEqual(identifier, "TON.GRAM")
     }
 
-    /// Canonicalisation is scoped to natives — a jetton that happens to carry a
-    /// ticker matching nothing curated must still quote under its own.
-    func testAssetIdentifierDoesNotCanonicaliseNonNativeTokens() {
-        let jetton = makeCoin(chain: .ton, ticker: "TON", contractAddress: "EQjetton", isNativeToken: false)
-
-        XCTAssertEqual(SwapKitService().assetIdentifier(for: jetton), "TON.TON-EQjetton")
-    }
-
-    func testAssetIdentifierLeavesOtherChainsUnchanged() {
+    func testCatalogReturnsNilForUnlistedAsset() async {
+        let catalog = SwapKitAssetCatalog()
+        await catalog.setSnapshot(Self.snapshot(tokens: []))
         let eth = makeCoin(chain: .ethereum, ticker: "ETH", isNativeToken: true)
-        let btc = makeCoin(chain: .bitcoin, ticker: "BTC", isNativeToken: true)
 
-        XCTAssertEqual(SwapKitService().assetIdentifier(for: eth), "ETH.ETH")
-        XCTAssertEqual(SwapKitService().assetIdentifier(for: btc), "BTC.BTC")
+        let identifier = await catalog.identifier(for: SwapKitAssetKey(coin: eth))
+
+        XCTAssertNil(identifier)
     }
 
     @MainActor
@@ -144,9 +128,17 @@ final class SwapKitTokensPickerFlagTests: XCTestCase {
             uniqueIds: [novel.uniqueId]
         )
         let cache = SwapKitTokensCache()
-        cache.setSnapshot(buckets: [.arbitrum: bucket])
+        await cache.setSnapshot(buckets: [.arbitrum: bucket])
         let read = await cache.tokens(for: .arbitrum)
         XCTAssertEqual(read.tokens.count, 1)
         XCTAssertEqual(read.tokens.first?.ticker, "NOVL")
+    }
+
+    private static func snapshot(tokens: [SwapKitToken]) -> SwapKitAssetCatalogSnapshot {
+        SwapKitAssetCatalog.buildSnapshot(
+            responses: [
+                SwapKitTokensResponse(provider: "TEST", count: tokens.count, tokens: tokens)
+            ]
+        )
     }
 }

--- a/VultisigApp/VultisigAppTests/Swap/SwapServiceErrorSurfacingTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapServiceErrorSurfacingTests.swift
@@ -198,6 +198,50 @@ final class SwapServiceErrorSurfacingTests: XCTestCase {
         XCTAssertEqual(swapKitAttempts, 1)
     }
 
+    @MainActor
+    func testUnsupportedSwapKitTxDoesNotHideLiFiQuote() async throws {
+        let service = SwapService(quoteFetcherOverride: { provider in
+            switch provider {
+            case .swapkit:
+                throw SwapKitError.unsupportedTxType("FUTURE_CHAIN")
+            case .lifi:
+                return .lifi(
+                    EVMQuote(
+                        dstAmount: "1000000000000000000",
+                        tx: EVMQuote.Transaction(
+                            from: "0xfrom",
+                            to: "0xto",
+                            data: "0x",
+                            value: "0",
+                            gasPrice: "0",
+                            gas: 0
+                        )
+                    ),
+                    fee: nil,
+                    integratorFee: nil
+                )
+            default:
+                throw SwapError.routeUnavailable
+            }
+        })
+        let ethereum = makeCoin(.ethereum, ticker: "ETH", decimals: 18)
+        let robinhood = makeCoin(.robinhood, ticker: "ETH", decimals: 18)
+
+        let quotes = try await service.fetchQuotes(
+            amount: 1,
+            fromCoin: ethereum,
+            toCoin: robinhood,
+            isAffiliate: false,
+            referredCode: "",
+            vultTierDiscount: 0,
+            slippageBps: nil,
+            recipientAddress: nil
+        )
+
+        XCTAssertEqual(quotes.best.kind, .lifi)
+        XCTAssertEqual(quotes.ranked.map(\.kind), [.lifi])
+    }
+
     private func makeCoin(_ chain: Chain, ticker: String, decimals: Int) -> Coin {
         let meta = CoinMeta(
             chain: chain,


### PR DESCRIPTION
## Summary

- derive SwapKit EVM chain IDs from `Chain.chainID` and quote with exact identifiers from the live token catalogue instead of local prefix/ticker tables
- add Robinhood (`4663`, `HOOD`) and HyperEVM (`999`, `HYPEREVM`) token/provider routing while keeping HyperCore (`HYPE`) separate
- enable HyperEVM as a Blockaid-checked SwapKit source and keep Robinhood destination-only until Blockaid supports chain 4663
- reject missing catalogue assets, disabled providers, unknown transaction types, and source/transaction mismatches as SwapKit-only misses so LI.FI, 1inch, KyberSwap, THORChain, and MayaChain can continue ranking
- remove the obsolete always-on `isFeatureEnabled` gate so SwapKit availability is governed directly by chain capabilities and catalogue validation
- collapse case-only EVM identifier variants published by different provider catalogues so token routes such as Ethereum USDC resolve reliably

## Verification

- `make generate`
- `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — completed with 27 warning-only baseline violations and 0 serious violations; changed files have 0 new violations
- `make test` — 6,845 tests executed, 11 skipped, 0 failures
- focused SwapKit catalogue, provider, routing, Blockaid, transaction-capability, fallback, inbound-fee, and feature-gate removal suites
- live proxy diagnostic through the app decoder confirmed Ethereum USDC now resolves from case-divergent provider catalogues

## Runtime transaction proof

- Robinhood.ETH → BNB.BNB (LI.FI): [transaction](https://scan.li.fi/tx/0x28d75f2b50abf1f94b164547c18b9e491c4a734fc53c7c9b6ca080b3c2c833e9)
- BNB.BNB → Robinhood.ETH (SwapKit): [transaction](https://track.swapkit.dev/?hash=0x372bc3d9a042c3edb29a21eb2ccd6e405f0cca73e6695604bb4830ad72fe7d15&chainId=56)
- ETH.USDC → HYPE.HYPE (SwapKit): [transaction](https://track.swapkit.dev/?hash=0x6018256c7697eef4b4631e048be96a9185057101af9687a933aaa6c950e8c258&chainId=1)
- HYPE.HYPE → ETH.USDC (LI.FI): [transaction](https://scan.li.fi/tx/0x187421c482ff89cb05b92564a64ec817973bcd373d1471e3520e84ef7398a67e)

Closes #5266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded swap support for Hyperliquid, HyperEVM, Robinhood, Cronos, and other supported chains.
  * Improved token discovery, asset matching, and numeric EVM chain identification.
  * Added more accurate destination compatibility checks.

* **Bug Fixes**
  * Prevented unsupported routes and transaction types from producing invalid quotes.
  * Improved signing validation and fee handling.
  * Valid alternative quotes remain available when another provider fails.

* **Security**
  * Added Hyperliquid transaction scanning and safer handling of unsupported chains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
