### PR TITLE
fix(tron): accept successful contract receipts

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Providers/TronTransactionStatusProvider.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Providers/TronTransactionStatusProvider.swift
@@ -8,9 +8,8 @@
 import Foundation
 
 /// Tron Transaction Status Logic:
-/// - receipt.result is ONLY present when transaction fails
-/// - If receipt exists but receipt.result is nil → SUCCESS
-/// - If receipt.result exists → FAILED (contains error like "OUT_OF_ENERGY", "REVERT", etc.)
+/// - If receipt.result is nil or "SUCCESS" → SUCCESS
+/// - Any other receipt.result → FAILED (contains error like "OUT_OF_ENERGY", "REVERT", etc.)
 /// - Top-level result field may also indicate "FAILED" with resMessage
 struct TronTransactionStatusProvider: TransactionStatusProvider {
     private let httpClient: HTTPClientProtocol
@@ -49,8 +48,8 @@ struct TronTransactionStatusProvider: TransactionStatusProvider {
 
             // Check receipt
             if let receipt = response.data.receipt {
-                // If receipt.result is present, transaction failed
-                if let receiptResult = receipt.result {
+                if let receiptResult = receipt.result,
+                   receiptResult.caseInsensitiveCompare("SUCCESS") != .orderedSame {
                     let failureReason = buildFailureReason(
                         receiptResult: receiptResult,
                         resMessage: response.data.resMessage
@@ -62,7 +61,6 @@ struct TronTransactionStatusProvider: TransactionStatusProvider {
                     )
                 }
 
-                // receipt exists but receipt.result is nil → SUCCESS
                 return TransactionStatusResult(
                     status: .confirmed,
                     blockNumber: blockNumber,

--- a/VultisigApp/VultisigAppTests/Services/TronTransactionStatusProviderTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/TronTransactionStatusProviderTests.swift
@@ -1,0 +1,170 @@
+//
+//  TronTransactionStatusProviderTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class TronTransactionStatusProviderTests: XCTestCase {
+    private static let query = TransactionStatusQuery(txHash: "deadbeef", chain: .tron)
+
+    func testSuccessReceiptIsConfirmed() async throws {
+        let result = try await checkStatus(
+            response(id: "deadbeef", blockNumber: 123, receiptResult: "SUCCESS")
+        )
+
+        XCTAssertEqual(result.status, .confirmed)
+        XCTAssertEqual(result.blockNumber, 123)
+    }
+
+    func testLowercaseSuccessReceiptIsConfirmed() async throws {
+        let result = try await checkStatus(
+            response(id: "deadbeef", blockNumber: 123, receiptResult: "success")
+        )
+
+        XCTAssertEqual(result.status, .confirmed)
+    }
+
+    func testNilReceiptResultIsConfirmed() async throws {
+        let result = try await checkStatus(
+            response(id: "deadbeef", blockNumber: 123, receiptResult: nil)
+        )
+
+        XCTAssertEqual(result.status, .confirmed)
+    }
+
+    func testFailureReceiptResultIncludesResponseMessage() async throws {
+        let result = try await checkStatus(
+            response(
+                id: "deadbeef",
+                blockNumber: 123,
+                receiptResult: "OUT_OF_ENERGY",
+                resMessage: "Not enough energy"
+            )
+        )
+
+        XCTAssertEqual(result.status, .failed(reason: "OUT_OF_ENERGY: Not enough energy"))
+    }
+
+    func testEmptyReceiptResultIsFailed() async throws {
+        let result = try await checkStatus(
+            response(id: "deadbeef", blockNumber: 123, receiptResult: "")
+        )
+
+        XCTAssertEqual(result.status, .failed(reason: ""))
+    }
+
+    func testUnknownReceiptResultIsFailed() async throws {
+        let result = try await checkStatus(
+            response(id: "deadbeef", blockNumber: 123, receiptResult: "UNKNOWN_FUTURE_CODE")
+        )
+
+        XCTAssertEqual(result.status, .failed(reason: "UNKNOWN_FUTURE_CODE"))
+    }
+
+    func testTopLevelFailureWinsOverSuccessfulReceipt() async throws {
+        let result = try await checkStatus(
+            response(
+                id: "deadbeef",
+                blockNumber: 123,
+                receiptResult: "SUCCESS",
+                result: "FAILED",
+                resMessage: "Validation failed"
+            )
+        )
+
+        XCTAssertEqual(result.status, .failed(reason: "Validation failed"))
+    }
+
+    func testMissingReceiptIsPending() async throws {
+        let result = try await checkStatus(
+            response(id: "deadbeef", blockNumber: 123, hasReceipt: false)
+        )
+
+        XCTAssertEqual(result.status, .pending)
+        XCTAssertEqual(result.blockNumber, 123)
+    }
+
+    func testMissingTransactionIdIsNotFound() async throws {
+        let result = try await checkStatus(
+            response(id: nil, blockNumber: nil, hasReceipt: false)
+        )
+
+        XCTAssertEqual(result.status, .notFound)
+        XCTAssertNil(result.blockNumber)
+    }
+
+    private func checkStatus(
+        _ response: TronTransactionStatusResponse
+    ) async throws -> TransactionStatusResult {
+        let client = TronTransactionStatusHTTPClient(response: response)
+        let provider = TronTransactionStatusProvider(httpClient: client)
+        return try await provider.checkStatus(query: Self.query)
+    }
+
+    private func response(
+        id: String?,
+        blockNumber: Int?,
+        receiptResult: String? = nil,
+        hasReceipt: Bool = true,
+        result: String? = nil,
+        resMessage: String? = nil
+    ) -> TronTransactionStatusResponse {
+        let receipt = hasReceipt
+            ? TronTransactionStatusResponse.TronReceipt(
+                result: receiptResult,
+                net_fee: nil,
+                energy_fee: nil,
+                energy_usage_total: nil
+            )
+            : nil
+
+        return TronTransactionStatusResponse(
+            id: id,
+            blockNumber: blockNumber,
+            blockTimeStamp: nil,
+            fee: nil,
+            receipt: receipt,
+            result: result,
+            resMessage: resMessage
+        )
+    }
+}
+
+private final class TronTransactionStatusHTTPClient: HTTPClientProtocol, @unchecked Sendable {
+    private let response: TronTransactionStatusResponse
+
+    init(response: TronTransactionStatusResponse) {
+        self.response = response
+    }
+
+    // The asynchronous signatures are protocol requirements; this in-memory
+    // test double intentionally does not suspend.
+    // swiftlint:disable async_without_await
+    func request(_: TargetType) async throws -> HTTPResponse<Data> {
+        throw HTTPError.invalidResponse
+    }
+
+    func request<T: Decodable>(
+        _: TargetType,
+        responseType _: T.Type
+    ) async throws -> HTTPResponse<T> {
+        guard let typedResponse = response as? T else {
+            throw HTTPError.invalidResponse
+        }
+
+        let urlResponse = HTTPURLResponse(
+            url: URL(string: "https://test.local")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return HTTPResponse(data: typedResponse, response: urlResponse)
+    }
+
+    func requestEmpty(_: TargetType) async throws -> HTTPResponse<EmptyResponse> {
+        throw HTTPError.invalidResponse
+    }
+    // swiftlint:enable async_without_await
+}


### PR DESCRIPTION
## Description

Fixes TRON transaction-status resolution so a contract receipt with result SUCCESS is confirmed instead of reported as failed. A nil receipt result also remains confirmed, while any other present result fails closed with the existing reason construction. Top-level FAILED keeps precedence.

Closes #5294

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [x] Sending - Live TRC-20 status validation still required before merge
- [ ] Swap
- [ ] New Chain / Chain related feature

## Parity

- Android: n/a: already treats case-insensitive SUCCESS as confirmed
- Windows + extension: n/a: use the SDK status resolver, which already accepts SUCCESS
- SDK: n/a: already accepts SUCCESS; it differs only on unknown future receipt codes

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

Not applicable.

## Additional context

The implementation follows the issue and Android fail-closed semantics for unknown non-SUCCESS values. Nine focused tests cover SUCCESS, lowercase success, nil, known failure, empty and unknown results, top-level failure precedence, pending, and not-found.

Verification: full local gate passed with 6,888 tests executed, 11 skipped, and 0 failures. Touched-file SwiftLint is clean.

Manual validation before merge: confirm a real successful TRC-20 transfer reaches the Done screen and history as confirmed.

## Agent Metadata (if applicable)
- **Agent**: Codex
- **Issue**: #5294
- **Confidence**: high
- **Needs human review for**: live TRC-20 status canary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Tron transaction status handling.
  * Transactions are now marked successful when the result is missing or equals “SUCCESS” regardless of letter casing.
  * Other available result values are correctly treated as failed.

* **Tests**
  * Added coverage for confirmed, failed, pending, and not-found transaction states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->