### PR TITLE
fix(tron): use shared proxy routes

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/EVM/Service/EvmServiceConfig.swift
+++ b/VultisigApp/VultisigApp/Blockchain/EVM/Service/EvmServiceConfig.swift
@@ -157,9 +157,9 @@ struct EvmServiceConfig {
         }
         // `.tron` is special: the custom-RPC override the user configures is a
         // TronGrid-compatible REST endpoint (`/wallet/*`) consumed by `TronAPI`,
-        // not an EVM JSON-RPC node. Applying it to this EVM-rpc proxy host would
+        // not an EVM JSON-RPC node. Applying it to the JSON-RPC proxy would
         // POST `eth_*` calls to a REST surface and break the TVM contract path,
-        // so the EVM-rpc host stays on its default proxy regardless of override.
+        // so the JSON-RPC host stays on its default proxy regardless of override.
         guard chain != .tron, let override = resolver.url(for: chain) else {
             return config
         }

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPI.swift
@@ -11,10 +11,10 @@ import Foundation
 /// The host is baked in at construction by the API service (see
 /// `TronAPIService.api`); this value never consults global state.
 ///
-/// The default host is the Vultisig proxy (`api.vultisig.com/tron-rest`), so
-/// when no override is set behavior is byte-identical to before. An override
-/// only swaps the host while keeping the TronGrid-compatible `/wallet/*` paths
-/// unchanged, so a real public TRON node (TronGrid scheme) works as-is.
+/// The default host is the shared Vultisig TRON proxy
+/// (`api.vultisig.com/tron`). An override only swaps the host while keeping the
+/// TronGrid-compatible `/wallet/*` paths unchanged, so a real public TRON node
+/// (TronGrid scheme) works as-is.
 struct TronAPI: TargetType {
     enum Endpoint {
         case getNowBlock
@@ -26,7 +26,7 @@ struct TronAPI: TargetType {
     }
 
     /// Default TRON REST host (Vultisig proxy).
-    static let defaultHost = URL(staticString: "https://api.vultisig.com/tron-rest")
+    static let defaultHost = URL(staticString: "https://api.vultisig.com/tron")
 
     let endpoint: Endpoint
     /// The resolved TRON REST host (override-aware), baked in by the API service.

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPIService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPIService.swift
@@ -29,7 +29,7 @@ struct TronAPIService {
 
     /// The override-aware TRON REST host. Falls back to the default proxy host
     /// when no override is set. The `.tron` override applies to this REST host
-    /// only; the EVM-rpc host (`EvmServiceConfig`) excludes `.tron` and is
+    /// only; the JSON-RPC host (`EvmServiceConfig`) excludes `.tron` and is
     /// unaffected.
     private var resolvedHost: URL {
         resolver.resolvedURL(for: .tron, default: TronAPI.defaultHost)

--- a/VultisigApp/VultisigApp/Core/Utils/Endpoint.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/Endpoint.swift
@@ -135,7 +135,7 @@ class Endpoint {
     /// `/qbtc/v1/params/{name}`, `/cosmos/tx/v1beta1/txs`. See `QBTCChainAPI`.
     static let qbtcRestBaseURL = "https://api.vultisig.com/qbtc-rpc"
 
-    static let tronEvmServiceRpc = "https://api.vultisig.com/tron-rpc"
+    static let tronEvmServiceRpc = "https://api.vultisig.com/tron/jsonrpc"
     static let tronWalletApi = "https://api.vultisig.com/tron"
 
     static func getExplorerByCoinURL(coin: Coin) -> String? {

--- a/VultisigApp/VultisigAppTests/Services/CustomRPCResolutionTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/CustomRPCResolutionTests.swift
@@ -205,7 +205,7 @@ final class CustomRPCResolutionTests: XCTestCase {
     func test_tronAPI_default_usesProxyHostAndWalletPaths() {
         let api = TronAPI(.getNowBlock)
         XCTAssertEqual(api.baseURL, TronAPI.defaultHost)
-        XCTAssertEqual(api.baseURL.absoluteString, "https://api.vultisig.com/tron-rest")
+        XCTAssertEqual(api.baseURL.absoluteString, "https://api.vultisig.com/tron")
         XCTAssertEqual(api.path, "/wallet/getnowblock")
     }
 
@@ -218,10 +218,11 @@ final class CustomRPCResolutionTests: XCTestCase {
 
     func test_tronEvmRpc_ignoresTronOverride_keepsProxy() throws {
         // The `.tron` override is a TronGrid REST endpoint, NOT an EVM JSON-RPC
-        // node, so the EVM-side tron-rpc host must stay on the proxy default.
+        // node, so the EVM-side JSON-RPC host must stay on the proxy default.
         let resolver = FakeRPCResolver(overrides: [.tron: "https://my-trongrid.example"])
         let config = try EvmServiceConfig.getConfig(forChain: .tron, resolver: resolver)
         XCTAssertEqual(config.rpcEndpoint, Endpoint.tronEvmServiceRpc)
+        XCTAssertEqual(config.rpcEndpoint, "https://api.vultisig.com/tron/jsonrpc")
     }
 
     // MARK: - Ton (proxy default; override swaps host, keeps /ton/v2|v3 paths)
@@ -311,9 +312,9 @@ final class CustomRPCResolutionTests: XCTestCase {
         // Bittensor (proxy/onfinality default baked at init)
         XCTAssertEqual(BittensorService.rpcEndpoint, "https://bittensor-finney.api.onfinality.io/public")
         XCTAssertEqual(Endpoint.bittensorServiceRpc, "https://bittensor-finney.api.onfinality.io/public")
-        // Tron REST proxy default + EVM-rpc proxy default
-        XCTAssertEqual(TronAPI.defaultHost.absoluteString, "https://api.vultisig.com/tron-rest")
-        XCTAssertEqual(Endpoint.tronEvmServiceRpc, "https://api.vultisig.com/tron-rpc")
+        // Tron REST proxy default + JSON-RPC proxy default
+        XCTAssertEqual(TronAPI.defaultHost.absoluteString, "https://api.vultisig.com/tron")
+        XCTAssertEqual(Endpoint.tronEvmServiceRpc, "https://api.vultisig.com/tron/jsonrpc")
         // Ton proxy default
         XCTAssertEqual(TonAPI.defaultHost.absoluteString, "https://api.vultisig.com")
         // Polkadot proxy default baked at init


### PR DESCRIPTION
## Description

Moves the iOS TRON REST and JSON-RPC defaults from the iOS-only proxy routes to the shared routes already used by Android:

- REST: https://api.vultisig.com/tron
- JSON-RPC: https://api.vultisig.com/tron/jsonrpc

TronGrid-compatible wallet paths and the existing custom-RPC split remain unchanged: a user override applies only to REST, never to JSON-RPC.

Closes #5290

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [x] Sending - Real-vault balance and broadcast validation still required before merge
- [ ] Swap
- [x] New Chain / Chain related feature - TRON endpoint routing

## Parity

- Android: n/a: already uses the shared https://api.vultisig.com/tron route
- Windows + extension: n/a: use direct TRON nodes rather than the Vultisig proxy
- SDK: n/a: uses direct TRON nodes rather than the Vultisig proxy

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

Not applicable.

## Additional context

The old REST route had recovered during implementation, so this PR is justified as consolidation away from two single-client routes, not as a claim that the old route remains unavailable.

Live probes returned HTTP 200 for getaccount, GET and POST getnowblock, and eth_blockNumber on the new routes.

Verification: full local gate passed with 6,879 tests executed, 11 skipped, and 0 failures. Touched-file SwiftLint is clean.

Manual validation before merge: refresh native TRX and TRC-20 balances on a real vault, then send and broadcast a TRON transaction.

## Agent Metadata (if applicable)
- **Agent**: Codex
- **Issue**: #5290
- **Confidence**: high
- **Needs human review for**: real-vault endpoint and broadcast validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated TRON network connections to use the current REST and JSON-RPC proxy endpoints.
  * Improved endpoint descriptions to clearly distinguish REST and JSON-RPC services.
  * Preserved existing endpoint paths and connection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->