### PR TITLE
fix(swap): set LI.FI Auto slippage tiers

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/LiFi/LiFiAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/LiFi/LiFiAPI.swift
@@ -24,9 +24,9 @@ enum LiFiAPI: TargetType {
         /// be set together to register the fee with LI.FI.
         let fee: String?
         /// Slippage as a decimal fraction in [0,1] (e.g. "0.005" = 0.5%).
-        /// Only attached when the user picks a custom slippage; `nil` lets
-        /// LI.FI apply its own default instead of sending an empty/zero value.
-        let slippage: String?
+        /// Always attached: Auto resolves to the pair-aware stable/volatile
+        /// tier before the request is built, while preset/custom values override it.
+        let slippage: String
     }
 
     private static let lifiBaseURL = URL(string: "https://li.quest")!
@@ -55,9 +55,7 @@ enum LiFiAPI: TargetType {
             if let fee = params.fee {
                 query["fee"] = fee
             }
-            if let slippage = params.slippage {
-                query["slippage"] = slippage
-            }
+            query["slippage"] = params.slippage
             return .requestParameters(query, .urlEncoding)
         }
     }

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/LiFi/LiFiService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/LiFi/LiFiService.swift
@@ -12,6 +12,10 @@ struct LiFiService {
 
     static let shared = LiFiService()
     static let integratorFeeBps: Int = 50
+    static let stableTickers: Set<String> = [
+        "USDC", "USDT", "DAI", "BUSD", "TUSD", "FRAX",
+        "USDP", "GUSD", "LUSD", "USDD", "FDUSD", "PYUSD"
+    ]
 
     private let integratorName: String = "vultisig-ios"
     private let httpClient: HTTPClientProtocol = HTTPClient()
@@ -46,7 +50,11 @@ struct LiFiService {
             toAddress: toCoin.address,
             integrator: integrator,
             fee: integratorFeeString,
-            slippage: Self.lifiSlippageFraction(bps: slippageBps)
+            slippage: Self.lifiSlippageFraction(
+                bps: slippageBps,
+                fromTicker: fromCoin.ticker,
+                toTicker: toCoin.ticker
+            )
         )
 
         let response: LifiQuoteResponse
@@ -117,18 +125,26 @@ struct LiFiService {
 
     /// Convert a user slippage in basis points to the decimal fraction in
     /// [0,1] that LI.FI's `slippage` query param expects (50 bps → "0.005",
-    /// 100 bps → "0.01", 300 bps → "0.03"). `nil` (Auto) returns `nil` so the
-    /// param is omitted and LI.FI applies its own default — never "0".
+    /// 100 bps → "0.01", 300 bps → "0.03"). Auto uses the same pair-aware
+    /// tiers as the SDK: 30 bps for stable-to-stable pairs, 100 bps otherwise.
     ///
     /// The bps value is clamped to 0–5000 (0–50%) before conversion, mirroring
     /// the 1inch path, so a bogus custom value can't produce an out-of-range
     /// fraction. Rendered with a C-locale `%`-format (always a dot separator),
     /// so it is locale-independent and never emits a comma.
-    static func lifiSlippageFraction(bps: Int?) -> String? {
-        guard let bps else { return nil }
-        let clamped = min(max(bps, 0), 5000)
+    static func lifiSlippageFraction(
+        bps: Int?,
+        fromTicker: String,
+        toTicker: String
+    ) -> String {
+        let resolvedBps = bps ?? (isStablePair(fromTicker: fromTicker, toTicker: toTicker) ? 30 : 100)
+        let clamped = min(max(resolvedBps, 0), 5000)
         let fraction = Double(clamped) / 10_000
         return String(format: "%g", fraction)
+    }
+
+    private static func isStablePair(fromTicker: String, toTicker: String) -> Bool {
+        stableTickers.contains(fromTicker.uppercased()) && stableTickers.contains(toTicker.uppercased())
     }
 }
 

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/LiFi/LiFiService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/LiFi/LiFiService.swift
@@ -128,19 +128,20 @@ struct LiFiService {
     /// 100 bps → "0.01", 300 bps → "0.03"). Auto uses the same pair-aware
     /// tiers as the SDK: 30 bps for stable-to-stable pairs, 100 bps otherwise.
     ///
-    /// The bps value is clamped to 0–5000 (0–50%) before conversion, mirroring
-    /// the 1inch path, so a bogus custom value can't produce an out-of-range
-    /// fraction. Rendered with a C-locale `%`-format (always a dot separator),
-    /// so it is locale-independent and never emits a comma.
+    /// A non-positive explicit value falls back to the pair-aware Auto tier so
+    /// LI.FI never receives a zero tolerance. Positive values are capped at
+    /// 5000 bps (50%), mirroring the 1inch upper bound. The POSIX locale keeps
+    /// the wire format locale-independent and guarantees a dot separator.
     static func lifiSlippageFraction(
         bps: Int?,
         fromTicker: String,
         toTicker: String
     ) -> String {
-        let resolvedBps = bps ?? (isStablePair(fromTicker: fromTicker, toTicker: toTicker) ? 30 : 100)
-        let clamped = min(max(resolvedBps, 0), 5000)
+        let autoBps = isStablePair(fromTicker: fromTicker, toTicker: toTicker) ? 30 : 100
+        let resolvedBps = bps.flatMap { $0 > 0 ? $0 : nil } ?? autoBps
+        let clamped = min(resolvedBps, 5000)
         let fraction = Double(clamped) / 10_000
-        return String(format: "%g", fraction)
+        return String(format: "%g", locale: Locale(identifier: "en_US_POSIX"), fraction)
     }
 
     private static func isStablePair(fromTicker: String, toTicker: String) -> Bool {

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapSlippage.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapSlippage.swift
@@ -2,15 +2,15 @@
 //  SwapSlippage.swift
 //  VultisigApp
 //
-//  User-selectable slippage tolerance for a swap. `Auto` preserves each
-//  provider's existing default (no caller override); the explicit cases carry a
-//  basis-points value threaded into every provider's quote/tx request.
+//  User-selectable slippage tolerance for a swap. `Auto` asks each provider
+//  path to resolve its own default; the explicit cases carry a basis-points
+//  value threaded into every provider's quote/tx request.
 //
 
 import Foundation
 
 enum SwapSlippage: Equatable, Hashable {
-    /// Keep today's per-provider default — no caller-supplied slippage.
+    /// Resolve the provider-path default (LI.FI uses pair-aware Auto tiers).
     case auto
     /// A preset slippage in basis points (e.g. 50 = 0.5%, 100 = 1%, 300 = 3%).
     case preset(bps: Int)
@@ -32,7 +32,7 @@ enum SwapSlippage: Equatable, Hashable {
         min(max(bps, 0), maxCustomBps)
     }
 
-    /// Basis points to send to providers, or `nil` for `Auto` (keep the default).
+    /// Basis points to send to providers, or `nil` for provider-path Auto resolution.
     var bps: Int? {
         switch self {
         case .auto:

--- a/VultisigApp/VultisigAppTests/Swap/LiFiSlippageTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/LiFiSlippageTests.swift
@@ -72,8 +72,9 @@ final class LiFiSlippageTests: XCTestCase {
         XCTAssertEqual(fraction(bps: 5001), "0.5")
     }
 
-    func testNegativeValueClampsToZero() {
-        XCTAssertEqual(fraction(bps: -100), "0")
+    func testNonPositiveExplicitValuesFallBackToAutoTier() {
+        XCTAssertEqual(fraction(bps: 0, from: "ETH", to: "USDC"), "0.01")
+        XCTAssertEqual(fraction(bps: -100, from: "USDC", to: "USDT"), "0.003")
     }
 
     func testFractionUsesDotDecimalSeparator() {

--- a/VultisigApp/VultisigAppTests/Swap/LiFiSlippageTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/LiFiSlippageTests.swift
@@ -5,8 +5,8 @@
 //  Pins the bps → LI.FI decimal-fraction conversion. LI.FI's `slippage`
 //  query param is a fraction in [0,1] (not a percent, not bps), so the user's
 //  basis-point slippage must be divided by 10_000 and rendered with a dot
-//  separator regardless of locale. `Auto` (nil) must omit the param entirely
-//  so LI.FI applies its own default rather than receiving "0".
+//  separator regardless of locale. `Auto` (nil) must resolve to the same
+//  stable/volatile pair tiers as the SDK rather than omitting the parameter.
 //
 
 import XCTest
@@ -15,33 +15,81 @@ import XCTest
 final class LiFiSlippageTests: XCTestCase {
 
     func testCommonPresetsMapToDecimalFraction() {
-        XCTAssertEqual(LiFiService.lifiSlippageFraction(bps: 50), "0.005")
-        XCTAssertEqual(LiFiService.lifiSlippageFraction(bps: 100), "0.01")
-        XCTAssertEqual(LiFiService.lifiSlippageFraction(bps: 300), "0.03")
+        XCTAssertEqual(fraction(bps: 50), "0.005")
+        XCTAssertEqual(fraction(bps: 100), "0.01")
+        XCTAssertEqual(fraction(bps: 300), "0.03")
     }
 
-    func testAutoReturnsNilSoParamIsOmitted() {
-        XCTAssertNil(LiFiService.lifiSlippageFraction(bps: nil))
+    func testAutoUsesThirtyBasisPointsForStablePair() {
+        XCTAssertEqual(fraction(bps: nil, from: "USDC", to: "USDT"), "0.003")
+        XCTAssertEqual(fraction(bps: nil, from: "dai", to: "usdc"), "0.003")
+    }
+
+    func testAutoUsesOneHundredBasisPointsForVolatilePair() {
+        XCTAssertEqual(fraction(bps: nil, from: "ETH", to: "USDC"), "0.01")
+        XCTAssertEqual(fraction(bps: nil, from: "SOL", to: "BONK"), "0.01")
+    }
+
+    func testStableTickerSetPinsCanonicalList() {
+        // Mirrors STABLE_TICKERS in vultisig-sdk's getLifiSwapQuote.ts.
+        XCTAssertEqual(
+            LiFiService.stableTickers,
+            ["USDC", "USDT", "DAI", "BUSD", "TUSD", "FRAX", "USDP", "GUSD", "LUSD", "USDD", "FDUSD", "PYUSD"]
+        )
+    }
+
+    func testExplicitSlippageOverridesAutoTier() {
+        XCTAssertEqual(fraction(bps: 50, from: "ETH", to: "USDC"), "0.005")
+        XCTAssertEqual(fraction(bps: 300, from: "USDC", to: "USDT"), "0.03")
+    }
+
+    func testQuoteRequestAlwaysEncodesAutoSlippage() {
+        let slippage = fraction(bps: nil, from: "USDC", to: "USDT")
+        let request = LiFiAPI.quote(params: .init(
+            fromChain: "1",
+            toChain: "10",
+            fromToken: "USDC",
+            toToken: "USDT",
+            fromAmount: "1000000",
+            fromAddress: "0x1111111111111111111111111111111111111111",
+            toAddress: "0x2222222222222222222222222222222222222222",
+            integrator: nil,
+            fee: nil,
+            slippage: slippage
+        ))
+
+        guard case let .requestParameters(params, _) = request.task else {
+            return XCTFail("LI.FI quote must build requestParameters")
+        }
+        XCTAssertEqual(params["slippage"] as? String, "0.003")
     }
 
     func testValueIsClampedAtFiftyPercent() {
         // 10_000 bps (100%) clamps to the 5000 bps (50%) ceiling, matching the
         // 1inch path, so a bogus custom value can't produce a >1 fraction.
-        XCTAssertEqual(LiFiService.lifiSlippageFraction(bps: 10_000), "0.5")
-        XCTAssertEqual(LiFiService.lifiSlippageFraction(bps: 5000), "0.5")
-        XCTAssertEqual(LiFiService.lifiSlippageFraction(bps: 5001), "0.5")
+        XCTAssertEqual(fraction(bps: 10_000), "0.5")
+        XCTAssertEqual(fraction(bps: 5000), "0.5")
+        XCTAssertEqual(fraction(bps: 5001), "0.5")
     }
 
     func testNegativeValueClampsToZero() {
-        XCTAssertEqual(LiFiService.lifiSlippageFraction(bps: -100), "0")
+        XCTAssertEqual(fraction(bps: -100), "0")
     }
 
     func testFractionUsesDotDecimalSeparator() {
         // Locale-independent: the rendered fraction must contain a dot and
         // never a comma, even though some locales localize the separator.
-        let fraction = LiFiService.lifiSlippageFraction(bps: 50)
+        let fraction = fraction(bps: 50)
         XCTAssertEqual(fraction, "0.005")
-        XCTAssertTrue(fraction?.contains(".") ?? false)
-        XCTAssertFalse(fraction?.contains(",") ?? true)
+        XCTAssertTrue(fraction.contains("."))
+        XCTAssertFalse(fraction.contains(","))
+    }
+
+    private func fraction(
+        bps: Int?,
+        from: String = "ETH",
+        to: String = "USDC"
+    ) -> String {
+        LiFiService.lifiSlippageFraction(bps: bps, fromTicker: from, toTicker: to)
     }
 }


### PR DESCRIPTION
## Description

LI.FI Auto omitted the `slippage` query parameter, so LI.FI silently applied its 0.5% default during the quote-to-keysign-to-broadcast window.

This change:

- resolves Auto to 30 bps for canonical stable-to-stable pairs and 100 bps otherwise, matching the SDK
- preserves preset and custom slippage as explicit overrides
- always encodes the resolved decimal fraction in the LI.FI quote request
- adds request-level regression coverage so Auto cannot return to an omitted or zero parameter

Closes #5309

## Which feature is affected?

- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [x] Swap - Robinhood failures are linked in #5309
- [ ] New Chain / Chain related feature  - Please attach tx link here

## Parity

- Android: linked: [vultisig-android#5801](https://github.com/vultisig/vultisig-android/issues/5801)
- Windows + extension: linked: [vultisig-sdk#524](https://github.com/vultisig/vultisig-sdk/issues/524) — these clients consume the SDK quote path
- SDK: linked: [vultisig-sdk#524](https://github.com/vultisig/vultisig-sdk/issues/524) — shipped policy this PR ports

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

Not applicable; there are no UI changes.

## Additional context

Verification:

- focused `LiFiSlippageTests`: 9 passed, 0 failed
- changed-file SwiftLint: 0 violations
- full `make test`: 6,927 tests executed, 11 skipped, 0 failures (`** TEST SUCCEEDED **`)
- independent per-step and whole-branch reviews completed; all actionable findings were addressed

Recommended manual check before ready-for-review: capture a live stable-pair and volatile-pair LI.FI quote and confirm `slippage=0.003` / `0.01` on the request.

## Agent Metadata (if applicable)

- **Agent**: Codex
- **Issue**: #5309
- **Confidence**: high
- **Needs human review for**: live LI.FI quote behavior and request-policy parity


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Li.FI swap quotes now always include a slippage value.
  * Automatic slippage adjusts by token pair, using tighter limits for stablecoin pairs and broader limits for other pairs.
  * Custom slippage values remain supported and safely constrained.
  * Slippage formatting is now consistent across locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->