### PR TITLE
fix(tron): separate TRC-20 burn estimate from fee limit

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPI.swift
@@ -214,6 +214,10 @@ struct TronAccountResourceResponse: Codable {
         let netBandwidthAvailable = NetLimit - NetUsed
         return freeBandwidthAvailable + netBandwidthAvailable
     }
+
+    func calculateAvailableEnergy() -> Int64 {
+        max(EnergyLimit - EnergyUsed, 0)
+    }
 }
 
 struct TronChainParametersResponse: Codable {

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPI.swift
@@ -217,6 +217,8 @@ struct TronAccountResourceResponse: Codable {
 }
 
 struct TronChainParametersResponse: Codable {
+    static let defaultEnergyFeePrice: Int64 = 100
+
     let chainParameter: [TronChainParameter]
 
     struct TronChainParameter: Codable {
@@ -228,13 +230,13 @@ struct TronChainParametersResponse: Codable {
         chainParameter.first { $0.key == "getTransactionFee" }?.value ?? 1000
     }
 
-    /// Sun per energy unit (≈420 sun/energy at the time of writing). Used to
+    /// Sun per energy unit. Used to
     /// translate an energy budget into a `fee_limit` value via
     /// `feeLimit = energyBudget * energyFeePrice`.
     /// See https://developers.tron.network/docs/resource-model#dynamic-energy-model.
     var energyFeePrice: Int64 {
         let value = chainParameter.first { $0.key == "getEnergyFee" }?.value ?? 0
-        return value > 0 ? value : 420
+        return value > 0 ? value : Self.defaultEnergyFeePrice
     }
 
     var memoFeeEstimate: Int64 {

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPI.swift
@@ -218,6 +218,8 @@ struct TronAccountResourceResponse: Codable {
 
 struct TronChainParametersResponse: Codable {
     static let defaultEnergyFeePrice: Int64 = 100
+    static let defaultDynamicEnergyMaxFactor: Int64 = 34_000
+    static let defaultMaxFeeLimit: Int64 = 15_000_000_000
 
     let chainParameter: [TronChainParameter]
 
@@ -237,6 +239,22 @@ struct TronChainParametersResponse: Codable {
     var energyFeePrice: Int64 {
         let value = chainParameter.first { $0.key == "getEnergyFee" }?.value ?? 0
         return value > 0 ? value : Self.defaultEnergyFeePrice
+    }
+
+    /// Maximum additional Dynamic Energy penalty, scaled by 10,000.
+    /// A value of 34,000 means base energy may grow by up to 3.4×, for a
+    /// total ceiling of 4.4× base energy.
+    var dynamicEnergyMaxFactor: Int64 {
+        guard let value = chainParameter.first(where: { $0.key == "getDynamicEnergyMaxFactor" })?.value,
+              value >= 0 else {
+            return Self.defaultDynamicEnergyMaxFactor
+        }
+        return value
+    }
+
+    var maxFeeLimit: Int64 {
+        let value = chainParameter.first { $0.key == "getMaxFeeLimit" }?.value ?? 0
+        return value > 0 ? value : Self.defaultMaxFeeLimit
     }
 
     var memoFeeEstimate: Int64 {

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
@@ -41,11 +41,10 @@ class TronService {
     /// Energy budget used as the `fee_limit` cap when contract simulation
     /// isn't available (network error, native-TRX swap path where we don't
     /// have the function selector + parameter at fee-calc time, etc.).
-    /// At ~420 sun/energy this works out to ~21 TRX — generous enough for
-    /// any typical TRC20 or swap, while still being a real number derived
-    /// from chain parameters rather than a magic constant. Mirrors
-    /// `vultisig-android` `TronFeeService.DEFAULT_MAX_ENERGY_USED`.
-    private static let DEFAULT_MAX_ENERGY_USED: Int64 = 50_000_000
+    /// At 420 sun/energy this works out to 21 TRX; at the current 100-sun
+    /// fallback price it is 5 TRX. This is a spending cap, not an upfront
+    /// charge; successful calls consume only the resources they use.
+    private static let DEFAULT_MAX_ENERGY_USED: Int64 = 50_000
 
     init(httpClient: HTTPClientProtocol = HTTPClient()) {
         self.apiService = TronAPIService(httpClient: httpClient)
@@ -168,7 +167,7 @@ class TronService {
     /// safety multiplier, translate to sun via the on-chain `energyFeePrice`.
     /// Replaces the prior fixed 1 TRX / 18 TRX / 36 TRX ladder that
     /// triggered `OUT_OF_ENERGY` whenever the actual energy cost exceeded
-    /// `fee_limit / energy_price` (see issue/PR #4131).
+    /// `fee_limit / energy_price`.
     ///
     /// **Native swap** (`triggerSmartContract` from a TRX coin) — we don't
     /// yet have the function selector + calldata at this layer, so fall
@@ -181,7 +180,7 @@ class TronService {
         let memoFee = (try? await getTronFeeMemo(memo: memo)) ?? .zero
         let activationFee = (try? await getTronInactiveDestinationFee(to: to)) ?? .zero
         let chainParams = try? await getCachedChainParameters()
-        let energyPrice = chainParams?.energyFeePrice ?? 420
+        let energyPrice = chainParams?.energyFeePrice ?? TronChainParametersResponse.defaultEnergyFeePrice
 
         let transactionFee: BigInt
         if coin.isNativeToken {

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
@@ -11,6 +11,11 @@ import WalletCore
 
 class TronService {
 
+    private struct FeeEstimate {
+        let displayFee: BigInt
+        let feeLimit: BigInt
+    }
+
     static let shared = TronService()
 
     private let apiService: TronAPIService
@@ -83,8 +88,7 @@ class TronService {
         let oneHourMillis = Int64(60 * 60 * 1000)
         let expiration = nowMillis + oneHourMillis
 
-        let calculatedFee = try await calculateTronFee(coin: coin, to: to, memo: memo, isSwap: isSwap)
-        let estimation = String(calculatedFee)
+        let estimate = try await calculateTronFee(coin: coin, to: to, memo: memo, isSwap: isSwap)
 
         return BlockChainSpecific.Tron(
             timestamp: currentTimestampMillis,
@@ -95,7 +99,8 @@ class TronService {
             blockHeaderTxTrieRoot: response.block_header?.raw_data?.txTrieRoot ?? "",
             blockHeaderParentHash: response.block_header?.raw_data?.parentHash ?? "",
             blockHeaderWitnessAddress: response.block_header?.raw_data?.witness_address ?? "",
-            gasFeeEstimation: UInt64(estimation) ?? 0
+            gasFeeEstimation: UInt64(estimate.displayFee.description) ?? 0,
+            feeLimit: UInt64(estimate.feeLimit.description) ?? 0
         )
     }
 
@@ -161,9 +166,8 @@ class TronService {
 
     // MARK: - Private Helpers
 
-    /// Returns the value that becomes both `gasFeeEstimation` (displayed in the
-    /// UI as "Fees") and `$0.feeLimit` for the signed transaction on
-    /// contract paths.
+    /// Returns both the user-visible fee estimate and the gross ceiling written
+    /// as `$0.feeLimit` on contract paths.
     ///
     /// **Native TRX transfer** — bandwidth-only fee. Signing path doesn't
     /// write `$0.feeLimit` for plain `transfer` contracts, so this number
@@ -181,7 +185,12 @@ class TronService {
     /// smaller UI estimate (`DEFAULT_MAX_ENERGY_USED × energyFeePrice`).
     ///
     /// See https://developers.tron.network/docs/set-feelimit.
-    private func calculateTronFee(coin: Coin, to: String?, memo: String?, isSwap: Bool) async throws -> BigInt {
+    private func calculateTronFee(
+        coin: Coin,
+        to: String?,
+        memo: String?,
+        isSwap: Bool
+    ) async throws -> FeeEstimate {
         let memoFee = (try? await getTronFeeMemo(memo: memo)) ?? .zero
         let activationFee = (try? await getTronInactiveDestinationFee(to: to)) ?? .zero
         let chainParams = try? await getCachedChainParameters()
@@ -190,13 +199,14 @@ class TronService {
             ?? TronChainParametersResponse.defaultDynamicEnergyMaxFactor
         let maxFeeLimit = chainParams?.maxFeeLimit ?? TronChainParametersResponse.defaultMaxFeeLimit
 
-        let transactionFee: BigInt
+        let transactionEstimate: FeeEstimate
         if coin.isNativeToken {
             if isSwap {
-                transactionFee = Self.cappedFeeLimit(
+                let feeLimit = Self.cappedFeeLimit(
                     Self.defaultContractFeeLimit(energyPrice: energyPrice),
                     maxFeeLimit: maxFeeLimit
                 )
+                transactionEstimate = FeeEstimate(displayFee: feeLimit, feeLimit: feeLimit)
             } else {
                 // A *successfully computed* 0 means sufficient bandwidth — a
                 // genuinely free transfer, surfaced as 0. But a thrown error
@@ -204,10 +214,11 @@ class TronService {
                 // is indistinguishable from that once collapsed to `.zero`,
                 // which would render a real transfer as falsely free. Fall back
                 // to the coin's conservative static fee only on that error path.
-                transactionFee = (try? await calculateNativeTrxFee(coin: coin)) ?? coin.feeDefault.toBigInt()
+                let fee = (try? await calculateNativeTrxFee(coin: coin)) ?? coin.feeDefault.toBigInt()
+                transactionEstimate = FeeEstimate(displayFee: fee, feeLimit: fee)
             }
         } else {
-            transactionFee = await calculateTrc20FeeLimit(
+            transactionEstimate = await calculateTrc20Fee(
                 coin: coin,
                 to: to,
                 energyPrice: energyPrice,
@@ -216,11 +227,15 @@ class TronService {
             )
         }
 
-        let totalFee = transactionFee + memoFee + activationFee
+        let displayFee = transactionEstimate.displayFee + memoFee + activationFee
+        let feeLimit = transactionEstimate.feeLimit + memoFee + activationFee
         if isSwap || !coin.isNativeToken {
-            return Self.cappedFeeLimit(totalFee, maxFeeLimit: maxFeeLimit)
+            return FeeEstimate(
+                displayFee: Self.cappedFeeLimit(displayFee, maxFeeLimit: maxFeeLimit),
+                feeLimit: Self.cappedFeeLimit(feeLimit, maxFeeLimit: maxFeeLimit)
+            )
         }
-        return totalFee
+        return FeeEstimate(displayFee: displayFee, feeLimit: feeLimit)
     }
 
     private func calculateNativeTrxFee(coin: Coin) async throws -> BigInt {
@@ -232,20 +247,21 @@ class TronService {
         )
     }
 
-    private func calculateTrc20FeeLimit(
+    private func calculateTrc20Fee(
         coin: Coin,
         to: String?,
         energyPrice: Int64,
         dynamicEnergyMaxFactor: Int64,
         maxFeeLimit: Int64
-    ) async -> BigInt {
+    ) async -> FeeEstimate {
         let fallback = Self.defaultTrc20FeeLimit(
             energyPrice: energyPrice,
             dynamicEnergyMaxFactor: dynamicEnergyMaxFactor,
             maxFeeLimit: maxFeeLimit
         )
+        let fallbackEstimate = FeeEstimate(displayFee: fallback, feeLimit: fallback)
         guard let to, !to.isEmpty, !coin.contractAddress.isEmpty else {
-            return fallback
+            return fallbackEstimate
         }
 
         let simulation: TronTriggerConstantResponse
@@ -256,18 +272,44 @@ class TronService {
                 toAddress: to
             )
         } catch {
-            return fallback
+            return fallbackEstimate
         }
 
-        guard simulation.result?.result == true,
-              let energyUsed = simulation.energy_used, energyUsed > 0 else {
-            return fallback
+        let simulationMessage = simulation.result?.message?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard simulation.result?.result == true, simulationMessage.isEmpty,
+              let energyUsed = simulation.energy_used,
+              let totalEnergyUsed = Self.simulatedTotalEnergy(
+                energyUsed: energyUsed,
+                energyPenalty: simulation.energy_penalty
+              ) else {
+            return fallbackEstimate
         }
 
-        return Self.cappedFeeLimit(
-            Self.contractFeeLimit(energyUsed: Int64(energyUsed), energyPrice: energyPrice),
+        let availableEnergy: Int64
+        do {
+            let accountResource = try await apiService.getAccountResource(address: coin.address)
+            availableEnergy = accountResource.calculateAvailableEnergy()
+        } catch {
+            // Unknown resources must never turn into a misleading zero-fee
+            // estimate. Assuming no staked Energy shows the full simulated burn
+            // while leaving the independently-computed signed ceiling intact.
+            availableEnergy = 0
+        }
+
+        let feeLimit = Self.cappedFeeLimit(
+            Self.contractFeeLimit(energyUsed: totalEnergyUsed, energyPrice: energyPrice),
             maxFeeLimit: maxFeeLimit
         )
+        let displayFee = Self.cappedFeeLimit(
+            Self.trc20DisplayFee(
+                totalEnergyUsed: totalEnergyUsed,
+                availableEnergy: availableEnergy,
+                energyPrice: energyPrice
+            ),
+            maxFeeLimit: maxFeeLimit
+        )
+        return FeeEstimate(displayFee: displayFee, feeLimit: feeLimit)
     }
 
     /// Opaque native-swap estimate. TRC20 simulation failures deliberately use
@@ -294,6 +336,31 @@ class TronService {
 
     static func cappedFeeLimit(_ feeLimit: BigInt, maxFeeLimit: Int64) -> BigInt {
         min(max(feeLimit, .zero), BigInt(max(maxFeeLimit, 0)))
+    }
+
+    /// `triggerconstantcontract.energy_used` is already the total Energy, and
+    /// `energy_penalty` is the Dynamic Energy portion inside that total. Rebuild
+    /// the total from base + penalty to make that relationship explicit and to
+    /// reject malformed responses where the reported subset exceeds the total.
+    /// See https://developers.tron.network/docs/set-feelimit#estimating-energy-before-broadcasting.
+    static func simulatedTotalEnergy(energyUsed: Int, energyPenalty: Int?) -> Int64? {
+        guard let total = Int64(exactly: energyUsed), total > 0 else { return nil }
+        guard let penalty = Int64(exactly: energyPenalty ?? 0), penalty >= 0, penalty <= total else {
+            return nil
+        }
+        let baseEnergy = total - penalty
+        return baseEnergy + penalty
+    }
+
+    /// Estimated TRX burn after applying the sender's currently available
+    /// staked Energy. This value is display-only; it never lowers `fee_limit`.
+    static func trc20DisplayFee(
+        totalEnergyUsed: Int64,
+        availableEnergy: Int64,
+        energyPrice: Int64
+    ) -> BigInt {
+        let energyToBurn = max(BigInt(totalEnergyUsed) - BigInt(max(availableEnergy, 0)), .zero)
+        return energyToBurn * BigInt(max(energyPrice, 0))
     }
 
     /// Translates a simulated `energy_used` into a `fee_limit` cap (in sun),

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
@@ -32,15 +32,22 @@ class TronService {
     private static let BYTES_PER_CONTRACT_TX: Int64 = 345
 
     /// Headroom multiplier applied to the simulated `energy_used` when
-    /// computing the on-chain `fee_limit` cap. 30% covers the contract's
-    /// per-call dynamic `energy_factor` surge during congested windows. See
+    /// computing the on-chain `fee_limit` cap. The margin covers ordinary
+    /// drift between simulation and broadcast; the max-factor fallback below
+    /// handles cases where simulation is unavailable. See
     /// https://developers.tron.network/docs/resource-model#dynamic-energy-model.
     private static let ENERGY_SAFETY_NUMERATOR: Int64 = 13
     private static let ENERGY_SAFETY_DENOMINATOR: Int64 = 10
 
-    /// Energy budget used as the `fee_limit` cap when contract simulation
-    /// isn't available (network error, native-TRX swap path where we don't
-    /// have the function selector + parameter at fee-calc time, etc.).
+    /// Base-energy estimate for a common high-volume TRC20 transfer. When
+    /// simulation is unavailable, this is multiplied by the chain's maximum
+    /// Dynamic Energy factor instead of sharing the much smaller opaque-swap
+    /// estimate below.
+    private static let DEFAULT_TRC20_BASE_ENERGY_USED: Int64 = 65_000
+    private static let DYNAMIC_ENERGY_FACTOR_SCALE: Int64 = 10_000
+
+    /// Energy estimate used for an opaque native-TRX contract swap when the
+    /// transaction bytes have not reached the fee layer yet.
     /// At 420 sun/energy this works out to 21 TRX; at the current 100-sun
     /// fallback price it is 5 TRX. This is a spending cap, not an upfront
     /// charge; successful calls consume only the resources they use.
@@ -169,11 +176,9 @@ class TronService {
     /// triggered `OUT_OF_ENERGY` whenever the actual energy cost exceeded
     /// `fee_limit / energy_price`.
     ///
-    /// **Native swap** (`triggerSmartContract` from a TRX coin) — we don't
-    /// yet have the function selector + calldata at this layer, so fall
-    /// back to a generous default budget (`DEFAULT_MAX_ENERGY_USED ×
-    /// energyFeePrice`) — same approach `vultisig-android` takes in
-    /// `TronFeeService.calculateDefaultFees`.
+    /// **Opaque native swap** — pre-built transaction bytes arrive after this
+    /// layer and cannot be simulated from the `isSwap` flag alone, so use the
+    /// smaller UI estimate (`DEFAULT_MAX_ENERGY_USED × energyFeePrice`).
     ///
     /// See https://developers.tron.network/docs/set-feelimit.
     private func calculateTronFee(coin: Coin, to: String?, memo: String?, isSwap: Bool) async throws -> BigInt {
@@ -181,11 +186,17 @@ class TronService {
         let activationFee = (try? await getTronInactiveDestinationFee(to: to)) ?? .zero
         let chainParams = try? await getCachedChainParameters()
         let energyPrice = chainParams?.energyFeePrice ?? TronChainParametersResponse.defaultEnergyFeePrice
+        let dynamicEnergyMaxFactor = chainParams?.dynamicEnergyMaxFactor
+            ?? TronChainParametersResponse.defaultDynamicEnergyMaxFactor
+        let maxFeeLimit = chainParams?.maxFeeLimit ?? TronChainParametersResponse.defaultMaxFeeLimit
 
         let transactionFee: BigInt
         if coin.isNativeToken {
             if isSwap {
-                transactionFee = Self.defaultContractFeeLimit(energyPrice: energyPrice)
+                transactionFee = Self.cappedFeeLimit(
+                    Self.defaultContractFeeLimit(energyPrice: energyPrice),
+                    maxFeeLimit: maxFeeLimit
+                )
             } else {
                 // A *successfully computed* 0 means sufficient bandwidth — a
                 // genuinely free transfer, surfaced as 0. But a thrown error
@@ -196,10 +207,20 @@ class TronService {
                 transactionFee = (try? await calculateNativeTrxFee(coin: coin)) ?? coin.feeDefault.toBigInt()
             }
         } else {
-            transactionFee = await calculateTrc20FeeLimit(coin: coin, to: to, energyPrice: energyPrice)
+            transactionFee = await calculateTrc20FeeLimit(
+                coin: coin,
+                to: to,
+                energyPrice: energyPrice,
+                dynamicEnergyMaxFactor: dynamicEnergyMaxFactor,
+                maxFeeLimit: maxFeeLimit
+            )
         }
 
-        return transactionFee + memoFee + activationFee
+        let totalFee = transactionFee + memoFee + activationFee
+        if isSwap || !coin.isNativeToken {
+            return Self.cappedFeeLimit(totalFee, maxFeeLimit: maxFeeLimit)
+        }
+        return totalFee
     }
 
     private func calculateNativeTrxFee(coin: Coin) async throws -> BigInt {
@@ -211,9 +232,20 @@ class TronService {
         )
     }
 
-    private func calculateTrc20FeeLimit(coin: Coin, to: String?, energyPrice: Int64) async -> BigInt {
+    private func calculateTrc20FeeLimit(
+        coin: Coin,
+        to: String?,
+        energyPrice: Int64,
+        dynamicEnergyMaxFactor: Int64,
+        maxFeeLimit: Int64
+    ) async -> BigInt {
+        let fallback = Self.defaultTrc20FeeLimit(
+            energyPrice: energyPrice,
+            dynamicEnergyMaxFactor: dynamicEnergyMaxFactor,
+            maxFeeLimit: maxFeeLimit
+        )
         guard let to, !to.isEmpty, !coin.contractAddress.isEmpty else {
-            return Self.defaultContractFeeLimit(energyPrice: energyPrice)
+            return fallback
         }
 
         let simulation: TronTriggerConstantResponse
@@ -224,29 +256,49 @@ class TronService {
                 toAddress: to
             )
         } catch {
-            return Self.defaultContractFeeLimit(energyPrice: energyPrice)
+            return fallback
         }
 
         guard simulation.result?.result == true,
               let energyUsed = simulation.energy_used, energyUsed > 0 else {
-            return Self.defaultContractFeeLimit(energyPrice: energyPrice)
+            return fallback
         }
 
-        return Self.contractFeeLimit(energyUsed: Int64(energyUsed), energyPrice: energyPrice)
+        return Self.cappedFeeLimit(
+            Self.contractFeeLimit(energyUsed: Int64(energyUsed), energyPrice: energyPrice),
+            maxFeeLimit: maxFeeLimit
+        )
     }
 
-    /// Conservative fallback budget for contract-execution paths whenever
-    /// simulation isn't possible or fails. Used so a transient RPC error
-    /// doesn't silently reintroduce `OUT_OF_ENERGY`. Operands are widened to
-    /// `BigInt` before multiplying so anomalous chain-parameter values can't
-    /// overflow `Int64`.
+    /// Opaque native-swap estimate. TRC20 simulation failures deliberately use
+    /// the larger max-factor budget below so this 50,000-energy value is never
+    /// written as a TRC20 `fee_limit`.
     static func defaultContractFeeLimit(energyPrice: Int64) -> BigInt {
         BigInt(DEFAULT_MAX_ENERGY_USED) * BigInt(energyPrice)
     }
 
+    /// Simulation-error budget for TRC20 transfers. TRON documents the
+    /// maximum Dynamic Energy factor as an additional multiplier scaled by
+    /// 10,000, so the total ceiling is `base × (1 + maxFactor)`.
+    static func defaultTrc20FeeLimit(
+        energyPrice: Int64,
+        dynamicEnergyMaxFactor: Int64,
+        maxFeeLimit: Int64
+    ) -> BigInt {
+        let safeMaxFactor = max(dynamicEnergyMaxFactor, 0)
+        let maxEnergyUnits = BigInt(DEFAULT_TRC20_BASE_ENERGY_USED)
+            * (BigInt(DYNAMIC_ENERGY_FACTOR_SCALE) + BigInt(safeMaxFactor))
+            / BigInt(DYNAMIC_ENERGY_FACTOR_SCALE)
+        return cappedFeeLimit(maxEnergyUnits * BigInt(energyPrice), maxFeeLimit: maxFeeLimit)
+    }
+
+    static func cappedFeeLimit(_ feeLimit: BigInt, maxFeeLimit: Int64) -> BigInt {
+        min(max(feeLimit, .zero), BigInt(max(maxFeeLimit, 0)))
+    }
+
     /// Translates a simulated `energy_used` into a `fee_limit` cap (in sun),
-    /// applying the documented 30% safety multiplier for dynamic-energy
-    /// surges. Pulled out so the math is testable in isolation. All
+    /// applying a 30% margin against estimate drift. Pulled out so the math
+    /// is testable in isolation. All
     /// multiplications are performed in `BigInt` so an unexpectedly large
     /// `energy_used` or `energyPrice` can't overflow `Int64` mid-calculation.
     static func contractFeeLimit(energyUsed: Int64, energyPrice: Int64) -> BigInt {

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Signing/Tron.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Signing/Tron.swift
@@ -31,9 +31,10 @@ enum TronHelper {
             throw HelperError.runtimeError("coin is not TRX")
         }
 
-        guard case .Tron(let timestamp, let expiration, let blockHeaderTimestamp, let blockHeaderNumber, let blockHeaderVersion, let blockHeaderTxTrieRoot, let blockHeaderParentHash, let blockHeaderWitnessAddress, let gasEstimation) = keysignPayload.chainSpecific else {
+        guard case .Tron(let timestamp, let expiration, let blockHeaderTimestamp, let blockHeaderNumber, let blockHeaderVersion, let blockHeaderTxTrieRoot, let blockHeaderParentHash, let blockHeaderWitnessAddress, let gasEstimation, let feeLimit) = keysignPayload.chainSpecific else {
             throw HelperError.runtimeError("fail to get Tron chain specific")
         }
+        let signedFeeLimit = feeLimit ?? gasEstimation
 
         guard Data(hexString: keysignPayload.coin.hexPublicKey) != nil else {
             throw HelperError.runtimeError("invalid hex public key")
@@ -54,7 +55,7 @@ enum TronHelper {
         if let smartContractPayload = keysignPayload.tronTriggerSmartContractPayload {
             return try buildTronSmartContractInput(
                 payload: smartContractPayload,
-                timestamp: timestamp, expiration: expiration, gasEstimation: gasEstimation,
+                timestamp: timestamp, expiration: expiration, gasEstimation: signedFeeLimit,
                 blockHeaderTimestamp: blockHeaderTimestamp, blockHeaderNumber: blockHeaderNumber,
                 blockHeaderVersion: blockHeaderVersion, blockHeaderTxTrieRoot: blockHeaderTxTrieRoot,
                 blockHeaderParentHash: blockHeaderParentHash, blockHeaderWitnessAddress: blockHeaderWitnessAddress,
@@ -65,7 +66,7 @@ enum TronHelper {
         if let assetPayload = keysignPayload.tronTransferAssetContractPayload {
             return try buildTronTransferAssetInput(
                 payload: assetPayload,
-                timestamp: timestamp, expiration: expiration, gasEstimation: gasEstimation,
+                timestamp: timestamp, expiration: expiration, gasEstimation: signedFeeLimit,
                 blockHeaderTimestamp: blockHeaderTimestamp, blockHeaderNumber: blockHeaderNumber,
                 blockHeaderVersion: blockHeaderVersion, blockHeaderTxTrieRoot: blockHeaderTxTrieRoot,
                 blockHeaderParentHash: blockHeaderParentHash, blockHeaderWitnessAddress: blockHeaderWitnessAddress,
@@ -82,7 +83,7 @@ enum TronHelper {
                 ownerAddress: keysignPayload.coin.address,
                 frozenBalance: keysignPayload.toAmount,
                 resource: resourceString,
-                timestamp: timestamp, expiration: expiration, gasEstimation: gasEstimation,
+                timestamp: timestamp, expiration: expiration, gasEstimation: signedFeeLimit,
                 blockHeaderTimestamp: blockHeaderTimestamp, blockHeaderNumber: blockHeaderNumber,
                 blockHeaderVersion: blockHeaderVersion, blockHeaderTxTrieRoot: blockHeaderTxTrieRoot,
                 blockHeaderParentHash: blockHeaderParentHash, blockHeaderWitnessAddress: blockHeaderWitnessAddress
@@ -99,7 +100,7 @@ enum TronHelper {
                 ownerAddress: keysignPayload.coin.address,
                 unfreezeBalance: keysignPayload.toAmount,
                 resource: resourceString,
-                timestamp: timestamp, expiration: expiration, gasEstimation: gasEstimation,
+                timestamp: timestamp, expiration: expiration, gasEstimation: signedFeeLimit,
                 blockHeaderTimestamp: blockHeaderTimestamp, blockHeaderNumber: blockHeaderNumber,
                 blockHeaderVersion: blockHeaderVersion, blockHeaderTxTrieRoot: blockHeaderTxTrieRoot,
                 blockHeaderParentHash: blockHeaderParentHash, blockHeaderWitnessAddress: blockHeaderWitnessAddress
@@ -167,7 +168,7 @@ enum TronHelper {
 
             let input = try TronSigningInput.with {
                 $0.transaction = try TronTransaction.with {
-                    $0.feeLimit = Int64(gasEstimation)
+                    $0.feeLimit = Int64(signedFeeLimit)
                     $0.transferTrc20Contract = contract
                     $0.timestamp = Int64(timestamp)
                     $0.blockHeader = try buildBlockHeader(

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/BlockChainSpecific.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/BlockChainSpecific.swift
@@ -58,7 +58,13 @@ enum BlockChainSpecific: Codable, Hashable {
         blockHeaderTxTrieRoot: String,
         blockHeaderParentHash: String,
         blockHeaderWitnessAddress: String,
-        gasFeeEstimation: UInt64
+        gasFeeEstimation: UInt64,
+        /// Gross ceiling written into the transaction. Local-only: the existing
+        /// protobuf `gas_estimation` field carries this value to co-signers, so
+        /// no wire/schema change is required. A decoded peer payload leaves this
+        /// nil and falls back to `gasFeeEstimation`, which is then the relayed
+        /// gross ceiling on that device.
+        feeLimit: UInt64? = nil
     )
 
     /// Return a copy with the EVM gas limit replaced. No-op for non-EVM cases
@@ -109,9 +115,20 @@ enum BlockChainSpecific: Codable, Hashable {
             return jettonAddress.isEmpty ? TonHelper.defaultFee : TonHelper.defaultJettonFee
         case .Ripple(_, let gas, _, _, _):
             return gas.description.toBigInt()
-        case .Tron(_, _, _, _, _, _, _, _, let gasFeeEstimation):
+        case .Tron(_, _, _, _, _, _, _, _, let gasFeeEstimation, _):
             return gasFeeEstimation.description.toBigInt()
         }
+    }
+
+    /// The gross TRON fee ceiling that every signer must put into the same
+    /// transaction bytes. Initiators keep a smaller post-resource display fee
+    /// beside it; peers receive this ceiling through the existing protobuf
+    /// `gas_estimation` field and therefore use the fallback.
+    var tronFeeLimit: UInt64? {
+        guard case .Tron(_, _, _, _, _, _, _, _, let gasFeeEstimation, let feeLimit) = self else {
+            return nil
+        }
+        return feeLimit ?? gasFeeEstimation
     }
 
     var fee: BigInt {

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
@@ -674,7 +674,8 @@ extension BlockChainSpecific {
             let blockHeaderTxTrieRoot,
             let blockHeaderParentHash,
             let blockHeaderWitnessAddress,
-            let gasEstimation
+            let gasEstimation,
+            let feeLimit
         ):
             return .tronSpecific(.with {
                 $0.timestamp = timestamp
@@ -685,7 +686,10 @@ extension BlockChainSpecific {
                 $0.blockHeaderParentHash = blockHeaderParentHash
                 $0.blockHeaderTxTrieRoot = blockHeaderTxTrieRoot
                 $0.blockHeaderWitnessAddress = blockHeaderWitnessAddress
-                $0.gasEstimation = gasEstimation
+                // Keep the wire contract unchanged: `gas_estimation` has always
+                // been the value signers write as `fee_limit`. The initiating
+                // device's post-stake display estimate is deliberately local.
+                $0.gasEstimation = feeLimit ?? gasEstimation
             })
         }
     }

--- a/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
@@ -19,6 +19,7 @@
 @testable import VultisigApp
 import XCTest
 import BigInt
+import WalletCore
 
 @MainActor
 final class TronServiceFeeLimitTests: XCTestCase {
@@ -114,22 +115,82 @@ final class TronServiceFeeLimitTests: XCTestCase {
 
     // MARK: - Dispatch (TronService.getBlockInfo)
 
-    /// Happy path: TRC20 transfer to an existing address with a successful
-    /// simulation. `gasFeeEstimation` should be derived from the simulated
-    /// energy_used (not the previous fixed 1 / 18 / 36 TRX ladder).
+    /// A successful simulation keeps two figures: the user's staked Energy
+    /// reduces the displayed burn to zero, while the signed ceiling remains the
+    /// gross simulated total plus headroom.
     func testGetBlockInfo_trc20Transfer_usesSimulationResult() async throws {
         let stub = TronStubHTTPClient()
-        stub.stubDefaults(energyUsed: 65_000)
+        stub.stubDefaults(energyUsed: 65_000, energyPenalty: 50_000)
         let service = TronService(httpClient: stub)
 
         let coin = makeTrc20Coin()
         let result = try await service.getBlockInfo(coin: coin, to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", memo: nil)
-        let gasFee = extractGasFee(result)
 
-        // 65,000 × 1.3 × 420 = 35,490,000 sun. memo and activation are 0
-        // in this scenario (no memo, destination account "exists" per the
-        // stub's getaccount response).
-        XCTAssertEqual(gasFee, 35_490_000)
+        XCTAssertEqual(extractGasFee(result), 0)
+        XCTAssertEqual(extractFeeLimit(result), 35_490_000)
+    }
+
+    func testPenaltyPortionRemainsInGrossAndDisplayedEnergy() async throws {
+        let stub = TronStubHTTPClient()
+        // Official TRON semantics: energy_used is the 65k TOTAL and
+        // energy_penalty is the 50k Dynamic Energy subset inside it. The fee
+        // must use 65k, not the 15k base and not a double-counted 115k.
+        stub.stubDefaults(energyUsed: 65_000, energyPenalty: 50_000)
+        stub.setAvailableEnergy(0)
+        let service = TronService(httpClient: stub)
+
+        let result = try await service.getBlockInfo(
+            coin: makeTrc20Coin(),
+            to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+        )
+
+        XCTAssertEqual(extractGasFee(result), 27_300_000)
+        XCTAssertEqual(extractFeeLimit(result), 35_490_000)
+    }
+
+    func testFullStakedEnergyOnlyDiscountsDisplayedBurn() async throws {
+        let stub = TronStubHTTPClient()
+        stub.stubDefaults(energyUsed: 65_000, energyPenalty: 50_000)
+        stub.setAvailableEnergy(65_000)
+        let service = TronService(httpClient: stub)
+
+        let result = try await service.getBlockInfo(
+            coin: makeTrc20Coin(),
+            to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+        )
+
+        XCTAssertEqual(extractGasFee(result), 0)
+        XCTAssertEqual(extractFeeLimit(result), 35_490_000)
+    }
+
+    func testPartialStakedEnergyOnlyDiscountsUncoveredBurn() async throws {
+        let stub = TronStubHTTPClient()
+        stub.stubDefaults(energyUsed: 65_000, energyPenalty: 50_000)
+        stub.setAvailableEnergy(30_000)
+        let service = TronService(httpClient: stub)
+
+        let result = try await service.getBlockInfo(
+            coin: makeTrc20Coin(),
+            to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+        )
+
+        XCTAssertEqual(extractGasFee(result), 14_700_000)
+        XCTAssertEqual(extractFeeLimit(result), 35_490_000)
+    }
+
+    func testResourceFetchFailureShowsFullBurnWithoutLoweringCeiling() async throws {
+        let stub = TronStubHTTPClient()
+        stub.stubDefaults(energyUsed: 65_000, energyPenalty: 50_000)
+        stub.errors["/wallet/getaccountresource"] = HTTPError.invalidResponse
+        let service = TronService(httpClient: stub)
+
+        let result = try await service.getBlockInfo(
+            coin: makeTrc20Coin(),
+            to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+        )
+
+        XCTAssertEqual(extractGasFee(result), 27_300_000)
+        XCTAssertEqual(extractFeeLimit(result), 35_490_000)
     }
 
     /// Simulation throws (network error / TRON gateway 5xx). Old behavior
@@ -179,6 +240,123 @@ final class TronServiceFeeLimitTests: XCTestCase {
                 maxFeeLimit: 15_000_000_000
             ))
         )
+    }
+
+    func testSuccessfulSimulationWithMessageFallsBack() async throws {
+        let stub = TronStubHTTPClient()
+        stub.stubDefaults(energyUsed: 10, energyPenalty: 0)
+        stub.setResponse(path: "/wallet/triggerconstantcontract", json: """
+        {"result":{"result":true,"message":"REVERT opcode executed"},"energy_used":10,"energy_penalty":0}
+        """)
+        let service = TronService(httpClient: stub)
+
+        let result = try await service.getBlockInfo(
+            coin: makeTrc20Coin(),
+            to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+        )
+        let fallback = UInt64(TronService.defaultTrc20FeeLimit(
+            energyPrice: 420,
+            dynamicEnergyMaxFactor: 34_000,
+            maxFeeLimit: 15_000_000_000
+        ))
+
+        XCTAssertEqual(extractGasFee(result), fallback)
+        XCTAssertEqual(extractFeeLimit(result), fallback)
+    }
+
+    func testDisplayedAndSignedFeesRespectChainMaximum() async throws {
+        let stub = TronStubHTTPClient()
+        stub.stubDefaults(energyUsed: 65_000, energyPenalty: 50_000)
+        stub.setAvailableEnergy(0)
+        stub.setResponse(path: "/wallet/getchainparameters", json: """
+        {"chainParameter":[
+            {"key":"getEnergyFee","value":420},
+            {"key":"getTransactionFee","value":1000},
+            {"key":"getDynamicEnergyMaxFactor","value":34000},
+            {"key":"getMaxFeeLimit","value":10000000}
+        ]}
+        """)
+        let service = TronService(httpClient: stub)
+
+        let result = try await service.getBlockInfo(
+            coin: makeTrc20Coin(),
+            to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+        )
+
+        XCTAssertEqual(extractGasFee(result), 10_000_000)
+        XCTAssertEqual(extractFeeLimit(result), 10_000_000)
+    }
+
+    func testProtoKeepsGrossCeilingWithoutNewWireField() throws {
+        let local = makeTronSpecific(displayFee: 1_000_000, feeLimit: 35_490_000)
+        guard case .tronSpecific(let proto) = local.mapToProtobuff() else {
+            return XCTFail("expected tron proto")
+        }
+
+        XCTAssertEqual(local.gas, 1_000_000)
+        XCTAssertEqual(local.tronFeeLimit, 35_490_000)
+        XCTAssertEqual(proto.gasEstimation, 35_490_000)
+
+        let legacy = makeTronSpecific(displayFee: 35_490_000)
+        guard case .tronSpecific(let legacyProto) = legacy.mapToProtobuff() else {
+            return XCTFail("expected legacy tron proto")
+        }
+        XCTAssertEqual(proto, legacyProto)
+
+        let peer = try BlockChainSpecific(proto: .tronSpecific(proto))
+        XCTAssertEqual(peer.gas, 35_490_000)
+        XCTAssertEqual(peer.tronFeeLimit, local.tronFeeLimit)
+    }
+
+    func testLocalAndProtoRoundTripSignIdenticalGrossFeeLimit() throws {
+        let localSpecific = makeTronSpecific(displayFee: 1_000_000, feeLimit: 35_490_000)
+        guard case .tronSpecific(let proto) = localSpecific.mapToProtobuff() else {
+            return XCTFail("expected tron proto")
+        }
+        let peerSpecific = try BlockChainSpecific(proto: .tronSpecific(proto))
+        let coin = SigningGoldenFactory.coin(
+            chain: .tron,
+            ticker: "USDT",
+            decimals: 6,
+            contractAddress: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+            isNativeToken: false,
+            curve: .secp256k1,
+            uncompressedSecp: true
+        )
+        let recipient = SigningGoldenFactory.recipient(.tron)
+        let localPayload = SigningGoldenFactory.payload(
+            coin: coin,
+            toAddress: recipient,
+            toAmount: 1,
+            chainSpecific: localSpecific
+        )
+        let peerPayload = SigningGoldenFactory.payload(
+            coin: coin,
+            toAddress: recipient,
+            toAmount: 1,
+            chainSpecific: peerSpecific
+        )
+
+        let localBytes = try TronHelper.getPreSignedInputData(keysignPayload: localPayload)
+        let peerBytes = try TronHelper.getPreSignedInputData(keysignPayload: peerPayload)
+        let localInput = try TronSigningInput(serializedBytes: localBytes)
+        let peerInput = try TronSigningInput(serializedBytes: peerBytes)
+
+        XCTAssertEqual(localInput.transaction.feeLimit, 35_490_000)
+        XCTAssertEqual(peerInput.transaction.feeLimit, 35_490_000)
+        XCTAssertEqual(localBytes, peerBytes)
+    }
+
+    func testLegacyTronSpecificCodableWithoutFeeLimitStillDecodes() throws {
+        let legacy = makeTronSpecific(displayFee: 35_490_000)
+        let encoded = try JSONEncoder().encode(legacy)
+        let json = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+
+        XCTAssertFalse(json.contains("feeLimit"))
+
+        let decoded = try JSONDecoder().decode(BlockChainSpecific.self, from: encoded)
+        XCTAssertEqual(decoded.gas, 35_490_000)
+        XCTAssertEqual(decoded.tronFeeLimit, 35_490_000)
     }
 
     /// Opaque native TRX swap (`isSwap == true`). The pre-built transaction
@@ -347,11 +525,34 @@ final class TronServiceFeeLimitTests: XCTestCase {
     }
 
     private func extractGasFee(_ specific: BlockChainSpecific) -> UInt64 {
-        guard case .Tron(_, _, _, _, _, _, _, _, let gasFee) = specific else {
+        guard case .Tron(_, _, _, _, _, _, _, _, let gasFee, _) = specific else {
             XCTFail("expected .Tron, got \(specific)")
             return 0
         }
         return gasFee
+    }
+
+    private func extractFeeLimit(_ specific: BlockChainSpecific) -> UInt64 {
+        guard let feeLimit = specific.tronFeeLimit else {
+            XCTFail("expected .Tron, got \(specific)")
+            return 0
+        }
+        return feeLimit
+    }
+
+    private func makeTronSpecific(displayFee: UInt64, feeLimit: UInt64? = nil) -> BlockChainSpecific {
+        .Tron(
+            timestamp: 1,
+            expiration: 2,
+            blockHeaderTimestamp: 3,
+            blockHeaderNumber: 4,
+            blockHeaderVersion: 5,
+            blockHeaderTxTrieRoot: String(repeating: "06", count: 32),
+            blockHeaderParentHash: String(repeating: "07", count: 32),
+            blockHeaderWitnessAddress: "41" + String(repeating: "08", count: 20),
+            gasFeeEstimation: displayFee,
+            feeLimit: feeLimit
+        )
     }
 }
 
@@ -412,7 +613,7 @@ private final class TronStubHTTPClient: HTTPClientProtocol {
 
     /// Wires up a baseline of valid responses for every endpoint the fee
     /// path touches. Individual tests override specific entries.
-    func stubDefaults(energyUsed: Int) {
+    func stubDefaults(energyUsed: Int, energyPenalty: Int = 0) {
         setResponse(path: "/wallet/getnowblock", json: """
         {"block_header":{"raw_data":{"timestamp":1700000000,"number":1,"version":0,"txTrieRoot":"00","parentHash":"00","witness_address":"00"}}}
         """)
@@ -432,7 +633,13 @@ private final class TronStubHTTPClient: HTTPClientProtocol {
         {"address":"TGexisting","balance":1}
         """)
         setResponse(path: "/wallet/triggerconstantcontract", json: """
-        {"result":{"result":true},"energy_used":\(energyUsed)}
+        {"result":{"result":true},"energy_used":\(energyUsed),"energy_penalty":\(energyPenalty)}
+        """)
+    }
+
+    func setAvailableEnergy(_ energy: Int64) {
+        setResponse(path: "/wallet/getaccountresource", json: """
+        {"freeNetUsed":0,"freeNetLimit":0,"NetUsed":0,"NetLimit":0,"EnergyUsed":0,"EnergyLimit":\(energy)}
         """)
     }
 }

--- a/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
@@ -43,8 +43,8 @@ final class TronServiceFeeLimitTests: XCTestCase {
         XCTAssertGreaterThan(withSafety, bare)
     }
 
-    /// `defaultContractFeeLimit` returns the docs-backed fallback budget
-    /// used when simulation isn't possible. 50,000 energy × 420 sun =
+    /// `defaultContractFeeLimit` returns the opaque-swap estimate used before
+    /// pre-built transaction bytes reach the fee layer. 50,000 energy × 420 sun =
     /// 21,000,000 sun (21 TRX).
     func testDefaultContractFeeLimitReturnsTwentyOneTrxAt420Sun() {
         XCTAssertEqual(
@@ -74,6 +74,8 @@ final class TronServiceFeeLimitTests: XCTestCase {
         )
 
         XCTAssertEqual(response.energyFeePrice, 100)
+        XCTAssertEqual(response.dynamicEnergyMaxFactor, 34_000)
+        XCTAssertEqual(response.maxFeeLimit, 15_000_000_000)
     }
 
     func testEnergyFeePriceFallsBackToCurrentBaselineWhenParameterInvalid() throws {
@@ -83,6 +85,31 @@ final class TronServiceFeeLimitTests: XCTestCase {
         )
 
         XCTAssertEqual(response.energyFeePrice, 100)
+    }
+
+    func testTrc20FallbackUsesMaximumDynamicEnergyFactor() {
+        let observedTransferWithHeadroom = TronService.contractFeeLimit(
+            energyUsed: 130_285,
+            energyPrice: 100
+        )
+        let fallback = TronService.defaultTrc20FeeLimit(
+            energyPrice: 100,
+            dynamicEnergyMaxFactor: 34_000,
+            maxFeeLimit: 15_000_000_000
+        )
+
+        XCTAssertEqual(
+            fallback,
+            BigInt(28_600_000)
+        )
+        XCTAssertGreaterThan(fallback, observedTransferWithHeadroom)
+    }
+
+    func testContractFeeLimitNeverExceedsChainMaximum() {
+        XCTAssertEqual(
+            TronService.cappedFeeLimit(BigInt(21_000_000_000), maxFeeLimit: 15_000_000_000),
+            BigInt(15_000_000_000)
+        )
     }
 
     // MARK: - Dispatch (TronService.getBlockInfo)
@@ -108,7 +135,7 @@ final class TronServiceFeeLimitTests: XCTestCase {
     /// Simulation throws (network error / TRON gateway 5xx). Old behavior
     /// fell through to `BYTES_PER_CONTRACT_TX * 1000` (~0.345 TRX), which
     /// silently re-introduced OUT_OF_ENERGY. New behavior: fall back to
-    /// the safe default budget (21 TRX at the test chain price).
+    /// the max-factor fallback (120.12 TRX at the test chain price).
     func testGetBlockInfo_trc20Transfer_fallsBackOnSimulationError() async throws {
         let stub = TronStubHTTPClient()
         stub.stubDefaults(energyUsed: 65_000)
@@ -119,7 +146,14 @@ final class TronServiceFeeLimitTests: XCTestCase {
         let result = try await service.getBlockInfo(coin: coin, to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", memo: nil)
         let gasFee = extractGasFee(result)
 
-        XCTAssertEqual(gasFee, UInt64(TronService.defaultContractFeeLimit(energyPrice: 420)))
+        XCTAssertEqual(
+            gasFee,
+            UInt64(TronService.defaultTrc20FeeLimit(
+                energyPrice: 420,
+                dynamicEnergyMaxFactor: 34_000,
+                maxFeeLimit: 15_000_000_000
+            ))
+        )
     }
 
     /// Simulation returns `result.result = false` (e.g. insufficient TRC20
@@ -137,13 +171,18 @@ final class TronServiceFeeLimitTests: XCTestCase {
         let result = try await service.getBlockInfo(coin: coin, to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", memo: nil)
         let gasFee = extractGasFee(result)
 
-        XCTAssertEqual(gasFee, UInt64(TronService.defaultContractFeeLimit(energyPrice: 420)))
+        XCTAssertEqual(
+            gasFee,
+            UInt64(TronService.defaultTrc20FeeLimit(
+                energyPrice: 420,
+                dynamicEnergyMaxFactor: 34_000,
+                maxFeeLimit: 15_000_000_000
+            ))
+        )
     }
 
-    /// Native TRX swap (`isSwap == true`). We don't yet have the contract
-    /// function selector + parameter at fee-calc time, so use the default
-    /// budget — better than the prior bandwidth-only fee that would
-    /// trigger OUT_OF_ENERGY on the swap's `triggerSmartContract` path.
+    /// Opaque native TRX swap (`isSwap == true`). The pre-built transaction
+    /// reaches the signer later, so this layer uses its smaller UI estimate.
     func testGetBlockInfo_nativeSwap_usesDefaultContractBudget() async throws {
         let stub = TronStubHTTPClient()
         stub.stubDefaults(energyUsed: 0)
@@ -170,6 +209,21 @@ final class TronServiceFeeLimitTests: XCTestCase {
         )
 
         XCTAssertEqual(extractGasFee(result), 5_000_000)
+    }
+
+    func testTrc20SimulationFailureNeverUsesOpaqueSwapEstimate() async throws {
+        let stub = TronStubHTTPClient()
+        stub.stubDefaults(energyUsed: 0)
+        stub.errors["/wallet/getchainparameters"] = HTTPError.invalidResponse
+        stub.errors["/wallet/triggerconstantcontract"] = HTTPError.invalidResponse
+        let service = TronService(httpClient: stub)
+
+        let result = try await service.getBlockInfo(
+            coin: makeTrc20Coin(),
+            to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+        )
+
+        XCTAssertEqual(extractGasFee(result), 28_600_000)
     }
 
     /// Native TRX transfer with sufficient bandwidth — the daily free-net
@@ -363,7 +417,12 @@ private final class TronStubHTTPClient: HTTPClientProtocol {
         {"block_header":{"raw_data":{"timestamp":1700000000,"number":1,"version":0,"txTrieRoot":"00","parentHash":"00","witness_address":"00"}}}
         """)
         setResponse(path: "/wallet/getchainparameters", json: """
-        {"chainParameter":[{"key":"getEnergyFee","value":420},{"key":"getTransactionFee","value":1000}]}
+        {"chainParameter":[
+            {"key":"getEnergyFee","value":420},
+            {"key":"getTransactionFee","value":1000},
+            {"key":"getDynamicEnergyMaxFactor","value":34000},
+            {"key":"getMaxFeeLimit","value":15000000000}
+        ]}
         """)
         setResponse(path: "/wallet/getaccountresource", json: """
         {"freeNetUsed":0,"freeNetLimit":0,"NetUsed":0,"NetLimit":0,"EnergyUsed":0,"EnergyLimit":1000000}

--- a/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
@@ -3,7 +3,7 @@
 //  VultisigAppTests
 //
 //  Pins the simulation-based `fee_limit` math behind the TRC20 / swap
-//  OUT_OF_ENERGY fix (issue/PR #4131). The bug being addressed:
+//  OUT_OF_ENERGY fix. The bug being addressed:
 //  `Vault.fee_limit` is a strict upper bound on the energy budget the TVM
 //  is willing to use for a contract call (`max_energy = fee_limit /
 //  energy_unit_price`). The pre-fix code returned a 1 TRX / 18 TRX / 36 TRX
@@ -44,13 +44,12 @@ final class TronServiceFeeLimitTests: XCTestCase {
     }
 
     /// `defaultContractFeeLimit` returns the docs-backed fallback budget
-    /// used when simulation isn't possible. 50,000,000 energy × 420 sun =
-    /// 21,000,000,000 sun (21 TRX). Mirrors the Android
-    /// `TronFeeService.DEFAULT_MAX_ENERGY_USED` reference.
-    func testDefaultContractFeeLimit_returnsTwentyOneTrxAtCurrentEnergyPrice() {
+    /// used when simulation isn't possible. 50,000 energy × 420 sun =
+    /// 21,000,000 sun (21 TRX).
+    func testDefaultContractFeeLimitReturnsTwentyOneTrxAt420Sun() {
         XCTAssertEqual(
             TronService.defaultContractFeeLimit(energyPrice: 420),
-            BigInt(21_000_000_000)
+            BigInt(21_000_000)
         )
     }
 
@@ -60,12 +59,30 @@ final class TronServiceFeeLimitTests: XCTestCase {
     func testDefaultContractFeeLimit_scalesWithEnergyPrice() {
         XCTAssertEqual(
             TronService.defaultContractFeeLimit(energyPrice: 100),
-            BigInt(5_000_000_000)
+            BigInt(5_000_000)
         )
         XCTAssertEqual(
             TronService.defaultContractFeeLimit(energyPrice: 1_000),
-            BigInt(50_000_000_000)
+            BigInt(50_000_000)
         )
+    }
+
+    func testEnergyFeePriceFallsBackToCurrentBaselineWhenParameterMissing() throws {
+        let response = try JSONDecoder().decode(
+            TronChainParametersResponse.self,
+            from: Data(#"{"chainParameter":[]}"#.utf8)
+        )
+
+        XCTAssertEqual(response.energyFeePrice, 100)
+    }
+
+    func testEnergyFeePriceFallsBackToCurrentBaselineWhenParameterInvalid() throws {
+        let response = try JSONDecoder().decode(
+            TronChainParametersResponse.self,
+            from: Data(#"{"chainParameter":[{"key":"getEnergyFee","value":0}]}"#.utf8)
+        )
+
+        XCTAssertEqual(response.energyFeePrice, 100)
     }
 
     // MARK: - Dispatch (TronService.getBlockInfo)
@@ -91,7 +108,7 @@ final class TronServiceFeeLimitTests: XCTestCase {
     /// Simulation throws (network error / TRON gateway 5xx). Old behavior
     /// fell through to `BYTES_PER_CONTRACT_TX * 1000` (~0.345 TRX), which
     /// silently re-introduced OUT_OF_ENERGY. New behavior: fall back to
-    /// the safe default budget (~21 TRX).
+    /// the safe default budget (21 TRX at the test chain price).
     func testGetBlockInfo_trc20Transfer_fallsBackOnSimulationError() async throws {
         let stub = TronStubHTTPClient()
         stub.stubDefaults(energyUsed: 65_000)
@@ -137,6 +154,22 @@ final class TronServiceFeeLimitTests: XCTestCase {
         let gasFee = extractGasFee(result)
 
         XCTAssertEqual(gasFee, UInt64(TronService.defaultContractFeeLimit(energyPrice: 420)))
+    }
+
+    func testNativeSwapUsesCurrentFallbackWhenChainParametersUnavailable() async throws {
+        let stub = TronStubHTTPClient()
+        stub.stubDefaults(energyUsed: 0)
+        stub.errors["/wallet/getchainparameters"] = HTTPError.invalidResponse
+        let service = TronService(httpClient: stub)
+
+        let result = try await service.getBlockInfo(
+            coin: makeNativeCoin(),
+            to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+            memo: nil,
+            isSwap: true
+        )
+
+        XCTAssertEqual(extractGasFee(result), 5_000_000)
     }
 
     /// Native TRX transfer with sufficient bandwidth — the daily free-net


### PR DESCRIPTION
## Description

Separate the user-visible TRC-20 burn estimate from the gross `fee_limit` used for signing.

- reject simulations that return a non-empty revert/error message
- treat `energy_used` as TRON's documented total (with `energy_penalty` already included)
- subtract available staked Energy only from the displayed burn
- preserve the buffered, chain-capped gross ceiling for every signer
- keep the protobuf schema unchanged by relaying the gross ceiling through the existing `gas_estimation` field
- prove local and proto-round-tripped peers produce identical signing bytes

This is stacked on #5299 because it extends that PR's corrected TRC-20 fallback and chain-parameter handling. Retarget to `main` after #5299 merges.

Fixes #5295

## Which feature is affected?

- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [x] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [x] New Chain / Chain related feature  -  Please attach tx link here

No transaction link: this draft requires on-device TRON validation before merge.

## Parity

- Android: first: iOS correction; Android's related fee paths were inspected and need a follow-up audit against the documented `energy_used` semantics
- Windows + extension: first: iOS TRC-20 display/gross split; no equivalent implementation was found in scope
- SDK: first: iOS correction; the SDK currently sums `energy_used` and `energy_penalty` and should be audited separately

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

Not applicable; fee presentation requires live-account validation rather than a static screenshot.

## Additional context

Official TRON semantics show `energy_penalty` is the dynamic-energy subset of `energy_used`, not an additional amount. Adding them would double-count. The full local suite passed: 6,894 tests, 11 skipped, 0 failures. Claude review was skipped as requested.

Manual validation requested for live USDT transfers with full, partial, and zero staked Energy; reverted simulation/resource-endpoint failures; and multi-device signing.

## Agent Metadata (if applicable)

- **Agent**: Codex
- **Issue**: #5295
- **Confidence**: medium
- **Needs human review for**: live TRON fee comparison and multi-device signing parity


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved TRON fee estimates by separating displayed costs from transaction fee limits.
  - Account resources, simulated energy usage, penalties, and available staked energy are now considered for more accurate TRC20 fee calculations.
  - Added safeguards and conservative fallbacks when fee simulation or resource data is unavailable.
  - TRON transactions now consistently apply the calculated fee limit across supported transaction types.
  - Existing transactions remain compatible when no fee limit is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->