### PR TITLE
fix(swap): preflight EVM aggregator calldata

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/EVM/Service/EVMSwapPreflight.swift
+++ b/VultisigApp/VultisigApp/Blockchain/EVM/Service/EVMSwapPreflight.swift
@@ -1,0 +1,115 @@
+//
+//  EVMSwapPreflight.swift
+//  VultisigApp
+//
+//  Rejects already-reverting EVM aggregator calldata before an MPC ceremony
+//  starts. Every participating device runs this from KeysignViewModel.
+//
+
+import BigInt
+import Foundation
+
+protocol EVMSwapPreflightChecking {
+    func validate(_ payload: KeysignPayload, localCoinAddress: String?) async throws
+}
+
+struct EVMSwapPreflightCall: Equatable {
+    let chain: Chain
+    let from: String
+    let to: String
+    let data: String
+    let valueHex: String
+}
+
+enum EVMSwapPreflightError: LocalizedError, Equatable {
+    case reverted(detail: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .reverted:
+            return SwapError.slippageToleranceTooTight.localizedDescription
+        }
+    }
+
+    static func isExecutionRevert(code: Int, message: String) -> Bool {
+        if code == 3 { return true }
+        let message = message.lowercased()
+        let abiPayload = message.dropFirst(2)
+        if message == "0x" ||
+            (message.hasPrefix("0x") && abiPayload.count >= 8 && abiPayload.allSatisfy(\.isHexDigit)) {
+            return true
+        }
+        let markers = [
+            "revert",
+            "vm execution",
+            "execution failed",
+            "insufficient output",
+            "return amount is not enough"
+        ]
+        return markers.contains { message.contains($0) }
+    }
+}
+
+struct EVMSwapPreflight: EVMSwapPreflightChecking {
+    typealias Simulator = (EVMSwapPreflightCall) async throws -> Void
+
+    private let simulator: Simulator
+
+    init(simulator: @escaping Simulator = Self.simulate) {
+        self.simulator = simulator
+    }
+
+    func validate(_ payload: KeysignPayload, localCoinAddress: String?) async throws {
+        guard let call = try Self.call(for: payload, localCoinAddress: localCoinAddress) else { return }
+        try await simulator(call)
+    }
+
+    static func call(for payload: KeysignPayload, localCoinAddress: String?) throws -> EVMSwapPreflightCall? {
+        guard payload.coin.chainType == .EVM,
+              // A router call against current state may fail only because this
+              // approval has not been mined yet. Ordinary eth_call cannot
+              // simulate the two transactions atomically, so keep that flow on
+              // its existing approval-first path instead of false-blocking it.
+              payload.approvePayload == nil,
+              case let .generic(swap)? = payload.swapPayload,
+              requiresPreflight(swap.provider) else {
+            return nil
+        }
+
+        let transaction = swap.quote.tx
+        guard let localCoinAddress,
+              swap.fromCoin.chain == payload.coin.chain,
+              SwapRecipientVerifier.addressesMatch(localCoinAddress, payload.coin.address),
+              transaction.from.isEmpty || SwapRecipientVerifier.addressesMatch(transaction.from, localCoinAddress),
+              !transaction.to.isEmpty,
+              !transaction.data.isEmpty,
+              let value = BigInt(transaction.value),
+              value >= 0 else {
+            throw SwapError.routeUnavailable
+        }
+
+        return EVMSwapPreflightCall(
+            chain: payload.coin.chain,
+            from: localCoinAddress,
+            to: transaction.to,
+            data: transaction.data,
+            valueHex: "0x" + String(value.magnitude, radix: 16)
+        )
+    }
+
+    private static func requiresPreflight(_ provider: SwapProviderId) -> Bool {
+        switch provider {
+        case .oneInch, .kyberSwap, .lifi:
+            return true
+        case .swapkit, .jupiter, .unknown:
+            return false
+        }
+    }
+
+    private static func simulate(_ call: EVMSwapPreflightCall) async throws {
+        let service = try EvmService.getService(forChain: call.chain)
+        try await withTimeout(seconds: 15) {
+            try await service.simulateSwap(call)
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/EVM/Service/EvmService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/EVM/Service/EvmService.swift
@@ -177,6 +177,10 @@ enum EvmService {
         return try await (try service).broadcastTransaction(hex: hex)
     }
 
+    func simulateSwap(_ call: EVMSwapPreflightCall) async throws {
+        return try await (try service).simulateSwap(call)
+    }
+
     func estimateGasForEthTransaction(senderAddress: String, recipientAddress: String, value: BigInt, memo: String?) async throws -> BigInt {
         return try await (try service).estimateGasForEthTransaction(senderAddress: senderAddress, recipientAddress: recipientAddress, value: value, memo: memo)
     }

--- a/VultisigApp/VultisigApp/Blockchain/EVM/Service/EvmServiceStruct.swift
+++ b/VultisigApp/VultisigApp/Blockchain/EVM/Service/EvmServiceStruct.swift
@@ -209,6 +209,27 @@ struct EvmServiceStruct {
         return try await rpcService.strRpcCall(method: "eth_sendRawTransaction", params: [hexWithPrefix])
     }
 
+    func simulateSwap(_ call: EVMSwapPreflightCall) async throws {
+        let transaction = Self.swapSimulationTransaction(call)
+        do {
+            _ = try await rpcService.strRpcCall(method: "eth_call", params: [transaction, "latest"])
+        } catch let RpcServiceError.rpcError(code, message) {
+            guard EVMSwapPreflightError.isExecutionRevert(code: code, message: message) else {
+                throw RpcServiceError.rpcError(code: code, message: message)
+            }
+            throw EVMSwapPreflightError.reverted(detail: message)
+        }
+    }
+
+    static func swapSimulationTransaction(_ call: EVMSwapPreflightCall) -> [String: String] {
+        [
+            "from": call.from,
+            "to": call.to,
+            "data": call.data,
+            "value": call.valueHex
+        ]
+    }
+
     func estimateGasForEthTransaction(senderAddress: String, recipientAddress: String, value: BigInt, memo: String?) async throws -> BigInt {
         // Convert the memo to hex (if present). Assume memo is a String.
         let memoDataHex = memo?.data(using: .utf8)?.map { byte in String(format: "%02x", byte) }.joined() ?? ""

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
@@ -73,6 +73,10 @@ class KeysignViewModel: ObservableObject {
     /// production singleton so runtime behaviour is unchanged.
     var transactionStatusChecker: TransactionStatusChecking = TransactionStatusService.shared
 
+    /// Runs the quoted EVM aggregator calldata against current chain state on
+    /// every participating device before MPC work starts.
+    var evmSwapPreflight: EVMSwapPreflightChecking = EVMSwapPreflight()
+
     /// Per-message stage budget. Each message's inbound poll already caps at
     /// 60s per attempt (see the DKLS/Schnorr/Dilithium `pullInboundMessages`
     /// loops); this adds headroom for the setup-message round-trips so a single
@@ -358,6 +362,9 @@ class KeysignViewModel: ObservableObject {
             return
         }
 
+        guard await validateEVMSwapPreflight() else { return }
+        guard !Task.isCancelled else { return }
+
         // Snapshot the (message-count-scaled) budget before entering the group
         // so the non-isolated sleeper closure stays Sendable-clean.
         let stageTimeout = keysignStageTimeout
@@ -399,6 +406,26 @@ class KeysignViewModel: ObservableObject {
             setStatus(.KeysignRetryRequested)
         } catch {
             logger.error("keysign stage race exited unexpectedly: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    func validateEVMSwapPreflight() async -> Bool {
+        guard let keysignPayload else { return true }
+        do {
+            try await evmSwapPreflight.validate(
+                keysignPayload,
+                localCoinAddress: vault.address(for: keysignPayload.coin.chain)
+            )
+            return true
+        } catch {
+            if Task.isCancelled || Self.isCancellation(error) {
+                logger.info("EVM swap preflight cancelled before keysign")
+                return false
+            }
+            logger.error("EVM swap preflight failed: \(error.localizedDescription, privacy: .private)")
+            keysignError = error.localizedDescription.redactingEndpointCredentials()
+            setStatus(.KeysignFailed)
+            return false
         }
     }
 

--- a/VultisigApp/VultisigAppTests/Swap/EVMSwapPreflightTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/EVMSwapPreflightTests.swift
@@ -1,0 +1,228 @@
+//
+//  EVMSwapPreflightTests.swift
+//  VultisigAppTests
+//
+
+import BigInt
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class EVMSwapPreflightTests: XCTestCase {
+    private let walletAddress = "0xEe36b9c09FB9c17cCc5a6ac1BD30E152A5faB1c0"
+    private let routerAddress = "0x1111111254EEB25477B68fb85Ed929f73A960582"
+
+    func testEligibleProvidersBuildExactEthCall() async throws {
+        for provider in [SwapProviderId.oneInch, .kyberSwap, .lifi] {
+            var captured: EVMSwapPreflightCall?
+            let preflight = EVMSwapPreflight { call in captured = call }
+            let transactionFrom = provider == .kyberSwap ? "" : walletAddress
+
+            try await preflight.validate(
+                makePayload(provider: provider, transactionFrom: transactionFrom),
+                localCoinAddress: walletAddress
+            )
+
+            XCTAssertEqual(
+                captured,
+                EVMSwapPreflightCall(
+                    chain: .ethereum,
+                    from: walletAddress,
+                    to: routerAddress,
+                    data: "0xdeadbeef",
+                    valueHex: "0x38d7ea4c68000"
+                )
+            )
+        }
+    }
+
+    func testRPCTransactionContainsOnlyExecutableFields() {
+        let call = EVMSwapPreflightCall(
+            chain: .ethereum,
+            from: walletAddress,
+            to: routerAddress,
+            data: "0xdeadbeef",
+            valueHex: "0x38d7ea4c68000"
+        )
+
+        XCTAssertEqual(
+            EvmServiceStruct.swapSimulationTransaction(call),
+            [
+                "from": walletAddress,
+                "to": routerAddress,
+                "data": "0xdeadbeef",
+                "value": "0x38d7ea4c68000"
+            ]
+        )
+    }
+
+    func testNonTargetProvidersDoNotCallRPC() async throws {
+        for provider in [SwapProviderId.swapkit, .jupiter, .unknown("future")] {
+            var callCount = 0
+            let preflight = EVMSwapPreflight { _ in callCount += 1 }
+
+            try await preflight.validate(makePayload(provider: provider), localCoinAddress: walletAddress)
+
+            XCTAssertEqual(callCount, 0)
+        }
+    }
+
+    func testApprovalBearingSwapDoesNotFalseFailAgainstPreApprovalState() async throws {
+        var callCount = 0
+        let preflight = EVMSwapPreflight { _ in callCount += 1 }
+
+        try await preflight.validate(
+            makePayload(provider: .oneInch, hasApproval: true),
+            localCoinAddress: walletAddress
+        )
+
+        XCTAssertEqual(callCount, 0)
+    }
+
+    func testNonEVMGenericPayloadDoesNotCallRPC() async throws {
+        var callCount = 0
+        let preflight = EVMSwapPreflight { _ in callCount += 1 }
+
+        try await preflight.validate(makePayload(provider: .lifi, chain: .solana), localCoinAddress: nil)
+
+        XCTAssertEqual(callCount, 0)
+    }
+
+    func testMalformedTransactionFailsClosed() async {
+        let payload = makePayload(provider: .oneInch, transactionFrom: routerAddress)
+        do {
+            try await EVMSwapPreflight().validate(payload, localCoinAddress: walletAddress)
+            XCTFail("Expected a mismatched sender to fail before RPC or keysign")
+        } catch let error as SwapError {
+            XCTAssertEqual(error, .routeUnavailable)
+        } catch {
+            XCTFail("Expected SwapError.routeUnavailable, got \(error)")
+        }
+    }
+
+    func testRevertMarkersCoverObservedAggregatorFailures() {
+        XCTAssertTrue(EVMSwapPreflightError.isExecutionRevert(code: -32000, message: "execution reverted"))
+        XCTAssertTrue(EVMSwapPreflightError.isExecutionRevert(code: -32000, message: "Insufficient output"))
+        XCTAssertTrue(EVMSwapPreflightError.isExecutionRevert(code: 3, message: "Return amount is not enough"))
+        XCTAssertTrue(EVMSwapPreflightError.isExecutionRevert(code: 3, message: "execution error"))
+        XCTAssertTrue(EVMSwapPreflightError.isExecutionRevert(code: -32000, message: "0x08c379a0deadbeef"))
+        XCTAssertTrue(EVMSwapPreflightError.isExecutionRevert(code: -32015, message: "0x4e487b71deadbeef"))
+        XCTAssertTrue(EVMSwapPreflightError.isExecutionRevert(code: -32000, message: "0x275c273c"))
+        XCTAssertTrue(EVMSwapPreflightError.isExecutionRevert(code: -32000, message: "0x"))
+        XCTAssertFalse(EVMSwapPreflightError.isExecutionRevert(code: -32000, message: "0xnothexdata"))
+        XCTAssertFalse(EVMSwapPreflightError.isExecutionRevert(code: -32000, message: "header not found"))
+        XCTAssertFalse(EVMSwapPreflightError.isExecutionRevert(code: -32603, message: "upstream unavailable"))
+    }
+
+    func testKeysignViewModelBlocksRevertBeforeCeremony() async {
+        let viewModel = KeysignViewModel()
+        viewModel.keysignPayload = makePayload(provider: .kyberSwap)
+        viewModel.evmSwapPreflight = StubPreflight(error: EVMSwapPreflightError.reverted(detail: "Insufficient output"))
+
+        let allowed = await viewModel.validateEVMSwapPreflight()
+
+        XCTAssertFalse(allowed)
+        XCTAssertEqual(viewModel.status, .KeysignFailed)
+        XCTAssertEqual(viewModel.keysignError, SwapError.slippageToleranceTooTight.localizedDescription)
+    }
+
+    func testKeysignViewModelFailsClosedOnTransportErrorWithoutCallingItSlippage() async {
+        let viewModel = KeysignViewModel()
+        viewModel.keysignPayload = makePayload(provider: .lifi)
+        let transport = URLError(.notConnectedToInternet)
+        viewModel.evmSwapPreflight = StubPreflight(error: transport)
+
+        let allowed = await viewModel.validateEVMSwapPreflight()
+
+        XCTAssertFalse(allowed)
+        XCTAssertEqual(viewModel.status, .KeysignFailed)
+        XCTAssertEqual(viewModel.keysignError, transport.localizedDescription)
+        XCTAssertNotEqual(viewModel.keysignError, SwapError.slippageToleranceTooTight.localizedDescription)
+    }
+
+    func testLocalVaultSenderMismatchFailsClosed() async {
+        let differentLocalAddress = "0x2222222254EEB25477B68fb85Ed929f73A960582"
+        do {
+            try await EVMSwapPreflight().validate(
+                makePayload(provider: .oneInch),
+                localCoinAddress: differentLocalAddress
+            )
+            XCTFail("Expected a local vault sender mismatch to fail before RPC or keysign")
+        } catch let error as SwapError {
+            XCTAssertEqual(error, .routeUnavailable)
+        } catch {
+            XCTFail("Expected SwapError.routeUnavailable, got \(error)")
+        }
+    }
+
+    private func makePayload(
+        provider: SwapProviderId,
+        chain: Chain = .ethereum,
+        hasApproval: Bool = false,
+        transactionFrom: String? = nil
+    ) -> KeysignPayload {
+        let fromCoin = makeCoin(chain: chain, ticker: chain == .solana ? "SOL" : "ETH", isNative: true)
+        let toCoin = makeCoin(chain: chain, ticker: "USDC", isNative: false)
+        let quote = EVMQuote(
+            dstAmount: "1000000",
+            tx: EVMQuote.Transaction(
+                from: transactionFrom ?? walletAddress,
+                to: routerAddress,
+                data: "0xdeadbeef",
+                value: "1000000000000000",
+                gasPrice: "1000000000",
+                gas: 300_000
+            )
+        )
+        let swap = GenericSwapPayload(
+            fromCoin: fromCoin,
+            toCoin: toCoin,
+            fromAmount: BigInt(1_000_000_000_000_000),
+            toAmountDecimal: 1,
+            quote: quote,
+            provider: provider
+        )
+        return KeysignPayload(
+            coin: fromCoin,
+            toAddress: routerAddress,
+            toAmount: BigInt(1_000_000_000_000_000),
+            chainSpecific: chain == .solana
+                ? .Solana(recentBlockHash: "hash", priorityFee: 0, priorityLimit: 0, fromAddressPubKey: nil, toAddressPubKey: nil, hasProgramId: false)
+                : .Ethereum(maxFeePerGasWei: 1_000_000_000, priorityFeeWei: 0, nonce: 1, gasLimit: 300_000),
+            utxos: [],
+            memo: nil,
+            swapPayload: .generic(swap),
+            approvePayload: hasApproval ? ERC20ApprovePayload(amount: swap.fromAmount, spender: routerAddress) : nil,
+            vaultPubKeyECDSA: "pub",
+            vaultLocalPartyID: "party",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: nil
+        )
+    }
+
+    private func makeCoin(chain: Chain, ticker: String, isNative: Bool) -> Coin {
+        let meta = CoinMeta.make(
+            chain: chain,
+            ticker: ticker,
+            decimals: chain == .solana ? 9 : 18,
+            isNativeToken: isNative
+        )
+        return Coin(asset: meta, address: walletAddress, hexPublicKey: "")
+    }
+}
+
+private struct StubPreflight: EVMSwapPreflightChecking {
+    let error: Error
+
+    func validate(_: KeysignPayload, localCoinAddress _: String?) async throws {
+        await Task.yield()
+        throw error
+    }
+}


### PR DESCRIPTION
## Description

EVM aggregator calldata could move directly from quote construction into an MPC keysign ceremony even when the transaction already reverted against current chain state. The user would then pay gas for a transaction that could not satisfy its minimum output.

This change:

- runs `eth_call` with the executable `from`, `to`, `data`, and `value` immediately before MPC for 1inch, Kyber, and LI.FI EVM swaps
- executes the guard on every participating device and binds `from` to that device's local vault address
- blocks confirmed textual and ABI-encoded execution reverts with the existing slippage-too-tight guidance
- fails closed on other RPC and transport errors without mislabeling them as slippage
- adds a 15-second wall-clock bound and preserves cancellation before ceremony startup
- deliberately skips approval-bearing ERC-20 swaps because a current-state call cannot atomically model the pending approval

The optional quote-ranking prefilter remains deferred; this PR secures the required common pre-keysign boundary.

Closes #5308

## Which feature is affected?

- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [x] Swap - reverted Robinhood transactions are linked in #5308
- [ ] New Chain / Chain related feature  - Please attach tx link here

## Parity

- Android: linked: [vultisig-android#5800](https://github.com/vultisig/vultisig-android/issues/5800)
- Windows + extension: linked: [vultisig-sdk#2302](https://github.com/vultisig/vultisig-sdk/issues/2302) — these clients consume the SDK signing/quote path
- SDK: linked: [vultisig-sdk#2302](https://github.com/vultisig/vultisig-sdk/issues/2302)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

Not applicable; the change reuses the existing keysign failure and slippage guidance surfaces.

## Additional context

Verification:

- focused `EVMSwapPreflightTests`: 10 passed, 0 failed
- changed-file SwiftLint: 0 violations
- full `make test`: 6,933 tests executed, 11 skipped, 0 failures (`** TEST SUCCEEDED **`)
- independent per-step and whole-branch reviews completed; Kyber's empty quote sender, ABI custom errors, joiner sender trust, cancellation, and timeout findings were addressed

Fund-safety / signing-path review requested. Before marking ready, manually exercise native and pre-approved EVM swaps across at least two devices, plus a custom-RPC failure. Approval-bearing ERC-20 swaps intentionally remain on the existing approval-first path because ordinary `eth_call` cannot model both transactions atomically.

Raw RPC revert details remain private to avoid leaking transaction context through public logs.

## Agent Metadata (if applicable)

- **Agent**: Codex
- **Issue**: #5308
- **Confidence**: high
- **Needs human review for**: fund-safety/signing boundary, cross-device behavior, custom RPCs, and approval-bearing swaps


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pre-signing validation for supported EVM swaps by simulating transactions before approval.
  - Detects invalid transactions, unsupported chains or providers, and execution reverts.
  - Enforces a 15-second validation timeout.
  - Prevents signing when validation fails and provides a user-facing error.

- **Bug Fixes**
  - Maps reverted swap simulations to a slippage-related error.
  - Preserves relevant network errors during transaction simulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->