### PR TITLE
fix(swap): explain min-output failures in transaction history

### DIFF
--- a/VultisigApp/VultisigApp/Features/TransactionHistory/Models/TransactionHistoryFailureReasonPresentation.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/Models/TransactionHistoryFailureReasonPresentation.swift
@@ -1,0 +1,24 @@
+//
+//  TransactionHistoryFailureReasonPresentation.swift
+//  VultisigApp
+//
+
+enum TransactionHistoryFailureReasonPresentation {
+    private static let minimumOutputSignatures = [
+        "return amount is not enough",
+        "insufficient output"
+    ]
+
+    /// Converts a stored provider reason into the copy shown in transaction history.
+    /// Raw reasons remain unchanged in storage so localization is resolved when rendered.
+    static func displayText(for rawReason: String?) -> String? {
+        guard let rawReason, !rawReason.isEmpty else { return nil }
+
+        let normalizedReason = rawReason.lowercased()
+        if minimumOutputSignatures.contains(where: normalizedReason.contains) {
+            return "swapSlippageToleranceTooTight".localized
+        }
+
+        return rawReason
+    }
+}

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryCardView.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryCardView.swift
@@ -21,6 +21,10 @@ struct TransactionHistoryCardView: View {
             && (transaction.type != .limit || transaction.toCoinTicker != nil)
     }
 
+    private var failureReasonText: String? {
+        TransactionHistoryFailureReasonPresentation.displayText(for: transaction.errorMessage)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             topRow
@@ -157,7 +161,7 @@ struct TransactionHistoryCardView: View {
         let display = LimitOrderStatusDisplay.make(
             uiStatus: transaction.swapTrackingUiStatus,
             details: limitOrder,
-            errorMessage: transaction.errorMessage
+            errorMessage: failureReasonText
         )
 
         VStack(alignment: .trailing, spacing: 4) {
@@ -224,7 +228,7 @@ struct TransactionHistoryCardView: View {
             case .error:
                 VStack(alignment: .trailing, spacing: 4) {
                     Text("error".localized)
-                    if let errorMessage = transaction.errorMessage {
+                    if let errorMessage = failureReasonText {
                         Text(errorMessage)
                     }
                 }

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryDetailSheet.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryDetailSheet.swift
@@ -311,7 +311,8 @@ struct TransactionHistoryDetailSheet: View {
         }
     }
 
-    /// Raw on-chain text, shown only for a genuine failure.
+    /// The presented on-chain reason, including actionable guidance for known
+    /// failures, shown only for a genuine failure.
     ///
     /// A limit row must not use the coarse `.error` status for this: the row
     /// storage collapses refunded / expired / cancelled into `.error` too, and

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryDetailSheet.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryDetailSheet.swift
@@ -299,7 +299,7 @@ struct TransactionHistoryDetailSheet: View {
             let display = LimitOrderStatusDisplay.make(
                 uiStatus: transaction.swapTrackingUiStatus,
                 details: limitOrder,
-                errorMessage: transaction.errorMessage
+                errorMessage: presentedFailureReason
             )
             detailRow(
                 title: "status".localized,
@@ -317,12 +317,16 @@ struct TransactionHistoryDetailSheet: View {
     /// storage collapses refunded / expired / cancelled into `.error` too, and
     /// an expired order is not a failure with a reason to report.
     private var failureReasonText: String? {
-        guard let message = transaction.errorMessage?.nilIfEmpty else { return nil }
+        guard let message = presentedFailureReason else { return nil }
         if isLimit {
             guard transaction.swapTrackingUiStatus == .failed else { return nil }
             return message
         }
         return transaction.status == .error ? message : nil
+    }
+
+    private var presentedFailureReason: String? {
+        TransactionHistoryFailureReasonPresentation.displayText(for: transaction.errorMessage)
     }
 
     // MARK: - Limit Order Rows

--- a/VultisigApp/VultisigAppTests/Features/TransactionHistory/TransactionHistoryFailureReasonPresentationTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/TransactionHistory/TransactionHistoryFailureReasonPresentationTests.swift
@@ -1,0 +1,55 @@
+//
+//  TransactionHistoryFailureReasonPresentationTests.swift
+//  VultisigAppTests
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class TransactionHistoryFailureReasonPresentationTests: XCTestCase {
+    func testReturnAmountIsNotEnoughUsesSlippageGuidance() {
+        XCTAssertEqual(
+            TransactionHistoryFailureReasonPresentation.displayText(for: "Return amount is not enough"),
+            "swapSlippageToleranceTooTight".localized
+        )
+    }
+
+    func testInsufficientOutputUsesSlippageGuidance() {
+        XCTAssertEqual(
+            TransactionHistoryFailureReasonPresentation.displayText(for: "Insufficient output"),
+            "swapSlippageToleranceTooTight".localized
+        )
+    }
+
+    func testReturnAmountSignatureMatchesInsideWrapperText() {
+        XCTAssertEqual(
+            TransactionHistoryFailureReasonPresentation.displayText(
+                for: "RPC error: RETURN AMOUNT IS NOT ENOUGH [code 3]"
+            ),
+            "swapSlippageToleranceTooTight".localized
+        )
+    }
+
+    func testMatchingIsCaseInsensitiveInsideWrapperText() {
+        XCTAssertEqual(
+            TransactionHistoryFailureReasonPresentation.displayText(
+                for: "execution reverted: INSUFFICIENT OUTPUT while routing"
+            ),
+            "swapSlippageToleranceTooTight".localized
+        )
+    }
+
+    func testUnknownReasonPassesThroughUnchanged() {
+        let rawReason = "  execution reverted: transfer failed  "
+
+        XCTAssertEqual(
+            TransactionHistoryFailureReasonPresentation.displayText(for: rawReason),
+            rawReason
+        )
+    }
+
+    func testNilAndEmptyReasonsAreSuppressed() {
+        XCTAssertNil(TransactionHistoryFailureReasonPresentation.displayText(for: nil))
+        XCTAssertNil(TransactionHistoryFailureReasonPresentation.displayText(for: ""))
+    }
+}


### PR DESCRIPTION
## Problem

Failed EVM swaps whose on-chain revert reason reports `Return amount is not enough` or `Insufficient output` appear in transaction history with provider wording. That does not tell users that the quoted minimum output was missed because the price moved, which can lead to an ineffective retry and another gas payment.

## Root cause

The transaction-status path correctly extracts and persists the raw revert reason, but the history card and detail sheet rendered that stored value directly. There was no shared presentation mapping for actionable swap failure guidance.

## Implementation

- Add one pure transaction-history failure-reason presenter.
- Recognize both known minimum-output signatures case-insensitively, including inside wrapped RPC text.
- Render the existing localized `swapSlippageToleranceTooTight` guidance on both the compact card and detail sheet.
- Preserve unknown non-empty provider reasons unchanged and suppress nil/empty reasons.
- Keep raw stored reasons unchanged; this is presentation-only and resolves localization when rendered.
- Add focused coverage for both signatures, casing and wrapper text, unknown passthrough, nil, and empty input.

## Verification

- `make test`: 6,929 tests, 11 skipped, 0 failures (`** TEST SUCCEEDED **`)
- Changed-file SwiftLint: 0 violations
- `git diff --check`: clean
- Required cross-model review completed; final whole-branch pass reported no actionable findings

## Manual validation

Not performed locally. The focused validation target is a failed EVM swap row carrying either known revert signature: the card and detail sheet should show the same localized slippage guidance while the stored raw reason remains intact.

Closes #5310


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction history error messages by replacing technical insufficient-output errors with clear slippage-tolerance guidance.
  * Suppressed empty or missing failure messages.
  * Preserved meaningful details for other transaction errors.
  * Applied consistent error-message formatting across transaction cards and detail views.

* **Tests**
  * Added coverage for recognized, unknown, wrapped, empty, and missing failure reasons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->