### PR TITLE
fix(tron): correct fee fallback budget

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPI.swift
@@ -217,6 +217,8 @@ struct TronAccountResourceResponse: Codable {
 }
 
 struct TronChainParametersResponse: Codable {
+    static let defaultEnergyFeePrice: Int64 = 100
+
     let chainParameter: [TronChainParameter]
 
     struct TronChainParameter: Codable {
@@ -228,13 +230,13 @@ struct TronChainParametersResponse: Codable {
         chainParameter.first { $0.key == "getTransactionFee" }?.value ?? 1000
     }
 
-    /// Sun per energy unit (≈420 sun/energy at the time of writing). Used to
+    /// Sun per energy unit. Used to
     /// translate an energy budget into a `fee_limit` value via
     /// `feeLimit = energyBudget * energyFeePrice`.
     /// See https://developers.tron.network/docs/resource-model#dynamic-energy-model.
     var energyFeePrice: Int64 {
         let value = chainParameter.first { $0.key == "getEnergyFee" }?.value ?? 0
-        return value > 0 ? value : 420
+        return value > 0 ? value : Self.defaultEnergyFeePrice
     }
 
     var memoFeeEstimate: Int64 {

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPI.swift
@@ -218,6 +218,8 @@ struct TronAccountResourceResponse: Codable {
 
 struct TronChainParametersResponse: Codable {
     static let defaultEnergyFeePrice: Int64 = 100
+    static let defaultDynamicEnergyMaxFactor: Int64 = 34_000
+    static let defaultMaxFeeLimit: Int64 = 15_000_000_000
 
     let chainParameter: [TronChainParameter]
 
@@ -237,6 +239,22 @@ struct TronChainParametersResponse: Codable {
     var energyFeePrice: Int64 {
         let value = chainParameter.first { $0.key == "getEnergyFee" }?.value ?? 0
         return value > 0 ? value : Self.defaultEnergyFeePrice
+    }
+
+    /// Maximum additional Dynamic Energy penalty, scaled by 10,000.
+    /// A value of 34,000 means base energy may grow by up to 3.4×, for a
+    /// total ceiling of 4.4× base energy.
+    var dynamicEnergyMaxFactor: Int64 {
+        guard let value = chainParameter.first(where: { $0.key == "getDynamicEnergyMaxFactor" })?.value,
+              value >= 0 else {
+            return Self.defaultDynamicEnergyMaxFactor
+        }
+        return value
+    }
+
+    var maxFeeLimit: Int64 {
+        let value = chainParameter.first { $0.key == "getMaxFeeLimit" }?.value ?? 0
+        return value > 0 ? value : Self.defaultMaxFeeLimit
     }
 
     var memoFeeEstimate: Int64 {

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
@@ -41,11 +41,10 @@ class TronService {
     /// Energy budget used as the `fee_limit` cap when contract simulation
     /// isn't available (network error, native-TRX swap path where we don't
     /// have the function selector + parameter at fee-calc time, etc.).
-    /// At ~420 sun/energy this works out to ~21 TRX — generous enough for
-    /// any typical TRC20 or swap, while still being a real number derived
-    /// from chain parameters rather than a magic constant. Mirrors
-    /// `vultisig-android` `TronFeeService.DEFAULT_MAX_ENERGY_USED`.
-    private static let DEFAULT_MAX_ENERGY_USED: Int64 = 50_000_000
+    /// At 420 sun/energy this works out to 21 TRX; at the current 100-sun
+    /// fallback price it is 5 TRX. This is a spending cap, not an upfront
+    /// charge; successful calls consume only the resources they use.
+    private static let DEFAULT_MAX_ENERGY_USED: Int64 = 50_000
 
     init(httpClient: HTTPClientProtocol = HTTPClient()) {
         self.apiService = TronAPIService(httpClient: httpClient)
@@ -168,7 +167,7 @@ class TronService {
     /// safety multiplier, translate to sun via the on-chain `energyFeePrice`.
     /// Replaces the prior fixed 1 TRX / 18 TRX / 36 TRX ladder that
     /// triggered `OUT_OF_ENERGY` whenever the actual energy cost exceeded
-    /// `fee_limit / energy_price` (see issue/PR #4131).
+    /// `fee_limit / energy_price`.
     ///
     /// **Native swap** (`triggerSmartContract` from a TRX coin) — we don't
     /// yet have the function selector + calldata at this layer, so fall
@@ -181,7 +180,7 @@ class TronService {
         let memoFee = (try? await getTronFeeMemo(memo: memo)) ?? .zero
         let activationFee = (try? await getTronInactiveDestinationFee(to: to)) ?? .zero
         let chainParams = try? await getCachedChainParameters()
-        let energyPrice = chainParams?.energyFeePrice ?? 420
+        let energyPrice = chainParams?.energyFeePrice ?? TronChainParametersResponse.defaultEnergyFeePrice
 
         let transactionFee: BigInt
         if coin.isNativeToken {

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
@@ -32,15 +32,22 @@ class TronService {
     private static let BYTES_PER_CONTRACT_TX: Int64 = 345
 
     /// Headroom multiplier applied to the simulated `energy_used` when
-    /// computing the on-chain `fee_limit` cap. 30% covers the contract's
-    /// per-call dynamic `energy_factor` surge during congested windows. See
+    /// computing the on-chain `fee_limit` cap. The margin covers ordinary
+    /// drift between simulation and broadcast; the max-factor fallback below
+    /// handles cases where simulation is unavailable. See
     /// https://developers.tron.network/docs/resource-model#dynamic-energy-model.
     private static let ENERGY_SAFETY_NUMERATOR: Int64 = 13
     private static let ENERGY_SAFETY_DENOMINATOR: Int64 = 10
 
-    /// Energy budget used as the `fee_limit` cap when contract simulation
-    /// isn't available (network error, native-TRX swap path where we don't
-    /// have the function selector + parameter at fee-calc time, etc.).
+    /// Base-energy estimate for a common high-volume TRC20 transfer. When
+    /// simulation is unavailable, this is multiplied by the chain's maximum
+    /// Dynamic Energy factor instead of sharing the much smaller opaque-swap
+    /// estimate below.
+    private static let DEFAULT_TRC20_BASE_ENERGY_USED: Int64 = 65_000
+    private static let DYNAMIC_ENERGY_FACTOR_SCALE: Int64 = 10_000
+
+    /// Energy estimate used for an opaque native-TRX contract swap when the
+    /// transaction bytes have not reached the fee layer yet.
     /// At 420 sun/energy this works out to 21 TRX; at the current 100-sun
     /// fallback price it is 5 TRX. This is a spending cap, not an upfront
     /// charge; successful calls consume only the resources they use.
@@ -169,11 +176,9 @@ class TronService {
     /// triggered `OUT_OF_ENERGY` whenever the actual energy cost exceeded
     /// `fee_limit / energy_price`.
     ///
-    /// **Native swap** (`triggerSmartContract` from a TRX coin) — we don't
-    /// yet have the function selector + calldata at this layer, so fall
-    /// back to a generous default budget (`DEFAULT_MAX_ENERGY_USED ×
-    /// energyFeePrice`) — same approach `vultisig-android` takes in
-    /// `TronFeeService.calculateDefaultFees`.
+    /// **Opaque native swap** — pre-built transaction bytes arrive after this
+    /// layer and cannot be simulated from the `isSwap` flag alone, so use the
+    /// smaller UI estimate (`DEFAULT_MAX_ENERGY_USED × energyFeePrice`).
     ///
     /// See https://developers.tron.network/docs/set-feelimit.
     private func calculateTronFee(coin: Coin, to: String?, memo: String?, isSwap: Bool) async throws -> BigInt {
@@ -181,11 +186,17 @@ class TronService {
         let activationFee = (try? await getTronInactiveDestinationFee(to: to)) ?? .zero
         let chainParams = try? await getCachedChainParameters()
         let energyPrice = chainParams?.energyFeePrice ?? TronChainParametersResponse.defaultEnergyFeePrice
+        let dynamicEnergyMaxFactor = chainParams?.dynamicEnergyMaxFactor
+            ?? TronChainParametersResponse.defaultDynamicEnergyMaxFactor
+        let maxFeeLimit = chainParams?.maxFeeLimit ?? TronChainParametersResponse.defaultMaxFeeLimit
 
         let transactionFee: BigInt
         if coin.isNativeToken {
             if isSwap {
-                transactionFee = Self.defaultContractFeeLimit(energyPrice: energyPrice)
+                transactionFee = Self.cappedFeeLimit(
+                    Self.defaultContractFeeLimit(energyPrice: energyPrice),
+                    maxFeeLimit: maxFeeLimit
+                )
             } else {
                 // A *successfully computed* 0 means sufficient bandwidth — a
                 // genuinely free transfer, surfaced as 0. But a thrown error
@@ -196,10 +207,20 @@ class TronService {
                 transactionFee = (try? await calculateNativeTrxFee(coin: coin)) ?? coin.feeDefault.toBigInt()
             }
         } else {
-            transactionFee = await calculateTrc20FeeLimit(coin: coin, to: to, energyPrice: energyPrice)
+            transactionFee = await calculateTrc20FeeLimit(
+                coin: coin,
+                to: to,
+                energyPrice: energyPrice,
+                dynamicEnergyMaxFactor: dynamicEnergyMaxFactor,
+                maxFeeLimit: maxFeeLimit
+            )
         }
 
-        return transactionFee + memoFee + activationFee
+        let totalFee = transactionFee + memoFee + activationFee
+        if isSwap || !coin.isNativeToken {
+            return Self.cappedFeeLimit(totalFee, maxFeeLimit: maxFeeLimit)
+        }
+        return totalFee
     }
 
     private func calculateNativeTrxFee(coin: Coin) async throws -> BigInt {
@@ -211,9 +232,20 @@ class TronService {
         )
     }
 
-    private func calculateTrc20FeeLimit(coin: Coin, to: String?, energyPrice: Int64) async -> BigInt {
+    private func calculateTrc20FeeLimit(
+        coin: Coin,
+        to: String?,
+        energyPrice: Int64,
+        dynamicEnergyMaxFactor: Int64,
+        maxFeeLimit: Int64
+    ) async -> BigInt {
+        let fallback = Self.defaultTrc20FeeLimit(
+            energyPrice: energyPrice,
+            dynamicEnergyMaxFactor: dynamicEnergyMaxFactor,
+            maxFeeLimit: maxFeeLimit
+        )
         guard let to, !to.isEmpty, !coin.contractAddress.isEmpty else {
-            return Self.defaultContractFeeLimit(energyPrice: energyPrice)
+            return fallback
         }
 
         let simulation: TronTriggerConstantResponse
@@ -224,29 +256,49 @@ class TronService {
                 toAddress: to
             )
         } catch {
-            return Self.defaultContractFeeLimit(energyPrice: energyPrice)
+            return fallback
         }
 
         guard simulation.result?.result == true,
               let energyUsed = simulation.energy_used, energyUsed > 0 else {
-            return Self.defaultContractFeeLimit(energyPrice: energyPrice)
+            return fallback
         }
 
-        return Self.contractFeeLimit(energyUsed: Int64(energyUsed), energyPrice: energyPrice)
+        return Self.cappedFeeLimit(
+            Self.contractFeeLimit(energyUsed: Int64(energyUsed), energyPrice: energyPrice),
+            maxFeeLimit: maxFeeLimit
+        )
     }
 
-    /// Conservative fallback budget for contract-execution paths whenever
-    /// simulation isn't possible or fails. Used so a transient RPC error
-    /// doesn't silently reintroduce `OUT_OF_ENERGY`. Operands are widened to
-    /// `BigInt` before multiplying so anomalous chain-parameter values can't
-    /// overflow `Int64`.
+    /// Opaque native-swap estimate. TRC20 simulation failures deliberately use
+    /// the larger max-factor budget below so this 50,000-energy value is never
+    /// written as a TRC20 `fee_limit`.
     static func defaultContractFeeLimit(energyPrice: Int64) -> BigInt {
         BigInt(DEFAULT_MAX_ENERGY_USED) * BigInt(energyPrice)
     }
 
+    /// Simulation-error budget for TRC20 transfers. TRON documents the
+    /// maximum Dynamic Energy factor as an additional multiplier scaled by
+    /// 10,000, so the total ceiling is `base × (1 + maxFactor)`.
+    static func defaultTrc20FeeLimit(
+        energyPrice: Int64,
+        dynamicEnergyMaxFactor: Int64,
+        maxFeeLimit: Int64
+    ) -> BigInt {
+        let safeMaxFactor = max(dynamicEnergyMaxFactor, 0)
+        let maxEnergyUnits = BigInt(DEFAULT_TRC20_BASE_ENERGY_USED)
+            * (BigInt(DYNAMIC_ENERGY_FACTOR_SCALE) + BigInt(safeMaxFactor))
+            / BigInt(DYNAMIC_ENERGY_FACTOR_SCALE)
+        return cappedFeeLimit(maxEnergyUnits * BigInt(energyPrice), maxFeeLimit: maxFeeLimit)
+    }
+
+    static func cappedFeeLimit(_ feeLimit: BigInt, maxFeeLimit: Int64) -> BigInt {
+        min(max(feeLimit, .zero), BigInt(max(maxFeeLimit, 0)))
+    }
+
     /// Translates a simulated `energy_used` into a `fee_limit` cap (in sun),
-    /// applying the documented 30% safety multiplier for dynamic-energy
-    /// surges. Pulled out so the math is testable in isolation. All
+    /// applying a 30% margin against estimate drift. Pulled out so the math
+    /// is testable in isolation. All
     /// multiplications are performed in `BigInt` so an unexpectedly large
     /// `energy_used` or `energyPrice` can't overflow `Int64` mid-calculation.
     static func contractFeeLimit(energyUsed: Int64, energyPrice: Int64) -> BigInt {

--- a/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
@@ -43,8 +43,8 @@ final class TronServiceFeeLimitTests: XCTestCase {
         XCTAssertGreaterThan(withSafety, bare)
     }
 
-    /// `defaultContractFeeLimit` returns the docs-backed fallback budget
-    /// used when simulation isn't possible. 50,000 energy × 420 sun =
+    /// `defaultContractFeeLimit` returns the opaque-swap estimate used before
+    /// pre-built transaction bytes reach the fee layer. 50,000 energy × 420 sun =
     /// 21,000,000 sun (21 TRX).
     func testDefaultContractFeeLimitReturnsTwentyOneTrxAt420Sun() {
         XCTAssertEqual(
@@ -74,6 +74,8 @@ final class TronServiceFeeLimitTests: XCTestCase {
         )
 
         XCTAssertEqual(response.energyFeePrice, 100)
+        XCTAssertEqual(response.dynamicEnergyMaxFactor, 34_000)
+        XCTAssertEqual(response.maxFeeLimit, 15_000_000_000)
     }
 
     func testEnergyFeePriceFallsBackToCurrentBaselineWhenParameterInvalid() throws {
@@ -83,6 +85,31 @@ final class TronServiceFeeLimitTests: XCTestCase {
         )
 
         XCTAssertEqual(response.energyFeePrice, 100)
+    }
+
+    func testTrc20FallbackUsesMaximumDynamicEnergyFactor() {
+        let observedTransferWithHeadroom = TronService.contractFeeLimit(
+            energyUsed: 130_285,
+            energyPrice: 100
+        )
+        let fallback = TronService.defaultTrc20FeeLimit(
+            energyPrice: 100,
+            dynamicEnergyMaxFactor: 34_000,
+            maxFeeLimit: 15_000_000_000
+        )
+
+        XCTAssertEqual(
+            fallback,
+            BigInt(28_600_000)
+        )
+        XCTAssertGreaterThan(fallback, observedTransferWithHeadroom)
+    }
+
+    func testContractFeeLimitNeverExceedsChainMaximum() {
+        XCTAssertEqual(
+            TronService.cappedFeeLimit(BigInt(21_000_000_000), maxFeeLimit: 15_000_000_000),
+            BigInt(15_000_000_000)
+        )
     }
 
     // MARK: - Dispatch (TronService.getBlockInfo)
@@ -108,7 +135,7 @@ final class TronServiceFeeLimitTests: XCTestCase {
     /// Simulation throws (network error / TRON gateway 5xx). Old behavior
     /// fell through to `BYTES_PER_CONTRACT_TX * 1000` (~0.345 TRX), which
     /// silently re-introduced OUT_OF_ENERGY. New behavior: fall back to
-    /// the safe default budget (21 TRX at the test chain price).
+    /// the max-factor fallback (120.12 TRX at the test chain price).
     func testGetBlockInfo_trc20Transfer_fallsBackOnSimulationError() async throws {
         let stub = TronStubHTTPClient()
         stub.stubDefaults(energyUsed: 65_000)
@@ -119,7 +146,14 @@ final class TronServiceFeeLimitTests: XCTestCase {
         let result = try await service.getBlockInfo(coin: coin, to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", memo: nil)
         let gasFee = extractGasFee(result)
 
-        XCTAssertEqual(gasFee, UInt64(TronService.defaultContractFeeLimit(energyPrice: 420)))
+        XCTAssertEqual(
+            gasFee,
+            UInt64(TronService.defaultTrc20FeeLimit(
+                energyPrice: 420,
+                dynamicEnergyMaxFactor: 34_000,
+                maxFeeLimit: 15_000_000_000
+            ))
+        )
     }
 
     /// Simulation returns `result.result = false` (e.g. insufficient TRC20
@@ -137,13 +171,18 @@ final class TronServiceFeeLimitTests: XCTestCase {
         let result = try await service.getBlockInfo(coin: coin, to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", memo: nil)
         let gasFee = extractGasFee(result)
 
-        XCTAssertEqual(gasFee, UInt64(TronService.defaultContractFeeLimit(energyPrice: 420)))
+        XCTAssertEqual(
+            gasFee,
+            UInt64(TronService.defaultTrc20FeeLimit(
+                energyPrice: 420,
+                dynamicEnergyMaxFactor: 34_000,
+                maxFeeLimit: 15_000_000_000
+            ))
+        )
     }
 
-    /// Native TRX swap (`isSwap == true`). We don't yet have the contract
-    /// function selector + parameter at fee-calc time, so use the default
-    /// budget — better than the prior bandwidth-only fee that would
-    /// trigger OUT_OF_ENERGY on the swap's `triggerSmartContract` path.
+    /// Opaque native TRX swap (`isSwap == true`). The pre-built transaction
+    /// reaches the signer later, so this layer uses its smaller UI estimate.
     func testGetBlockInfo_nativeSwap_usesDefaultContractBudget() async throws {
         let stub = TronStubHTTPClient()
         stub.stubDefaults(energyUsed: 0)
@@ -170,6 +209,21 @@ final class TronServiceFeeLimitTests: XCTestCase {
         )
 
         XCTAssertEqual(extractGasFee(result), 5_000_000)
+    }
+
+    func testTrc20SimulationFailureNeverUsesOpaqueSwapEstimate() async throws {
+        let stub = TronStubHTTPClient()
+        stub.stubDefaults(energyUsed: 0)
+        stub.errors["/wallet/getchainparameters"] = HTTPError.invalidResponse
+        stub.errors["/wallet/triggerconstantcontract"] = HTTPError.invalidResponse
+        let service = TronService(httpClient: stub)
+
+        let result = try await service.getBlockInfo(
+            coin: makeTrc20Coin(),
+            to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+        )
+
+        XCTAssertEqual(extractGasFee(result), 28_600_000)
     }
 
     /// Native TRX transfer with sufficient bandwidth — the daily free-net
@@ -363,7 +417,12 @@ private final class TronStubHTTPClient: HTTPClientProtocol {
         {"block_header":{"raw_data":{"timestamp":1700000000,"number":1,"version":0,"txTrieRoot":"00","parentHash":"00","witness_address":"00"}}}
         """)
         setResponse(path: "/wallet/getchainparameters", json: """
-        {"chainParameter":[{"key":"getEnergyFee","value":420},{"key":"getTransactionFee","value":1000}]}
+        {"chainParameter":[
+            {"key":"getEnergyFee","value":420},
+            {"key":"getTransactionFee","value":1000},
+            {"key":"getDynamicEnergyMaxFactor","value":34000},
+            {"key":"getMaxFeeLimit","value":15000000000}
+        ]}
         """)
         setResponse(path: "/wallet/getaccountresource", json: """
         {"freeNetUsed":0,"freeNetLimit":0,"NetUsed":0,"NetLimit":0,"EnergyUsed":0,"EnergyLimit":1000000}

--- a/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
@@ -3,7 +3,7 @@
 //  VultisigAppTests
 //
 //  Pins the simulation-based `fee_limit` math behind the TRC20 / swap
-//  OUT_OF_ENERGY fix (issue/PR #4131). The bug being addressed:
+//  OUT_OF_ENERGY fix. The bug being addressed:
 //  `Vault.fee_limit` is a strict upper bound on the energy budget the TVM
 //  is willing to use for a contract call (`max_energy = fee_limit /
 //  energy_unit_price`). The pre-fix code returned a 1 TRX / 18 TRX / 36 TRX
@@ -44,13 +44,12 @@ final class TronServiceFeeLimitTests: XCTestCase {
     }
 
     /// `defaultContractFeeLimit` returns the docs-backed fallback budget
-    /// used when simulation isn't possible. 50,000,000 energy × 420 sun =
-    /// 21,000,000,000 sun (21 TRX). Mirrors the Android
-    /// `TronFeeService.DEFAULT_MAX_ENERGY_USED` reference.
-    func testDefaultContractFeeLimit_returnsTwentyOneTrxAtCurrentEnergyPrice() {
+    /// used when simulation isn't possible. 50,000 energy × 420 sun =
+    /// 21,000,000 sun (21 TRX).
+    func testDefaultContractFeeLimitReturnsTwentyOneTrxAt420Sun() {
         XCTAssertEqual(
             TronService.defaultContractFeeLimit(energyPrice: 420),
-            BigInt(21_000_000_000)
+            BigInt(21_000_000)
         )
     }
 
@@ -60,12 +59,30 @@ final class TronServiceFeeLimitTests: XCTestCase {
     func testDefaultContractFeeLimit_scalesWithEnergyPrice() {
         XCTAssertEqual(
             TronService.defaultContractFeeLimit(energyPrice: 100),
-            BigInt(5_000_000_000)
+            BigInt(5_000_000)
         )
         XCTAssertEqual(
             TronService.defaultContractFeeLimit(energyPrice: 1_000),
-            BigInt(50_000_000_000)
+            BigInt(50_000_000)
         )
+    }
+
+    func testEnergyFeePriceFallsBackToCurrentBaselineWhenParameterMissing() throws {
+        let response = try JSONDecoder().decode(
+            TronChainParametersResponse.self,
+            from: Data(#"{"chainParameter":[]}"#.utf8)
+        )
+
+        XCTAssertEqual(response.energyFeePrice, 100)
+    }
+
+    func testEnergyFeePriceFallsBackToCurrentBaselineWhenParameterInvalid() throws {
+        let response = try JSONDecoder().decode(
+            TronChainParametersResponse.self,
+            from: Data(#"{"chainParameter":[{"key":"getEnergyFee","value":0}]}"#.utf8)
+        )
+
+        XCTAssertEqual(response.energyFeePrice, 100)
     }
 
     // MARK: - Dispatch (TronService.getBlockInfo)
@@ -91,7 +108,7 @@ final class TronServiceFeeLimitTests: XCTestCase {
     /// Simulation throws (network error / TRON gateway 5xx). Old behavior
     /// fell through to `BYTES_PER_CONTRACT_TX * 1000` (~0.345 TRX), which
     /// silently re-introduced OUT_OF_ENERGY. New behavior: fall back to
-    /// the safe default budget (~21 TRX).
+    /// the safe default budget (21 TRX at the test chain price).
     func testGetBlockInfo_trc20Transfer_fallsBackOnSimulationError() async throws {
         let stub = TronStubHTTPClient()
         stub.stubDefaults(energyUsed: 65_000)
@@ -137,6 +154,22 @@ final class TronServiceFeeLimitTests: XCTestCase {
         let gasFee = extractGasFee(result)
 
         XCTAssertEqual(gasFee, UInt64(TronService.defaultContractFeeLimit(energyPrice: 420)))
+    }
+
+    func testNativeSwapUsesCurrentFallbackWhenChainParametersUnavailable() async throws {
+        let stub = TronStubHTTPClient()
+        stub.stubDefaults(energyUsed: 0)
+        stub.errors["/wallet/getchainparameters"] = HTTPError.invalidResponse
+        let service = TronService(httpClient: stub)
+
+        let result = try await service.getBlockInfo(
+            coin: makeNativeCoin(),
+            to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+            memo: nil,
+            isSwap: true
+        )
+
+        XCTAssertEqual(extractGasFee(result), 5_000_000)
     }
 
     /// Native TRX transfer with sufficient bandwidth — the daily free-net


### PR DESCRIPTION
## Description

Corrects the 1000x TRON fallback-energy typo without replacing it with an underfunded signed TRC-20 fee limit.

The 50,000-energy value is now limited to the opaque SwapKit native-TRX UI estimate. TRC-20 simulation failures use a 65,000 base-energy estimate multiplied by the live maximum Dynamic Energy factor, and every contract fee limit is capped by the live chain maximum. The stale energy-price fallback is updated from 420 to the current 100 sun value.

Closes #5293

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [x] Sending - On-device TRC-20 send still required before merge
- [x] Swap - On-device SwapKit fee-display validation still required before merge
- [ ] New Chain / Chain related feature

## Parity

- Android: first: corrected dynamic max-factor fallback; Android still carries the 50,000,000 constant in its separate default-fee path and needs follow-up assessment
- Windows + extension: n/a: use provider-prebuilt TRON transactions rather than this iOS fee-estimation path
- SDK: n/a: estimates from exact calldata and fetches live energy pricing in its separate implementation

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

Not applicable.

## Additional context

Investigation found that THORChain and Maya TRON swaps already build ordinary transfers. SwapKit supplies pre-built raw transaction bytes only after this fee layer, and its signer hashes those bytes verbatim, so exact SwapKit simulation cannot be added safely here.

Verification: full local gate passed with 6,885 tests executed, 11 skipped, and 0 failures. Touched-file SwiftLint is clean.

Manual validation before merge: real-vault TRC-20 send/broadcast and SwapKit native-TRX fee display. This touches fee computation and should receive money-path review.

## Agent Metadata (if applicable)
- **Agent**: Codex
- **Issue**: #5293
- **Confidence**: medium
- **Needs human review for**: TRON fee-limit math and on-device send/swap validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved TRON transaction fee estimation using current network energy parameters.
  * Added safety margins and maximum fee limits to prevent excessive fee estimates.
  * Improved fee estimation for native swaps and TRC20 transfers, including fallback handling when simulation data is unavailable or invalid.
  * Added safeguards for missing or invalid network parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->