### PR TITLE
test(swap): cover native quote minimum guard

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -625,9 +625,12 @@ private extension SwapService {
                 throw SwapError.swapAmountTooSmall
             }
 
-            if let minSwapAmountDecimal = Decimal(string: rapidQuote.recommendedMinAmountIn), normalizedAmount < minSwapAmountDecimal {
-                let recommendedAmount = "\(minSwapAmountDecimal / fromCoin.thorswapMultiplier) \(fromCoin.ticker)"
-                throw SwapError.lessThenMinSwapAmount(amount: recommendedAmount)
+            if let belowMinimum = Self.belowRecommendedMinimumError(
+                normalizedAmount: normalizedAmount,
+                recommendedMinAmountIn: rapidQuote.recommendedMinAmountIn,
+                fromCoin: fromCoin
+            ) {
+                throw belowMinimum
             }
 
             let quote = await maybeUpgradeToStreaming(
@@ -809,6 +812,33 @@ private extension SwapService {
             slippageBps: slippageBps
         )
         return .jupiter(quote, fee: fee, platformFee: platformFee, feeOnInput: feeOnInput)
+    }
+}
+
+// MARK: - Recommended-minimum guard
+
+extension SwapService {
+    /// The per-candidate "below the node's own recommended floor" verdict for a
+    /// native THORChain/MAYAChain quote, or `nil` when the amount clears it.
+    ///
+    /// The comparison stays in node fixed-point units. The multiplier comes from
+    /// the source coin's native scale (1e10 for CACAO), while off-chain assets
+    /// use THORChain's 1e8 scale. The same multiplier converts the node's floor
+    /// back to a user-facing amount.
+    ///
+    /// A present but malformed floor fails open. An omitted floor fails quote
+    /// decoding earlier because `recommendedMinAmountIn` is required.
+    static func belowRecommendedMinimumError(
+        normalizedAmount: Decimal,
+        recommendedMinAmountIn: String,
+        fromCoin: Coin
+    ) -> SwapError? {
+        guard let minimum = Decimal(string: recommendedMinAmountIn),
+              normalizedAmount < minimum else {
+            return nil
+        }
+        let recommendedAmount = "\(minimum / fromCoin.thorswapMultiplier) \(fromCoin.ticker)"
+        return .lessThenMinSwapAmount(amount: recommendedAmount)
     }
 }
 

--- a/VultisigApp/VultisigAppTests/Swap/DefaultSwapInteractorTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/DefaultSwapInteractorTests.swift
@@ -190,7 +190,7 @@ final class DefaultSwapInteractorTests: XCTestCase {
     /// Ties the fix to the observable symptom: a Gold vault must send
     /// `affiliate_bps = 30`, not the undiscounted 50. Mayanode's
     /// `recommended_min_amount_in` is inversely proportional to the affiliate
-    /// bps, so sending 50 raised the minimum the reporter's route was measured
+    /// bps, so sending 50 lowered the minimum the reporter's route was measured
     /// against and changed which routes were offered.
     func testGoldTierYieldsThirtyAffiliateBps() async throws {
         let tierResolver = MockDiscountTierResolver(tier: .gold)

--- a/VultisigApp/VultisigAppTests/Swap/SwapRecommendedMinimumGuardTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapRecommendedMinimumGuardTests.swift
@@ -1,0 +1,150 @@
+//
+//  SwapRecommendedMinimumGuardTests.swift
+//  VultisigAppTests
+//
+//  Pins the per-candidate minimum guard that keeps below-floor native routes
+//  out of the ranked set and therefore out of the Select-route picker.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class SwapRecommendedMinimumGuardTests: XCTestCase {
+
+    /// 0.00014844 BTC in THORChain 1e8 fixed point.
+    private let normalizedBtcAmount = Decimal(14_844)
+
+    /// Historical Mayanode floor at 30 affiliate bps for the reported swap.
+    func testGuardRejectsAmountBelowNodeFloor() {
+        let verdict = SwapService.belowRecommendedMinimumError(
+            normalizedAmount: normalizedBtcAmount,
+            recommendedMinAmountIn: "24092",
+            fromCoin: makeCoin(.bitcoin, ticker: "BTC", decimals: 8)
+        )
+
+        guard case .lessThenMinSwapAmount(let amount)? = verdict else {
+            return XCTFail("A node floor above the swap amount must produce the minimum-amount verdict")
+        }
+        XCTAssertEqual(amount, "0.00024092 BTC")
+    }
+
+    /// Historical Mayanode floor at 50 affiliate bps for the same swap.
+    func testGuardAllowsAmountAboveNodeFloor() {
+        XCTAssertNil(
+            SwapService.belowRecommendedMinimumError(
+                normalizedAmount: normalizedBtcAmount,
+                recommendedMinAmountIn: "14455",
+                fromCoin: makeCoin(.bitcoin, ticker: "BTC", decimals: 8)
+            )
+        )
+    }
+
+    /// Historical Mayanode fallback floor when the request sent zero affiliate bps.
+    func testGuardAllowsAmountWithoutAffiliateFloor() {
+        XCTAssertNil(
+            SwapService.belowRecommendedMinimumError(
+                normalizedAmount: normalizedBtcAmount,
+                recommendedMinAmountIn: "8944",
+                fromCoin: makeCoin(.bitcoin, ticker: "BTC", decimals: 8)
+            )
+        )
+    }
+
+    func testGuardComparesNodeFixedPointUnits() {
+        let bitcoin = makeCoin(.bitcoin, ticker: "BTC", decimals: 8)
+        let oneBitcoin = Decimal(1)
+
+        XCTAssertNil(
+            SwapService.belowRecommendedMinimumError(
+                normalizedAmount: oneBitcoin * bitcoin.thorswapMultiplier,
+                recommendedMinAmountIn: "24092",
+                fromCoin: bitcoin
+            )
+        )
+        XCTAssertNotNil(
+            SwapService.belowRecommendedMinimumError(
+                normalizedAmount: oneBitcoin,
+                recommendedMinAmountIn: "24092",
+                fromCoin: bitcoin
+            ),
+            "Skipping normalization must be observable"
+        )
+    }
+
+    func testGuardUsesMayaNativeScaleForSourceCoin() {
+        let cacao = makeCoin(.mayaChain, ticker: "CACAO", decimals: 10)
+        XCTAssertEqual(cacao.thorswapMultiplier, Decimal(10_000_000_000))
+
+        let verdict = SwapService.belowRecommendedMinimumError(
+            normalizedAmount: Decimal(10) * cacao.thorswapMultiplier,
+            recommendedMinAmountIn: "246000000000",
+            fromCoin: cacao
+        )
+
+        guard case .lessThenMinSwapAmount(let amount)? = verdict else {
+            return XCTFail("A Maya-native input below the floor must be rejected")
+        }
+        XCTAssertEqual(amount, "24.6 CACAO")
+    }
+
+    func testGuardUsesThorchainScaleForEighteenDecimalCoin() {
+        let ethereum = makeCoin(.ethereum, ticker: "ETH", decimals: 18)
+        XCTAssertEqual(ethereum.thorswapMultiplier, Decimal(100_000_000))
+
+        let verdict = SwapService.belowRecommendedMinimumError(
+            normalizedAmount: Decimal(string: "0.001")! * ethereum.thorswapMultiplier,
+            recommendedMinAmountIn: "1000000",
+            fromCoin: ethereum
+        )
+
+        guard case .lessThenMinSwapAmount(let amount)? = verdict else {
+            return XCTFail("0.001 ETH is below a 0.01 ETH floor")
+        }
+        XCTAssertEqual(amount, "0.01 ETH")
+    }
+
+    func testGuardAllowsAmountExactlyAtFloor() {
+        XCTAssertNil(
+            SwapService.belowRecommendedMinimumError(
+                normalizedAmount: normalizedBtcAmount,
+                recommendedMinAmountIn: "14844",
+                fromCoin: makeCoin(.bitcoin, ticker: "BTC", decimals: 8)
+            )
+        )
+    }
+
+    func testGuardFailsOpenOnMalformedFloor() {
+        let bitcoin = makeCoin(.bitcoin, ticker: "BTC", decimals: 8)
+
+        for floor in ["", "n/a", "null"] {
+            XCTAssertNil(
+                SwapService.belowRecommendedMinimumError(
+                    normalizedAmount: normalizedBtcAmount,
+                    recommendedMinAmountIn: floor,
+                    fromCoin: bitcoin
+                ),
+                "A malformed floor (\(floor)) must not block the quote"
+            )
+        }
+    }
+
+    func testGuardAllowsZeroFloor() {
+        XCTAssertNil(
+            SwapService.belowRecommendedMinimumError(
+                normalizedAmount: normalizedBtcAmount,
+                recommendedMinAmountIn: "0",
+                fromCoin: makeCoin(.bitcoin, ticker: "BTC", decimals: 8)
+            )
+        )
+    }
+
+    private func makeCoin(_ chain: Chain, ticker: String, decimals: Int) -> Coin {
+        let asset = CoinMeta.make(
+            chain: chain,
+            ticker: ticker,
+            decimals: decimals,
+            isNativeToken: true
+        )
+        return Coin(asset: asset, address: "test-address-\(ticker)", hexPublicKey: "")
+    }
+}


### PR DESCRIPTION
## Description

Follow-up regression coverage for #5099. The production root cause was already resolved by #5133; this PR pins the existing per-provider `recommended_min_amount_in` behavior so it cannot regress.

- Extract the existing minimum check into an internal static helper without changing runtime semantics.
- Cover below, equal, above, zero, and malformed minimums.
- Cover the off-chain 1e8 normalization and the CACAO 1e10 native scale.
- Preserve the historical 30, 50, and zero affiliate-bps fixtures from the original report.
- Correct the reversed affiliate-bps explanation in the existing interactor test.

Related to #5099

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [x] Swap - Test-only follow-up; no transaction or production behavior change
- [ ] New Chain / Chain related feature  - Please attach tx link here

## Parity

- Android: n/a — no production behavior change; iOS regression coverage only
- Windows + extension: n/a — no production behavior change; iOS regression coverage only
- SDK: n/a — no production behavior change; app-level quote guard coverage

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

Not applicable; no UI changes.

## Additional context

Verification:
- `make test`: 6,897 tests executed, 11 skipped, 0 failures
- SwiftLint on all three changed files: 0 violations
- Independent Claude whole-branch review: no actionable findings

## Agent Metadata (if applicable)
- **Agent**: Codex
- **Issue**: #5099
- **Confidence**: high
- **Needs human review for**: none; behavior-preserving extraction plus regression tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-chain swap minimum-amount validation using normalized values from the network.
  * Users now receive clearer minimum-amount errors when a swap is below the required threshold.
  * Invalid or unavailable minimum values no longer incorrectly block swaps.

* **Tests**
  * Added coverage for minimum thresholds across Bitcoin, Maya, and Ethereum swaps, including exact-limit and formatting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->