### PR TITLE
fix(send): hide memo for ERC-20 transfers

### DIFF
--- a/VultisigApp/VultisigApp/Components/Send/SendDetailsAdditionalSection.swift
+++ b/VultisigApp/VultisigApp/Components/Send/SendDetailsAdditionalSection.swift
@@ -17,9 +17,7 @@ struct SendDetailsAdditionalSection: View {
 
     var body: some View {
         VStack(spacing: 14) {
-            // Memo input is gated by `Chain.supportsMemo` so per-chain
-            // capability lives in the model, not scattered across UI.
-            if viewModel.coin.chain.supportsMemo {
+            if viewModel.coin.supportsMemo {
                 addMemoField
             }
             if viewModel.coin.chain.supportsDestinationTag {

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendDetailsScreen.swift
@@ -57,11 +57,9 @@ struct SendDetailsScreen: View {
                 viewModel.initializePendingTransactionState(for: newValue.chain)
                 PendingTransactionManager.shared.stopPollingForChain(oldValue.chain)
                 viewModel.refreshPendingTransactionState()
-                // Per-chain capability lives on `Chain.supportsMemo`. Clear
-                // any previously-typed memo when switching into a chain that
-                // doesn't support memos so it doesn't ride along invisibly.
-                // (See #4326 / #4377 for the Cardano case.)
-                if !newValue.chain.supportsMemo {
+                // Clear any previously-typed memo when switching into a coin
+                // whose signer cannot carry it so it doesn't ride invisibly.
+                if !newValue.supportsMemo {
                     viewModel.memo = ""
                 }
                 // Same treatment for the XRP-only destination tag.

--- a/VultisigApp/VultisigApp/Model/Coin.swift
+++ b/VultisigApp/VultisigApp/Model/Coin.swift
@@ -220,6 +220,15 @@ class Coin: ObservableObject, Codable, Hashable {
         }
     }
 
+    /// Whether this coin's send signer carries a user-entered memo on-chain.
+    /// ERC-20 transfers encode only `transfer(to, amount)`, while native EVM
+    /// transfers put the memo in transaction data. Other token signers follow
+    /// their chain-level memo capability.
+    var supportsMemo: Bool {
+        guard chain.supportsMemo else { return false }
+        return chainType != .EVM || isNativeToken
+    }
+
     var feeDefault: String {
         switch self.chain {
         case .thorChain, .thorChainChainnet, .thorChainStagenet:

--- a/VultisigApp/VultisigAppTests/Model/CoinMemoSupportTests.swift
+++ b/VultisigApp/VultisigAppTests/Model/CoinMemoSupportTests.swift
@@ -1,0 +1,43 @@
+//
+//  CoinMemoSupportTests.swift
+//  VultisigAppTests
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class CoinMemoSupportTests: XCTestCase {
+    func testNativeEvmCoinSupportsMemo() {
+        let coin = makeCoin(chain: .ethereum, isNativeToken: true)
+
+        XCTAssertTrue(coin.supportsMemo)
+    }
+
+    func testErc20CoinDoesNotSupportMemo() {
+        let coin = makeCoin(chain: .ethereum, isNativeToken: false)
+
+        XCTAssertFalse(coin.supportsMemo)
+    }
+
+    func testSuiCoinStillDoesNotSupportMemo() {
+        let coin = makeCoin(chain: .sui, isNativeToken: true)
+
+        XCTAssertFalse(coin.supportsMemo)
+    }
+
+    private func makeCoin(chain: Chain, isNativeToken: Bool) -> Coin {
+        Coin(
+            asset: CoinMeta(
+                chain: chain,
+                ticker: isNativeToken ? chain.ticker : "TOKEN",
+                logo: "logo",
+                decimals: 18,
+                priceProviderId: "price-provider",
+                contractAddress: isNativeToken ? "" : "0xcontract",
+                isNativeToken: isNativeToken
+            ),
+            address: "address",
+            hexPublicKey: "public-key"
+        )
+    }
+}


### PR DESCRIPTION
## Description

Hide the memo input when the selected send asset is an ERC-20 token, because the ERC-20 signer encodes only transfer(to, amount) and cannot carry a user-entered memo on-chain.

The memo capability now follows the selected coin's signing path instead of only its chain. Native EVM sends retain memo support, existing Sui behavior is unchanged, and a memo is cleared when switching into an unsupported token.

Fixes #5292

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [x] Sending - UI-only capability fix; no on-chain transaction was produced
- [ ] Swap - Please attach tx link for the swap here
- [ ] New Chain / Chain related feature - Please attach tx link here

## Parity

- Android: linked: vultisig/vultisig-android#5763 tracks the mirror memo-visibility mismatch
- Windows + extension: n/a: iOS SwiftUI send-form capability; no shared implementation changed
- SDK: n/a: client UI capability; no SDK signing path changed

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

Not attached. The change removes the existing memo disclosure for ERC-20 assets while preserving it for native EVM assets.

## Additional context

- Focused tests: 3 passed, 0 failed
- Full gate: 6,926 passed, 11 skipped, 0 failed
- Changed-file SwiftLint: 0 violations
- Native EVM signing and ERC-20 calldata construction are unchanged

## Agent Metadata (if applicable)
- **Agent**: Codex
- **Issue**: #5292
- **Confidence**: high
- **Needs human review for**: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Memo fields now appear only for coins that support memo data.
  * Memo content is cleared automatically when switching to a coin that does not support memos.
  * Non-native EVM token transfers no longer incorrectly display memo options.

* **Tests**
  * Added coverage for memo support across native Ethereum coins, ERC-20 tokens, and Sui coins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->