### PR TITLE
feat: add app-configured widget watchlist

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1814,6 +1814,11 @@
 "weJustSentYourBackupShare" = "Wir haben gerade Ihre Backup -Freigabe an Ihre E -Mail gesendet. Wenn Sie es nicht sehen, überprüfen Sie Ihren Spam -Ordner.";
 "whereDoYouMigrateFrom" = "Von wo migrierst du?";
 "whitespaceNotAllowed" = "Leerzeichen sind nicht erlaubt.";
+"widgetWatchlist" = "Widget-Beobachtungsliste";
+"widgetWatchlistAssets" = "Assets";
+"widgetWatchlistDescription" = "Wähle bis zu fünf Assets für deine Watchlist-Widgets. Sie erscheinen in der Reihenfolge, in der du sie aktivierst.";
+"widgetWatchlistLoadError" = "Markt-Assets konnten nicht geladen werden. Prüfe deine Verbindung und versuche es erneut.";
+"widgetWatchlistSelectionCount" = "%d von %d ausgewählt";
 "withdraw" = "Abheben";
 "withdrawAmount" = "%@ abheben";
 "withdrawBelowMinimum" = "Betrag zu klein — mindestens %@ %@ abheben";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1811,9 +1811,11 @@
 "walletBalanceExceededError" = "Die Gesamtmenge und die Gebühr überschreiten das Saldo deiner Brieftasche. Versuche es erneut.";
 "wantToCreateVaultPrivately" = "Möchtest du den Tresor privat erstellen?";
 "wantToSignPrivately" = "Möchtest du privat signieren?";
+"watchlist" = "Beobachtungsliste";
 "weJustSentYourBackupShare" = "Wir haben gerade Ihre Backup -Freigabe an Ihre E -Mail gesendet. Wenn Sie es nicht sehen, überprüfen Sie Ihren Spam -Ordner.";
 "whereDoYouMigrateFrom" = "Von wo migrierst du?";
 "whitespaceNotAllowed" = "Leerzeichen sind nicht erlaubt.";
+"widgets" = "Widgets";
 "widgetWatchlist" = "Widget-Beobachtungsliste";
 "widgetWatchlistAssets" = "Assets";
 "widgetWatchlistDescription" = "Wähle bis zu fünf Assets für deine Watchlist-Widgets. Sie erscheinen in der Reihenfolge, in der du sie aktivierst.";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1814,6 +1814,11 @@
 "weJustSentYourBackupShare" = "We just sent your backup share to your email. If you don’t see it, check your spam folder.";
 "whereDoYouMigrateFrom" = "Where do you migrate from";
 "whitespaceNotAllowed" = "Whitespace character is not allowed";
+"widgetWatchlist" = "Widget Watchlist";
+"widgetWatchlistAssets" = "Assets";
+"widgetWatchlistDescription" = "Choose up to five assets for your Watchlist widgets. They appear in the order you enable them.";
+"widgetWatchlistLoadError" = "Couldn’t load market assets. Check your connection and try again.";
+"widgetWatchlistSelectionCount" = "%d of %d selected";
 "withdraw" = "Withdraw";
 "withdrawAmount" = "Withdraw %@";
 "withdrawBelowMinimum" = "Amount too small — withdraw at least %@ %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1811,9 +1811,11 @@
 "walletBalanceExceededError" = "The total amount and fee exceed your wallet's balance. Try again.";
 "wantToCreateVaultPrivately" = "Want to create vault privately?";
 "wantToSignPrivately" = "Want to sign privately?";
+"watchlist" = "Watchlist";
 "weJustSentYourBackupShare" = "We just sent your backup share to your email. If you don’t see it, check your spam folder.";
 "whereDoYouMigrateFrom" = "Where do you migrate from";
 "whitespaceNotAllowed" = "Whitespace character is not allowed";
+"widgets" = "Widgets";
 "widgetWatchlist" = "Widget Watchlist";
 "widgetWatchlistAssets" = "Assets";
 "widgetWatchlistDescription" = "Choose up to five assets for your Watchlist widgets. They appear in the order you enable them.";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1814,6 +1814,11 @@
 "weJustSentYourBackupShare" = "Acabamos de enviar su compartir su copia de seguridad a su correo electrónico. Si no lo ve, revise su carpeta de spam.";
 "whereDoYouMigrateFrom" = "¿De dónde migras?";
 "whitespaceNotAllowed" = "No se permiten espacios en blanco.";
+"widgetWatchlist" = "Lista de seguimiento del widget";
+"widgetWatchlistAssets" = "Activos";
+"widgetWatchlistDescription" = "Elige hasta cinco activos para tus widgets de seguimiento. Aparecen en el orden en que los activas.";
+"widgetWatchlistLoadError" = "No se pudieron cargar los activos del mercado. Comprueba tu conexión e inténtalo de nuevo.";
+"widgetWatchlistSelectionCount" = "%d de %d seleccionados";
 "withdraw" = "Retirar";
 "withdrawAmount" = "Retirar %@";
 "withdrawBelowMinimum" = "Monto demasiado pequeño — retira al menos %@ %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1811,9 +1811,11 @@
 "walletBalanceExceededError" = "El total de la cantidad y la tarifa excede el saldo de tu cartera. Intenta de nuevo.";
 "wantToCreateVaultPrivately" = "¿Quieres crear la bóveda en privado?";
 "wantToSignPrivately" = "¿Quieres firmar en privado?";
+"watchlist" = "Lista de seguimiento";
 "weJustSentYourBackupShare" = "Acabamos de enviar su compartir su copia de seguridad a su correo electrónico. Si no lo ve, revise su carpeta de spam.";
 "whereDoYouMigrateFrom" = "¿De dónde migras?";
 "whitespaceNotAllowed" = "No se permiten espacios en blanco.";
+"widgets" = "Widgets";
 "widgetWatchlist" = "Lista de seguimiento del widget";
 "widgetWatchlistAssets" = "Activos";
 "widgetWatchlistDescription" = "Elige hasta cinco activos para tus widgets de seguimiento. Aparecen en el orden en que los activas.";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1814,6 +1814,11 @@
 "weJustSentYourBackupShare" = "Upravo smo poslali vašu sigurnosnu kopiju u vašu e -poštu. Ako ga ne vidite, provjerite mapu neželjene pošte.";
 "whereDoYouMigrateFrom" = "Odakle migrirate?";
 "whitespaceNotAllowed" = "Karakter bijelog prostora nije dopušten";
+"widgetWatchlist" = "Popis za praćenje widgeta";
+"widgetWatchlistAssets" = "Imovina";
+"widgetWatchlistDescription" = "Odaberi do pet stavki za widgete popisa za praćenje. Prikazuju se redoslijedom kojim ih uključiš.";
+"widgetWatchlistLoadError" = "Nije moguće učitati tržišnu imovinu. Provjeri vezu i pokušaj ponovno.";
+"widgetWatchlistSelectionCount" = "Odabrano %d od %d";
 "withdraw" = "Povuci";
 "withdrawAmount" = "Podignite %@";
 "withdrawBelowMinimum" = "Iznos je premalen — podignite barem %@ %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1811,9 +1811,11 @@
 "walletBalanceExceededError" = "Ukupni iznosi naknada premašuju saldo vašeg novčanika. Pokušajte ponovno.";
 "wantToCreateVaultPrivately" = "Želite li stvoriti trezor privatno?";
 "wantToSignPrivately" = "Želite li potpisivati privatno?";
+"watchlist" = "Popis za praćenje";
 "weJustSentYourBackupShare" = "Upravo smo poslali vašu sigurnosnu kopiju u vašu e -poštu. Ako ga ne vidite, provjerite mapu neželjene pošte.";
 "whereDoYouMigrateFrom" = "Odakle migrirate?";
 "whitespaceNotAllowed" = "Karakter bijelog prostora nije dopušten";
+"widgets" = "Widgeti";
 "widgetWatchlist" = "Popis za praćenje widgeta";
 "widgetWatchlistAssets" = "Imovina";
 "widgetWatchlistDescription" = "Odaberi do pet stavki za widgete popisa za praćenje. Prikazuju se redoslijedom kojim ih uključiš.";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1814,6 +1814,11 @@
 "weJustSentYourBackupShare" = "Abbiamo appena inviato la tua condivisione di backup alla tua email. Se non lo vedi, controlla la cartella spam.";
 "whereDoYouMigrateFrom" = "Da dove stai migrando?";
 "whitespaceNotAllowed" = "I caratteri di spazio non sono consentiti.";
+"widgetWatchlist" = "Watchlist del widget";
+"widgetWatchlistAssets" = "Asset";
+"widgetWatchlistDescription" = "Scegli fino a cinque asset per i widget Watchlist. Appariranno nell’ordine in cui li attivi.";
+"widgetWatchlistLoadError" = "Impossibile caricare gli asset di mercato. Controlla la connessione e riprova.";
+"widgetWatchlistSelectionCount" = "%d di %d selezionati";
 "withdraw" = "Preleva";
 "withdrawAmount" = "Preleva %@";
 "withdrawBelowMinimum" = "Importo troppo piccolo — preleva almeno %@ %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1811,9 +1811,11 @@
 "walletBalanceExceededError" = "La quantità totale e la commissione superano il saldo del tuo portafoglio. Riprova.";
 "wantToCreateVaultPrivately" = "Vuoi creare il vault in privato?";
 "wantToSignPrivately" = "Vuoi firmare in privato?";
+"watchlist" = "Watchlist";
 "weJustSentYourBackupShare" = "Abbiamo appena inviato la tua condivisione di backup alla tua email. Se non lo vedi, controlla la cartella spam.";
 "whereDoYouMigrateFrom" = "Da dove stai migrando?";
 "whitespaceNotAllowed" = "I caratteri di spazio non sono consentiti.";
+"widgets" = "Widget";
 "widgetWatchlist" = "Watchlist del widget";
 "widgetWatchlistAssets" = "Asset";
 "widgetWatchlistDescription" = "Scegli fino a cinque asset per i widget Watchlist. Appariranno nell’ordine in cui li attivi.";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1811,9 +1811,11 @@
 "walletBalanceExceededError" = "총 금액과 수수료가 지갑 잔액을 초과합니다. 다시 시도하세요.";
 "wantToCreateVaultPrivately" = "개인적으로 볼트를 만들고 싶으신가요?";
 "wantToSignPrivately" = "개인적으로 서명하고 싶으신가요?";
+"watchlist" = "관심 목록";
 "weJustSentYourBackupShare" = "이메일로 백업 공유를 보냈습니다. 보이지 않으면 스팸 폴더를 확인하세요.";
 "whereDoYouMigrateFrom" = "어디서 마이그레이션하시나요";
 "whitespaceNotAllowed" = "공백 문자는 허용되지 않습니다";
+"widgets" = "위젯";
 "widgetWatchlist" = "위젯 관심 목록";
 "widgetWatchlistAssets" = "자산";
 "widgetWatchlistDescription" = "관심 목록 위젯에 표시할 자산을 최대 5개 선택하세요. 활성화한 순서대로 표시됩니다.";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1814,6 +1814,11 @@
 "weJustSentYourBackupShare" = "이메일로 백업 공유를 보냈습니다. 보이지 않으면 스팸 폴더를 확인하세요.";
 "whereDoYouMigrateFrom" = "어디서 마이그레이션하시나요";
 "whitespaceNotAllowed" = "공백 문자는 허용되지 않습니다";
+"widgetWatchlist" = "위젯 관심 목록";
+"widgetWatchlistAssets" = "자산";
+"widgetWatchlistDescription" = "관심 목록 위젯에 표시할 자산을 최대 5개 선택하세요. 활성화한 순서대로 표시됩니다.";
+"widgetWatchlistLoadError" = "시장 자산을 불러올 수 없습니다. 연결을 확인하고 다시 시도하세요.";
+"widgetWatchlistSelectionCount" = "%d/%d개 선택됨";
 "withdraw" = "출금";
 "withdrawAmount" = "%@ 출금";
 "withdrawBelowMinimum" = "금액이 너무 적음 — 최소 %@ %@을(를) 출금하세요";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1811,9 +1811,11 @@
 "walletBalanceExceededError" = "O total da quantidade e da taxa excede o saldo da sua carteira. Tente novamente.";
 "wantToCreateVaultPrivately" = "Deseja criar o cofre de forma privada?";
 "wantToSignPrivately" = "Deseja assinar de forma privada?";
+"watchlist" = "Lista de acompanhamento";
 "weJustSentYourBackupShare" = "Acabamos de enviar seu compartilhamento de backup para o seu e -mail. Se você não vir, verifique sua pasta de spam.";
 "whereDoYouMigrateFrom" = "De onde você está migrando?";
 "whitespaceNotAllowed" = "Caracteres de espaço não são permitidos.";
+"widgets" = "Widgets";
 "widgetWatchlist" = "Lista de acompanhamento do widget";
 "widgetWatchlistAssets" = "Ativos";
 "widgetWatchlistDescription" = "Escolha até cinco ativos para os widgets da sua lista. Eles aparecem na ordem em que forem ativados.";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1814,6 +1814,11 @@
 "weJustSentYourBackupShare" = "Acabamos de enviar seu compartilhamento de backup para o seu e -mail. Se você não vir, verifique sua pasta de spam.";
 "whereDoYouMigrateFrom" = "De onde você está migrando?";
 "whitespaceNotAllowed" = "Caracteres de espaço não são permitidos.";
+"widgetWatchlist" = "Lista de acompanhamento do widget";
+"widgetWatchlistAssets" = "Ativos";
+"widgetWatchlistDescription" = "Escolha até cinco ativos para os widgets da sua lista. Eles aparecem na ordem em que forem ativados.";
+"widgetWatchlistLoadError" = "Não foi possível carregar os ativos do mercado. Verifique a conexão e tente novamente.";
+"widgetWatchlistSelectionCount" = "%d de %d selecionados";
 "withdraw" = "Sacar";
 "withdrawAmount" = "Retirar %@";
 "withdrawBelowMinimum" = "Valor muito pequeno — retire pelo menos %@ %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1811,9 +1811,11 @@
 "walletBalanceExceededError" = "总金额和费用超过您钱包的余额。请重试";
 "wantToCreateVaultPrivately" = "想要私密创建保险库？";
 "wantToSignPrivately" = "想要私密签名？";
+"watchlist" = "关注列表";
 "weJustSentYourBackupShare" = "我们刚刚将您的备份份额发送到您的电子邮件。如果您没有看到它，请检查您的垃圾邮件文件夹";
 "whereDoYouMigrateFrom" = "您从哪里迁移？";
 "whitespaceNotAllowed" = "不允许空格字符";
+"widgets" = "小组件";
 "widgetWatchlist" = "小组件关注列表";
 "widgetWatchlistAssets" = "资产";
 "widgetWatchlistDescription" = "为关注列表小组件选择最多五项资产。资产将按启用顺序显示。";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1814,6 +1814,11 @@
 "weJustSentYourBackupShare" = "我们刚刚将您的备份份额发送到您的电子邮件。如果您没有看到它，请检查您的垃圾邮件文件夹";
 "whereDoYouMigrateFrom" = "您从哪里迁移？";
 "whitespaceNotAllowed" = "不允许空格字符";
+"widgetWatchlist" = "小组件关注列表";
+"widgetWatchlistAssets" = "资产";
+"widgetWatchlistDescription" = "为关注列表小组件选择最多五项资产。资产将按启用顺序显示。";
+"widgetWatchlistLoadError" = "无法加载市场资产。请检查网络连接后重试。";
+"widgetWatchlistSelectionCount" = "已选择 %d/%d";
 "withdraw" = "提取";
 "withdrawAmount" = "提取 %@";
 "withdrawBelowMinimum" = "金额过小 — 请至少提取 %@ %@";

--- a/VultisigApp/VultisigApp/Core/Networking/HTTPClient.swift
+++ b/VultisigApp/VultisigApp/Core/Networking/HTTPClient.swift
@@ -8,6 +8,14 @@
 import Foundation
 import OSLog
 
+private let defaultHTTPClientLogger: Logger = {
+    #if WIDGET_EXTENSION
+    Logger(subsystem: "com.vultisig.wallet.widgets", category: "network")
+    #else
+    Log.app.other
+    #endif
+}()
+
 /// Concrete implementation of HTTPClientProtocol using URLSession
 final class HTTPClient: HTTPClientProtocol {
 
@@ -26,7 +34,7 @@ final class HTTPClient: HTTPClientProtocol {
         session: URLSession = .shared,
         jsonEncoder: JSONEncoder = JSONEncoder(),
         jsonDecoder: JSONDecoder = JSONDecoder(),
-        logger: Logger = Log.app.other
+        logger: Logger = defaultHTTPClientLogger
     ) {
         self.session = session
         self.jsonEncoder = jsonEncoder
@@ -184,9 +192,7 @@ private extension HTTPClient {
         var queryItems: [URLQueryItem] = []
 
         for (key, value) in parameters {
-            let valueString = "\(value)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "\(value)"
-            let queryItem = URLQueryItem(name: key, value: valueString)
-            queryItems.append(queryItem)
+            queryItems.append(URLQueryItem(name: key, value: "\(value)"))
         }
 
         urlComponents?.queryItems = queryItems

--- a/VultisigApp/VultisigApp/Core/Networking/HTTPClientProtocol.swift
+++ b/VultisigApp/VultisigApp/Core/Networking/HTTPClientProtocol.swift
@@ -8,7 +8,13 @@
 import Foundation
 import OSLog
 
-private let logger = Log.app.other
+private let logger: Logger = {
+    #if WIDGET_EXTENSION
+    Logger(subsystem: "com.vultisig.wallet.widgets", category: "network")
+    #else
+    Log.app.other
+    #endif
+}()
 
 /// Protocol defining the HTTP client interface
 protocol HTTPClientProtocol: Sendable {

--- a/VultisigApp/VultisigApp/Core/Utils/AccessibilityID.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/AccessibilityID.swift
@@ -33,6 +33,7 @@ enum AccessibilityID {
         static let container = "settings.container"
         static let languageCell = "settings.languageCell"
         static let currencyCell = "settings.currencyCell"
+        static let widgetsCell = "settings.widgetsCell"
         static let widgetWatchlistCell = "settings.widgetWatchlistCell"
         static let vaultSettingsCell = "settings.vaultSettingsCell"
         static let faqCell = "settings.faqCell"

--- a/VultisigApp/VultisigApp/Core/Utils/AccessibilityID.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/AccessibilityID.swift
@@ -33,6 +33,7 @@ enum AccessibilityID {
         static let container = "settings.container"
         static let languageCell = "settings.languageCell"
         static let currencyCell = "settings.currencyCell"
+        static let widgetWatchlistCell = "settings.widgetWatchlistCell"
         static let vaultSettingsCell = "settings.vaultSettingsCell"
         static let faqCell = "settings.faqCell"
         static let managePasscodeCell = "settings.managePasscodeCell"

--- a/VultisigApp/VultisigApp/Features/Settings/Models/SettingsOption.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Models/SettingsOption.swift
@@ -28,6 +28,7 @@ enum SettingsOption: String, Identifiable {
     case vultDiscountTiers
     case language
     case currency
+    case widgets
     case widgetWatchlist
     case notifications
     case addressBook
@@ -54,8 +55,10 @@ enum SettingsOption: String, Identifiable {
             return "language"
         case .currency:
             return "currency"
+        case .widgets:
+            return "widgets"
         case .widgetWatchlist:
-            return "widgetWatchlist"
+            return "watchlist"
         case .notifications:
             return "notifications"
         case .addressBook:
@@ -97,6 +100,8 @@ enum SettingsOption: String, Identifiable {
             return .language
         case .currency:
             return .circleDollar
+        case .widgets:
+            return .gridPlus
         case .widgetWatchlist:
             return .eye
         case .notifications:
@@ -134,6 +139,7 @@ enum SettingsOption: String, Identifiable {
         switch self {
         case .language: return AccessibilityID.Settings.languageCell
         case .currency: return AccessibilityID.Settings.currencyCell
+        case .widgets: return AccessibilityID.Settings.widgetsCell
         case .widgetWatchlist: return AccessibilityID.Settings.widgetWatchlistCell
         case .vaultSettings: return AccessibilityID.Settings.vaultSettingsCell
         case .faq: return AccessibilityID.Settings.faqCell

--- a/VultisigApp/VultisigApp/Features/Settings/Models/SettingsOption.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Models/SettingsOption.swift
@@ -28,6 +28,7 @@ enum SettingsOption: String, Identifiable {
     case vultDiscountTiers
     case language
     case currency
+    case widgetWatchlist
     case notifications
     case addressBook
     case managePasscode
@@ -53,6 +54,8 @@ enum SettingsOption: String, Identifiable {
             return "language"
         case .currency:
             return "currency"
+        case .widgetWatchlist:
+            return "widgetWatchlist"
         case .notifications:
             return "notifications"
         case .addressBook:
@@ -94,6 +97,8 @@ enum SettingsOption: String, Identifiable {
             return .language
         case .currency:
             return .circleDollar
+        case .widgetWatchlist:
+            return .eye
         case .notifications:
             return .bell
         case .addressBook:
@@ -129,6 +134,7 @@ enum SettingsOption: String, Identifiable {
         switch self {
         case .language: return AccessibilityID.Settings.languageCell
         case .currency: return AccessibilityID.Settings.currencyCell
+        case .widgetWatchlist: return AccessibilityID.Settings.widgetWatchlistCell
         case .vaultSettings: return AccessibilityID.Settings.vaultSettingsCell
         case .faq: return AccessibilityID.Settings.faqCell
         case .managePasscode: return AccessibilityID.Settings.managePasscodeCell

--- a/VultisigApp/VultisigApp/Features/Settings/ViewModels/WidgetWatchlistSettingsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/ViewModels/WidgetWatchlistSettingsViewModel.swift
@@ -1,0 +1,90 @@
+//
+//  WidgetWatchlistSettingsViewModel.swift
+//  VultisigApp
+//
+
+import Foundation
+import WidgetKit
+
+@MainActor
+final class WidgetWatchlistSettingsViewModel: ObservableObject {
+    @Published private(set) var selectedAssets: [WidgetWatchlistAsset]
+    @Published private(set) var catalogAssets: [WidgetWatchlistAsset] = []
+    @Published private(set) var isLoading = false
+    @Published private(set) var loadFailed = false
+
+    private let marketClient: any WidgetMarketRemote
+    private let defaults: UserDefaults?
+    private var hasLoaded = false
+
+    init(
+        marketClient: any WidgetMarketRemote = WidgetMarketClient(),
+        defaults: UserDefaults? = WidgetSharedStorage.defaults
+    ) {
+        self.marketClient = marketClient
+        self.defaults = defaults
+        self.selectedAssets = WidgetSharedStorage.watchlistAssets(in: defaults)
+    }
+
+    var assets: [WidgetWatchlistAsset] {
+        let catalogIDs = Set(catalogAssets.map(\.id))
+        return selectedAssets.filter { !catalogIDs.contains($0.id) } + catalogAssets
+    }
+
+    var selectionCount: Int { selectedAssets.count }
+
+    var canSelectMore: Bool {
+        selectionCount < WidgetSharedStorage.maximumWatchlistAssets
+    }
+
+    func isSelected(_ asset: WidgetWatchlistAsset) -> Bool {
+        selectedAssets.contains(where: { $0.id == asset.id })
+    }
+
+    func load(force: Bool = false) async {
+        guard force || !hasLoaded else { return }
+        hasLoaded = true
+        isLoading = true
+        loadFailed = false
+        defer { isLoading = false }
+
+        do {
+            let marketAssets = try await marketClient.markets(
+                query: .catalog(limit: 50),
+                currency: WidgetSharedStorage.currencyCode
+            )
+            let fetched = marketAssets.map(WidgetWatchlistAsset.init)
+            let fetchedByID = Dictionary(uniqueKeysWithValues: fetched.map { ($0.id, $0) })
+            let refreshedSelection = selectedAssets.map { fetchedByID[$0.id] ?? $0 }
+
+            catalogAssets = fetched
+            if refreshedSelection != selectedAssets {
+                selectedAssets = refreshedSelection
+                persistSelection(reloadWidget: false)
+            }
+        } catch is CancellationError {
+            return
+        } catch let error as URLError where error.code == .cancelled {
+            return
+        } catch {
+            loadFailed = true
+        }
+    }
+
+    func setSelected(_ selected: Bool, asset: WidgetWatchlistAsset) {
+        if selected {
+            guard !isSelected(asset), canSelectMore else { return }
+            selectedAssets.append(asset)
+        } else {
+            selectedAssets.removeAll(where: { $0.id == asset.id })
+        }
+
+        persistSelection(reloadWidget: true)
+    }
+
+    private func persistSelection(reloadWidget: Bool) {
+        WidgetSharedStorage.setWatchlistAssets(selectedAssets, in: defaults)
+        guard reloadWidget else { return }
+        WidgetCenter.shared.reloadTimelines(ofKind: WidgetSharedStorage.watchlistWidgetKind)
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Settings/ViewModels/WidgetWatchlistSettingsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/ViewModels/WidgetWatchlistSettingsViewModel.swift
@@ -10,12 +10,13 @@ import WidgetKit
 final class WidgetWatchlistSettingsViewModel: ObservableObject {
     @Published private(set) var selectedAssets: [WidgetWatchlistAsset]
     @Published private(set) var catalogAssets: [WidgetWatchlistAsset] = []
-    @Published private(set) var isLoading = false
+    @Published var isLoading = false
     @Published private(set) var loadFailed = false
 
     private let marketClient: any WidgetMarketRemote
     private let defaults: UserDefaults?
     private var hasLoaded = false
+    private var hasStoredSelection: Bool
 
     init(
         marketClient: any WidgetMarketRemote = WidgetMarketClient(),
@@ -24,6 +25,7 @@ final class WidgetWatchlistSettingsViewModel: ObservableObject {
         self.marketClient = marketClient
         self.defaults = defaults
         self.selectedAssets = WidgetSharedStorage.watchlistAssets(in: defaults)
+        self.hasStoredSelection = WidgetSharedStorage.hasStoredWatchlist(in: defaults)
     }
 
     var assets: [WidgetWatchlistAsset] {
@@ -58,7 +60,10 @@ final class WidgetWatchlistSettingsViewModel: ObservableObject {
             let refreshedSelection = selectedAssets.map { fetchedByID[$0.id] ?? $0 }
 
             catalogAssets = fetched
-            if refreshedSelection != selectedAssets {
+            if !hasStoredSelection {
+                selectedAssets = Array(fetched.prefix(WidgetSharedStorage.maximumWatchlistAssets))
+                persistSelection(reloadWidget: true)
+            } else if refreshedSelection != selectedAssets {
                 selectedAssets = refreshedSelection
                 persistSelection(reloadWidget: false)
             }
@@ -84,6 +89,7 @@ final class WidgetWatchlistSettingsViewModel: ObservableObject {
 
     private func persistSelection(reloadWidget: Bool) {
         WidgetSharedStorage.setWatchlistAssets(selectedAssets, in: defaults)
+        hasStoredSelection = true
         guard reloadWidget else { return }
         WidgetCenter.shared.reloadTimelines(ofKind: WidgetSharedStorage.watchlistWidgetKind)
     }

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Navigation/SettingsRoute.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Navigation/SettingsRoute.swift
@@ -13,6 +13,7 @@ enum SettingsRoute: Hashable {
     case vultDiscountTiers(vault: Vault)
     case language
     case currency
+    case widgetWatchlist
     case addressBook
     case addAddressBook(address: String? = nil, chain: AddressBookChainType? = nil)
     case editAddressBook(addressBookItem: AddressBookItem)

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Navigation/SettingsRoute.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Navigation/SettingsRoute.swift
@@ -13,6 +13,7 @@ enum SettingsRoute: Hashable {
     case vultDiscountTiers(vault: Vault)
     case language
     case currency
+    case widgets
     case widgetWatchlist
     case addressBook
     case addAddressBook(address: String? = nil, chain: AddressBookChainType? = nil)

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Navigation/SettingsRouteBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Navigation/SettingsRouteBuilder.swift
@@ -34,6 +34,11 @@ struct SettingsRouteBuilder {
     }
 
     @ViewBuilder
+    func buildWidgetsScreen() -> some View {
+        WidgetsSettingsScreen()
+    }
+
+    @ViewBuilder
     func buildWidgetWatchlistScreen() -> some View {
         WidgetWatchlistSettingsScreen()
     }

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Navigation/SettingsRouteBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Navigation/SettingsRouteBuilder.swift
@@ -34,6 +34,11 @@ struct SettingsRouteBuilder {
     }
 
     @ViewBuilder
+    func buildWidgetWatchlistScreen() -> some View {
+        WidgetWatchlistSettingsScreen()
+    }
+
+    @ViewBuilder
     func buildNotificationsScreen() -> some View {
         NotificationsSettingsScreen()
     }

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Navigation/SettingsRouter.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Navigation/SettingsRouter.swift
@@ -23,6 +23,8 @@ struct SettingsRouter {
             viewBuilder.buildLanguageScreen()
         case .currency:
             viewBuilder.buildCurrencyScreen()
+        case .widgetWatchlist:
+            viewBuilder.buildWidgetWatchlistScreen()
         case .notifications:
             viewBuilder.buildNotificationsScreen()
         case .addressBook:

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Navigation/SettingsRouter.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Navigation/SettingsRouter.swift
@@ -23,6 +23,8 @@ struct SettingsRouter {
             viewBuilder.buildLanguageScreen()
         case .currency:
             viewBuilder.buildCurrencyScreen()
+        case .widgets:
+            viewBuilder.buildWidgetsScreen()
         case .widgetWatchlist:
             viewBuilder.buildWidgetWatchlistScreen()
         case .notifications:

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsMainScreen/SettingsMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsMainScreen/SettingsMainScreen.swift
@@ -26,13 +26,17 @@ struct SettingsMainScreen: View {
     @State var showReferralBannerSheet = false
 
     var groups: [SettingsOptionGroup] {
-        let generalOptions: [SettingsOption] = [
+        var generalOptions: [SettingsOption] = [
             .notifications,
             .referralCode,
             .language,
-            .currency,
-            .addressBook
+            .currency
         ]
+
+        #if os(iOS)
+        generalOptions.append(.widgetWatchlist)
+        #endif
+        generalOptions.append(.addressBook)
 
         // Hidden until a tester opts in from Settings → Advanced, so merging
         // this layer does not put the feature in front of anyone. Shown anyway
@@ -167,6 +171,8 @@ struct SettingsMainScreen: View {
             router.navigate(to: SettingsRoute.language)
         case .currency:
             router.navigate(to: SettingsRoute.currency)
+        case .widgetWatchlist:
+            router.navigate(to: SettingsRoute.widgetWatchlist)
         case .notifications:
             router.navigate(to: SettingsRoute.notifications)
         case .addressBook:

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsMainScreen/SettingsMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsMainScreen/SettingsMainScreen.swift
@@ -34,7 +34,7 @@ struct SettingsMainScreen: View {
         ]
 
         #if os(iOS)
-        generalOptions.append(.widgetWatchlist)
+        generalOptions.append(.widgets)
         #endif
         generalOptions.append(.addressBook)
 
@@ -171,6 +171,8 @@ struct SettingsMainScreen: View {
             router.navigate(to: SettingsRoute.language)
         case .currency:
             router.navigate(to: SettingsRoute.currency)
+        case .widgets:
+            router.navigate(to: SettingsRoute.widgets)
         case .widgetWatchlist:
             router.navigate(to: SettingsRoute.widgetWatchlist)
         case .notifications:

--- a/VultisigApp/VultisigApp/Features/Settings/Views/WidgetWatchlist/WidgetWatchlistSettingsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/WidgetWatchlist/WidgetWatchlistSettingsScreen.swift
@@ -19,7 +19,8 @@ struct WidgetWatchlistSettingsScreen: View {
                 }
             }
         }
-        .screenTitle("widgetWatchlist".localized)
+        .screenTitle("watchlist".localized)
+        .withLoading(isLoading: $viewModel.isLoading)
         .task { await viewModel.load() }
     }
 
@@ -78,12 +79,7 @@ struct WidgetWatchlistSettingsScreen: View {
 
     @ViewBuilder
     private var statusView: some View {
-        if viewModel.isLoading {
-            ProgressView()
-                .tint(Theme.colors.primaryAccent4)
-                .frame(maxWidth: .infinity)
-                .padding(24)
-        } else if viewModel.loadFailed {
+        if viewModel.loadFailed {
             VStack(spacing: 12) {
                 Text("widgetWatchlistLoadError".localized)
                     .font(Theme.fonts.bodySRegular)

--- a/VultisigApp/VultisigApp/Features/Settings/Views/WidgetWatchlist/WidgetWatchlistSettingsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/WidgetWatchlist/WidgetWatchlistSettingsScreen.swift
@@ -1,0 +1,148 @@
+//
+//  WidgetWatchlistSettingsScreen.swift
+//  VultisigApp
+//
+
+import SwiftUI
+
+struct WidgetWatchlistSettingsScreen: View {
+    @StateObject private var viewModel = WidgetWatchlistSettingsViewModel()
+
+    var body: some View {
+        Screen {
+            ScrollView(showsIndicators: false) {
+                LazyVStack(alignment: .leading, spacing: 14) {
+                    selectionSummary
+                    partialLoadError
+                        .showIf(viewModel.loadFailed && !viewModel.assets.isEmpty)
+                    assetSection
+                }
+            }
+        }
+        .screenTitle("widgetWatchlist".localized)
+        .task { await viewModel.load() }
+    }
+
+    private var partialLoadError: some View {
+        HStack(spacing: 12) {
+            Text("widgetWatchlistLoadError".localized)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+
+            Spacer(minLength: 8)
+
+            Button("retry".localized) {
+                Task { await viewModel.load(force: true) }
+            }
+            .font(Theme.fonts.bodySMedium)
+            .foregroundStyle(Theme.colors.primaryAccent4)
+        }
+        .padding(16)
+        .background(Theme.radius.xl.shape.fill(Theme.colors.bgSurface1))
+        .overlay(Theme.radius.xl.shape.strokeBorder(Theme.colors.borderLight, lineWidth: 1))
+    }
+
+    private var selectionSummary: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(
+                String(
+                    format: "widgetWatchlistSelectionCount".localized,
+                    viewModel.selectionCount,
+                    WidgetSharedStorage.maximumWatchlistAssets
+                )
+            )
+            .font(Theme.fonts.bodyMMedium)
+            .foregroundStyle(Theme.colors.textPrimary)
+
+            Text("widgetWatchlistDescription".localized)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private var assetSection: some View {
+        SettingsSectionView(title: "widgetWatchlistAssets".localized) {
+            if viewModel.assets.isEmpty {
+                statusView
+            } else {
+                ForEach(Array(viewModel.assets.enumerated()), id: \.element.id) { index, asset in
+                    assetRow(asset)
+                        .commonListItemContainer(index: index, itemsCount: viewModel.assets.count)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var statusView: some View {
+        if viewModel.isLoading {
+            ProgressView()
+                .tint(Theme.colors.primaryAccent4)
+                .frame(maxWidth: .infinity)
+                .padding(24)
+        } else if viewModel.loadFailed {
+            VStack(spacing: 12) {
+                Text("widgetWatchlistLoadError".localized)
+                    .font(Theme.fonts.bodySRegular)
+                    .foregroundStyle(Theme.colors.textSecondary)
+                    .multilineTextAlignment(.center)
+
+                Button("retry".localized) {
+                    Task { await viewModel.load(force: true) }
+                }
+                .font(Theme.fonts.bodySMedium)
+                .foregroundStyle(Theme.colors.primaryAccent4)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(24)
+        }
+    }
+
+    private func assetRow(_ asset: WidgetWatchlistAsset) -> some View {
+        let selected = viewModel.isSelected(asset)
+        let selection = Binding(
+            get: { viewModel.isSelected(asset) },
+            set: { viewModel.setSelected($0, asset: asset) }
+        )
+
+        return HStack(spacing: 12) {
+            AsyncImageView(
+                logo: asset.iconLogo,
+                size: CGSize(width: 36, height: 36),
+                ticker: asset.symbol,
+                tokenChainLogo: nil
+            )
+            .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(asset.symbol)
+                    .font(Theme.fonts.bodySMedium)
+                    .foregroundStyle(Theme.colors.textPrimary)
+                    .lineLimit(1)
+
+                Text(asset.name)
+                    .font(Theme.fonts.caption12)
+                    .foregroundStyle(Theme.colors.textSecondary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 12)
+
+            VultiToggle(isOn: selection)
+                .fixedSize()
+                .disabled(!selected && !viewModel.canSelectMore)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+#if DEBUG
+#Preview {
+    WidgetWatchlistSettingsScreen()
+}
+#endif

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Widgets/WidgetsSettingsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Widgets/WidgetsSettingsScreen.swift
@@ -1,0 +1,36 @@
+//
+//  WidgetsSettingsScreen.swift
+//  VultisigApp
+//
+
+import SwiftUI
+
+struct WidgetsSettingsScreen: View {
+    @Environment(\.router) private var router
+
+    var body: some View {
+        Screen {
+            VStack(spacing: 0) {
+                Button {
+                    router.navigate(to: SettingsRoute.widgetWatchlist)
+                } label: {
+                    SettingsCommonOptionView(
+                        icon: .eye,
+                        title: "watchlist".localized
+                    )
+                }
+                .commonListContainer()
+                .accessibilityIdentifier(AccessibilityID.Settings.widgetWatchlistCell)
+
+                Spacer()
+            }
+        }
+        .screenTitle("widgets".localized)
+    }
+}
+
+#if DEBUG
+#Preview {
+    WidgetsSettingsScreen()
+}
+#endif

--- a/VultisigApp/VultisigApp/Shared/WidgetShared/WidgetMarketAsset.swift
+++ b/VultisigApp/VultisigApp/Shared/WidgetShared/WidgetMarketAsset.swift
@@ -56,6 +56,7 @@ struct WidgetMarketResult: Equatable, Sendable {
 
 enum WidgetMarketQuery: Hashable, Sendable {
     case top(limit: Int)
+    case catalog(limit: Int)
     case ids([String])
 
     var normalizedIDs: [String] {
@@ -75,15 +76,24 @@ enum WidgetMarketQuery: Hashable, Sendable {
         switch self {
         case .top(let limit):
             return min(5, max(1, limit))
+        case .catalog(let limit):
+            return min(50, max(1, limit))
         case .ids:
             return min(5, max(1, normalizedIDs.count))
         }
+    }
+
+    var includesSparkline: Bool {
+        guard case .catalog = self else { return true }
+        return false
     }
 
     var cacheKey: String {
         switch self {
         case .top:
             return "top-\(limit)"
+        case .catalog:
+            return "catalog-\(limit)"
         case .ids:
             return "ids-\(normalizedIDs.joined(separator: ","))"
         }

--- a/VultisigApp/VultisigApp/Shared/WidgetShared/WidgetMarketClient.swift
+++ b/VultisigApp/VultisigApp/Shared/WidgetShared/WidgetMarketClient.swift
@@ -5,11 +5,6 @@
 
 import Foundation
 
-// The WidgetKit extension cannot link the application's TargetType/HTTPClient
-// graph. This small Foundation-only client is deliberately shared by the app
-// and extension so the extension stays independently buildable.
-// swiftlint:disable no_raw_urlsession no_raw_urlrequest
-
 enum WidgetMarketError: Error, Equatable {
     case invalidURL
     case invalidResponse
@@ -20,46 +15,24 @@ enum WidgetMarketError: Error, Equatable {
     case unapprovedImageURL
 }
 
-enum WidgetMarketEndpoint {
-    private static let proxyBaseURL = URL(string: "https://api.vultisig.com/coingeicko/api/v3")
+enum WidgetMarketAPI: TargetType {
+    case marketData(query: WidgetMarketQuery, currency: String)
+    case search(query: String)
+    case icon(URL)
+
+    private static let proxyBaseURL: URL = {
+        guard let url = URL(string: "https://api.vultisig.com") else {
+            preconditionFailure("Invalid Vultisig API base URL")
+        }
+        return url
+    }()
     private static let approvedImageHost = "coin-images.coingecko.com"
 
-    static func url(query: WidgetMarketQuery, currency: String) throws -> URL {
-        guard let baseURL = proxyBaseURL?.appendingPathComponent("coins/markets"),
-              var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
-            throw WidgetMarketError.invalidURL
+    static func markets(query: WidgetMarketQuery, currency: String) throws -> Self {
+        if case .ids = query, query.normalizedIDs.isEmpty {
+            throw WidgetMarketError.emptySelection
         }
-
-        var items = [
-            URLQueryItem(name: "vs_currency", value: currency.lowercased()),
-            URLQueryItem(name: "order", value: "market_cap_desc"),
-            URLQueryItem(name: "per_page", value: String(query.limit)),
-            URLQueryItem(name: "page", value: "1"),
-            URLQueryItem(name: "sparkline", value: query.includesSparkline ? "true" : "false")
-        ]
-
-        if query.includesSparkline {
-            items.append(URLQueryItem(name: "price_change_percentage", value: "24h"))
-        }
-
-        if case .ids = query {
-            guard !query.normalizedIDs.isEmpty else { throw WidgetMarketError.emptySelection }
-            items.append(URLQueryItem(name: "ids", value: query.normalizedIDs.joined(separator: ",")))
-        }
-
-        components.queryItems = items
-        guard let url = components.url else { throw WidgetMarketError.invalidURL }
-        return url
-    }
-
-    static func searchURL(query: String) throws -> URL {
-        guard let baseURL = proxyBaseURL?.appendingPathComponent("search"),
-              var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
-            throw WidgetMarketError.invalidURL
-        }
-        components.queryItems = [URLQueryItem(name: "query", value: query)]
-        guard let url = components.url else { throw WidgetMarketError.invalidURL }
-        return url
+        return .marketData(query: query, currency: currency.lowercased())
     }
 
     static func validatedImageURL(_ url: URL) throws -> URL {
@@ -71,6 +44,67 @@ enum WidgetMarketEndpoint {
             throw WidgetMarketError.unapprovedImageURL
         }
         return url
+    }
+
+    static func validatedIcon(_ url: URL) throws -> Self {
+        .icon(try validatedImageURL(url))
+    }
+
+    var baseURL: URL {
+        switch self {
+        case .marketData, .search:
+            Self.proxyBaseURL
+        case .icon(let url):
+            url
+        }
+    }
+
+    var path: String {
+        switch self {
+        case .marketData:
+            "/coingeicko/api/v3/coins/markets"
+        case .search:
+            "/coingeicko/api/v3/search"
+        case .icon:
+            ""
+        }
+    }
+
+    var method: HTTPMethod {
+        .get
+    }
+
+    var task: HTTPTask {
+        switch self {
+        case .marketData(let query, let currency):
+            var parameters: [String: Any] = [
+                "vs_currency": currency,
+                "order": "market_cap_desc",
+                "per_page": query.limit,
+                "page": 1,
+                "sparkline": query.includesSparkline
+            ]
+            if query.includesSparkline {
+                parameters["price_change_percentage"] = "24h"
+            }
+            if case .ids = query {
+                parameters["ids"] = query.normalizedIDs.joined(separator: ",")
+            }
+            return .requestParameters(parameters, .urlEncoding)
+        case .search(let query):
+            return .requestParameters(["query": query], .urlEncoding)
+        case .icon:
+            return .requestPlain
+        }
+    }
+
+    var timeoutInterval: TimeInterval {
+        switch self {
+        case .marketData:
+            12
+        case .search, .icon:
+            8
+        }
     }
 }
 
@@ -92,35 +126,29 @@ protocol WidgetMarketRemote: Sendable {
 protocol WidgetMarketLookup: WidgetMarketRemote, WidgetAssetSearching {}
 
 final class WidgetMarketClient: WidgetMarketLookup, @unchecked Sendable {
-    private let session: URLSession
+    private let httpClient: any HTTPClientProtocol
     private let decoder: JSONDecoder
     private let maximumIconByteCount: Int
 
     init(
-        session: URLSession = .shared,
+        httpClient: any HTTPClientProtocol = HTTPClient(),
         decoder: JSONDecoder = JSONDecoder(),
         maximumIconByteCount: Int = 64 * 1_024
     ) {
-        self.session = session
+        self.httpClient = httpClient
         self.decoder = decoder
         self.maximumIconByteCount = maximumIconByteCount
     }
 
     func markets(query: WidgetMarketQuery, currency: String) async throws -> [WidgetMarketAsset] {
-        let url = try WidgetMarketEndpoint.url(query: query, currency: currency)
-        var request = URLRequest(url: url)
-        request.timeoutInterval = 12
-        let (data, response) = try await session.data(for: request)
-        try Self.validate(response)
-        return try Self.decode(data: data, query: query, decoder: decoder)
+        let target = try WidgetMarketAPI.markets(query: query, currency: currency)
+        let response = try await httpClient.request(target)
+        return try Self.decode(data: response.data, query: query, decoder: decoder)
     }
 
     func iconData(from url: URL) async throws -> Data {
-        let approvedURL = try WidgetMarketEndpoint.validatedImageURL(url)
-        var request = URLRequest(url: approvedURL)
-        request.timeoutInterval = 8
-        let (data, response) = try await session.data(for: request)
-        try Self.validate(response)
+        let response = try await httpClient.request(WidgetMarketAPI.validatedIcon(url))
+        let data = response.data
         guard !data.isEmpty else { throw WidgetMarketError.emptyResponse }
         guard data.count <= maximumIconByteCount else { throw WidgetMarketError.imageTooLarge }
         return data
@@ -129,13 +157,8 @@ final class WidgetMarketClient: WidgetMarketLookup, @unchecked Sendable {
     func searchAssets(matching query: String) async throws -> [WidgetAssetIdentity] {
         let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedQuery.isEmpty else { return [] }
-        let url = try WidgetMarketEndpoint.searchURL(query: trimmedQuery)
-
-        var request = URLRequest(url: url)
-        request.timeoutInterval = 8
-        let (data, response) = try await session.data(for: request)
-        try Self.validate(response)
-        let responseBody = try decoder.decode(RemoteSearchResponse.self, from: data)
+        let response = try await httpClient.request(WidgetMarketAPI.search(query: trimmedQuery))
+        let responseBody = try decoder.decode(RemoteSearchResponse.self, from: response.data)
         return responseBody.coins.prefix(20).map {
             WidgetAssetIdentity(id: $0.id.lowercased(), symbol: $0.symbol.uppercased(), name: $0.name)
         }
@@ -160,15 +183,6 @@ final class WidgetMarketClient: WidgetMarketLookup, @unchecked Sendable {
             return assets.sorted {
                 positions[$0.id, default: .max] < positions[$1.id, default: .max]
             }
-        }
-    }
-
-    private static func validate(_ response: URLResponse) throws {
-        guard let response = response as? HTTPURLResponse else {
-            throw WidgetMarketError.invalidResponse
-        }
-        guard (200..<300).contains(response.statusCode) else {
-            throw WidgetMarketError.httpStatus(response.statusCode)
         }
     }
 }
@@ -212,7 +226,7 @@ private struct RemoteMarketAsset: Decodable {
             id: id.lowercased(),
             symbol: symbol.uppercased(),
             name: name,
-            imageURL: image.flatMap { try? WidgetMarketEndpoint.validatedImageURL($0) },
+            imageURL: image.flatMap { try? WidgetMarketAPI.validatedImageURL($0) },
             iconData: nil,
             currentPrice: currentPrice,
             priceChangePercentage24h: priceChangePercentage24h,
@@ -221,5 +235,3 @@ private struct RemoteMarketAsset: Decodable {
         )
     }
 }
-
-// swiftlint:enable no_raw_urlsession no_raw_urlrequest

--- a/VultisigApp/VultisigApp/Shared/WidgetShared/WidgetMarketClient.swift
+++ b/VultisigApp/VultisigApp/Shared/WidgetShared/WidgetMarketClient.swift
@@ -35,9 +35,12 @@ enum WidgetMarketEndpoint {
             URLQueryItem(name: "order", value: "market_cap_desc"),
             URLQueryItem(name: "per_page", value: String(query.limit)),
             URLQueryItem(name: "page", value: "1"),
-            URLQueryItem(name: "sparkline", value: "true"),
-            URLQueryItem(name: "price_change_percentage", value: "24h")
+            URLQueryItem(name: "sparkline", value: query.includesSparkline ? "true" : "false")
         ]
+
+        if query.includesSparkline {
+            items.append(URLQueryItem(name: "price_change_percentage", value: "24h"))
+        }
 
         if case .ids = query {
             guard !query.normalizedIDs.isEmpty else { throw WidgetMarketError.emptySelection }
@@ -148,7 +151,7 @@ final class WidgetMarketClient: WidgetMarketLookup, @unchecked Sendable {
         guard !assets.isEmpty else { throw WidgetMarketError.emptyResponse }
 
         switch query {
-        case .top:
+        case .top, .catalog:
             return Array(assets.prefix(query.limit))
         case .ids:
             let positions = Dictionary(

--- a/VultisigApp/VultisigApp/Shared/WidgetShared/WidgetSharedStorage.swift
+++ b/VultisigApp/VultisigApp/Shared/WidgetShared/WidgetSharedStorage.swift
@@ -12,6 +12,9 @@ import Foundation
 enum WidgetSharedStorage {
     static let appGroupIdentifier = "group.com.vultisig.wallet"
     static let currencyKey = "marketWidgets.currency"
+    static let watchlistKey = "marketWidgets.watchlist"
+    static let watchlistWidgetKind = "com.vultisig.widget.crypto-watchlist"
+    static let maximumWatchlistAssets = 5
 
     static var defaults: UserDefaults? {
         UserDefaults(suiteName: appGroupIdentifier)
@@ -23,5 +26,82 @@ enum WidgetSharedStorage {
 
     static func setCurrencyCode(_ value: String) {
         defaults?.set(value.uppercased(), forKey: currencyKey)
+    }
+
+    static func watchlistAssets(
+        in defaults: UserDefaults? = WidgetSharedStorage.defaults
+    ) -> [WidgetWatchlistAsset] {
+        guard let data = defaults?.data(forKey: watchlistKey),
+              let assets = try? JSONDecoder().decode([WidgetWatchlistAsset].self, from: data) else {
+            return []
+        }
+        return normalizedWatchlist(assets)
+    }
+
+    static func setWatchlistAssets(
+        _ assets: [WidgetWatchlistAsset],
+        in defaults: UserDefaults? = WidgetSharedStorage.defaults
+    ) {
+        guard let defaults,
+              let data = try? JSONEncoder().encode(normalizedWatchlist(assets)) else {
+            return
+        }
+        defaults.set(data, forKey: watchlistKey)
+    }
+
+    private static func normalizedWatchlist(_ assets: [WidgetWatchlistAsset]) -> [WidgetWatchlistAsset] {
+        assets.reduce(into: [WidgetWatchlistAsset]()) { result, asset in
+            let normalized = WidgetWatchlistAsset(
+                id: asset.id,
+                symbol: asset.symbol,
+                name: asset.name,
+                imageURL: asset.imageURL
+            )
+            guard !normalized.id.isEmpty,
+                  !result.contains(where: { $0.id == normalized.id }) else {
+                return
+            }
+            result.append(normalized)
+        }
+        .prefix(maximumWatchlistAssets)
+        .map { $0 }
+    }
+}
+
+struct WidgetWatchlistAsset: Codable, Equatable, Identifiable, Sendable {
+    let id: String
+    let symbol: String
+    let name: String
+    let imageURL: URL?
+
+    init(id: String, symbol: String, name: String, imageURL: URL?) {
+        self.id = id.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        self.symbol = symbol.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        self.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.imageURL = imageURL
+    }
+
+    init(_ asset: WidgetMarketAsset) {
+        self.init(
+            id: asset.id,
+            symbol: asset.symbol,
+            name: asset.name,
+            imageURL: asset.imageURL
+        )
+    }
+
+    var iconLogo: String {
+        if let imageURL {
+            return imageURL.absoluteString
+        }
+
+        switch id {
+        case "bitcoin": return "btc"
+        case "ethereum": return "eth"
+        case "tether": return "usdt"
+        case "binancecoin": return "bsc"
+        case "solana": return "solana"
+        default: return ""
+        }
     }
 }

--- a/VultisigApp/VultisigApp/Shared/WidgetShared/WidgetSharedStorage.swift
+++ b/VultisigApp/VultisigApp/Shared/WidgetShared/WidgetSharedStorage.swift
@@ -38,6 +38,12 @@ enum WidgetSharedStorage {
         return normalizedWatchlist(assets)
     }
 
+    static func hasStoredWatchlist(
+        in defaults: UserDefaults? = WidgetSharedStorage.defaults
+    ) -> Bool {
+        defaults?.object(forKey: watchlistKey) != nil
+    }
+
     static func setWatchlistAssets(
         _ assets: [WidgetWatchlistAsset],
         in defaults: UserDefaults? = WidgetSharedStorage.defaults

--- a/VultisigApp/VultisigAppTests/Widgets/WidgetMarketDataTests.swift
+++ b/VultisigApp/VultisigAppTests/Widgets/WidgetMarketDataTests.swift
@@ -149,6 +149,58 @@ final class WidgetMarketDataTests: XCTestCase {
         XCTAssertTrue(WidgetSharedStorage.watchlistAssets(in: defaults).isEmpty)
     }
 
+    func testWatchlistStorageDistinguishesDefaultFromExplicitlyEmptySelection() throws {
+        let suiteName = "WidgetMarketDataTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertFalse(WidgetSharedStorage.hasStoredWatchlist(in: defaults))
+
+        WidgetSharedStorage.setWatchlistAssets([], in: defaults)
+
+        XCTAssertTrue(WidgetSharedStorage.hasStoredWatchlist(in: defaults))
+        XCTAssertTrue(WidgetSharedStorage.watchlistAssets(in: defaults).isEmpty)
+    }
+
+    @MainActor
+    func testWatchlistSettingsSeedsTopFiveOnlyWithoutStoredSelection() async throws {
+        let suiteName = "WidgetMarketDataTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let assets = (1...6).map { index in
+            WidgetMarketAsset(
+                id: "asset-\(index)",
+                symbol: "A\(index)",
+                name: "Asset \(index)",
+                imageURL: nil,
+                iconData: nil,
+                currentPrice: Double(index),
+                priceChangePercentage24h: nil,
+                marketCapRank: index,
+                sparkline: []
+            )
+        }
+        let remote = WidgetMarketListStub(assets: assets)
+
+        let defaultViewModel = WidgetWatchlistSettingsViewModel(
+            marketClient: remote,
+            defaults: defaults
+        )
+        await defaultViewModel.load()
+
+        XCTAssertEqual(defaultViewModel.selectedAssets.map(\.id), assets.prefix(5).map(\.id))
+        XCTAssertTrue(WidgetSharedStorage.hasStoredWatchlist(in: defaults))
+
+        WidgetSharedStorage.setWatchlistAssets([], in: defaults)
+        let clearedViewModel = WidgetWatchlistSettingsViewModel(
+            marketClient: remote,
+            defaults: defaults
+        )
+        await clearedViewModel.load()
+
+        XCTAssertTrue(clearedViewModel.selectedAssets.isEmpty)
+    }
+
     func testSparklineSamplerKeepsEndpointsAndRequestedCount() {
         let source = (0..<100).map(Double.init)
         let sampled = WidgetSparklineSampler.resample(source, to: 28)
@@ -360,5 +412,21 @@ private actor WidgetMarketRemoteStub: WidgetMarketRemote {
 
     func iconData(from url: URL) throws -> Data {
         Data(url.absoluteString.utf8)
+    }
+}
+
+private actor WidgetMarketListStub: WidgetMarketRemote {
+    let assets: [WidgetMarketAsset]
+
+    init(assets: [WidgetMarketAsset]) {
+        self.assets = assets
+    }
+
+    func markets(query _: WidgetMarketQuery, currency _: String) -> [WidgetMarketAsset] {
+        assets
+    }
+
+    func iconData(from _: URL) -> Data {
+        Data()
     }
 }

--- a/VultisigApp/VultisigAppTests/Widgets/WidgetMarketDataTests.swift
+++ b/VultisigApp/VultisigAppTests/Widgets/WidgetMarketDataTests.swift
@@ -34,11 +34,13 @@ final class WidgetMarketDataTests: XCTestCase {
     """#.utf8)
 
     func testTopRequestIncludesOneBulkMarketQuery() throws {
-        let url = try WidgetMarketEndpoint.url(query: .top(limit: 5), currency: "USD")
-        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
-        let items = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value) })
+        let target = try WidgetMarketAPI.markets(query: .top(limit: 5), currency: "USD")
+        let items = try requestParameters(from: target)
 
-        XCTAssertEqual(components.path, "/coingeicko/api/v3/coins/markets")
+        XCTAssertEqual(target.baseURL.absoluteString, "https://api.vultisig.com")
+        XCTAssertEqual(target.path, "/coingeicko/api/v3/coins/markets")
+        XCTAssertEqual(target.method, .get)
+        XCTAssertEqual(target.timeoutInterval, 12)
         XCTAssertEqual(items["vs_currency"], "usd")
         XCTAssertEqual(items["order"], "market_cap_desc")
         XCTAssertEqual(items["per_page"], "5")
@@ -48,11 +50,8 @@ final class WidgetMarketDataTests: XCTestCase {
     }
 
     func testCatalogRequestSupportsSettingsAssetListWithoutChangingWidgetCap() throws {
-        let catalogURL = try WidgetMarketEndpoint.url(query: .catalog(limit: 100), currency: "USD")
-        let catalogComponents = try XCTUnwrap(URLComponents(url: catalogURL, resolvingAgainstBaseURL: false))
-        let catalogItems = Dictionary(
-            uniqueKeysWithValues: (catalogComponents.queryItems ?? []).map { ($0.name, $0.value) }
-        )
+        let target = try WidgetMarketAPI.markets(query: .catalog(limit: 100), currency: "USD")
+        let catalogItems = try requestParameters(from: target)
 
         XCTAssertEqual(catalogItems["per_page"], "50")
         XCTAssertEqual(catalogItems["sparkline"], "false")
@@ -62,9 +61,8 @@ final class WidgetMarketDataTests: XCTestCase {
 
     func testSelectedAssetRequestNormalizesIDsAndPreservesSelectionOrder() throws {
         let query = WidgetMarketQuery.ids([" Ethereum ", "BITCOIN"])
-        let url = try WidgetMarketEndpoint.url(query: query, currency: "eur")
-        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
-        let ids = components.queryItems?.first(where: { $0.name == "ids" })?.value
+        let target = try WidgetMarketAPI.markets(query: query, currency: "eur")
+        let ids = try requestParameters(from: target)["ids"]
         let assets = try WidgetMarketClient.decode(data: Self.responseData, query: query)
 
         XCTAssertEqual(ids, "ethereum,bitcoin")
@@ -72,12 +70,19 @@ final class WidgetMarketDataTests: XCTestCase {
         XCTAssertEqual(assets.map(\.symbol), ["ETH", "BTC"])
     }
 
-    func testSearchRequestUsesSharedProxyBasePath() throws {
-        let url = try WidgetMarketEndpoint.searchURL(query: "bitcoin cash")
-        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    func testSearchRequestUsesSharedProxyAndEncodesSpacesOnce() async throws {
+        WidgetURLCapturingProtocol.reset()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [WidgetURLCapturingProtocol.self]
+        let httpClient = HTTPClient(session: URLSession(configuration: configuration))
 
+        _ = try await httpClient.request(WidgetMarketAPI.search(query: "bitcoin cash"))
+
+        let url = try XCTUnwrap(WidgetURLCapturingProtocol.capturedURL)
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
         XCTAssertEqual(components.path, "/coingeicko/api/v3/search")
         XCTAssertEqual(components.queryItems, [URLQueryItem(name: "query", value: "bitcoin cash")])
+        XCTAssertEqual(url.absoluteString, "https://api.vultisig.com/coingeicko/api/v3/search?query=bitcoin%20cash")
     }
 
     func testIconURLAcceptsOnlyCoinGeckoHTTPSCDN() throws {
@@ -89,21 +94,37 @@ final class WidgetMarketDataTests: XCTestCase {
             URL(string: "http://coin-images.coingecko.com/coins/images/1/large/bitcoin.png")
         )
 
-        XCTAssertEqual(try WidgetMarketEndpoint.validatedImageURL(approved), approved)
-        XCTAssertThrowsError(try WidgetMarketEndpoint.validatedImageURL(unapproved)) { error in
+        XCTAssertEqual(try WidgetMarketAPI.validatedImageURL(approved), approved)
+        XCTAssertThrowsError(try WidgetMarketAPI.validatedImageURL(unapproved)) { error in
             XCTAssertEqual(error as? WidgetMarketError, .unapprovedImageURL)
         }
-        XCTAssertThrowsError(try WidgetMarketEndpoint.validatedImageURL(insecure)) { error in
+        XCTAssertThrowsError(try WidgetMarketAPI.validatedImageURL(insecure)) { error in
             XCTAssertEqual(error as? WidgetMarketError, .unapprovedImageURL)
         }
     }
 
     func testEmptyAssetSelectionDoesNotFallThroughToTopMarkets() {
         XCTAssertThrowsError(
-            try WidgetMarketEndpoint.url(query: .ids([" "]), currency: "usd")
+            try WidgetMarketAPI.markets(query: .ids([" "]), currency: "usd")
         ) { error in
             XCTAssertEqual(error as? WidgetMarketError, .emptySelection)
         }
+    }
+
+    func testMarketClientUsesInjectedHTTPClient() async throws {
+        let httpClient = WidgetHTTPClientStub(data: Self.responseData)
+        let client = WidgetMarketClient(httpClient: httpClient)
+
+        let assets = try await client.markets(query: .top(limit: 2), currency: "EUR")
+        let targets = await httpClient.targets
+
+        XCTAssertEqual(assets.map(\.id), ["ethereum", "bitcoin"])
+        let target = try XCTUnwrap(targets.first)
+        guard case .marketData(let query, let currency) = target else {
+            return XCTFail("Expected a market-data target")
+        }
+        XCTAssertEqual(query, .top(limit: 2))
+        XCTAssertEqual(currency, "eur")
     }
 
     func testAssetSelectionDeduplicatesAndCapsAtFiveIDs() {
@@ -390,6 +411,81 @@ final class WidgetMarketDataTests: XCTestCase {
     private func watchlistAsset(id: String, symbol: String) -> WidgetWatchlistAsset {
         WidgetWatchlistAsset(id: id, symbol: symbol, name: id.capitalized, imageURL: nil)
     }
+
+    private func requestParameters(from target: WidgetMarketAPI) throws -> [String: String] {
+        guard case .requestParameters(let parameters, .urlEncoding) = target.task else {
+            throw WidgetMarketError.invalidResponse
+        }
+        return parameters.mapValues { String(describing: $0) }
+    }
+}
+
+private actor WidgetHTTPClientStub: HTTPClientProtocol {
+    let data: Data
+    private(set) var targets: [WidgetMarketAPI] = []
+
+    init(data: Data) {
+        self.data = data
+    }
+
+    func request(_ target: TargetType) throws -> HTTPResponse<Data> {
+        guard let widgetTarget = target as? WidgetMarketAPI,
+              let response = HTTPURLResponse(
+                url: HTTPClient.url(for: target),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+              ) else {
+            throw WidgetMarketError.invalidResponse
+        }
+        targets.append(widgetTarget)
+        return HTTPResponse(data: data, response: response)
+    }
+}
+
+private final class WidgetURLCapturingProtocol: URLProtocol {
+    private static let lock = NSLock()
+    private static var storedURL: URL?
+
+    static var capturedURL: URL? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedURL
+    }
+
+    static func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        storedURL = nil
+    }
+
+    // swiftlint:disable static_over_final_class
+    override class func canInit(with _: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    // swiftlint:enable static_over_final_class
+
+    override func startLoading() {
+        Self.lock.lock()
+        Self.storedURL = request.url
+        Self.lock.unlock()
+
+        guard let url = request.url,
+              let response = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+              ) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(#"{"coins":[]}"#.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
 }
 
 private actor WidgetMarketRemoteStub: WidgetMarketRemote {

--- a/VultisigApp/VultisigAppTests/Widgets/WidgetMarketDataTests.swift
+++ b/VultisigApp/VultisigAppTests/Widgets/WidgetMarketDataTests.swift
@@ -47,6 +47,19 @@ final class WidgetMarketDataTests: XCTestCase {
         XCTAssertFalse(items.keys.contains("ids"))
     }
 
+    func testCatalogRequestSupportsSettingsAssetListWithoutChangingWidgetCap() throws {
+        let catalogURL = try WidgetMarketEndpoint.url(query: .catalog(limit: 100), currency: "USD")
+        let catalogComponents = try XCTUnwrap(URLComponents(url: catalogURL, resolvingAgainstBaseURL: false))
+        let catalogItems = Dictionary(
+            uniqueKeysWithValues: (catalogComponents.queryItems ?? []).map { ($0.name, $0.value) }
+        )
+
+        XCTAssertEqual(catalogItems["per_page"], "50")
+        XCTAssertEqual(catalogItems["sparkline"], "false")
+        XCTAssertNil(catalogItems["price_change_percentage"])
+        XCTAssertEqual(WidgetMarketQuery.top(limit: 100).limit, 5)
+    }
+
     func testSelectedAssetRequestNormalizesIDsAndPreservesSelectionOrder() throws {
         let query = WidgetMarketQuery.ids([" Ethereum ", "BITCOIN"])
         let url = try WidgetMarketEndpoint.url(query: query, currency: "eur")
@@ -103,6 +116,37 @@ final class WidgetMarketDataTests: XCTestCase {
             ["bitcoin", "ethereum", "solana", "tether", "usd-coin"]
         )
         XCTAssertEqual(query.limit, 5)
+    }
+
+    func testWatchlistStoragePreservesEnableOrderDeduplicatesAndCapsAtFive() throws {
+        let suiteName = "WidgetMarketDataTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let assets = [
+            watchlistAsset(id: "bitcoin", symbol: "btc"),
+            watchlistAsset(id: "ethereum", symbol: "eth"),
+            watchlistAsset(id: "bitcoin", symbol: "BTC"),
+            watchlistAsset(id: "solana", symbol: "sol"),
+            watchlistAsset(id: "tether", symbol: "usdt"),
+            watchlistAsset(id: "usd-coin", symbol: "usdc"),
+            watchlistAsset(id: "dogecoin", symbol: "doge")
+        ]
+
+        WidgetSharedStorage.setWatchlistAssets(assets, in: defaults)
+        let stored = WidgetSharedStorage.watchlistAssets(in: defaults)
+
+        XCTAssertEqual(stored.map(\.id), ["bitcoin", "ethereum", "solana", "tether", "usd-coin"])
+        XCTAssertEqual(stored.map(\.symbol), ["BTC", "ETH", "SOL", "USDT", "USDC"])
+    }
+
+    func testWatchlistStorageRejectsCorruptPayload() throws {
+        let suiteName = "WidgetMarketDataTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(Data("not-json".utf8), forKey: WidgetSharedStorage.watchlistKey)
+
+        XCTAssertTrue(WidgetSharedStorage.watchlistAssets(in: defaults).isEmpty)
     }
 
     func testSparklineSamplerKeepsEndpointsAndRequestedCount() {
@@ -289,6 +333,10 @@ final class WidgetMarketDataTests: XCTestCase {
             guard let imageURL = asset.imageURL else { return false }
             return asset.iconData == Data(imageURL.absoluteString.utf8)
         })
+    }
+
+    private func watchlistAsset(id: String, symbol: String) -> WidgetWatchlistAsset {
+        WidgetWatchlistAsset(id: id, symbol: symbol, name: id.capitalized, imageURL: nil)
     }
 }
 

--- a/VultisigApp/VultisigWidgets/CryptoWatchlistWidget.swift
+++ b/VultisigApp/VultisigWidgets/CryptoWatchlistWidget.swift
@@ -49,9 +49,10 @@ struct CryptoWatchlistProvider: TimelineProvider {
 
     private func loadEntry() async -> CryptoWatchlistEntry {
         let selection = WidgetSharedStorage.watchlistAssets()
+        let hasStoredSelection = WidgetSharedStorage.hasStoredWatchlist()
         let currency = WidgetSharedStorage.currencyCode
 
-        guard !selection.isEmpty else {
+        guard !hasStoredSelection || !selection.isEmpty else {
             return CryptoWatchlistEntry(
                 date: Date(),
                 assets: [],
@@ -62,7 +63,10 @@ struct CryptoWatchlistProvider: TimelineProvider {
         }
 
         do {
-            let result = try await service.load(query: .ids(selection.map(\.id)), currency: currency)
+            let query: WidgetMarketQuery = hasStoredSelection
+            ? .ids(selection.map(\.id))
+            : .top(limit: WidgetSharedStorage.maximumWatchlistAssets)
+            let result = try await service.load(query: query, currency: currency)
             return CryptoWatchlistEntry(
                 date: result.updatedAt,
                 assets: result.assets,
@@ -169,14 +173,15 @@ struct CryptoWatchlistEntryView: View {
     }
 
     private var unavailableContent: some View {
-        VStack(alignment: .leading) {
+        VStack {
             Spacer()
             Text(unavailableKey)
                 .font(WidgetTheme.labelFont(size: 12))
                 .foregroundStyle(WidgetTheme.secondaryText)
+                .multilineTextAlignment(.center)
             Spacer()
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
         .accessibilityLabel(Text(unavailableAccessibilityKey))
     }
 

--- a/VultisigApp/VultisigWidgets/CryptoWatchlistWidget.swift
+++ b/VultisigApp/VultisigWidgets/CryptoWatchlistWidget.swift
@@ -1,0 +1,216 @@
+//
+//  CryptoWatchlistWidget.swift
+//  VultisigWidgets
+//
+
+import SwiftUI
+import WidgetKit
+
+struct CryptoWatchlistEntry: TimelineEntry {
+    let date: Date
+    let assets: [WidgetMarketAsset]
+    let currency: String
+    let hasSelection: Bool
+    let isStale: Bool
+
+    static let preview = CryptoWatchlistEntry(
+        date: TopCryptosEntry.preview.date,
+        assets: TopCryptosEntry.preview.assets,
+        currency: TopCryptosEntry.preview.currency,
+        hasSelection: true,
+        isStale: false
+    )
+}
+
+struct CryptoWatchlistProvider: TimelineProvider {
+    private let service = WidgetMarketService()
+
+    func placeholder(in _: Context) -> CryptoWatchlistEntry {
+        .preview
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (CryptoWatchlistEntry) -> Void) {
+        guard !context.isPreview else {
+            completion(.preview)
+            return
+        }
+        Task {
+            completion(await loadEntry())
+        }
+    }
+
+    func getTimeline(in _: Context, completion: @escaping (Timeline<CryptoWatchlistEntry>) -> Void) {
+        Task {
+            let entry = await loadEntry()
+            let refresh = Calendar.current.date(byAdding: .minute, value: 30, to: Date()) ?? Date()
+            completion(Timeline(entries: [entry], policy: .after(refresh)))
+        }
+    }
+
+    private func loadEntry() async -> CryptoWatchlistEntry {
+        let selection = WidgetSharedStorage.watchlistAssets()
+        let currency = WidgetSharedStorage.currencyCode
+
+        guard !selection.isEmpty else {
+            return CryptoWatchlistEntry(
+                date: Date(),
+                assets: [],
+                currency: currency,
+                hasSelection: false,
+                isStale: false
+            )
+        }
+
+        do {
+            let result = try await service.load(query: .ids(selection.map(\.id)), currency: currency)
+            return CryptoWatchlistEntry(
+                date: result.updatedAt,
+                assets: result.assets,
+                currency: currency,
+                hasSelection: true,
+                isStale: result.isStale
+            )
+        } catch {
+            return CryptoWatchlistEntry(
+                date: Date(),
+                assets: [],
+                currency: currency,
+                hasSelection: true,
+                isStale: false
+            )
+        }
+    }
+}
+
+struct CryptoWatchlistWidget: Widget {
+    static let kind = WidgetSharedStorage.watchlistWidgetKind
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: Self.kind, provider: CryptoWatchlistProvider()) { entry in
+            CryptoWatchlistEntryView(entry: entry)
+                .containerBackground(for: .widget) {
+                    WidgetTheme.background
+                }
+        }
+        .configurationDisplayName(LocalizedStringResource("widget.watchlist"))
+        .description(LocalizedStringResource("widget.watchlist.description"))
+        .supportedFamilies([.systemMedium, .systemLarge])
+        .contentMarginsDisabled()
+    }
+}
+
+struct CryptoWatchlistEntryView: View {
+    let entry: CryptoWatchlistEntry
+
+    @Environment(\.widgetFamily) private var family
+    @Environment(\.widgetContentMargins) private var contentMargins
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if family == .systemLarge {
+                header
+            }
+
+            if entry.assets.isEmpty {
+                unavailableContent
+            } else {
+                rows
+            }
+        }
+        .padding(contentMargins)
+        .foregroundStyle(WidgetTheme.primaryText)
+    }
+
+    private var header: some View {
+        VStack(spacing: 8) {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text("widget.watchlist")
+                    .font(WidgetTheme.labelFont(size: 15))
+                Spacer(minLength: 4)
+                staleIndicator
+                WidgetBrandMark(size: 18)
+            }
+
+            HStack(spacing: 10) {
+                Text("widget.asset")
+                    .frame(width: 104, alignment: .leading)
+                Text("widget.sevenDay")
+                    .frame(maxWidth: .infinity, alignment: .center)
+                Text("widget.price")
+                    .frame(width: 104, alignment: .trailing)
+            }
+            .font(WidgetTheme.labelFont(size: 10))
+            .foregroundStyle(WidgetTheme.tertiaryText)
+        }
+        .padding(.bottom, 7)
+        .accessibilityElement(children: .combine)
+    }
+
+    private var rows: some View {
+        let isCompact = family == .systemMedium
+        let assets = entry.assets.prefix(isCompact ? 3 : 5)
+
+        return VStack(spacing: 0) {
+            ForEach(Array(assets.enumerated()), id: \.element.id) { index, asset in
+                if index > 0 {
+                    Rectangle()
+                        .fill(WidgetTheme.separator)
+                        .frame(height: 1)
+                }
+
+                WidgetMarketRow(
+                    asset: asset,
+                    currency: entry.currency,
+                    isCompact: isCompact
+                )
+                .frame(maxHeight: .infinity)
+            }
+        }
+    }
+
+    private var unavailableContent: some View {
+        VStack(alignment: .leading) {
+            Spacer()
+            Text(unavailableKey)
+                .font(WidgetTheme.labelFont(size: 12))
+                .foregroundStyle(WidgetTheme.secondaryText)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityLabel(Text(unavailableAccessibilityKey))
+    }
+
+    private var unavailableKey: LocalizedStringKey {
+        entry.hasSelection ? "widget.marketDataUnavailable" : "widget.watchlist.configure"
+    }
+
+    private var unavailableAccessibilityKey: LocalizedStringKey {
+        entry.hasSelection ? "widget.watchlist.marketDataUnavailable" : "widget.watchlist.configure"
+    }
+
+    @ViewBuilder
+    private var staleIndicator: some View {
+        if entry.isStale {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(WidgetTheme.iconFont(size: 10))
+                .foregroundStyle(WidgetTheme.tertiaryText)
+                .accessibilityLabel(Text("widget.cached"))
+        }
+    }
+}
+
+#if DEBUG
+struct CryptoWatchlistWidgetPreviews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            CryptoWatchlistEntryView(entry: .preview)
+                .containerBackground(for: .widget) { WidgetTheme.background }
+                .previewContext(WidgetPreviewContext(family: .systemMedium))
+
+            CryptoWatchlistEntryView(entry: .preview)
+                .containerBackground(for: .widget) { WidgetTheme.background }
+                .previewContext(WidgetPreviewContext(family: .systemLarge))
+        }
+    }
+}
+#endif

--- a/VultisigApp/VultisigWidgets/Resources/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigWidgets/Resources/de.lproj/Localizable.strings
@@ -8,11 +8,11 @@
 "widget.change" = "%@ 24H";
 "widget.changeUnavailable" = "nicht verfügbar";
 "widget.changeUnavailableDisplay" = "— 24H";
+"widget.cryptocurrency" = "Kryptowährung";
 "widget.cryptoMarketDataUnavailable" = "Krypto-Marktdaten sind vorübergehend nicht verfügbar";
 "widget.cryptoTicker" = "Krypto-Ticker";
 "widget.cryptoTicker.choose" = "Wähle die Kryptowährung für dieses Widget.";
 "widget.cryptoTicker.description" = "Verfolge Preis und Sieben-Tage-Trend einer Kryptowährung.";
-"widget.cryptocurrency" = "Kryptowährung";
 "widget.down" = "gefallen um";
 "widget.marketCap" = "Marktkapitalisierung";
 "widget.marketData" = "Marktdaten";
@@ -26,3 +26,7 @@
 "widget.up" = "gestiegen um";
 "widget.updatedData" = "aktualisierte Daten";
 "widget.valueUnavailableDisplay" = "—";
+"widget.watchlist" = "Beobachtungsliste";
+"widget.watchlist.configure" = "Wähle Assets in den Vultisig-Einstellungen";
+"widget.watchlist.description" = "Verfolge bis zu fünf in Vultisig ausgewählte Kryptowährungen.";
+"widget.watchlist.marketDataUnavailable" = "Marktdaten der Beobachtungsliste sind vorübergehend nicht verfügbar";

--- a/VultisigApp/VultisigWidgets/Resources/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigWidgets/Resources/en.lproj/Localizable.strings
@@ -8,11 +8,11 @@
 "widget.change" = "%@ 24H";
 "widget.changeUnavailable" = "unavailable";
 "widget.changeUnavailableDisplay" = "— 24H";
+"widget.cryptocurrency" = "Cryptocurrency";
 "widget.cryptoMarketDataUnavailable" = "Crypto market data is temporarily unavailable";
 "widget.cryptoTicker" = "Crypto Ticker";
 "widget.cryptoTicker.choose" = "Choose the cryptocurrency shown in this widget.";
 "widget.cryptoTicker.description" = "Track the price and seven-day trend of a cryptocurrency.";
-"widget.cryptocurrency" = "Cryptocurrency";
 "widget.down" = "down";
 "widget.marketCap" = "Market Cap";
 "widget.marketData" = "Market data";
@@ -26,3 +26,7 @@
 "widget.up" = "up";
 "widget.updatedData" = "updated data";
 "widget.valueUnavailableDisplay" = "—";
+"widget.watchlist" = "Watchlist";
+"widget.watchlist.configure" = "Choose assets in Vultisig Settings";
+"widget.watchlist.description" = "Follow up to five cryptocurrencies selected in Vultisig.";
+"widget.watchlist.marketDataUnavailable" = "Watchlist market data is temporarily unavailable";

--- a/VultisigApp/VultisigWidgets/Resources/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigWidgets/Resources/es.lproj/Localizable.strings
@@ -8,11 +8,11 @@
 "widget.change" = "%@ 24H";
 "widget.changeUnavailable" = "no disponible";
 "widget.changeUnavailableDisplay" = "— 24H";
+"widget.cryptocurrency" = "Criptomoneda";
 "widget.cryptoMarketDataUnavailable" = "Los datos del mercado cripto no están disponibles temporalmente";
 "widget.cryptoTicker" = "Ticker cripto";
 "widget.cryptoTicker.choose" = "Elige la criptomoneda que se mostrará en este widget.";
 "widget.cryptoTicker.description" = "Sigue el precio y la tendencia de siete días de una criptomoneda.";
-"widget.cryptocurrency" = "Criptomoneda";
 "widget.down" = "bajó";
 "widget.marketCap" = "Capitalización";
 "widget.marketData" = "Datos de mercado";
@@ -26,3 +26,7 @@
 "widget.up" = "subió";
 "widget.updatedData" = "datos actualizados";
 "widget.valueUnavailableDisplay" = "—";
+"widget.watchlist" = "Lista de seguimiento";
+"widget.watchlist.configure" = "Elige activos en Ajustes de Vultisig";
+"widget.watchlist.description" = "Sigue hasta cinco criptomonedas seleccionadas en Vultisig.";
+"widget.watchlist.marketDataUnavailable" = "Los datos de mercado de la lista no están disponibles temporalmente";

--- a/VultisigApp/VultisigWidgets/Resources/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigWidgets/Resources/hr.lproj/Localizable.strings
@@ -8,11 +8,11 @@
 "widget.change" = "%@ 24H";
 "widget.changeUnavailable" = "nedostupno";
 "widget.changeUnavailableDisplay" = "— 24H";
+"widget.cryptocurrency" = "Kriptovaluta";
 "widget.cryptoMarketDataUnavailable" = "Podaci kripto tržišta privremeno nisu dostupni";
 "widget.cryptoTicker" = "Kripto ticker";
 "widget.cryptoTicker.choose" = "Odaberite kriptovalutu prikazanu u ovom widgetu.";
 "widget.cryptoTicker.description" = "Pratite cijenu i sedmodnevni trend kriptovalute.";
-"widget.cryptocurrency" = "Kriptovaluta";
 "widget.down" = "palo";
 "widget.marketCap" = "Tržišna kapitalizacija";
 "widget.marketData" = "Tržišni podaci";
@@ -26,3 +26,7 @@
 "widget.up" = "poraslo";
 "widget.updatedData" = "ažurirani podaci";
 "widget.valueUnavailableDisplay" = "—";
+"widget.watchlist" = "Popis za praćenje";
+"widget.watchlist.configure" = "Odaberi imovinu u postavkama Vultisiga";
+"widget.watchlist.description" = "Prati do pet kriptovaluta odabranih u Vultisigu.";
+"widget.watchlist.marketDataUnavailable" = "Tržišni podaci popisa privremeno nisu dostupni";

--- a/VultisigApp/VultisigWidgets/Resources/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigWidgets/Resources/it.lproj/Localizable.strings
@@ -8,11 +8,11 @@
 "widget.change" = "%@ 24H";
 "widget.changeUnavailable" = "non disponibile";
 "widget.changeUnavailableDisplay" = "— 24H";
+"widget.cryptocurrency" = "Criptovaluta";
 "widget.cryptoMarketDataUnavailable" = "I dati del mercato cripto non sono temporaneamente disponibili";
 "widget.cryptoTicker" = "Ticker cripto";
 "widget.cryptoTicker.choose" = "Scegli la criptovaluta mostrata in questo widget.";
 "widget.cryptoTicker.description" = "Segui il prezzo e l'andamento di sette giorni di una criptovaluta.";
-"widget.cryptocurrency" = "Criptovaluta";
 "widget.down" = "in calo";
 "widget.marketCap" = "Capitalizzazione";
 "widget.marketData" = "Dati di mercato";
@@ -26,3 +26,7 @@
 "widget.up" = "in rialzo";
 "widget.updatedData" = "dati aggiornati";
 "widget.valueUnavailableDisplay" = "—";
+"widget.watchlist" = "Watchlist";
+"widget.watchlist.configure" = "Scegli gli asset nelle Impostazioni di Vultisig";
+"widget.watchlist.description" = "Segui fino a cinque criptovalute selezionate in Vultisig.";
+"widget.watchlist.marketDataUnavailable" = "I dati di mercato della watchlist non sono temporaneamente disponibili";

--- a/VultisigApp/VultisigWidgets/Resources/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigWidgets/Resources/ko.lproj/Localizable.strings
@@ -8,11 +8,11 @@
 "widget.change" = "%@ 24H";
 "widget.changeUnavailable" = "사용 불가";
 "widget.changeUnavailableDisplay" = "— 24H";
+"widget.cryptocurrency" = "암호화폐";
 "widget.cryptoMarketDataUnavailable" = "암호화폐 시장 데이터를 일시적으로 사용할 수 없습니다";
 "widget.cryptoTicker" = "암호화폐 티커";
 "widget.cryptoTicker.choose" = "이 위젯에 표시할 암호화폐를 선택하세요.";
 "widget.cryptoTicker.description" = "암호화폐의 가격과 7일 추세를 확인하세요.";
-"widget.cryptocurrency" = "암호화폐";
 "widget.down" = "하락";
 "widget.marketCap" = "시가총액";
 "widget.marketData" = "시장 데이터";
@@ -26,3 +26,7 @@
 "widget.up" = "상승";
 "widget.updatedData" = "업데이트된 데이터";
 "widget.valueUnavailableDisplay" = "—";
+"widget.watchlist" = "관심 목록";
+"widget.watchlist.configure" = "Vultisig 설정에서 자산을 선택하세요";
+"widget.watchlist.description" = "Vultisig에서 선택한 암호화폐를 최대 5개 추적하세요.";
+"widget.watchlist.marketDataUnavailable" = "관심 목록 시장 데이터를 일시적으로 사용할 수 없습니다";

--- a/VultisigApp/VultisigWidgets/Resources/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigWidgets/Resources/pt.lproj/Localizable.strings
@@ -8,11 +8,11 @@
 "widget.change" = "%@ 24H";
 "widget.changeUnavailable" = "indisponível";
 "widget.changeUnavailableDisplay" = "— 24H";
+"widget.cryptocurrency" = "Criptomoeda";
 "widget.cryptoMarketDataUnavailable" = "Os dados do mercado cripto estão temporariamente indisponíveis";
 "widget.cryptoTicker" = "Ticker cripto";
 "widget.cryptoTicker.choose" = "Escolha a criptomoeda exibida neste widget.";
 "widget.cryptoTicker.description" = "Acompanhe o preço e a tendência de sete dias de uma criptomoeda.";
-"widget.cryptocurrency" = "Criptomoeda";
 "widget.down" = "caiu";
 "widget.marketCap" = "Capitalização";
 "widget.marketData" = "Dados de mercado";
@@ -26,3 +26,7 @@
 "widget.up" = "subiu";
 "widget.updatedData" = "dados atualizados";
 "widget.valueUnavailableDisplay" = "—";
+"widget.watchlist" = "Lista de acompanhamento";
+"widget.watchlist.configure" = "Escolha ativos nos Ajustes do Vultisig";
+"widget.watchlist.description" = "Acompanhe até cinco criptomoedas selecionadas no Vultisig.";
+"widget.watchlist.marketDataUnavailable" = "Os dados de mercado da lista estão temporariamente indisponíveis";

--- a/VultisigApp/VultisigWidgets/Resources/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigWidgets/Resources/zh-Hans.lproj/Localizable.strings
@@ -8,11 +8,11 @@
 "widget.change" = "%@ 24H";
 "widget.changeUnavailable" = "不可用";
 "widget.changeUnavailableDisplay" = "— 24H";
+"widget.cryptocurrency" = "加密货币";
 "widget.cryptoMarketDataUnavailable" = "加密货币市场数据暂时不可用";
 "widget.cryptoTicker" = "加密货币行情";
 "widget.cryptoTicker.choose" = "选择此小组件中显示的加密货币。";
 "widget.cryptoTicker.description" = "跟踪一种加密货币的价格和七日趋势。";
-"widget.cryptocurrency" = "加密货币";
 "widget.down" = "下跌";
 "widget.marketCap" = "市值";
 "widget.marketData" = "市场数据";
@@ -26,3 +26,7 @@
 "widget.up" = "上涨";
 "widget.updatedData" = "更新的数据";
 "widget.valueUnavailableDisplay" = "—";
+"widget.watchlist" = "关注列表";
+"widget.watchlist.configure" = "请在 Vultisig 设置中选择资产";
+"widget.watchlist.description" = "关注最多五种在 Vultisig 中选择的加密货币。";
+"widget.watchlist.marketDataUnavailable" = "关注列表市场数据暂时不可用";

--- a/VultisigApp/VultisigWidgets/VultisigWidgetsBundle.swift
+++ b/VultisigApp/VultisigWidgets/VultisigWidgetsBundle.swift
@@ -16,5 +16,6 @@ struct VultisigWidgetsBundle: WidgetBundle {
     var body: some Widget {
         CryptoTickerWidget()
         TopCryptosWidget()
+        CryptoWatchlistWidget()
     }
 }

--- a/VultisigApp/project.yml
+++ b/VultisigApp/project.yml
@@ -291,6 +291,16 @@ targets:
         group: VultisigApp/Shared/WidgetShared
       - path: VultisigApp/Shared/WidgetShared/WidgetSparklineSampler.swift
         group: VultisigApp/Shared/WidgetShared
+      - path: VultisigApp/Core/Networking/HTTPMethod.swift
+        group: VultisigApp/Core/Networking
+      - path: VultisigApp/Core/Networking/TargetType.swift
+        group: VultisigApp/Core/Networking
+      - path: VultisigApp/Core/Networking/HTTPError.swift
+        group: VultisigApp/Core/Networking
+      - path: VultisigApp/Core/Networking/HTTPClientProtocol.swift
+        group: VultisigApp/Core/Networking
+      - path: VultisigApp/Core/Networking/HTTPClient.swift
+        group: VultisigApp/Core/Networking
       - path: VultisigApp/Components/ImageView/AsyncImageView.swift
         group: VultisigApp/Components/ImageView
       - path: VultisigApp/Components/ImageView/CachedAsyncImage.swift


### PR DESCRIPTION
## Summary

- restore Medium and Large Watchlist widgets using the existing market row and centered gradient sparkline presentation
- add Settings → Widgets → Watchlist configuration with downloaded CoinGecko icons, ticker, name, and on/off toggles
- share the ordered selection through the App Group, capped at five assets; Medium renders the first three and Large renders up to five
- default an unconfigured Watchlist to CoinGecko's top five while preserving an explicitly cleared selection
- reload the Watchlist timeline after changes and use the shared `withLoading` presentation in Settings

## Stack

This PR is intentionally based on #5284, which introduces the shared UI resources and Theme packages used by both the app and widget extension. Rebase the PR onto `main` after #5284 merges.

## Verification

- focused `WidgetMarketDataTests`: 20 passed, 0 failures
- full unit suite: 6,886 tests, 11 skipped, 0 failures
- iOS simulator build and runtime Settings navigation verified
- macOS app build passed
- SwiftLint: no new warnings (27-warning repository baseline)

## Follow-ups

- search and long-tail pagination
- manual reordering
- per-widget Watchlist selections

Closes #5286