### PR TITLE
fix: overlay foreground notification banner

### DIFF
--- a/VultisigApp/VultisigApp/Components/NotificationBanner/ForegroundNotificationBannerModifier.swift
+++ b/VultisigApp/VultisigApp/Components/NotificationBanner/ForegroundNotificationBannerModifier.swift
@@ -16,7 +16,9 @@ private struct ForegroundNotificationBannerModifier: ViewModifier {
     @State private var showBackground: Bool = false
 
     func body(content: Content) -> some View {
-        VStack(spacing: 12) {
+        ZStack(alignment: .top) {
+            content
+
             if isVisible, let data = currentData {
                 ForegroundNotificationBannerView(
                     data: data,
@@ -27,10 +29,9 @@ private struct ForegroundNotificationBannerModifier: ViewModifier {
                         dismiss()
                     }
                 )
+                .zIndex(1)
                 .transition(.move(edge: .top))
             }
-
-            content
         }
         .background(showBackground ? Theme.colors.bgPrimary.ignoresSafeArea() : nil)
         .onReceive(pushNotificationManager.$foregroundNotification) { newValue in

--- a/VultisigApp/VultisigApp/Components/NotificationBanner/ForegroundNotificationBannerView.swift
+++ b/VultisigApp/VultisigApp/Components/NotificationBanner/ForegroundNotificationBannerView.swift
@@ -13,29 +13,36 @@ struct ForegroundNotificationBannerView: View {
     @State private var dragOffset: CGFloat = 0
 
     var body: some View {
-        ZStack {
-            bannerBackground
+        ZStack(alignment: .bottom) {
+            Theme.colors.bgPrimary
+                .offset(y: 25)
+                .frame(height: 100)
+                .blur(radius: 10)
+
+            ZStack {
+                bannerBackground
                 // Off the scale on purpose. This is a full-bleed banner that
                 // drops from under the status bar and ignores the safe area; its
                 // bottom curve is drawn against the device's own screen corners,
                 // not against the app's card geometry, and 24 reads as a card
                 // stuck to the top of the screen.
-                .clipShape(
-                    UnevenRoundedRectangle(
-                        bottomLeadingRadius: 40, // swiftlint:disable:this no_raw_corner_radius
-                        bottomTrailingRadius: 40 // swiftlint:disable:this no_raw_corner_radius
+                    .clipShape(
+                        UnevenRoundedRectangle(
+                            bottomLeadingRadius: 40, // swiftlint:disable:this no_raw_corner_radius
+                            bottomTrailingRadius: 40 // swiftlint:disable:this no_raw_corner_radius
+                        )
                     )
-                )
-            VStack(spacing: 11) {
-                iconCircle
-                titleLabel
-                vaultPill
-                descriptionLabel
+                VStack(spacing: 11) {
+                    iconCircle
+                    titleLabel
+                    vaultPill
+                    descriptionLabel
+                }
+                .padding(.bottom, 24)
+                .padding(.horizontal, 24)
+                .frame(maxWidth: .infinity)
+                .offset(y: 32)
             }
-            .padding(.bottom, 24)
-            .padding(.horizontal, 24)
-            .frame(maxWidth: .infinity)
-            .offset(y: 32)
         }
         .offset(y: dragOffset)
         .gesture(swipeUpGesture)


### PR DESCRIPTION
## Summary

- overlay the foreground notification banner instead of pushing screen content down
- add a soft background fade below the rounded banner edge
- keep the banner above screen content during its dismissal transition
- apply drag and tap behavior to the complete banner presentation

Closes #4800

## Testing

- manually verified banner presentation and animated swipe dismissal in the iPhone Air simulator
- SwiftLint: touched files clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the foreground notification banner layout to display over app content at the top of the screen.
  * Added a blurred background layer behind the banner for improved visual clarity.
  * Preserved the existing banner content and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->