### PR TITLE
fix(tron): remove phantom staking memo fee

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
@@ -288,11 +288,10 @@ class TronService {
             return BigInt.zero
         }
 
-        // This marker selects a local WalletCore system-contract builder; it
-        // is deliberately omitted from the transaction's `data` field. A TRON
-        // memo fee is charged only for data that actually reaches the wire, so
-        // adding getMemoFee here would show a fee the claim cannot incur.
-        guard memo != TronHelper.withdrawExpireUnfreezeMemo else {
+        // System-contract routing markers are omitted from the transaction's
+        // `data` field. A TRON memo fee applies only to data that reaches the
+        // wire, so these local instructions must not add getMemoFee.
+        guard !TronHelper.isSystemContractRoutingMemo(memo) else {
             return BigInt.zero
         }
 

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Signing/Tron.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Signing/Tron.swift
@@ -13,12 +13,23 @@ import OSLog
 
 enum TronHelper {
 
+    static let freezeMemoPrefix = "FREEZE:"
+    static let unfreezeMemoPrefix = "UNFREEZE:"
+
     /// Memo that routes a self-addressed native TRX payload to
     /// `WithdrawExpireUnfreezeContract` — the Stake 2.0 claim that moves every
     /// expired `UnfreezeBalanceV2` entry back into the spendable balance.
     /// Matched exactly (no argument: the contract takes none) and named after
     /// the TRON contract so co-signing platforms can mirror the convention.
     static let withdrawExpireUnfreezeMemo = "WITHDRAW_EXPIRE_UNFREEZE"
+
+    /// These app-local markers select WalletCore system-contract builders and
+    /// are never serialized into the transaction data field.
+    static func isSystemContractRoutingMemo(_ memo: String) -> Bool {
+        memo == withdrawExpireUnfreezeMemo
+            || memo.hasPrefix(freezeMemoPrefix)
+            || memo.hasPrefix(unfreezeMemoPrefix)
+    }
 
     static func getSwapPreSignedInputData(keysignPayload: KeysignPayload) throws -> Data {
         // For TRX swaps, we use the same logic as regular transactions but with swap memo
@@ -73,8 +84,8 @@ enum TronHelper {
             )
         }
         // FreezeBalanceV2 (Stake 2.0) - detect from memo
-        if let memo = keysignPayload.memo, memo.hasPrefix("FREEZE:") {
-            let resourceString = String(memo.dropFirst("FREEZE:".count))
+        if let memo = keysignPayload.memo, memo.hasPrefix(freezeMemoPrefix) {
+            let resourceString = String(memo.dropFirst(freezeMemoPrefix.count))
             guard resourceString == "BANDWIDTH" || resourceString == "ENERGY" else {
                 throw HelperError.runtimeError("Invalid TRON resource type: \(resourceString)")
             }
@@ -90,8 +101,8 @@ enum TronHelper {
         }
 
         // UnfreezeBalanceV2 (Stake 2.0) - detect from memo
-        if let memo = keysignPayload.memo, memo.hasPrefix("UNFREEZE:") {
-            let resourceString = String(memo.dropFirst("UNFREEZE:".count))
+        if let memo = keysignPayload.memo, memo.hasPrefix(unfreezeMemoPrefix) {
+            let resourceString = String(memo.dropFirst(unfreezeMemoPrefix.count))
             guard resourceString == "BANDWIDTH" || resourceString == "ENERGY" else {
                 throw HelperError.runtimeError("Invalid TRON resource type: \(resourceString)")
             }

--- a/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
@@ -182,6 +182,26 @@ final class TronServiceFeeLimitTests: XCTestCase {
         XCTAssertEqual(extractGasFee(result), 0)
     }
 
+    func testFreezeAndUnfreezeDoNotChargeRoutingMemoFee() async throws {
+        for memo in ["FREEZE:BANDWIDTH", "FREEZE:ENERGY", "UNFREEZE:BANDWIDTH", "UNFREEZE:ENERGY"] {
+            let stub = TronStubHTTPClient()
+            stub.stubDefaults(energyUsed: 0)
+            stub.setResponse(path: "/wallet/getaccountresource", json: """
+            {"freeNetUsed":0,"freeNetLimit":600,"NetUsed":0,"NetLimit":10000,"EnergyUsed":0,"EnergyLimit":0}
+            """)
+            let service = TronService(httpClient: stub)
+            let coin = makeNativeCoin()
+
+            let result = try await service.getBlockInfo(
+                coin: coin,
+                to: coin.address,
+                memo: memo
+            )
+
+            XCTAssertEqual(extractGasFee(result), 0, "Unexpected memo fee for \(memo)")
+        }
+    }
+
     /// A real memo still pays the chain's getMemoFee parameter; the routing-
     /// marker exception above must not weaken ordinary TRON fee estimation.
     func testNativeTransferRealMemoStillChargesMemoFee() async throws {


### PR DESCRIPTION
## Description

Stop charging TRON's 1 TRX memo fee for the app-local `FREEZE:` and `UNFREEZE:` routing markers. These markers select WalletCore staking builders but are never serialized into the transaction memo/data field.

The change shares the routing-marker detection with signing and adds regression coverage for both BANDWIDTH and ENERGY freeze/unfreeze operations while preserving the fee for real memos.

Fixes #5296

## Which feature is affected?

- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [x] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [x] New Chain / Chain related feature  -  Please attach tx link here

No transaction link: this draft requires an on-device freeze/unfreeze check before merge.

## Parity

- Android: linked: vultisig/vultisig-android#5481
- Windows + extension: n/a: the iOS WalletCore routing markers are not used there
- SDK: n/a: the iOS WalletCore routing markers are not used there

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

Not applicable; fee behavior is covered by service-level tests.

## Additional context

The full local suite passed: 6,880 tests, 11 skipped, 0 failures. Claude review was skipped as requested.

## Agent Metadata (if applicable)

- **Agent**: Codex
- **Issue**: #5296
- **Confidence**: high
- **Needs human review for**: on-device freeze/unfreeze fee confirmation
