### PR TITLE
feat: broaden App Store review eligibility

### DIFF
--- a/VultisigApp/VultisigApp/App/VultisigApp.swift
+++ b/VultisigApp/VultisigApp/App/VultisigApp.swift
@@ -209,6 +209,7 @@ extension VultisigApp {
             .environmentObject(coinSelectionViewModel)
             .environmentObject(deeplinkViewModel)
             .environmentObject(pushNotificationManager)
+            .appReviewPromptHost()
             .onChange(of: scenePhase) { previousPhase, newPhase in
                 switch newPhase {
                 case .active:

--- a/VultisigApp/VultisigApp/Components/TransactionDone/DoneScreen.swift
+++ b/VultisigApp/VultisigApp/Components/TransactionDone/DoneScreen.swift
@@ -24,9 +24,6 @@
 //
 
 import SwiftUI
-#if os(iOS)
-import StoreKit
-#endif
 
 struct DoneScreen<
     TokenContent: View,
@@ -38,13 +35,12 @@ struct DoneScreen<
     @StateObject private var statusService: DoneStatusService
 
     #if os(iOS)
-    @Environment(\.requestReview) private var requestReview
-
     /// Flipped once the arrival animation has actually finished. The review
-    /// sheet waits on this rather than on `isExpanded`, which only says the
+    /// event waits on this rather than on `isExpanded`, which only says the
     /// spring has been *scheduled* — it flips synchronously inside
     /// `withAnimation`, half a second before the hero has arrived.
     @State private var hasSettled = false
+    @State private var didOfferReviewOpportunity = false
     #endif
 
     /// Nav-bar title for the screen. Defaults to "Done"; the initiator
@@ -76,7 +72,7 @@ struct DoneScreen<
     private let revealDelay: UInt64 = 1_150_000_000 // ≈ 0.35s crossfade + 0.8s hold
 
     /// Response of the settle spring, and so roughly how long the hero takes
-    /// to arrive. Named rather than inlined because the review prompt has to
+    /// to arrive. Named rather than inlined because the review event has to
     /// wait it out, and a second literal would drift away from the animation.
     private let settleResponse: Double = 0.55
 
@@ -201,24 +197,25 @@ struct DoneScreen<
     }
 
     #if os(iOS)
-    /// Counts a confirmed transaction and, if the throttle allows, asks for an
-    /// App Store review.
+    /// Records a confirmed outbound transaction as a positive review event.
     ///
     /// Deliberately safe to call repeatedly: this is the one place in the app
     /// where "confirmed" is decided for every flow, and the view is not
     /// guaranteed to observe it once — a re-render, a re-entry, or the poller
     /// re-reporting a terminal status all land here again. `AppReviewService`
-    /// keys everything on the transaction hash, so the extra calls are inert
-    /// and, importantly, cannot spend an ask on a transaction already counted.
+    /// keys everything on the transaction hash, so the extra calls are inert.
     ///
     /// Waiting for `hasSettled` keeps the system sheet from landing on top of
     /// the hero settle animation.
     private func handleConfirmedTransactionIfNeeded() {
-        guard statusService.status == .confirmed, hasSettled else { return }
-        guard AppReviewService.shared.claimReviewPrompt(forConfirmedTransaction: input.hash) else {
+        guard statusService.status == .confirmed,
+              hasSettled,
+              !didOfferReviewOpportunity else {
             return
         }
-        requestReview()
+        didOfferReviewOpportunity = true
+        AppReviewService.shared.record(.confirmedOutboundTransaction(id: input.hash))
+        AppReviewService.shared.requestPromptEvaluation()
     }
     #endif
 }

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1178,6 +1178,7 @@
 "quantumSecurityIntroDescription" = "Klassische Schlüssel können von Quantencomputern geknackt werden. Um QBTC zu aktivieren, muss ein neues Schlüsselpaar erzeugt werden.";
 "quantumSecurityIntroTitle" = "Neue Quantensicherheit";
 "quotedWithdrawalVerifyTitle" = "Du hebst ab";
+"rateTheApp" = "App bewerten";
 "rawPayload" = "Rohdaten";
 "ready" = "Bereit";
 "Rebond" = "Rebond";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1178,6 +1178,7 @@
 "quantumSecurityIntroDescription" = "Classical keys can be broken by quantum computers. Enabling QBTC requires generating a new key pair.";
 "quantumSecurityIntroTitle" = "New quantum security";
 "quotedWithdrawalVerifyTitle" = "You are withdrawing";
+"rateTheApp" = "Rate the App";
 "rawPayload" = "Raw Payload";
 "ready" = "Ready";
 "Rebond" = "Rebond";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1178,6 +1178,7 @@
 "quantumSecurityIntroDescription" = "Las claves clásicas pueden ser vulneradas por ordenadores cuánticos. Habilitar QBTC requiere generar un nuevo par de claves.";
 "quantumSecurityIntroTitle" = "Nueva seguridad cuántica";
 "quotedWithdrawalVerifyTitle" = "Estás retirando";
+"rateTheApp" = "Valora la app";
 "rawPayload" = "Datos sin procesar";
 "ready" = "Listo";
 "Rebond" = "Rebond";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1178,6 +1178,7 @@
 "quantumSecurityIntroDescription" = "Klasične ključeve mogu probiti kvantna računala. Omogućavanje QBTC-a zahtijeva generiranje novog para ključeva.";
 "quantumSecurityIntroTitle" = "Nova kvantna sigurnost";
 "quotedWithdrawalVerifyTitle" = "Podižete";
+"rateTheApp" = "Ocijeni aplikaciju";
 "rawPayload" = "Sirovi podaci";
 "ready" = "Spreman";
 "Rebond" = "Rebond";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1178,6 +1178,7 @@
 "quantumSecurityIntroDescription" = "Le chiavi classiche possono essere violate dai computer quantistici. Per abilitare QBTC è necessario generare una nuova coppia di chiavi.";
 "quantumSecurityIntroTitle" = "Nuova sicurezza quantistica";
 "quotedWithdrawalVerifyTitle" = "Stai prelevando";
+"rateTheApp" = "Valuta l'App";
 "rawPayload" = "Dati grezzi";
 "ready" = "Pronto";
 "Rebond" = "Rebond";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1178,6 +1178,7 @@
 "quantumSecurityIntroDescription" = "기존 키는 양자 컴퓨터에 의해 해독될 수 있습니다. QBTC를 활성화하려면 새 키 쌍을 생성해야 합니다.";
 "quantumSecurityIntroTitle" = "새로운 양자 보안";
 "quotedWithdrawalVerifyTitle" = "출금 중입니다";
+"rateTheApp" = "앱 평가하기";
 "rawPayload" = "원시 페이로드";
 "ready" = "준비 완료";
 "Rebond" = "재본드";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1178,6 +1178,7 @@
 "quantumSecurityIntroDescription" = "Chaves clássicas podem ser quebradas por computadores quânticos. Ativar QBTC requer gerar um novo par de chaves.";
 "quantumSecurityIntroTitle" = "Nova segurança quântica";
 "quotedWithdrawalVerifyTitle" = "Você está retirando";
+"rateTheApp" = "Avalie o app";
 "rawPayload" = "Dados brutos";
 "ready" = "Pronto";
 "Rebond" = "Rebond";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1178,6 +1178,7 @@
 "quantumSecurityIntroDescription" = "经典密钥可能被量子计算机破解。启用 QBTC 需要生成新的密钥对。";
 "quantumSecurityIntroTitle" = "全新量子安全";
 "quotedWithdrawalVerifyTitle" = "您正在提取";
+"rateTheApp" = "为应用评分";
 "rawPayload" = "原始数据";
 "ready" = "就绪";
 "Rebond" = "重新绑定";

--- a/VultisigApp/VultisigApp/Core/Services/Review/AppReviewPolicy.swift
+++ b/VultisigApp/VultisigApp/Core/Services/Review/AppReviewPolicy.swift
@@ -2,73 +2,59 @@
 //  AppReviewPolicy.swift
 //  VultisigApp
 //
-//  Decides whether the app may ask for an App Store review right now.
-//
-//  Deliberately a pure function over (state, now) with no persistence,
-//  no clock and no StoreKit: the throttle is the part that carries real
-//  cost when it is wrong — asking too early burns the system's ~3
-//  prompts/year budget and our own 120-day window — so it is kept
-//  isolated and exhaustively unit-tested. `AppReviewService` owns the
-//  storage and feeds a snapshot in.
-//
-//  All three windows are lower bounds, so every comparison is `>=`:
-//  hitting exactly the threshold is eligible.
-//
 
 import Foundation
 
 /// Snapshot of the persisted review state the policy decides over.
 struct AppReviewState: Equatable {
-    /// Lifetime count of distinct on-chain-confirmed transactions the user
-    /// has watched complete.
-    var confirmedTransactionCount: Int
+    /// Lifetime count of distinct positive events recorded on this device.
+    var qualifyingEventCount: Int
 
-    /// When the app first launched on this device. `nil` until seeded,
-    /// which blocks the prompt — a missing install date is treated as
-    /// "just installed", never as "installed long ago".
+    /// When the app first launched on this device. A missing value fails closed.
     var installDate: Date?
 
-    /// When the review sheet was last requested, or `nil` if never.
+    /// When StoreKit was most recently asked to present a review prompt.
     var lastPromptDate: Date?
+
+    /// Marketing version (`CFBundleShortVersionString`) claimed by the most
+    /// recent request. A build number is deliberately not part of this gate.
+    var lastPromptedVersion: String?
 }
 
 enum AppReviewPolicy {
-    /// Enough completed transactions that the user has a formed opinion.
-    static let minimumConfirmedTransactions = 3
+    /// Two distinct positive moments are enough to form a useful opinion.
+    static let minimumQualifyingEvents = 2
 
-    /// Enough time on the device that the rating reflects the app, not the
-    /// onboarding.
+    /// Avoid asking during onboarding or the user's first week with the app.
     static let minimumTimeSinceInstall: TimeInterval = 7 * 24 * 60 * 60
 
-    /// Cooldown between two asks. Well above Apple's own ~3-per-year cap so
-    /// we never spend the budget faster than the system would allow.
-    static let minimumTimeBetweenPrompts: TimeInterval = 120 * 24 * 60 * 60
+    /// Even a new release cannot ask immediately after the preceding release.
+    static let minimumTimeBetweenPrompts: TimeInterval = 14 * 24 * 60 * 60
 
-    /// Whether the review sheet may be requested at `now`.
-    ///
-    /// `now` is injected so the boundaries can be pinned deterministically;
-    /// production callers pass the current date.
-    static func shouldRequestReview(state: AppReviewState, now: Date) -> Bool {
-        guard state.confirmedTransactionCount >= minimumConfirmedTransactions else {
+    /// Whether StoreKit may be asked for this marketing version at `now`.
+    static func shouldRequestReview(
+        state: AppReviewState,
+        now: Date,
+        currentVersion: String?
+    ) -> Bool {
+        guard state.qualifyingEventCount >= minimumQualifyingEvents else {
             return false
         }
 
-        // A missing install date means the seeding step has not run yet.
-        // Fail closed rather than treating "unknown" as "old enough".
-        guard let installDate = state.installDate else {
+        guard let installDate = state.installDate,
+              now.timeIntervalSince(installDate) >= minimumTimeSinceInstall else {
             return false
         }
 
-        // A negative interval (device clock moved backwards, or a restored
-        // backup carrying a future-dated seed) also fails this check, which
-        // is the conservative direction.
-        guard now.timeIntervalSince(installDate) >= minimumTimeSinceInstall else {
+        guard let currentVersion = currentVersion?.nilIfEmpty,
+              state.lastPromptedVersion != currentVersion else {
             return false
         }
 
         guard let lastPromptDate = state.lastPromptDate else {
             return true
         }
+
         return now.timeIntervalSince(lastPromptDate) >= minimumTimeBetweenPrompts
     }
 }

--- a/VultisigApp/VultisigApp/Core/Services/Review/AppReviewService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/Review/AppReviewService.swift
@@ -3,6 +3,7 @@
 //  VultisigApp
 //
 
+import BigInt
 import Foundation
 
 /// A positive event that can contribute to App Store review eligibility.
@@ -116,11 +117,11 @@ final class AppReviewService {
         return true
     }
 
-    /// Compatibility for the existing Done screen while event producers move
-    /// to the typed API.
-    @discardableResult
-    func recordConfirmedTransaction(id: String) -> Bool {
-        record(.confirmedOutboundTransaction(id: id))
+    /// Tells the app-level StoreKit host that the current visible surface can
+    /// safely consume a claim. Recording and presentation are separate so a
+    /// pairing event can navigate into signing without presenting over it.
+    func requestPromptEvaluation() {
+        NotificationCenter.default.post(name: .appReviewPromptOpportunity, object: nil)
     }
 
     // MARK: - Decision and atomic claim
@@ -152,21 +153,6 @@ final class AppReviewService {
             "[AppReview] Prompt claimed for version \(version, privacy: .public) claimCount=\(claimCount, privacy: .public)"
         )
         return true
-    }
-
-    /// Compatibility for the existing Done screen. This remains count-first,
-    /// then claim, until the shared app-level prompt host lands.
-    func claimReviewPrompt(forConfirmedTransaction id: String) -> Bool {
-        guard recordConfirmedTransaction(id: id) else { return false }
-        return claimReviewPrompt()
-    }
-
-    func shouldRequestReview() -> Bool {
-        AppReviewPolicy.shouldRequestReview(
-            state: state,
-            now: now(),
-            currentVersion: bundleVersion()
-        )
     }
 
     var state: AppReviewState {
@@ -220,3 +206,123 @@ struct AppReviewInstrumentation: Equatable {
     let policyEvaluationCount: Int
     let promptClaimCount: Int
 }
+
+extension Notification.Name {
+    static let appReviewPromptOpportunity = Notification.Name("appReviewPromptOpportunity")
+}
+
+/// Conservative balance-delta qualification for the coin detail surface.
+/// A spendable increase comes from a confirmed balance; pending balance is not
+/// an input. Priced assets must clear a fiat floor, while an unpriced asset is
+/// accepted only when it is native and clears its chain dust floor.
+enum AppReviewIncomingBalancePolicy {
+    static let dwellDuration: Duration = .seconds(3)
+    static let minimumFiatValue = Decimal(1)
+
+    static func eventID(
+        coinID: String,
+        previousRawBalance: String,
+        currentRawBalance: String,
+        decimals: Int,
+        fiatRate: Decimal?,
+        isNativeToken: Bool,
+        minimumRawAmount: BigInt,
+        isLikelySpam: Bool,
+        baselineRefreshSucceeded: Bool,
+        confirmationRefreshSucceeded: Bool
+    ) -> String? {
+        guard baselineRefreshSucceeded,
+              confirmationRefreshSucceeded,
+              !isLikelySpam,
+              (0...38).contains(decimals),
+              let previous = BigInt(previousRawBalance),
+              let current = BigInt(currentRawBalance),
+              previous >= 0,
+              current > previous else {
+            return nil
+        }
+
+        let delta = current - previous
+        if let fiatRate, fiatRate > 0 {
+            guard let rawDecimal = Decimal(
+                string: delta.description,
+                locale: Locale(identifier: "en_US_POSIX")
+            ) else {
+                return nil
+            }
+            let decimalDelta = rawDecimal / pow(Decimal(10), decimals)
+            guard decimalDelta * fiatRate >= minimumFiatValue else { return nil }
+        } else {
+            guard isNativeToken, delta >= max(minimumRawAmount, 1) else { return nil }
+        }
+
+        guard let normalizedCoinID = coinID.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty else {
+            return nil
+        }
+        return "\(normalizedCoinID):\(current)"
+    }
+}
+
+#if os(iOS)
+import StoreKit
+import SwiftUI
+
+private struct AppReviewPromptHost: ViewModifier {
+    @Environment(\.requestReview) private var requestReview
+    @Environment(\.scenePhase) private var scenePhase
+
+    @State private var hasPendingEvaluation = false
+    @State private var evaluationGeneration = 0
+    @State private var isSceneActive = false
+
+    func body(content: Content) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .appReviewPromptOpportunity)) { _ in
+                scheduleEvaluation()
+            }
+            .onAppear {
+                isSceneActive = scenePhase == .active
+            }
+            .onChange(of: scenePhase) { _, newPhase in
+                isSceneActive = newPhase == .active
+                guard hasPendingEvaluation else { return }
+                // Cancel an armed task on every phase transition. In
+                // particular, `.inactive` must cancel before a stale active
+                // environment snapshot can consume the version claim.
+                evaluationGeneration += 1
+            }
+            .task(id: evaluationGeneration) {
+                await evaluateAfterNavigationSettles()
+            }
+    }
+
+    private func scheduleEvaluation() {
+        hasPendingEvaluation = true
+        evaluationGeneration += 1
+    }
+
+    private func evaluateAfterNavigationSettles() async {
+        guard hasPendingEvaluation else { return }
+
+        do {
+            try await Task.sleep(for: .seconds(2))
+        } catch {
+            return
+        }
+
+        // Keep the pending bit set so returning to an active scene retries on a
+        // visible surface instead of spending an ask while the app is inactive.
+        guard isSceneActive else { return }
+        hasPendingEvaluation = false
+
+        guard AppReviewService.shared.claimReviewPrompt() else { return }
+        requestReview()
+    }
+}
+
+extension View {
+    func appReviewPromptHost() -> some View {
+        modifier(AppReviewPromptHost())
+    }
+}
+#endif

--- a/VultisigApp/VultisigApp/Core/Services/Review/AppReviewService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/Review/AppReviewService.swift
@@ -228,11 +228,9 @@ enum AppReviewIncomingBalancePolicy {
         isNativeToken: Bool,
         minimumRawAmount: BigInt,
         isLikelySpam: Bool,
-        baselineRefreshSucceeded: Bool,
-        confirmationRefreshSucceeded: Bool
+        refreshSucceeded: Bool
     ) -> String? {
-        guard baselineRefreshSucceeded,
-              confirmationRefreshSucceeded,
+        guard refreshSucceeded,
               !isLikelySpam,
               (0...38).contains(decimals),
               let previous = BigInt(previousRawBalance),
@@ -260,6 +258,24 @@ enum AppReviewIncomingBalancePolicy {
             return nil
         }
         return "\(normalizedCoinID):\(current)"
+    }
+
+    static func eventIDAfterDwell(
+        _ eventID: String?,
+        dwell: () async throws -> Void = {
+            try await Task.sleep(for: dwellDuration)
+        }
+    ) async -> String? {
+        guard let eventID else { return nil }
+
+        do {
+            try await dwell()
+        } catch {
+            return nil
+        }
+
+        guard !Task.isCancelled else { return nil }
+        return eventID
     }
 }
 

--- a/VultisigApp/VultisigApp/Core/Services/Review/AppReviewService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/Review/AppReviewService.swift
@@ -2,67 +2,92 @@
 //  AppReviewService.swift
 //  VultisigApp
 //
-//  Owns the persisted inputs to `AppReviewPolicy`: when the app was
-//  installed, how many distinct transactions the user has watched
-//  confirm, and when we last asked for a review.
-//
-//  Stored in `UserDefaults` rather than SwiftData on purpose — this is
-//  preference-shaped device state, not model data. It must survive
-//  independently of any vault, since a user can delete every vault and
-//  restore another one without that resetting how often we may ask.
-//
-//  Idempotency is the whole point of `recordConfirmedTransaction(id:)`.
-//  The done screen can observe the same `.confirmed` status more than
-//  once — a re-render, a re-entry, or the poller re-reporting a terminal
-//  status — so the tally is keyed on the transaction hash and a bounded
-//  ring of already-counted hashes is kept alongside it. Counting per
-//  observation would inflate the tally and fire the prompt early, which
-//  on a 120-day cooldown is not a cheap mistake.
-//
 
 import Foundation
+
+/// A positive event that can contribute to App Store review eligibility.
+///
+/// Associated values are stable identities, not display values. Persisting the
+/// namespaced identity makes every producer safe to call repeatedly across
+/// rerenders, navigation re-entry, and app launches.
+enum AppReviewEvent: Equatable {
+    case confirmedOutboundTransaction(id: String)
+    case confirmedIncomingTransaction(id: String)
+    case vaultBackupCompleted(vaultID: String)
+    case vaultRestoreCompleted(vaultID: String)
+    case devicePairingCompleted(sessionID: String)
+
+    fileprivate var storageID: String? {
+        let namespace: String
+        let identity: String
+
+        switch self {
+        case .confirmedOutboundTransaction(let id):
+            namespace = "outbound"
+            identity = id
+        case .confirmedIncomingTransaction(let id):
+            namespace = "incoming"
+            identity = id
+        case .vaultBackupCompleted(let vaultID):
+            namespace = "backup"
+            identity = vaultID
+        case .vaultRestoreCompleted(let vaultID):
+            namespace = "restore"
+            identity = vaultID
+        case .devicePairingCompleted(let sessionID):
+            namespace = "pairing"
+            identity = sessionID
+        }
+
+        guard let normalized = identity.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty else {
+            return nil
+        }
+        return "\(namespace):\(normalized)"
+    }
+}
 
 @MainActor
 final class AppReviewService {
     static let shared = AppReviewService()
 
-    /// How many recently-counted transaction hashes are retained for the
-    /// duplicate check. The ring only has to be long enough that a hash is
-    /// still remembered while the same done screen can re-report it, so a
-    /// session's worth of transactions is already generous; the bound exists
-    /// so the key cannot grow without limit over the lifetime of the install.
-    /// Once the ring does wrap, the tally is necessarily far past the
-    /// 3-transaction threshold, where an extra increment changes nothing.
-    static let countedTransactionIDLimit = 100
+    /// Bounds only the duplicate-check identities. The lifetime count remains
+    /// monotonic after older identities roll off.
+    static let countedEventIDLimit = 100
 
     private enum Key {
         static let installDate = "appReview.installDate"
-        static let confirmedTransactionCount = "appReview.confirmedTransactionCount"
+        static let qualifyingEventCount = "appReview.qualifyingEventCount"
+        static let countedEventIDs = "appReview.countedEventIDs"
         static let lastPromptDate = "appReview.lastPromptDate"
-        static let countedTransactionIDs = "appReview.countedTransactionIDs"
+        static let lastPromptedVersion = "appReview.lastPromptedVersion"
+        static let policyEvaluationCount = "appReview.policyEvaluationCount"
+        static let promptClaimCount = "appReview.promptClaimCount"
+
+        // v1.43.69 compatibility. Upgraders keep both their earned count and
+        // transaction dedupe identities when the event model broadens.
+        static let legacyConfirmedTransactionCount = "appReview.confirmedTransactionCount"
+        static let legacyCountedTransactionIDs = "appReview.countedTransactionIDs"
     }
 
     private let defaults: UserDefaults
     private let now: () -> Date
+    private let bundleVersion: () -> String?
     private let logger = Log.app.service
 
-    /// `now` is injected so tests can pin the 7-day / 120-day boundaries
-    /// without sleeping; production callers take the default.
-    init(defaults: UserDefaults = .standard, now: @escaping () -> Date = { Date() }) {
+    init(
+        defaults: UserDefaults = .standard,
+        now: @escaping () -> Date = { Date() },
+        bundleVersion: @escaping () -> String? = {
+            Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+        }
+    ) {
         self.defaults = defaults
         self.now = now
+        self.bundleVersion = bundleVersion
     }
 
     // MARK: - Install date
 
-    /// Stamps the install date the first time it is called and never again.
-    ///
-    /// Users upgrading into the first build that ships this are stamped with
-    /// the upgrade date, not their real install date, so they serve the full
-    /// 7-day wait. That is deliberate: the alternative — backdating so the
-    /// rule is already satisfied — would fire the prompt at the entire
-    /// existing base within days of the release, which is exactly the
-    /// audience whose ratings we least want to spend on a rushed ask.
     func seedInstallDateIfNeeded() {
         guard defaults.object(forKey: Key.installDate) == nil else { return }
         defaults.set(now().timeIntervalSince1970, forKey: Key.installDate)
@@ -71,91 +96,127 @@ final class AppReviewService {
 
     // MARK: - Recording
 
-    /// Counts a confirmed transaction towards the review threshold, at most
-    /// once per transaction hash.
-    ///
-    /// - Parameter id: the transaction hash. An empty id carries no identity,
-    ///   so it cannot be de-duplicated and is not counted — undercounting is
-    ///   the safe direction here.
-    /// - Returns: whether this call actually incremented the tally.
+    /// Records a qualifying event once for its stable identity.
+    @discardableResult
+    func record(_ event: AppReviewEvent) -> Bool {
+        guard let eventID = event.storageID else { return false }
+
+        var counted = countedEventIDs
+        guard !counted.contains(eventID) else { return false }
+
+        counted.append(eventID)
+        if counted.count > Self.countedEventIDLimit {
+            counted.removeFirst(counted.count - Self.countedEventIDLimit)
+        }
+        defaults.set(counted, forKey: Key.countedEventIDs)
+
+        let updatedCount = qualifyingEventCount + 1
+        defaults.set(updatedCount, forKey: Key.qualifyingEventCount)
+        logger.info("[AppReview] Qualifying event count is now \(updatedCount, privacy: .public)")
+        return true
+    }
+
+    /// Compatibility for the existing Done screen while event producers move
+    /// to the typed API.
     @discardableResult
     func recordConfirmedTransaction(id: String) -> Bool {
-        guard !id.isEmpty else { return false }
+        record(.confirmedOutboundTransaction(id: id))
+    }
 
-        var counted = countedTransactionIDs
-        guard !counted.contains(id) else { return false }
+    // MARK: - Decision and atomic claim
 
-        counted.append(id)
-        if counted.count > Self.countedTransactionIDLimit {
-            counted.removeFirst(counted.count - Self.countedTransactionIDLimit)
-        }
-        defaults.set(counted, forKey: Key.countedTransactionIDs)
+    /// Evaluates and atomically consumes the current marketing-version ask.
+    /// StoreKit reports no display result, so a successful claim is persisted
+    /// before the caller invokes `requestReview()`.
+    func claimReviewPrompt() -> Bool {
+        let evaluationCount = policyEvaluationCount + 1
+        defaults.set(evaluationCount, forKey: Key.policyEvaluationCount)
 
-        let updatedCount = confirmedTransactionCount + 1
-        defaults.set(updatedCount, forKey: Key.confirmedTransactionCount)
-        logger.info("[AppReview] Confirmed transaction count is now \(updatedCount, privacy: .public)")
+        let version = bundleVersion()?.nilIfEmpty
+        let eligible = AppReviewPolicy.shouldRequestReview(
+            state: state,
+            now: now(),
+            currentVersion: version
+        )
+        logger.info(
+            "[AppReview] Policy evaluated eligible=\(eligible, privacy: .public) count=\(evaluationCount, privacy: .public)"
+        )
+        guard eligible, let version else { return false }
+
+        defaults.set(now().timeIntervalSince1970, forKey: Key.lastPromptDate)
+        defaults.set(version, forKey: Key.lastPromptedVersion)
+
+        let claimCount = promptClaimCount + 1
+        defaults.set(claimCount, forKey: Key.promptClaimCount)
+        logger.info(
+            "[AppReview] Prompt claimed for version \(version, privacy: .public) claimCount=\(claimCount, privacy: .public)"
+        )
         return true
     }
 
-    /// Records that the review sheet was requested.
-    ///
-    /// Called whenever `requestReview` is invoked, even though StoreKit may
-    /// silently decline to show anything — the API reports nothing back, so
-    /// the only safe assumption is that the ask was spent.
-    func recordPromptShown() {
-        defaults.set(now().timeIntervalSince1970, forKey: Key.lastPromptDate)
-        logger.info("[AppReview] Recorded review prompt request")
-    }
-
-    // MARK: - Decision
-
-    /// Records a just-confirmed transaction and reports whether this is the
-    /// moment to show the review sheet, consuming the ask when it is.
-    ///
-    /// Returns `true` only when the call counted a *new* transaction **and**
-    /// the throttle allows an ask. Requiring a new count is what stops an ask
-    /// being spent without a transaction behind it — a repeat observation of
-    /// a hash already counted, or a done screen that carries no hash of its
-    /// own, as custom-message signing does. Both otherwise arrive at a
-    /// throttle that is already satisfied from earlier transactions and would
-    /// pass.
-    ///
-    /// Composed here rather than at the call site so the ordering — count
-    /// first, then decide, then spend — is covered by unit tests instead of
-    /// living in a view.
+    /// Compatibility for the existing Done screen. This remains count-first,
+    /// then claim, until the shared app-level prompt host lands.
     func claimReviewPrompt(forConfirmedTransaction id: String) -> Bool {
         guard recordConfirmedTransaction(id: id) else { return false }
-        guard shouldRequestReview() else { return false }
-        recordPromptShown()
-        return true
+        return claimReviewPrompt()
     }
 
-    /// Whether the throttle currently allows asking for a review.
     func shouldRequestReview() -> Bool {
-        AppReviewPolicy.shouldRequestReview(state: state, now: now())
+        AppReviewPolicy.shouldRequestReview(
+            state: state,
+            now: now(),
+            currentVersion: bundleVersion()
+        )
     }
 
-    /// Current persisted snapshot, as the policy sees it.
     var state: AppReviewState {
         AppReviewState(
-            confirmedTransactionCount: confirmedTransactionCount,
+            qualifyingEventCount: qualifyingEventCount,
             installDate: date(forKey: Key.installDate),
-            lastPromptDate: date(forKey: Key.lastPromptDate)
+            lastPromptDate: date(forKey: Key.lastPromptDate),
+            lastPromptedVersion: defaults.string(forKey: Key.lastPromptedVersion)
+        )
+    }
+
+    var instrumentation: AppReviewInstrumentation {
+        AppReviewInstrumentation(
+            policyEvaluationCount: policyEvaluationCount,
+            promptClaimCount: promptClaimCount
         )
     }
 
     // MARK: - Storage
 
-    private var confirmedTransactionCount: Int {
-        defaults.integer(forKey: Key.confirmedTransactionCount)
+    private var qualifyingEventCount: Int {
+        if defaults.object(forKey: Key.qualifyingEventCount) != nil {
+            return defaults.integer(forKey: Key.qualifyingEventCount)
+        }
+        return defaults.integer(forKey: Key.legacyConfirmedTransactionCount)
     }
 
-    private var countedTransactionIDs: [String] {
-        defaults.stringArray(forKey: Key.countedTransactionIDs) ?? []
+    private var countedEventIDs: [String] {
+        if defaults.object(forKey: Key.countedEventIDs) != nil {
+            return defaults.stringArray(forKey: Key.countedEventIDs) ?? []
+        }
+        return (defaults.stringArray(forKey: Key.legacyCountedTransactionIDs) ?? [])
+            .map { "outbound:\($0)" }
+    }
+
+    private var policyEvaluationCount: Int {
+        defaults.integer(forKey: Key.policyEvaluationCount)
+    }
+
+    private var promptClaimCount: Int {
+        defaults.integer(forKey: Key.promptClaimCount)
     }
 
     private func date(forKey key: String) -> Date? {
         guard defaults.object(forKey: key) != nil else { return nil }
         return Date(timeIntervalSince1970: defaults.double(forKey: key))
     }
+}
+
+struct AppReviewInstrumentation: Equatable {
+    let policyEvaluationCount: Int
+    let promptClaimCount: Int
 }

--- a/VultisigApp/VultisigApp/Core/Utils/URL.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/URL.swift
@@ -25,6 +25,9 @@ class StaticURL {
     static let GithubVultisigURL = URL(string: "https://github.com/vultisig/vultisig-ios")!
     static let XVultisigURL = URL(string: "https://x.com/vultisig")!
     static let AppStoreVultisigURL = URL(string: "https://apps.apple.com/app/vultisig/id6503023896")!
+    static let AppStoreVultisigReviewURL = URL(
+        staticString: "https://apps.apple.com/app/vultisig/id6503023896?action=write-review"
+    )
     static let DiscordVultisigURL = URL(string: "https://discord.gg/ngvW8tRRfB")!
     static let PrivacyPolicyURL = URL(string: "https://vultisig.com/privacy")!
     static let TermsOfServiceURL = URL(string: "https://vultisig.com/termofservice")!

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/PeerDiscoveryScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/PeerDiscoveryScreen.swift
@@ -416,7 +416,7 @@ struct PeerDiscoveryScreen: View {
     var bottomButton: some View {
         if !isFixedDeviceMode {
             PrimaryButton(title: continueButtonTitle) {
-                viewModel.startKeygen()
+                startKeygenAndRecordPairing()
             }
             .padding(.horizontal, 16)
             .padding(.top, 20)
@@ -450,7 +450,15 @@ struct PeerDiscoveryScreen: View {
 
     func autoStartKeygenIfReady() {
         guard viewModel.shouldAutoStartKeygen(totalDeviceCount: totalDeviceCount) else { return }
+        startKeygenAndRecordPairing()
+    }
+
+    func startKeygenAndRecordPairing() {
         viewModel.startKeygen()
+        guard selectedTab.hasOtherDevices, viewModel.keygenCommittee.count > 1 else { return }
+        AppReviewService.shared.record(
+            .devicePairingCompleted(sessionID: viewModel.sessionID)
+        )
     }
 
     var showWaitingOnDevice: Bool {

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignDiscoveryView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignDiscoveryView.swift
@@ -343,6 +343,11 @@ struct KeysignDiscoveryView: View {
     func startKeysign() {
         if viewModel.isValidPeers(vault: vault) {
             guard let keysignInput = viewModel.startKeysign(vault: vault) else { return }
+            if fastVaultPassword == nil {
+                AppReviewService.shared.record(
+                    .devicePairingCompleted(sessionID: keysignInput.sessionID)
+                )
+            }
             onKeysignInput(keysignInput)
         }
     }

--- a/VultisigApp/VultisigApp/Features/Onboarding/ImportVault/Main/Views/ImportVaultShareScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Onboarding/ImportVault/Main/Views/ImportVaultShareScreen.swift
@@ -14,6 +14,8 @@ struct ImportVaultShareScreen: View {
     @StateObject var backupViewModel = EncryptedBackupViewModel()
 
     @State var isUploading: Bool = false
+    @State private var startedWithoutVaults = false
+    @State private var didCaptureInitialVaultState = false
 
     @Query var vaults: [Vault]
     @EnvironmentObject var vultExtensionViewModel: VultExtensionViewModel
@@ -33,6 +35,12 @@ struct ImportVaultShareScreen: View {
         }
         .onChange(of: backupViewModel.isVaultImported) { _, isVaultImported in
             guard isVaultImported else { return }
+            if startedWithoutVaults, let restoredVault = backupViewModel.selectedVault {
+                AppReviewService.shared.record(
+                    .vaultRestoreCompleted(vaultID: restoredVault.pubKeyECDSA)
+                )
+                AppReviewService.shared.requestPromptEvaluation()
+            }
             appViewModel.showOnboarding = false
             appViewModel.set(selectedVault: backupViewModel.selectedVault)
         }
@@ -97,6 +105,10 @@ struct ImportVaultShareScreen: View {
     }
 
     private func setData() {
+        if !didCaptureInitialVaultState {
+            startedWithoutVaults = vaults.isEmpty
+            didCaptureInitialVaultState = true
+        }
         resetData()
 
         if let data = vultExtensionViewModel.documentData, let url = data.fileURL {

--- a/VultisigApp/VultisigApp/Features/Settings/Models/SettingsOption.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Models/SettingsOption.swift
@@ -35,6 +35,7 @@ enum SettingsOption: String, Identifiable {
     case faq
     case education
     case checkForUpdates
+    case rateApp
     case shareApp
     case twitter
     case discord
@@ -67,6 +68,8 @@ enum SettingsOption: String, Identifiable {
             return "vultisigEducation"
         case .checkForUpdates:
             return "checkForUpdates"
+        case .rateApp:
+            return "rateTheApp"
         case .shareApp:
             return "shareTheApp"
         case .twitter:
@@ -108,6 +111,8 @@ enum SettingsOption: String, Identifiable {
             return .books
         case .checkForUpdates:
             return .cloudUpload
+        case .rateApp:
+            return .stars
         case .shareApp:
             return .connectedDots3
         case .twitter:
@@ -148,6 +153,8 @@ enum SettingsOption: String, Identifiable {
             return .link(url: StaticURL.GithubVultisigURL)
         case .shareApp:
             return .shareLink(url: StaticURL.AppStoreVultisigURL)
+        case .rateApp:
+            return .link(url: StaticURL.AppStoreVultisigReviewURL)
         case .privacyPolicy:
             return .link(url: StaticURL.PrivacyPolicyURL)
         case .termsOfService:

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsMainScreen/SettingsMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsMainScreen/SettingsMainScreen.swift
@@ -64,6 +64,7 @@ struct SettingsMainScreen: View {
                 .faq,
                 .checkForUpdates,
                 .education,
+                .rateApp,
                 .shareApp
             ]
         ),

--- a/VultisigApp/VultisigApp/Features/Wallet/CoinDetail/CoinDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/CoinDetail/CoinDetailScreen.swift
@@ -275,29 +275,28 @@ private extension CoinDetailScreen {
     }
 
     func refreshAndRecordIncomingAfterDwell() async {
-        let baselineRefreshSucceeded = await refresh()
-        let baselineRawBalance = coin.rawBalance
-
-        do {
-            try await Task.sleep(for: AppReviewIncomingBalancePolicy.dwellDuration)
-        } catch {
-            return
-        }
-
-        let confirmationRefreshSucceeded = await refresh()
+        // `rawBalance` is the persisted result of the last successful live
+        // refresh. Capture it before refreshing so funds that arrived while
+        // this screen was closed are recognized on their first live sighting.
+        let previouslyObservedRawBalance = coin.rawBalance
+        let refreshSucceeded = await refresh()
         let coinPrice = coin.price
-        guard let eventID = AppReviewIncomingBalancePolicy.eventID(
+        let candidateEventID = AppReviewIncomingBalancePolicy.eventID(
             coinID: coin.id,
-            previousRawBalance: baselineRawBalance,
+            previousRawBalance: previouslyObservedRawBalance,
             currentRawBalance: coin.rawBalance,
             decimals: coin.decimals,
             fiatRate: coinPrice.isFinite && coinPrice > 0 ? Decimal(coinPrice) : nil,
             isNativeToken: coin.isNativeToken,
             minimumRawAmount: BigInt(coin.coinType.getFixedDustThreshold()),
             isLikelySpam: CoinService.isLikelySpam(coin.toCoinMeta()),
-            baselineRefreshSucceeded: baselineRefreshSucceeded,
-            confirmationRefreshSucceeded: confirmationRefreshSucceeded
-        ) else {
+            refreshSucceeded: refreshSucceeded
+        )
+
+        // The live confirmed balance is already persisted by `refresh()`. Only
+        // the review event waits: SwiftUI cancels this task if the sheet
+        // disappears before the user has dwelled on the visible balance.
+        guard let eventID = await AppReviewIncomingBalancePolicy.eventIDAfterDwell(candidateEventID) else {
             return
         }
 

--- a/VultisigApp/VultisigApp/Features/Wallet/CoinDetail/CoinDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/CoinDetail/CoinDetailScreen.swift
@@ -5,6 +5,7 @@
 //  Created by Gaston Mazzeo on 29/09/2025.
 //
 
+import BigInt
 import SwiftUI
 
 struct CoinDetailScreen: View {
@@ -164,8 +165,8 @@ struct CoinDetailScreen: View {
         .overlay(bottomFade)
         .task {
             viewModel.setup()
+            await refreshAndRecordIncomingAfterDwell()
         }
-        .onAppear(perform: onAppear)
         .withAddressCopy(coin: $addressToCopy)
         .overlay(
             NotificationBannerView(
@@ -258,23 +259,52 @@ struct CoinDetailScreen: View {
 }
 
 private extension CoinDetailScreen {
-    func onAppear() {
-        Task {
-            await refresh()
-        }
-    }
-
     func onRefreshButton() {
         Task {
             await refresh()
         }
     }
 
-    func refresh() async {
-        await BalanceService.shared.updateBalance(for: coin)
+    @discardableResult
+    func refresh() async -> Bool {
+        let didRefreshBalance = await BalanceService.shared.updateBalance(for: coin)
         if viewModel.isTron {
             await MainActor.run { viewModel.tronLoader?.load() }
         }
+        return didRefreshBalance
+    }
+
+    func refreshAndRecordIncomingAfterDwell() async {
+        let baselineRefreshSucceeded = await refresh()
+        let baselineRawBalance = coin.rawBalance
+
+        do {
+            try await Task.sleep(for: AppReviewIncomingBalancePolicy.dwellDuration)
+        } catch {
+            return
+        }
+
+        let confirmationRefreshSucceeded = await refresh()
+        let coinPrice = coin.price
+        guard let eventID = AppReviewIncomingBalancePolicy.eventID(
+            coinID: coin.id,
+            previousRawBalance: baselineRawBalance,
+            currentRawBalance: coin.rawBalance,
+            decimals: coin.decimals,
+            fiatRate: coinPrice.isFinite && coinPrice > 0 ? Decimal(coinPrice) : nil,
+            isNativeToken: coin.isNativeToken,
+            minimumRawAmount: BigInt(coin.coinType.getFixedDustThreshold()),
+            isLikelySpam: CoinService.isLikelySpam(coin.toCoinMeta()),
+            baselineRefreshSucceeded: baselineRefreshSucceeded,
+            confirmationRefreshSucceeded: confirmationRefreshSucceeded
+        ) else {
+            return
+        }
+
+        AppReviewService.shared.record(
+            .confirmedIncomingTransaction(id: eventID)
+        )
+        AppReviewService.shared.requestPromptEvaluation()
     }
 
     func onExplorer() {

--- a/VultisigApp/VultisigApp/Features/Wallet/Views/Backup/VaultBackupContainerView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/Views/Backup/VaultBackupContainerView.swift
@@ -49,6 +49,10 @@ struct VaultBackupContainerView<Content: View>: View {
 
     func fileSaved() {
         backupType.markBackedUp()
+        AppReviewService.shared.record(
+            .vaultBackupCompleted(vaultID: backupType.vault.pubKeyECDSA)
+        )
+        AppReviewService.shared.requestPromptEvaluation()
         FileManager.default.clearTmpDirectory()
     }
 

--- a/VultisigApp/VultisigAppTests/Services/Review/AppReviewPolicyTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/Review/AppReviewPolicyTests.swift
@@ -2,26 +2,20 @@
 //  AppReviewPolicyTests.swift
 //  VultisigAppTests
 //
-//  Exhaustive coverage of the review throttle: each rule in isolation,
-//  each boundary (exactly 3 transactions, exactly 7 days, exactly 120
-//  days) and the combined gate. Every date is pinned — the policy takes
-//  `now` as a parameter, so nothing here sleeps.
-//
 
 import XCTest
 @testable import VultisigApp
 
 final class AppReviewPolicyTests: XCTestCase {
-
     private let day: TimeInterval = 24 * 60 * 60
     private let installed = Date(timeIntervalSince1970: 1_700_000_000)
 
-    /// A state that satisfies every rule, so each test can break exactly one.
     private func eligibleState() -> AppReviewState {
         AppReviewState(
-            confirmedTransactionCount: 3,
+            qualifyingEventCount: 2,
             installDate: installed,
-            lastPromptDate: nil
+            lastPromptDate: nil,
+            lastPromptedVersion: nil
         )
     }
 
@@ -29,69 +23,46 @@ final class AppReviewPolicyTests: XCTestCase {
         installed.addingTimeInterval(days * day)
     }
 
-    // MARK: - Combined gate
-
     func testPromptsWhenEveryRuleIsSatisfied() {
         XCTAssertTrue(
             AppReviewPolicy.shouldRequestReview(
                 state: eligibleState(),
-                now: now(daysAfterInstall: 7)
+                now: now(daysAfterInstall: 7),
+                currentVersion: "1.2.3"
             )
         )
     }
 
-    func testDoesNotPromptWhenEveryRuleFails() {
-        let state = AppReviewState(
-            confirmedTransactionCount: 0,
-            installDate: installed,
-            lastPromptDate: installed
-        )
+    func testDoesNotPromptBelowTwoEvents() {
+        var state = eligibleState()
+        state.qualifyingEventCount = 1
         XCTAssertFalse(
-            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 1))
+            AppReviewPolicy.shouldRequestReview(
+                state: state,
+                now: now(daysAfterInstall: 30),
+                currentVersion: "1.2.3"
+            )
         )
     }
 
-    // MARK: - Transaction count
-
-    func testDoesNotPromptBelowTransactionThreshold() {
+    func testPromptsAtExactlyTwoEvents() {
         var state = eligibleState()
-        state.confirmedTransactionCount = 2
-        XCTAssertFalse(
-            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 30))
-        )
-    }
-
-    func testPromptsAtExactlyThreeTransactions() {
-        var state = eligibleState()
-        state.confirmedTransactionCount = 3
+        state.qualifyingEventCount = 2
         XCTAssertTrue(
-            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 30))
+            AppReviewPolicy.shouldRequestReview(
+                state: state,
+                now: now(daysAfterInstall: 30),
+                currentVersion: "1.2.3"
+            )
         )
     }
-
-    func testPromptsAboveTransactionThreshold() {
-        var state = eligibleState()
-        state.confirmedTransactionCount = 50
-        XCTAssertTrue(
-            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 30))
-        )
-    }
-
-    func testDoesNotPromptWithZeroTransactions() {
-        var state = eligibleState()
-        state.confirmedTransactionCount = 0
-        XCTAssertFalse(
-            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 30))
-        )
-    }
-
-    // MARK: - Install age
 
     func testDoesNotPromptBeforeSevenDaysSinceInstall() {
         XCTAssertFalse(
             AppReviewPolicy.shouldRequestReview(
                 state: eligibleState(),
-                now: installed.addingTimeInterval(7 * day - 1)
+                now: installed.addingTimeInterval(7 * day - 1),
+                currentVersion: "1.2.3"
             )
         )
     }
@@ -100,100 +71,111 @@ final class AppReviewPolicyTests: XCTestCase {
         XCTAssertTrue(
             AppReviewPolicy.shouldRequestReview(
                 state: eligibleState(),
-                now: installed.addingTimeInterval(7 * day)
+                now: installed.addingTimeInterval(7 * day),
+                currentVersion: "1.2.3"
             )
         )
     }
 
-    func testDoesNotPromptWithoutAnInstallDate() {
+    func testDoesNotPromptWithoutInstallDate() {
         var state = eligibleState()
         state.installDate = nil
         XCTAssertFalse(
-            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 365))
+            AppReviewPolicy.shouldRequestReview(
+                state: state,
+                now: now(daysAfterInstall: 365),
+                currentVersion: "1.2.3"
+            )
         )
     }
 
-    func testDoesNotPromptWhenInstallDateIsInTheFuture() {
+    func testDoesNotPromptWhenInstallDateIsInFuture() {
         var state = eligibleState()
         state.installDate = now(daysAfterInstall: 30)
         XCTAssertFalse(
-            AppReviewPolicy.shouldRequestReview(state: state, now: installed)
+            AppReviewPolicy.shouldRequestReview(
+                state: state,
+                now: installed,
+                currentVersion: "1.2.3"
+            )
         )
     }
 
-    // MARK: - Prompt cooldown
+    func testDoesNotPromptWithoutCurrentVersion() {
+        XCTAssertFalse(
+            AppReviewPolicy.shouldRequestReview(
+                state: eligibleState(),
+                now: now(daysAfterInstall: 30),
+                currentVersion: nil
+            )
+        )
+        XCTAssertFalse(
+            AppReviewPolicy.shouldRequestReview(
+                state: eligibleState(),
+                now: now(daysAfterInstall: 30),
+                currentVersion: ""
+            )
+        )
+    }
 
-    func testDoesNotPromptBeforeOneHundredTwentyDaysSinceLastPrompt() {
+    func testDoesNotPromptTwiceForSameVersion() {
         var state = eligibleState()
-        state.lastPromptDate = now(daysAfterInstall: 10)
+        state.lastPromptDate = now(daysAfterInstall: 7)
+        state.lastPromptedVersion = "1.2.3"
+
         XCTAssertFalse(
             AppReviewPolicy.shouldRequestReview(
                 state: state,
-                now: now(daysAfterInstall: 10).addingTimeInterval(120 * day - 1)
+                now: now(daysAfterInstall: 365),
+                currentVersion: "1.2.3"
             )
         )
     }
 
-    func testPromptsAtExactlyOneHundredTwentyDaysSinceLastPrompt() {
+    func testDoesNotPromptNewVersionBeforeFourteenDayFloor() {
         var state = eligibleState()
-        state.lastPromptDate = now(daysAfterInstall: 10)
+        state.lastPromptDate = now(daysAfterInstall: 7)
+        state.lastPromptedVersion = "1.2.3"
+
+        XCTAssertFalse(
+            AppReviewPolicy.shouldRequestReview(
+                state: state,
+                now: now(daysAfterInstall: 7).addingTimeInterval(14 * day - 1),
+                currentVersion: "1.2.4"
+            )
+        )
+    }
+
+    func testPromptsNewVersionAtExactlyFourteenDayFloor() {
+        var state = eligibleState()
+        state.lastPromptDate = now(daysAfterInstall: 7)
+        state.lastPromptedVersion = "1.2.3"
+
         XCTAssertTrue(
             AppReviewPolicy.shouldRequestReview(
                 state: state,
-                now: now(daysAfterInstall: 10).addingTimeInterval(120 * day)
+                now: now(daysAfterInstall: 21),
+                currentVersion: "1.2.4"
             )
         )
     }
 
-    func testPromptsWhenNeverPromptedBefore() {
-        var state = eligibleState()
-        state.lastPromptDate = nil
-        XCTAssertTrue(
-            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 7))
-        )
-    }
-
-    func testDoesNotPromptWhenLastPromptIsInTheFuture() {
+    func testDoesNotPromptWhenLastPromptDateIsInFuture() {
         var state = eligibleState()
         state.lastPromptDate = now(daysAfterInstall: 400)
+        state.lastPromptedVersion = "1.2.2"
         XCTAssertFalse(
-            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 30))
+            AppReviewPolicy.shouldRequestReview(
+                state: state,
+                now: now(daysAfterInstall: 30),
+                currentVersion: "1.2.3"
+            )
         )
     }
 
-    // MARK: - One failing rule vetoes the rest
-
-    func testTransactionCountVetoesAnOtherwiseEligibleState() {
-        var state = eligibleState()
-        state.confirmedTransactionCount = 2
-        state.lastPromptDate = nil
-        XCTAssertFalse(
-            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 1_000))
-        )
-    }
-
-    func testInstallAgeVetoesAnOtherwiseEligibleState() {
-        var state = eligibleState()
-        state.confirmedTransactionCount = 100
-        XCTAssertFalse(
-            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 6))
-        )
-    }
-
-    func testCooldownVetoesAnOtherwiseEligibleState() {
-        var state = eligibleState()
-        state.confirmedTransactionCount = 100
-        state.lastPromptDate = now(daysAfterInstall: 100)
-        XCTAssertFalse(
-            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 200))
-        )
-    }
-
-    // MARK: - Thresholds
-
-    func testThresholdsMatchTheAgreedPolicy() {
-        XCTAssertEqual(AppReviewPolicy.minimumConfirmedTransactions, 3)
+    func testThresholdsMatchAgreedPolicy() {
+        XCTAssertEqual(AppReviewPolicy.minimumQualifyingEvents, 2)
         XCTAssertEqual(AppReviewPolicy.minimumTimeSinceInstall, 7 * day)
-        XCTAssertEqual(AppReviewPolicy.minimumTimeBetweenPrompts, 120 * day)
+        XCTAssertEqual(AppReviewPolicy.minimumTimeBetweenPrompts, 14 * day)
     }
 }

--- a/VultisigApp/VultisigAppTests/Services/Review/AppReviewServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/Review/AppReviewServiceTests.swift
@@ -176,14 +176,149 @@ final class AppReviewServiceTests: XCTestCase {
         XCTAssertNil(service.state.lastPromptedVersion)
     }
 
-    func testConfirmedTransactionCompatibilityClaimsOnSecondEvent() {
-        let service = makeService()
-        service.seedInstallDateIfNeeded()
-        service.record(.vaultBackupCompleted(vaultID: "vault-a"))
-        advance(days: 7)
+    func testPricedIncomingBalanceIncreaseMustClearFiatFloor() {
+        XCTAssertNotNil(
+            AppReviewIncomingBalancePolicy.eventID(
+                coinID: "btc-address",
+                previousRawBalance: "100000000",
+                currentRawBalance: "300000000",
+                decimals: 8,
+                fiatRate: 1,
+                isNativeToken: true,
+                minimumRawAmount: 100,
+                isLikelySpam: false,
+                baselineRefreshSucceeded: true,
+                confirmationRefreshSucceeded: true
+            )
+        )
+        XCTAssertNil(
+            AppReviewIncomingBalancePolicy.eventID(
+                coinID: "btc-address",
+                previousRawBalance: "100000000",
+                currentRawBalance: "150000000",
+                decimals: 8,
+                fiatRate: 1,
+                isNativeToken: true,
+                minimumRawAmount: 100,
+                isLikelySpam: false,
+                baselineRefreshSucceeded: true,
+                confirmationRefreshSucceeded: true
+            )
+        )
+    }
 
-        XCTAssertTrue(service.claimReviewPrompt(forConfirmedTransaction: "hash-a"))
-        XCTAssertFalse(service.claimReviewPrompt(forConfirmedTransaction: "hash-a"))
+    func testUnpricedIncomingRequiresNativeAmountAboveDust() {
+        XCTAssertEqual(
+            AppReviewIncomingBalancePolicy.eventID(
+                coinID: "native-address",
+                previousRawBalance: "0",
+                currentRawBalance: "100",
+                decimals: 8,
+                fiatRate: nil,
+                isNativeToken: true,
+                minimumRawAmount: 100,
+                isLikelySpam: false,
+                baselineRefreshSucceeded: true,
+                confirmationRefreshSucceeded: true
+            ),
+            "native-address:100"
+        )
+        XCTAssertNil(
+            AppReviewIncomingBalancePolicy.eventID(
+                coinID: "token-address",
+                previousRawBalance: "0",
+                currentRawBalance: "1000000",
+                decimals: 6,
+                fiatRate: nil,
+                isNativeToken: false,
+                minimumRawAmount: 1,
+                isLikelySpam: false,
+                baselineRefreshSucceeded: true,
+                confirmationRefreshSucceeded: true
+            )
+        )
+    }
+
+    func testIncomingRejectsSpamFailedRefreshAndInvalidBalances() {
+        let validArguments = (
+            coinID: "coin-address",
+            previous: "0",
+            current: "2000000"
+        )
+
+        XCTAssertNil(
+            AppReviewIncomingBalancePolicy.eventID(
+                coinID: validArguments.coinID,
+                previousRawBalance: validArguments.previous,
+                currentRawBalance: validArguments.current,
+                decimals: 6,
+                fiatRate: 1,
+                isNativeToken: false,
+                minimumRawAmount: 1,
+                isLikelySpam: true,
+                baselineRefreshSucceeded: true,
+                confirmationRefreshSucceeded: true
+            )
+        )
+        XCTAssertNil(
+            AppReviewIncomingBalancePolicy.eventID(
+                coinID: validArguments.coinID,
+                previousRawBalance: validArguments.previous,
+                currentRawBalance: validArguments.current,
+                decimals: 6,
+                fiatRate: 1,
+                isNativeToken: false,
+                minimumRawAmount: 1,
+                isLikelySpam: false,
+                baselineRefreshSucceeded: true,
+                confirmationRefreshSucceeded: false
+            )
+        )
+        XCTAssertNil(
+            AppReviewIncomingBalancePolicy.eventID(
+                coinID: validArguments.coinID,
+                previousRawBalance: validArguments.previous,
+                currentRawBalance: validArguments.current,
+                decimals: 6,
+                fiatRate: 1,
+                isNativeToken: false,
+                minimumRawAmount: 1,
+                isLikelySpam: false,
+                baselineRefreshSucceeded: false,
+                confirmationRefreshSucceeded: true
+            )
+        )
+        XCTAssertNil(
+            AppReviewIncomingBalancePolicy.eventID(
+                coinID: validArguments.coinID,
+                previousRawBalance: "",
+                currentRawBalance: validArguments.current,
+                decimals: 6,
+                fiatRate: 1,
+                isNativeToken: false,
+                minimumRawAmount: 1,
+                isLikelySpam: false,
+                baselineRefreshSucceeded: true,
+                confirmationRefreshSucceeded: true
+            )
+        )
+    }
+
+    func testIncomingIgnoresBalanceAlreadyPresentAtLiveBaseline() {
+        XCTAssertNil(
+            AppReviewIncomingBalancePolicy.eventID(
+                coinID: "coin-address",
+                previousRawBalance: "2000000",
+                currentRawBalance: "2000000",
+                decimals: 6,
+                fiatRate: 1,
+                isNativeToken: false,
+                minimumRawAmount: 1,
+                isLikelySpam: false,
+                baselineRefreshSucceeded: true,
+                confirmationRefreshSucceeded: true
+            )
+        )
     }
 
     func testStateIsIsolatedPerDefaultsSuite() {

--- a/VultisigApp/VultisigAppTests/Services/Review/AppReviewServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/Review/AppReviewServiceTests.swift
@@ -187,8 +187,7 @@ final class AppReviewServiceTests: XCTestCase {
                 isNativeToken: true,
                 minimumRawAmount: 100,
                 isLikelySpam: false,
-                baselineRefreshSucceeded: true,
-                confirmationRefreshSucceeded: true
+                refreshSucceeded: true
             )
         )
         XCTAssertNil(
@@ -201,8 +200,7 @@ final class AppReviewServiceTests: XCTestCase {
                 isNativeToken: true,
                 minimumRawAmount: 100,
                 isLikelySpam: false,
-                baselineRefreshSucceeded: true,
-                confirmationRefreshSucceeded: true
+                refreshSucceeded: true
             )
         )
     }
@@ -218,8 +216,7 @@ final class AppReviewServiceTests: XCTestCase {
                 isNativeToken: true,
                 minimumRawAmount: 100,
                 isLikelySpam: false,
-                baselineRefreshSucceeded: true,
-                confirmationRefreshSucceeded: true
+                refreshSucceeded: true
             ),
             "native-address:100"
         )
@@ -233,13 +230,81 @@ final class AppReviewServiceTests: XCTestCase {
                 isNativeToken: false,
                 minimumRawAmount: 1,
                 isLikelySpam: false,
-                baselineRefreshSucceeded: true,
-                confirmationRefreshSucceeded: true
+                refreshSucceeded: true
             )
         )
     }
 
-    func testIncomingRejectsSpamFailedRefreshAndInvalidBalances() {
+    func testIncomingBalancePresentAtEntryRecordsAfterDwell() async {
+        let candidate = AppReviewIncomingBalancePolicy.eventID(
+            coinID: "coin-address",
+            previousRawBalance: "0",
+            currentRawBalance: "2000000",
+            decimals: 6,
+            fiatRate: 1,
+            isNativeToken: false,
+            minimumRawAmount: 1,
+            isLikelySpam: false,
+            refreshSucceeded: true
+        )
+
+        let eventID = await AppReviewIncomingBalancePolicy.eventIDAfterDwell(
+            candidate,
+            dwell: {}
+        )
+
+        XCTAssertEqual(eventID, "coin-address:2000000")
+    }
+
+    func testIncomingSameBalanceRepeatDoesNotCreateCandidate() {
+        XCTAssertNil(
+            AppReviewIncomingBalancePolicy.eventID(
+                coinID: "coin-address",
+                previousRawBalance: "2000000",
+                currentRawBalance: "2000000",
+                decimals: 6,
+                fiatRate: 1,
+                isNativeToken: false,
+                minimumRawAmount: 1,
+                isLikelySpam: false,
+                refreshSucceeded: true
+            )
+        )
+    }
+
+    func testIncomingFailedRefreshDoesNotCreateCandidate() {
+        XCTAssertNil(
+            AppReviewIncomingBalancePolicy.eventID(
+                coinID: "coin-address",
+                previousRawBalance: "0",
+                currentRawBalance: "2000000",
+                decimals: 6,
+                fiatRate: 1,
+                isNativeToken: false,
+                minimumRawAmount: 1,
+                isLikelySpam: false,
+                refreshSucceeded: false
+            )
+        )
+    }
+
+    func testIncomingTaskCancellationBeforeDwellDoesNotRecord() async {
+        let service = makeService()
+        let task = Task {
+            let eventID = await AppReviewIncomingBalancePolicy.eventIDAfterDwell("coin-address:2000000") {
+                try await Task.sleep(for: .seconds(60))
+            }
+            guard let eventID else { return }
+            service.record(.confirmedIncomingTransaction(id: eventID))
+        }
+
+        task.cancel()
+        await task.value
+
+        XCTAssertEqual(service.state.qualifyingEventCount, 0)
+    }
+
+    func testIncomingRejectsSpamAndInvalidBalances() {
         let validArguments = (
             coinID: "coin-address",
             previous: "0",
@@ -256,36 +321,7 @@ final class AppReviewServiceTests: XCTestCase {
                 isNativeToken: false,
                 minimumRawAmount: 1,
                 isLikelySpam: true,
-                baselineRefreshSucceeded: true,
-                confirmationRefreshSucceeded: true
-            )
-        )
-        XCTAssertNil(
-            AppReviewIncomingBalancePolicy.eventID(
-                coinID: validArguments.coinID,
-                previousRawBalance: validArguments.previous,
-                currentRawBalance: validArguments.current,
-                decimals: 6,
-                fiatRate: 1,
-                isNativeToken: false,
-                minimumRawAmount: 1,
-                isLikelySpam: false,
-                baselineRefreshSucceeded: true,
-                confirmationRefreshSucceeded: false
-            )
-        )
-        XCTAssertNil(
-            AppReviewIncomingBalancePolicy.eventID(
-                coinID: validArguments.coinID,
-                previousRawBalance: validArguments.previous,
-                currentRawBalance: validArguments.current,
-                decimals: 6,
-                fiatRate: 1,
-                isNativeToken: false,
-                minimumRawAmount: 1,
-                isLikelySpam: false,
-                baselineRefreshSucceeded: false,
-                confirmationRefreshSucceeded: true
+                refreshSucceeded: true
             )
         )
         XCTAssertNil(
@@ -298,25 +334,7 @@ final class AppReviewServiceTests: XCTestCase {
                 isNativeToken: false,
                 minimumRawAmount: 1,
                 isLikelySpam: false,
-                baselineRefreshSucceeded: true,
-                confirmationRefreshSucceeded: true
-            )
-        )
-    }
-
-    func testIncomingIgnoresBalanceAlreadyPresentAtLiveBaseline() {
-        XCTAssertNil(
-            AppReviewIncomingBalancePolicy.eventID(
-                coinID: "coin-address",
-                previousRawBalance: "2000000",
-                currentRawBalance: "2000000",
-                decimals: 6,
-                fiatRate: 1,
-                isNativeToken: false,
-                minimumRawAmount: 1,
-                isLikelySpam: false,
-                baselineRefreshSucceeded: true,
-                confirmationRefreshSucceeded: true
+                refreshSucceeded: true
             )
         )
     }

--- a/VultisigApp/VultisigAppTests/Services/Review/AppReviewServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/Review/AppReviewServiceTests.swift
@@ -2,28 +2,24 @@
 //  AppReviewServiceTests.swift
 //  VultisigAppTests
 //
-//  Persistence + idempotency coverage for the review throttle's state
-//  layer. Each test gets its own `UserDefaults` suite so nothing touches
-//  `.standard`, and the clock is injected so the 7-day / 120-day windows
-//  are crossed by moving a variable, never by sleeping.
-//
 
 import XCTest
 @testable import VultisigApp
 
 @MainActor
 final class AppReviewServiceTests: XCTestCase {
-
     private let day: TimeInterval = 24 * 60 * 60
     private var suiteName = ""
     private var defaults = UserDefaults.standard
     private var clock = Date(timeIntervalSince1970: 1_700_000_000)
+    private var version: String? = "1.2.3"
 
     override func setUp() async throws {
         try await super.setUp()
         suiteName = "AppReviewServiceTests-\(UUID().uuidString)"
         defaults = UserDefaults(suiteName: suiteName)!
         clock = Date(timeIntervalSince1970: 1_700_000_000)
+        version = "1.2.3"
     }
 
     override func tearDown() async throws {
@@ -32,22 +28,27 @@ final class AppReviewServiceTests: XCTestCase {
     }
 
     private func makeService() -> AppReviewService {
-        AppReviewService(defaults: defaults, now: { [unowned self] in self.clock })
+        AppReviewService(
+            defaults: defaults,
+            now: { [unowned self] in self.clock },
+            bundleVersion: { [unowned self] in self.version }
+        )
     }
 
     private func advance(days: Double) {
         clock = clock.addingTimeInterval(days * day)
     }
 
-    // MARK: - Install date seeding
-
-    func testSeedInstallDateStoresTheCurrentDate() {
+    private func makeEligibleService() -> AppReviewService {
         let service = makeService()
         service.seedInstallDateIfNeeded()
-        XCTAssertEqual(service.state.installDate, clock)
+        service.record(.vaultBackupCompleted(vaultID: "vault-a"))
+        service.record(.devicePairingCompleted(sessionID: "session-a"))
+        advance(days: 7)
+        return service
     }
 
-    func testSeedInstallDateIsWrittenOnlyOnce() {
+    func testSeedInstallDateStoresCurrentDateOnce() {
         let service = makeService()
         service.seedInstallDateIfNeeded()
         let seeded = clock
@@ -58,240 +59,148 @@ final class AppReviewServiceTests: XCTestCase {
         XCTAssertEqual(service.state.installDate, seeded)
     }
 
-    func testInstallDateIsNilBeforeSeeding() {
-        XCTAssertNil(makeService().state.installDate)
-    }
-
-    func testInstallDateSurvivesANewServiceInstance() {
-        let first = makeService()
-        first.seedInstallDateIfNeeded()
-
-        advance(days: 5)
-        let second = makeService()
-        second.seedInstallDateIfNeeded()
-
-        XCTAssertEqual(second.state.installDate, first.state.installDate)
-    }
-
-    // MARK: - Counting
-
-    func testRecordingIncrementsTheCount() {
+    func testEachDistinctEventIncrementsCount() {
         let service = makeService()
-        XCTAssertTrue(service.recordConfirmedTransaction(id: "hash-a"))
-        XCTAssertTrue(service.recordConfirmedTransaction(id: "hash-b"))
-        XCTAssertEqual(service.state.confirmedTransactionCount, 2)
+        XCTAssertTrue(service.record(.confirmedOutboundTransaction(id: "hash-a")))
+        XCTAssertTrue(service.record(.confirmedIncomingTransaction(id: "hash-b")))
+        XCTAssertTrue(service.record(.vaultBackupCompleted(vaultID: "vault-a")))
+        XCTAssertTrue(service.record(.vaultRestoreCompleted(vaultID: "vault-b")))
+        XCTAssertTrue(service.record(.devicePairingCompleted(sessionID: "session-a")))
+        XCTAssertEqual(service.state.qualifyingEventCount, 5)
     }
 
-    /// The main correctness risk: the done screen can observe the same
-    /// `.confirmed` status repeatedly, so re-recording one hash must be inert.
-    func testRepeatedObservationsOfTheSameTransactionCountOnce() {
+    func testRepeatedEventCountsOnceAcrossInstances() {
+        XCTAssertTrue(makeService().record(.vaultBackupCompleted(vaultID: "vault-a")))
+        XCTAssertFalse(makeService().record(.vaultBackupCompleted(vaultID: "vault-a")))
+        XCTAssertEqual(makeService().state.qualifyingEventCount, 1)
+    }
+
+    func testSameIdentityInDifferentNamespacesCountsSeparately() {
         let service = makeService()
-        XCTAssertTrue(service.recordConfirmedTransaction(id: "hash-a"))
-        XCTAssertFalse(service.recordConfirmedTransaction(id: "hash-a"))
-        XCTAssertFalse(service.recordConfirmedTransaction(id: "hash-a"))
-        XCTAssertEqual(service.state.confirmedTransactionCount, 1)
+        XCTAssertTrue(service.record(.confirmedOutboundTransaction(id: "same")))
+        XCTAssertTrue(service.record(.confirmedIncomingTransaction(id: "same")))
+        XCTAssertEqual(service.state.qualifyingEventCount, 2)
     }
 
-    /// A remount builds a fresh service against the same defaults; the
-    /// duplicate check has to survive that, not just live in memory.
-    func testDuplicateSuppressionSurvivesANewServiceInstance() {
-        makeService().recordConfirmedTransaction(id: "hash-a")
-        let remounted = makeService()
-
-        XCTAssertFalse(remounted.recordConfirmedTransaction(id: "hash-a"))
-        XCTAssertEqual(remounted.state.confirmedTransactionCount, 1)
-    }
-
-    func testEmptyTransactionIDIsNotCounted() {
+    func testBlankEventIdentityIsNotCounted() {
         let service = makeService()
-        XCTAssertFalse(service.recordConfirmedTransaction(id: ""))
-        XCTAssertFalse(service.recordConfirmedTransaction(id: ""))
-        XCTAssertEqual(service.state.confirmedTransactionCount, 0)
+        XCTAssertFalse(service.record(.confirmedOutboundTransaction(id: "")))
+        XCTAssertFalse(service.record(.devicePairingCompleted(sessionID: "   ")))
+        XCTAssertEqual(service.state.qualifyingEventCount, 0)
     }
 
-    func testCountedTransactionIDsAreBounded() {
+    func testCountedEventIDsAreBounded() {
         let service = makeService()
-        let overflow = AppReviewService.countedTransactionIDLimit + 10
+        let overflow = AppReviewService.countedEventIDLimit + 10
         for index in 0..<overflow {
-            XCTAssertTrue(service.recordConfirmedTransaction(id: "hash-\(index)"))
+            XCTAssertTrue(service.record(.confirmedOutboundTransaction(id: "hash-\(index)")))
         }
 
-        XCTAssertEqual(service.state.confirmedTransactionCount, overflow)
-        let stored = defaults.stringArray(forKey: "appReview.countedTransactionIDs") ?? []
-        XCTAssertEqual(stored.count, AppReviewService.countedTransactionIDLimit)
-        // Oldest hashes are evicted first; the most recent ones stay guarded.
-        XCTAssertFalse(stored.contains("hash-0"))
-        XCTAssertTrue(stored.contains("hash-\(overflow - 1)"))
+        XCTAssertEqual(service.state.qualifyingEventCount, overflow)
+        let stored = defaults.stringArray(forKey: "appReview.countedEventIDs") ?? []
+        XCTAssertEqual(stored.count, AppReviewService.countedEventIDLimit)
+        XCTAssertFalse(stored.contains("outbound:hash-0"))
+        XCTAssertTrue(stored.contains("outbound:hash-\(overflow - 1)"))
     }
 
-    func testCountSurvivesANewServiceInstance() {
-        makeService().recordConfirmedTransaction(id: "hash-a")
-        makeService().recordConfirmedTransaction(id: "hash-b")
-        XCTAssertEqual(makeService().state.confirmedTransactionCount, 2)
-    }
-
-    // MARK: - Prompt recording
-
-    func testRecordPromptShownStoresTheCurrentDate() {
+    func testLegacyTransactionStateMigratesWithoutLosingCountOrDedupe() {
+        defaults.set(2, forKey: "appReview.confirmedTransactionCount")
+        defaults.set(["hash-a", "hash-b"], forKey: "appReview.countedTransactionIDs")
         let service = makeService()
-        XCTAssertNil(service.state.lastPromptDate)
 
-        service.recordPromptShown()
+        XCTAssertEqual(service.state.qualifyingEventCount, 2)
+        XCTAssertFalse(service.record(.confirmedOutboundTransaction(id: "hash-a")))
+        XCTAssertTrue(service.record(.vaultBackupCompleted(vaultID: "vault-a")))
+        XCTAssertEqual(service.state.qualifyingEventCount, 3)
+    }
+
+    func testLegacyPromptOlderThanFourteenDaysCanClaimCurrentVersion() {
+        defaults.set(2, forKey: "appReview.confirmedTransactionCount")
+        defaults.set(clock.addingTimeInterval(-30 * day).timeIntervalSince1970, forKey: "appReview.installDate")
+        defaults.set(clock.addingTimeInterval(-15 * day).timeIntervalSince1970, forKey: "appReview.lastPromptDate")
+
+        let service = makeService()
+        XCTAssertNil(service.state.lastPromptedVersion)
+        XCTAssertTrue(service.claimReviewPrompt())
+        XCTAssertEqual(service.state.lastPromptedVersion, "1.2.3")
+    }
+
+    func testClaimPersistsVersionDateAndInstrumentation() {
+        let service = makeEligibleService()
+        XCTAssertTrue(service.claimReviewPrompt())
+
         XCTAssertEqual(service.state.lastPromptDate, clock)
-    }
-
-    func testRecordPromptShownOverwritesThePreviousDate() {
-        let service = makeService()
-        service.recordPromptShown()
-
-        advance(days: 200)
-        service.recordPromptShown()
-
-        XCTAssertEqual(service.state.lastPromptDate, clock)
-    }
-
-    // MARK: - End-to-end throttle
-
-    func testDoesNotAskBeforeTheThresholdsAreMet() {
-        let service = makeService()
-        service.seedInstallDateIfNeeded()
-
-        service.recordConfirmedTransaction(id: "hash-a")
-        service.recordConfirmedTransaction(id: "hash-b")
-        advance(days: 10)
-        XCTAssertFalse(service.shouldRequestReview(), "two transactions is below the threshold")
-
-        service.recordConfirmedTransaction(id: "hash-c")
-        XCTAssertTrue(service.shouldRequestReview())
-    }
-
-    func testDoesNotAskWithinTheFirstWeek() {
-        let service = makeService()
-        service.seedInstallDateIfNeeded()
-
-        for id in ["hash-a", "hash-b", "hash-c"] {
-            service.recordConfirmedTransaction(id: id)
-        }
-
-        advance(days: 6)
-        XCTAssertFalse(service.shouldRequestReview())
-
-        advance(days: 1)
-        XCTAssertTrue(service.shouldRequestReview())
-    }
-
-    func testAskingClosesTheWindowForOneHundredTwentyDays() {
-        let service = makeService()
-        service.seedInstallDateIfNeeded()
-        for id in ["hash-a", "hash-b", "hash-c"] {
-            service.recordConfirmedTransaction(id: id)
-        }
-        advance(days: 7)
-        XCTAssertTrue(service.shouldRequestReview())
-
-        service.recordPromptShown()
-        XCTAssertFalse(service.shouldRequestReview())
-
-        advance(days: 119)
-        service.recordConfirmedTransaction(id: "hash-d")
-        XCTAssertFalse(service.shouldRequestReview())
-
-        advance(days: 1)
-        XCTAssertTrue(service.shouldRequestReview())
-    }
-
-    /// Re-observing the same three hashes must not push a two-transaction
-    /// user over the threshold.
-    func testRepeatedObservationsDoNotUnlockThePromptEarly() {
-        let service = makeService()
-        service.seedInstallDateIfNeeded()
-        advance(days: 30)
-
-        for _ in 0..<5 {
-            service.recordConfirmedTransaction(id: "hash-a")
-            service.recordConfirmedTransaction(id: "hash-b")
-        }
-
-        XCTAssertEqual(service.state.confirmedTransactionCount, 2)
-        XCTAssertFalse(service.shouldRequestReview())
-    }
-
-    // MARK: - Claiming the ask
-
-    /// Brings a service to the point where only a fresh transaction is
-    /// missing: seeded, past the 7-day wait, two transactions counted.
-    private func makeAlmostEligibleService() -> AppReviewService {
-        let service = makeService()
-        service.seedInstallDateIfNeeded()
-        service.recordConfirmedTransaction(id: "hash-a")
-        service.recordConfirmedTransaction(id: "hash-b")
-        advance(days: 30)
-        return service
-    }
-
-    func testClaimingAsksOnceTheThirdTransactionConfirms() {
-        let service = makeAlmostEligibleService()
-        XCTAssertTrue(service.claimReviewPrompt(forConfirmedTransaction: "hash-c"))
-        XCTAssertEqual(service.state.lastPromptDate, clock)
-    }
-
-    /// The ask must follow a *newly counted* transaction. Re-observing a hash
-    /// that already counted has no transaction behind it, so it must not ask
-    /// even when every throttle rule is otherwise satisfied.
-    func testClaimingRequiresANewlyCountedTransaction() {
-        let service = makeAlmostEligibleService()
-        XCTAssertTrue(service.claimReviewPrompt(forConfirmedTransaction: "hash-c"))
-
-        advance(days: 200)
-        XCTAssertFalse(
-            service.claimReviewPrompt(forConfirmedTransaction: "hash-c"),
-            "a repeat observation of an already-counted hash must not ask again"
+        XCTAssertEqual(service.state.lastPromptedVersion, "1.2.3")
+        XCTAssertEqual(
+            service.instrumentation,
+            AppReviewInstrumentation(policyEvaluationCount: 1, promptClaimCount: 1)
         )
     }
 
-    /// The custom-message signing flow renders the done screen already
-    /// `.confirmed` with an empty hash. Signing a message is not a
-    /// transaction, so it must never spend an ask.
-    func testClaimingWithAnEmptyIDNeverAsks() {
-        let service = makeAlmostEligibleService()
-        service.recordConfirmedTransaction(id: "hash-c")
-
-        XCTAssertTrue(service.shouldRequestReview(), "the throttle is otherwise satisfied")
-        XCTAssertFalse(service.claimReviewPrompt(forConfirmedTransaction: ""))
-        XCTAssertNil(service.state.lastPromptDate)
+    func testRefusedClaimStillIncrementsPolicyEvaluationOnly() {
+        let service = makeService()
+        XCTAssertFalse(service.claimReviewPrompt())
+        XCTAssertEqual(
+            service.instrumentation,
+            AppReviewInstrumentation(policyEvaluationCount: 1, promptClaimCount: 0)
+        )
     }
 
-    func testClaimingDoesNotSpendTheAskWhenTheThrottleRefuses() {
+    func testClaimCannotRepeatForSameVersion() {
+        let service = makeEligibleService()
+        XCTAssertTrue(service.claimReviewPrompt())
+        advance(days: 100)
+        XCTAssertFalse(service.claimReviewPrompt())
+        XCTAssertEqual(
+            service.instrumentation,
+            AppReviewInstrumentation(policyEvaluationCount: 2, promptClaimCount: 1)
+        )
+    }
+
+    func testNewVersionWaitsFourteenDays() {
+        let service = makeEligibleService()
+        XCTAssertTrue(service.claimReviewPrompt())
+        version = "1.2.4"
+
+        advance(days: 13)
+        XCTAssertFalse(service.claimReviewPrompt())
+        advance(days: 1)
+        XCTAssertTrue(service.claimReviewPrompt())
+    }
+
+    func testMissingVersionFailsClosed() {
+        let service = makeEligibleService()
+        version = nil
+        XCTAssertFalse(service.claimReviewPrompt())
+        XCTAssertNil(service.state.lastPromptDate)
+        XCTAssertNil(service.state.lastPromptedVersion)
+    }
+
+    func testConfirmedTransactionCompatibilityClaimsOnSecondEvent() {
         let service = makeService()
         service.seedInstallDateIfNeeded()
+        service.record(.vaultBackupCompleted(vaultID: "vault-a"))
+        advance(days: 7)
 
+        XCTAssertTrue(service.claimReviewPrompt(forConfirmedTransaction: "hash-a"))
         XCTAssertFalse(service.claimReviewPrompt(forConfirmedTransaction: "hash-a"))
-        XCTAssertNil(service.state.lastPromptDate)
-        XCTAssertEqual(service.state.confirmedTransactionCount, 1, "the transaction still counts")
-    }
-
-    func testClaimingClosesTheWindowForOneHundredTwentyDays() {
-        let service = makeAlmostEligibleService()
-        XCTAssertTrue(service.claimReviewPrompt(forConfirmedTransaction: "hash-c"))
-
-        advance(days: 119)
-        XCTAssertFalse(service.claimReviewPrompt(forConfirmedTransaction: "hash-d"))
-
-        advance(days: 1)
-        XCTAssertTrue(service.claimReviewPrompt(forConfirmedTransaction: "hash-e"))
     }
 
     func testStateIsIsolatedPerDefaultsSuite() {
         let service = makeService()
         service.seedInstallDateIfNeeded()
-        service.recordConfirmedTransaction(id: "hash-a")
+        service.record(.vaultBackupCompleted(vaultID: "vault-a"))
 
         let otherSuiteName = "AppReviewServiceTests-other-\(UUID().uuidString)"
         let otherDefaults = UserDefaults(suiteName: otherSuiteName)!
         defer { otherDefaults.removePersistentDomain(forName: otherSuiteName) }
-        let other = AppReviewService(defaults: otherDefaults, now: { [unowned self] in self.clock })
+        let other = AppReviewService(
+            defaults: otherDefaults,
+            now: { [unowned self] in self.clock },
+            bundleVersion: { "1.2.3" }
+        )
 
-        XCTAssertEqual(other.state.confirmedTransactionCount, 0)
+        XCTAssertEqual(other.state.qualifyingEventCount, 0)
         XCTAssertNil(other.state.installDate)
     }
 }

--- a/VultisigApp/VultisigAppTests/Settings/SettingsAppReviewOptionTests.swift
+++ b/VultisigApp/VultisigAppTests/Settings/SettingsAppReviewOptionTests.swift
@@ -1,0 +1,26 @@
+//
+//  SettingsAppReviewOptionTests.swift
+//  VultisigAppTests
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class SettingsAppReviewOptionTests: XCTestCase {
+    func testRateAppOpensAppStoreWriteReviewAction() throws {
+        guard case .link(let url) = SettingsOption.rateApp.type else {
+            return XCTFail("Rate the App must open a direct link")
+        }
+
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        XCTAssertEqual(components.host, "apps.apple.com")
+        XCTAssertEqual(components.path, "/app/vultisig/id6503023896")
+        XCTAssertEqual(components.queryItems, [URLQueryItem(name: "action", value: "write-review")])
+    }
+
+    func testRateAppUsesLocalizedTitleAndSparkleIcon() {
+        XCTAssertEqual(SettingsOption.rateApp.title, "rateTheApp")
+        XCTAssertNotEqual(SettingsOption.rateApp.title.localized, SettingsOption.rateApp.title)
+        XCTAssertEqual(SettingsOption.rateApp.icon, .stars)
+    }
+}


### PR DESCRIPTION
## Problem

The App Store review prompt only considered confirmed outbound transactions, required three of them, was hosted by the transaction Done screen, and used a 120-day cooldown. This excluded other positive wallet moments and did not give users a direct review action in Settings.

## Root cause

Review state stored transaction-only counters and hashes, the policy had no bundle-version claim, and StoreKit presentation was coupled to one transactional success screen. Other successful flows had no shared event model or safe visible presentation boundary.

## Fix

- Introduce a deduplicated positive-event model for confirmed outbound/incoming funds, completed backup, successful new-device restore, and completed device pairing.
- Lower eligibility to two events while retaining the seven-day install floor; claim at most once per marketing version with a fourteen-day floor between claims.
- Preserve legacy outbound count/dedupe state and add persistent policy-evaluation/prompt-claim counters plus structured logging.
- Move StoreKit presentation to one app-root iOS host so success flows record events independently from the main/UI claim boundary.
- Detect incoming funds by comparing the persisted last-confirmed balance with a successful live refresh, reject spam/dust, require a visible dwell, and cancel cleanly when the balance screen disappears.
- Add a localized Settings “Rate the App” row using the existing Settings row visuals and the direct App Store `action=write-review` URL.

## Verification

- `make generate` — passed; the new Settings test is included in the generated project.
- Changed-file SwiftLint (15 Swift files) — 0 violations, 0 serious.
- Focused `AppReviewServiceTests` — `** TEST SUCCEEDED **`, exit 0.
- Full `make test DESTINATION='platform=iOS Simulator,id=…'` — `** TEST SUCCEEDED **`, exit 0.
- Full-gate disk guard — 11 GiB before, 9.3 GiB after; no ENOSPC and no abort. Exact worktree DerivedData was verified by `info.plist` and removed afterward.
- Cross-model step reviews — policy/event steps and Settings step completed; findings were fixed or explicitly triaged. The user waived the remaining whole-branch review pass.

## Manual validation / risk

- StoreKit may decline to show a claimed system prompt; its API exposes no display result, so evaluation and claim counters are recorded separately.
- Incoming qualification deliberately uses confirmed spendable balance, never pending balance. It requires a meaningful priced amount or native-chain dust floor and ignores likely spam assets.
- Manually verify the system prompt opportunity after two qualifying events on an install older than seven days, a new marketing version after fourteen days, and the Settings App Store deep link on a device/App Store-capable build.

Closes #5273


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Rate the App” option to Settings, linking to the App Store review page.
  - Introduced localized review labels in supported languages.
  - Added review prompts based on qualifying actions such as transactions, backups, restores, and device pairing.
  - Added safeguards to prevent repetitive or untimely review prompts.

- **Bug Fixes**
  - Improved review prompt timing after completed actions and navigation.
  - Filtered invalid, duplicate, spam, and insignificant balance updates before considering review prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->