### PR TITLE
fix(swap): show gross 0.50% fee and applied discounts

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Signing/THORChainSwaps.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Signing/THORChainSwaps.swift
@@ -26,12 +26,6 @@ class THORChainSwaps {
 
     static let affiliateFeeAddress = "vi"
 
-    /// SwapKit's affiliate share is set on the partner dashboard, not sent per
-    /// transaction, so it's a fixed 0.50% baked into the quoted rate regardless
-    /// of build (the DEBUG toggle on `affiliateFeeRateBp` only affects the
-    /// native `affiliate_bps` we send ourselves).
-    static let swapKitAffiliateFeeBps = 50
-
     /// Effective per-affiliate bps after applying the VULT tier discount,
     /// clamped at zero. Quote request builders use this for the wire
     /// `affiliate_bps`; display surfaces separately show the gross list rate.
@@ -40,10 +34,7 @@ class THORChainSwaps {
     }
 
     /// Total affiliate bps the protocol charges for a swap — the sum of every
-    /// affiliate entry the request sends. The node computes `fees.affiliate`
-    /// from this, so it is the number behind the "Vultisig Fee (X.XX%)"
-    /// percentage and reconciles with the shown affiliate amount by
-    /// construction. `isReferred` mirrors the request builder's
+    /// affiliate entry the request sends. `isReferred` mirrors the request builder's
     /// `!referredCode.isEmpty` branch: a referred swap splits the fee into the
     /// referrer's fixed share plus the discounted Vultisig share. This helper is
     /// wire-focused; the UI itemizes gross fee and discounts separately.

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Signing/THORChainSwaps.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Signing/THORChainSwaps.swift
@@ -33,9 +33,8 @@ class THORChainSwaps {
     static let swapKitAffiliateFeeBps = 50
 
     /// Effective per-affiliate bps after applying the VULT tier discount,
-    /// clamped at zero. Single source of truth consumed by BOTH the quote
-    /// request builders (the `affiliate_bps` query param) and the fee-percentage
-    /// display, so the shown % equals the bps actually sent by construction.
+    /// clamped at zero. Quote request builders use this for the wire
+    /// `affiliate_bps`; display surfaces separately show the gross list rate.
     static func discountedAffiliateBps(baseBps: Int, discountBps: Int) -> Int {
         max(0, baseBps - discountBps)
     }
@@ -46,7 +45,8 @@ class THORChainSwaps {
     /// percentage and reconciles with the shown affiliate amount by
     /// construction. `isReferred` mirrors the request builder's
     /// `!referredCode.isEmpty` branch: a referred swap splits the fee into the
-    /// referrer's fixed share plus the discounted Vultisig share.
+    /// referrer's fixed share plus the discounted Vultisig share. This helper is
+    /// wire-focused; the UI itemizes gross fee and discounts separately.
     static func effectiveAffiliateFeeBps(discountBps: Int, isReferred: Bool) -> Int {
         if isReferred {
             let referrerBps = Int(referredUserFeeRateBp) ?? 0

--- a/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
@@ -164,7 +164,7 @@ struct SwapDetailsSummary: View {
 
     var appliedDiscounts: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("swap.applied_discounts".localized)
+            Text("swapAppliedDiscounts".localized)
                 .font(Theme.fonts.caption12)
                 .foregroundStyle(Theme.colors.textTertiary)
 

--- a/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
@@ -19,8 +19,7 @@ struct SwapDetailsSummary: View {
         vm.showGas ||
         vm.showAffiliateFeeRow ||
         vm.showProtocolFeeRow ||
-        !vm.vultDiscount.isEmpty ||
-        !vm.referralDiscount.isEmpty ||
+        vm.hasAppliedDiscounts ||
         !vm.priceImpactString.isEmpty
     }
 
@@ -128,12 +127,8 @@ struct SwapDetailsSummary: View {
                 outboundFee
             }
 
-            if !vm.vultDiscount.isEmpty {
-                vultDiscount
-            }
-
-            if !vm.referralDiscount.isEmpty {
-                referralDiscount
+            if vm.hasAppliedDiscounts {
+                appliedDiscounts
             }
 
             if !vm.priceImpactString.isEmpty {
@@ -165,6 +160,22 @@ struct SwapDetailsSummary: View {
                 .foregroundStyle(Theme.colors.textSecondary)
         }
         .font(Theme.fonts.caption12)
+    }
+
+    var appliedDiscounts: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("swap.applied_discounts".localized)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textTertiary)
+
+            if !vm.vultDiscount.isEmpty {
+                vultDiscount
+            }
+
+            if !vm.referralDiscount.isEmpty {
+                referralDiscount
+            }
+        }
     }
 
     var vultDiscount: some View {

--- a/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
@@ -179,19 +179,14 @@ struct SwapDetailsSummary: View {
     }
 
     var vultDiscount: some View {
-        HStack {
+        HStack(spacing: 4) {
             vultTierIcon
 
             Text(vm.vultDiscountLabel)
                 .foregroundStyle(Theme.colors.textTertiary)
                 .font(Theme.fonts.caption12)
-
-            Spacer()
-
-            Text(vm.vultDiscount)
-                .foregroundStyle(Theme.colors.textSecondary)
-                .font(Theme.fonts.caption12)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     @ViewBuilder
@@ -216,7 +211,7 @@ struct SwapDetailsSummary: View {
     }
 
     var referralDiscount: some View {
-        HStack {
+        HStack(spacing: 4) {
             Image(systemName: "megaphone.fill")
                 .font(Theme.fonts.caption12)
                 .foregroundStyle(Theme.colors.primaryAccent4)
@@ -224,13 +219,8 @@ struct SwapDetailsSummary: View {
             Text(vm.referralDiscountLabel)
                 .foregroundStyle(Theme.colors.textTertiary)
                 .font(Theme.fonts.caption12)
-
-            Spacer()
-
-            Text(vm.referralDiscount)
-                .foregroundStyle(Theme.colors.textSecondary)
-                .font(Theme.fonts.caption12)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     var priceImpact: some View {

--- a/VultisigApp/VultisigApp/Components/Swap/SwapFromToField.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapFromToField.swift
@@ -24,8 +24,6 @@ struct SwapFromToField: View {
     @Bindable var detailsViewModel: SwapDetailsViewModel
     let handlePercentageSelection: ((Int) -> Void)?
 
-    @StateObject var referredViewModel = ReferredViewModel()
-
     private var isFromField: Bool { title == "from" }
 
     var body: some View {
@@ -54,9 +52,6 @@ struct SwapFromToField: View {
         // typing isn't animated.
         .animation(isFromField ? nil : .easeInOut(duration: 0.25), value: amount)
         .animation(isFromField ? nil : .easeInOut(duration: 0.25), value: fiatAmount)
-        .onLoad {
-            referredViewModel.setData()
-        }
     }
 
     private func handleAmountEdit(oldValue: String, newValue: String) {
@@ -66,7 +61,6 @@ struct SwapFromToField: View {
         let immediate = abs(newValue.count - oldValue.count) > 1
         detailsViewModel.updateFromAmount(
             vault: vault,
-            referredCode: referredViewModel.savedReferredCode,
             immediate: immediate
         )
         detailsViewModel.showAllPercentageButtons = true

--- a/VultisigApp/VultisigApp/Components/TransactionDone/SwapDoneSummaryCard.swift
+++ b/VultisigApp/VultisigApp/Components/TransactionDone/SwapDoneSummaryCard.swift
@@ -259,6 +259,8 @@ struct SwapDoneSummaryCard: View {
             // Gross list-rate Vultisig fee. Discounts below reconcile this row
             // to the net affiliate component retained in Total Fees.
             if transaction.showAffiliateFeeRow {
+                // `swapFeeLabel` is already localized and embeds the percentage;
+                // unknown-key localization intentionally echoes it unchanged.
                 getCell(title: transaction.swapFeeLabel, value: transaction.baseAffiliateFee)
             }
             // Protocol Fee (native THOR/Maya outbound).
@@ -295,7 +297,7 @@ struct SwapDoneSummaryCard: View {
                         .foregroundStyle(Theme.colors.textPrimary)
                 }
                 .font(Theme.fonts.bodySMedium)
-                .padding(.vertical)
+                .padding(.vertical, 8)
             }
 
             if !transaction.referralDiscount.isEmpty {
@@ -309,7 +311,7 @@ struct SwapDoneSummaryCard: View {
                         .foregroundStyle(Theme.colors.textPrimary)
                 }
                 .font(Theme.fonts.bodySMedium)
-                .padding(.vertical)
+                .padding(.vertical, 8)
             }
         }
     }

--- a/VultisigApp/VultisigApp/Components/TransactionDone/SwapDoneSummaryCard.swift
+++ b/VultisigApp/VultisigApp/Components/TransactionDone/SwapDoneSummaryCard.swift
@@ -256,9 +256,8 @@ struct SwapDoneSummaryCard: View {
                     value: "\(transaction.swapGasString)(\(transaction.approveFeeString))"
                 )
             }
-            // Vultisig Fee (affiliate only) — matches the reconciled Total, so the
-            // breakdown no longer shows THORChain's composite as the swap fee. The
-            // label is already localized (embeds the %), so it's used verbatim.
+            // Gross list-rate Vultisig fee. Discounts below reconcile this row
+            // to the net affiliate component retained in Total Fees.
             if transaction.showAffiliateFeeRow {
                 getCell(title: transaction.swapFeeLabel, value: transaction.baseAffiliateFee)
             }
@@ -266,6 +265,65 @@ struct SwapDoneSummaryCard: View {
             if transaction.showProtocolFeeRow {
                 getCell(title: "swap.protocol_fee", value: transaction.outboundFeeString)
             }
+            if transaction.hasAppliedDiscounts {
+                appliedDiscounts(transaction)
+            }
+            if !transaction.priceImpactString.isEmpty {
+                getCell(
+                    title: "swap.price_impact",
+                    value: transaction.priceImpactString,
+                    valueColor: transaction.priceImpactColor
+                )
+            }
+        }
+    }
+
+    private func appliedDiscounts(_ transaction: SwapTransaction) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("swap.applied_discounts".localized)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textTertiary)
+                .padding(.vertical, 8)
+
+            if !transaction.vultDiscount.isEmpty {
+                HStack(spacing: 4) {
+                    vultTierIcon(transaction)
+                    Text(transaction.vultDiscountLabel)
+                        .foregroundStyle(Theme.colors.textTertiary)
+                    Spacer()
+                    Text(transaction.vultDiscount)
+                        .foregroundStyle(Theme.colors.textPrimary)
+                }
+                .font(Theme.fonts.bodySMedium)
+                .padding(.vertical)
+            }
+
+            if !transaction.referralDiscount.isEmpty {
+                HStack(spacing: 4) {
+                    Image(systemName: "megaphone.fill")
+                        .foregroundStyle(Theme.colors.primaryAccent4)
+                    Text(transaction.referralDiscountLabel)
+                        .foregroundStyle(Theme.colors.textTertiary)
+                    Spacer()
+                    Text(transaction.referralDiscount)
+                        .foregroundStyle(Theme.colors.textPrimary)
+                }
+                .font(Theme.fonts.bodySMedium)
+                .padding(.vertical)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func vultTierIcon(_ transaction: SwapTransaction) -> some View {
+        if let tier = VultDiscountTier.from(bpsDiscount: transaction.vultDiscountBps) {
+            Image(tier.icon)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 16, height: 16)
+        } else {
+            Image(systemName: "star.circle.fill")
+                .foregroundStyle(Theme.colors.turquoise)
         }
     }
 
@@ -313,7 +371,8 @@ struct SwapDoneSummaryCard: View {
         bracketValue: String? = nil,
         valueMaxWidth: CGFloat? = nil,
         bracketMaxWidth: CGFloat? = nil,
-        showCopyButton: Bool = false
+        showCopyButton: Bool = false,
+        valueColor: Color = Theme.colors.textPrimary
     ) -> some View {
         HStack {
             Text(title.localized)
@@ -324,7 +383,7 @@ struct SwapDoneSummaryCard: View {
             Text(value)
                 .lineLimit(1)
                 .truncationMode(.middle)
-                .foregroundStyle(Theme.colors.textPrimary)
+                .foregroundStyle(valueColor)
                 .frame(maxWidth: valueMaxWidth, alignment: .trailing)
 
             if let bracketValue {

--- a/VultisigApp/VultisigApp/Components/TransactionDone/SwapDoneSummaryCard.swift
+++ b/VultisigApp/VultisigApp/Components/TransactionDone/SwapDoneSummaryCard.swift
@@ -292,11 +292,9 @@ struct SwapDoneSummaryCard: View {
                     vultTierIcon(transaction)
                     Text(transaction.vultDiscountLabel)
                         .foregroundStyle(Theme.colors.textTertiary)
-                    Spacer()
-                    Text(transaction.vultDiscount)
-                        .foregroundStyle(Theme.colors.textPrimary)
                 }
                 .font(Theme.fonts.bodySMedium)
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.vertical, 8)
             }
 
@@ -306,11 +304,9 @@ struct SwapDoneSummaryCard: View {
                         .foregroundStyle(Theme.colors.primaryAccent4)
                     Text(transaction.referralDiscountLabel)
                         .foregroundStyle(Theme.colors.textTertiary)
-                    Spacer()
-                    Text(transaction.referralDiscount)
-                        .foregroundStyle(Theme.colors.textPrimary)
                 }
                 .font(Theme.fonts.bodySMedium)
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.vertical, 8)
             }
         }

--- a/VultisigApp/VultisigApp/Components/TransactionDone/SwapDoneSummaryCard.swift
+++ b/VultisigApp/VultisigApp/Components/TransactionDone/SwapDoneSummaryCard.swift
@@ -282,7 +282,7 @@ struct SwapDoneSummaryCard: View {
 
     private func appliedDiscounts(_ transaction: SwapTransaction) -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text("swap.applied_discounts".localized)
+            Text("swapAppliedDiscounts".localized)
                 .font(Theme.fonts.caption12)
                 .foregroundStyle(Theme.colors.textTertiary)
                 .padding(.vertical, 8)

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1492,7 +1492,6 @@
 "support" = "Unterstützung";
 "supportedFileTypesUpload" = "Unterstützte Dateitypen: .bak, .vult & .zip";
 "swap" = "Tausch";
-"swap.applied_discounts" = "Angewandte Rabatte:";
 "swap.duration.instant" = "Sofort";
 "swap.included_in_rate" = "im angebotenen Kurs enthalten";
 "swap.outbound_fee" = "Ausgangsgebühr";
@@ -1501,15 +1500,14 @@
 "swap.price_impact.good" = "Gut";
 "swap.price_impact.high" = "Hoch";
 "swap.protocol_fee" = "Protokollgebühr";
-"swap.referral_discount" = "Empfehlung: %@";
 "swap.tab.limit" = "Limit";
 "swap.tab.market" = "Markt";
-"swap.vult_discount" = "VULT %@: %d%%";
 "swap.vult_waiver" = "VULT (100% Erlass)";
 "swapAdvancedSettingsLockedSubtitle" = "Feinabstimmung von Slippage, Gas, Routing und Empfänger für jeden Swap.";
 "swapAdvancedSettingsLockedTitle" = "Erweiterte Swap-Einstellungen";
 "swapAmountTooSmall" = "Tauschbetrag zu klein";
 "swapAmountTooSmallRecommended" = "Tauschbetrag zu klein. Empfohlener Betrag %@";
+"swapAppliedDiscounts" = "Angewandte Rabatte:";
 "swapErrorAmountTooSmallDescription" = "Der Tauschbetrag ist zu klein. Bitte erhöhen Sie den Betrag.";
 "swapErrorAmountTooSmallTitle" = "Betrag zu klein";
 "swapErrorInboundAddressDescription" = "Die Eingangsadresse ist ungültig. Bitte versuchen Sie es erneut.";
@@ -1558,6 +1556,7 @@
 "swapOverview" = "Tauschübersicht";
 "swapRecipientRouteNotAvailable" = "Für dieses Paar ist keine Route zu einem externen Empfänger verfügbar. Entfernen Sie den Empfänger oder wählen Sie ein anderes Paar.";
 "swapRecipientVerificationFailed" = "Es konnte nicht bestätigt werden, dass der Swap an den gewählten Empfänger geht; er wurde vor dem Signieren gestoppt. Bitte versuchen Sie es erneut.";
+"swapReferralDiscount" = "Empfehlung: %@";
 "swapRouteEta" = "~%lds";
 "swapRouteNotAvailable" = "Tauschroute nicht verfügbar";
 "swaps" = "Swaps";
@@ -1570,6 +1569,8 @@
 "swapVerifyCheckbox1Description" = "Der Tauschbetrag ist korrekt";
 "swapVerifyCheckbox2Description" = "Ich stimme dem Mindestbetrag zu, den ich erhalten werde";
 "swapVerifyCheckbox3Description" = "Ich stimme zu, eine ERC20-Genehmigung für den genauen Tauschbetrag zu erteilen";
+"swapVultDiscount" = "VULT %@: %d%%";
+"swapVultDiscountFallback" = "VULT: %d%%";
 "switchBackToInternetMode" = "Kein lokaler Modus gewünscht? Zurückwechseln.";
 "switchToLocalMode" = "Zum lokalen Modus wechseln";
 "systemErrorMessage" = "Systemfehler. Bitte versuche es erneut.";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1492,6 +1492,7 @@
 "support" = "Unterstützung";
 "supportedFileTypesUpload" = "Unterstützte Dateitypen: .bak, .vult & .zip";
 "swap" = "Tausch";
+"swap.applied_discounts" = "Angewandte Rabatte:";
 "swap.duration.instant" = "Sofort";
 "swap.included_in_rate" = "im angebotenen Kurs enthalten";
 "swap.outbound_fee" = "Ausgangsgebühr";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1501,10 +1501,10 @@
 "swap.price_impact.good" = "Gut";
 "swap.price_impact.high" = "Hoch";
 "swap.protocol_fee" = "Protokollgebühr";
-"swap.referral_discount" = "Empfehlung (-%d bps)";
+"swap.referral_discount" = "Empfehlung: %@";
 "swap.tab.limit" = "Limit";
 "swap.tab.market" = "Markt";
-"swap.vult_discount" = "VULT (-%d bps)";
+"swap.vult_discount" = "VULT %@: %d%%";
 "swap.vult_waiver" = "VULT (100% Erlass)";
 "swapAdvancedSettingsLockedSubtitle" = "Feinabstimmung von Slippage, Gas, Routing und Empfänger für jeden Swap.";
 "swapAdvancedSettingsLockedTitle" = "Erweiterte Swap-Einstellungen";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1492,6 +1492,7 @@
 "support" = "Support";
 "supportedFileTypesUpload" = "Supported file types: .bak, .vult & .zip";
 "swap" = "Swap";
+"swap.applied_discounts" = "Applied Discounts:";
 "swap.duration.instant" = "Instant";
 "swap.included_in_rate" = "included in quoted rate";
 "swap.outbound_fee" = "Outbound Fee";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1492,7 +1492,6 @@
 "support" = "Support";
 "supportedFileTypesUpload" = "Supported file types: .bak, .vult & .zip";
 "swap" = "Swap";
-"swap.applied_discounts" = "Applied Discounts:";
 "swap.duration.instant" = "Instant";
 "swap.included_in_rate" = "included in quoted rate";
 "swap.outbound_fee" = "Outbound Fee";
@@ -1501,15 +1500,14 @@
 "swap.price_impact.good" = "Good";
 "swap.price_impact.high" = "High";
 "swap.protocol_fee" = "Protocol Fee";
-"swap.referral_discount" = "Referral: %@";
 "swap.tab.limit" = "Limit";
 "swap.tab.market" = "Market";
-"swap.vult_discount" = "VULT %@: %d%%";
 "swap.vult_waiver" = "VULT (100% waiver)";
 "swapAdvancedSettingsLockedSubtitle" = "Fine-tune slippage, gas, routing, and recipient for every swap.";
 "swapAdvancedSettingsLockedTitle" = "Advanced Swap Settings";
 "swapAmountTooSmall" = "Swap amount too small";
 "swapAmountTooSmallRecommended" = "Swap amount too small. Recommended amount %@";
+"swapAppliedDiscounts" = "Applied Discounts:";
 "swapErrorAmountTooSmallDescription" = "The swap amount is too small. Please increase the amount.";
 "swapErrorAmountTooSmallTitle" = "Amount Too Small";
 "swapErrorInboundAddressDescription" = "The inbound address is invalid. Please try again.";
@@ -1558,6 +1556,7 @@
 "swapOverview" = "Swap overview";
 "swapRecipientRouteNotAvailable" = "No route to an external recipient is available for this pair. Remove the recipient or choose a different pair.";
 "swapRecipientVerificationFailed" = "The swap could not be confirmed to deliver to your chosen recipient and was stopped before signing. Please try again.";
+"swapReferralDiscount" = "Referral: %@";
 "swapRouteEta" = "~%lds";
 "swapRouteNotAvailable" = "Swap route not available";
 "swaps" = "Swaps";
@@ -1570,6 +1569,8 @@
 "swapVerifyCheckbox1Description" = "The swap amount is correct";
 "swapVerifyCheckbox2Description" = "I agree with the min. amount I'll receive";
 "swapVerifyCheckbox3Description" = "I agree with providing ERC20 allowance for exact swap amount";
+"swapVultDiscount" = "VULT %@: %d%%";
+"swapVultDiscountFallback" = "VULT: %d%%";
 "switchBackToInternetMode" = "Not want to use local? Switch back.";
 "switchToLocalMode" = "Switch to local mode";
 "systemErrorMessage" = "System error. Please try again.";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1501,10 +1501,10 @@
 "swap.price_impact.good" = "Good";
 "swap.price_impact.high" = "High";
 "swap.protocol_fee" = "Protocol Fee";
-"swap.referral_discount" = "Referral (-%d bps)";
+"swap.referral_discount" = "Referral: %@";
 "swap.tab.limit" = "Limit";
 "swap.tab.market" = "Market";
-"swap.vult_discount" = "VULT (-%d bps)";
+"swap.vult_discount" = "VULT %@: %d%%";
 "swap.vult_waiver" = "VULT (100% waiver)";
 "swapAdvancedSettingsLockedSubtitle" = "Fine-tune slippage, gas, routing, and recipient for every swap.";
 "swapAdvancedSettingsLockedTitle" = "Advanced Swap Settings";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1492,7 +1492,6 @@
 "support" = "Apoyo";
 "supportedFileTypesUpload" = "Tipos de archivos soportados: .bak, .vult & .zip";
 "swap" = "Intercambio";
-"swap.applied_discounts" = "Descuentos aplicados:";
 "swap.duration.instant" = "Instantáneo";
 "swap.included_in_rate" = "incluido en la tarifa cotizada";
 "swap.outbound_fee" = "Tarifa de Salida";
@@ -1501,15 +1500,14 @@
 "swap.price_impact.good" = "Bueno";
 "swap.price_impact.high" = "Alto";
 "swap.protocol_fee" = "Comisión de protocolo";
-"swap.referral_discount" = "Referido: %@";
 "swap.tab.limit" = "Límite";
 "swap.tab.market" = "Mercado";
-"swap.vult_discount" = "VULT %@: %d%%";
 "swap.vult_waiver" = "VULT (100% exención)";
 "swapAdvancedSettingsLockedSubtitle" = "Ajusta el deslizamiento, el gas, la ruta y el destinatario en cada swap.";
 "swapAdvancedSettingsLockedTitle" = "Ajustes avanzados de swap";
 "swapAmountTooSmall" = "Cantidad de intercambio demasiado pequeña";
 "swapAmountTooSmallRecommended" = "Cantidad de intercambio demasiado pequeña. Cantidad recomendada %@";
+"swapAppliedDiscounts" = "Descuentos aplicados:";
 "swapErrorAmountTooSmallDescription" = "La cantidad del intercambio es muy pequeña. Por favor, aumenta la cantidad.";
 "swapErrorAmountTooSmallTitle" = "Cantidad Muy Pequeña";
 "swapErrorInboundAddressDescription" = "La dirección de entrada es inválida. Por favor, inténtalo de nuevo.";
@@ -1558,6 +1556,7 @@
 "swapOverview" = "Resumen del intercambio";
 "swapRecipientRouteNotAvailable" = "No hay ninguna ruta hacia un destinatario externo disponible para este par. Quita el destinatario o elige otro par.";
 "swapRecipientVerificationFailed" = "No se pudo confirmar que el intercambio se entregue al destinatario elegido y se detuvo antes de firmar. Inténtalo de nuevo.";
+"swapReferralDiscount" = "Referido: %@";
 "swapRouteEta" = "~%lds";
 "swapRouteNotAvailable" = "Ruta de intercambio no disponible";
 "swaps" = "Intercambios";
@@ -1570,6 +1569,8 @@
 "swapVerifyCheckbox1Description" = "La cantidad del intercambio es correcta";
 "swapVerifyCheckbox2Description" = "Acepto el monto mínimo que recibiré";
 "swapVerifyCheckbox3Description" = "Acepto proporcionar autorización ERC20 por el monto exacto del intercambio";
+"swapVultDiscount" = "VULT %@: %d%%";
+"swapVultDiscountFallback" = "VULT: %d%%";
 "switchBackToInternetMode" = "¿No quieres usar el modo local? Volver.";
 "switchToLocalMode" = "Cambiar a modo local";
 "systemErrorMessage" = "Error del sistema. Inténtalo de nuevo.";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1492,6 +1492,7 @@
 "support" = "Apoyo";
 "supportedFileTypesUpload" = "Tipos de archivos soportados: .bak, .vult & .zip";
 "swap" = "Intercambio";
+"swap.applied_discounts" = "Descuentos aplicados:";
 "swap.duration.instant" = "Instantáneo";
 "swap.included_in_rate" = "incluido en la tarifa cotizada";
 "swap.outbound_fee" = "Tarifa de Salida";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1501,10 +1501,10 @@
 "swap.price_impact.good" = "Bueno";
 "swap.price_impact.high" = "Alto";
 "swap.protocol_fee" = "Comisión de protocolo";
-"swap.referral_discount" = "Referido (-%d bps)";
+"swap.referral_discount" = "Referido: %@";
 "swap.tab.limit" = "Límite";
 "swap.tab.market" = "Mercado";
-"swap.vult_discount" = "VULT (-%d bps)";
+"swap.vult_discount" = "VULT %@: %d%%";
 "swap.vult_waiver" = "VULT (100% exención)";
 "swapAdvancedSettingsLockedSubtitle" = "Ajusta el deslizamiento, el gas, la ruta y el destinatario en cada swap.";
 "swapAdvancedSettingsLockedTitle" = "Ajustes avanzados de swap";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1492,6 +1492,7 @@
 "support" = "Podržati";
 "supportedFileTypesUpload" = "Podržane vrste datoteka: .bak, .vult & .zip";
 "swap" = "Zamjena";
+"swap.applied_discounts" = "Primijenjeni popusti:";
 "swap.duration.instant" = "Trenutno";
 "swap.included_in_rate" = "uključeno u ponuđeni tečaj";
 "swap.outbound_fee" = "Izlazna naknada";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1492,7 +1492,6 @@
 "support" = "Podržati";
 "supportedFileTypesUpload" = "Podržane vrste datoteka: .bak, .vult & .zip";
 "swap" = "Zamjena";
-"swap.applied_discounts" = "Primijenjeni popusti:";
 "swap.duration.instant" = "Trenutno";
 "swap.included_in_rate" = "uključeno u ponuđeni tečaj";
 "swap.outbound_fee" = "Izlazna naknada";
@@ -1501,15 +1500,14 @@
 "swap.price_impact.good" = "Dobro";
 "swap.price_impact.high" = "Visoko";
 "swap.protocol_fee" = "Naknada protokola";
-"swap.referral_discount" = "Preporuka: %@";
 "swap.tab.limit" = "Limit";
 "swap.tab.market" = "Tržište";
-"swap.vult_discount" = "VULT %@: %d%%";
 "swap.vult_waiver" = "VULT (100% oslobođenje)";
 "swapAdvancedSettingsLockedSubtitle" = "Precizno podesite slippage, gas, rutu i primatelja za svaku zamjenu.";
 "swapAdvancedSettingsLockedTitle" = "Napredne postavke zamjene";
 "swapAmountTooSmall" = "Iznos zamjene je premali";
 "swapAmountTooSmallRecommended" = "Iznos zamjene je premali. Preporučeni iznos %@";
+"swapAppliedDiscounts" = "Primijenjeni popusti:";
 "swapErrorAmountTooSmallDescription" = "Iznos zamjene je premali. Molimo povećajte iznos.";
 "swapErrorAmountTooSmallTitle" = "Iznos Premali";
 "swapErrorInboundAddressDescription" = "Ulazna adresa je nevažeća. Molimo pokušajte ponovo.";
@@ -1558,6 +1556,7 @@
 "swapOverview" = "Pregled zamjene";
 "swapRecipientRouteNotAvailable" = "Za ovaj par nije dostupna ruta do vanjskog primatelja. Uklonite primatelja ili odaberite drugi par.";
 "swapRecipientVerificationFailed" = "Nije se moglo potvrditi da će zamjena biti isporučena odabranom primatelju te je zaustavljena prije potpisivanja. Pokušajte ponovno.";
+"swapReferralDiscount" = "Preporuka: %@";
 "swapRouteEta" = "~%lds";
 "swapRouteNotAvailable" = "Ruta zamjene nije dostupna";
 "swaps" = "Zamjene";
@@ -1570,6 +1569,8 @@
 "swapVerifyCheckbox1Description" = "Iznos zamjene je točan";
 "swapVerifyCheckbox2Description" = "Slažem se s minimalnim iznosom koji ću primiti";
 "swapVerifyCheckbox3Description" = "Slažem se dati ERC20 dopuštenje za točan iznos zamjene";
+"swapVultDiscount" = "VULT %@: %d%%";
+"swapVultDiscountFallback" = "VULT: %d%%";
 "switchBackToInternetMode" = "Ne želite koristiti lokalni način? Vratite se.";
 "switchToLocalMode" = "Prebaci na lokalni način";
 "systemErrorMessage" = "Sistemska greška. Pokušajte ponovno.";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1501,10 +1501,10 @@
 "swap.price_impact.good" = "Dobro";
 "swap.price_impact.high" = "Visoko";
 "swap.protocol_fee" = "Naknada protokola";
-"swap.referral_discount" = "Preporuka (-%d bps)";
+"swap.referral_discount" = "Preporuka: %@";
 "swap.tab.limit" = "Limit";
 "swap.tab.market" = "Tržište";
-"swap.vult_discount" = "VULT (-%d bps)";
+"swap.vult_discount" = "VULT %@: %d%%";
 "swap.vult_waiver" = "VULT (100% oslobođenje)";
 "swapAdvancedSettingsLockedSubtitle" = "Precizno podesite slippage, gas, rutu i primatelja za svaku zamjenu.";
 "swapAdvancedSettingsLockedTitle" = "Napredne postavke zamjene";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1492,7 +1492,6 @@
 "support" = "Supporto";
 "supportedFileTypesUpload" = "Tipi di file supportati: .bak, .vult & .zip";
 "swap" = "Scambio";
-"swap.applied_discounts" = "Sconti applicati:";
 "swap.duration.instant" = "Istantaneo";
 "swap.included_in_rate" = "incluso nel tasso quotato";
 "swap.outbound_fee" = "Commissione in Uscita";
@@ -1501,15 +1500,14 @@
 "swap.price_impact.good" = "Buono";
 "swap.price_impact.high" = "Alto";
 "swap.protocol_fee" = "Commissione di protocollo";
-"swap.referral_discount" = "Referral: %@";
 "swap.tab.limit" = "Limite";
 "swap.tab.market" = "Mercato";
-"swap.vult_discount" = "VULT %@: %d%%";
 "swap.vult_waiver" = "VULT (100% esenzione)";
 "swapAdvancedSettingsLockedSubtitle" = "Regola slippage, gas, percorso e destinatario per ogni swap.";
 "swapAdvancedSettingsLockedTitle" = "Impostazioni avanzate dello swap";
 "swapAmountTooSmall" = "Importo dello scambio troppo piccolo";
 "swapAmountTooSmallRecommended" = "Importo dello scambio troppo piccolo. Importo raccomandato %@";
+"swapAppliedDiscounts" = "Sconti applicati:";
 "swapErrorAmountTooSmallDescription" = "L'importo dello scambio è troppo piccolo. Per favore aumenta l'importo.";
 "swapErrorAmountTooSmallTitle" = "Importo Troppo Piccolo";
 "swapErrorInboundAddressDescription" = "L'indirizzo in entrata non è valido. Per favore riprova.";
@@ -1558,6 +1556,7 @@
 "swapOverview" = "Panoramica dello scambio";
 "swapRecipientRouteNotAvailable" = "Nessun percorso verso un destinatario esterno è disponibile per questa coppia. Rimuovi il destinatario o scegli un'altra coppia.";
 "swapRecipientVerificationFailed" = "Non è stato possibile confermare che lo swap venga consegnato al destinatario scelto ed è stato interrotto prima della firma. Riprova.";
+"swapReferralDiscount" = "Referral: %@";
 "swapRouteEta" = "~%lds";
 "swapRouteNotAvailable" = "Percorso di scambio non disponibile";
 "swaps" = "Scambi";
@@ -1570,6 +1569,8 @@
 "swapVerifyCheckbox1Description" = "L'importo dello scambio è corretto";
 "swapVerifyCheckbox2Description" = "Accetto l'importo minimo che riceverò";
 "swapVerifyCheckbox3Description" = "Accetto di fornire l'autorizzazione ERC20 per l'importo esatto dello scambio";
+"swapVultDiscount" = "VULT %@: %d%%";
+"swapVultDiscountFallback" = "VULT: %d%%";
 "switchBackToInternetMode" = "Non vuoi usare la modalità locale? Torna indietro.";
 "switchToLocalMode" = "Passa alla modalità locale";
 "systemErrorMessage" = "Errore di sistema. Riprova.";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1492,6 +1492,7 @@
 "support" = "Supporto";
 "supportedFileTypesUpload" = "Tipi di file supportati: .bak, .vult & .zip";
 "swap" = "Scambio";
+"swap.applied_discounts" = "Sconti applicati:";
 "swap.duration.instant" = "Istantaneo";
 "swap.included_in_rate" = "incluso nel tasso quotato";
 "swap.outbound_fee" = "Commissione in Uscita";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1501,10 +1501,10 @@
 "swap.price_impact.good" = "Buono";
 "swap.price_impact.high" = "Alto";
 "swap.protocol_fee" = "Commissione di protocollo";
-"swap.referral_discount" = "Referral (-%d bps)";
+"swap.referral_discount" = "Referral: %@";
 "swap.tab.limit" = "Limite";
 "swap.tab.market" = "Mercato";
-"swap.vult_discount" = "VULT (-%d bps)";
+"swap.vult_discount" = "VULT %@: %d%%";
 "swap.vult_waiver" = "VULT (100% esenzione)";
 "swapAdvancedSettingsLockedSubtitle" = "Regola slippage, gas, percorso e destinatario per ogni swap.";
 "swapAdvancedSettingsLockedTitle" = "Impostazioni avanzate dello swap";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1492,6 +1492,7 @@
 "support" = "지원";
 "supportedFileTypesUpload" = "지원되는 파일 형식: .bak, .vult & .zip";
 "swap" = "스왑";
+"swap.applied_discounts" = "적용된 할인:";
 "swap.duration.instant" = "즉시";
 "swap.included_in_rate" = "제시된 환율에 포함됨";
 "swap.outbound_fee" = "아웃바운드 수수료";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1492,7 +1492,6 @@
 "support" = "지원";
 "supportedFileTypesUpload" = "지원되는 파일 형식: .bak, .vult & .zip";
 "swap" = "스왑";
-"swap.applied_discounts" = "적용된 할인:";
 "swap.duration.instant" = "즉시";
 "swap.included_in_rate" = "제시된 환율에 포함됨";
 "swap.outbound_fee" = "아웃바운드 수수료";
@@ -1501,15 +1500,14 @@
 "swap.price_impact.good" = "양호";
 "swap.price_impact.high" = "높음";
 "swap.protocol_fee" = "프로토콜 수수료";
-"swap.referral_discount" = "추천: %@";
 "swap.tab.limit" = "지정가";
 "swap.tab.market" = "시장";
-"swap.vult_discount" = "VULT %@: %d%%";
 "swap.vult_waiver" = "VULT (100% 면제)";
 "swapAdvancedSettingsLockedSubtitle" = "모든 스왑에 대해 슬리피지, 가스, 경로, 수신자를 세밀하게 조정하세요.";
 "swapAdvancedSettingsLockedTitle" = "고급 스왑 설정";
 "swapAmountTooSmall" = "스왑 금액이 너무 작습니다";
 "swapAmountTooSmallRecommended" = "스왑 금액이 너무 작습니다. 권장 금액 %@";
+"swapAppliedDiscounts" = "적용된 할인:";
 "swapErrorAmountTooSmallDescription" = "스왑 금액이 너무 작습니다. 금액을 늘려주세요.";
 "swapErrorAmountTooSmallTitle" = "금액이 너무 작음";
 "swapErrorInboundAddressDescription" = "인바운드 주소가 유효하지 않습니다. 다시 시도하세요.";
@@ -1558,6 +1556,7 @@
 "swapOverview" = "스왑 개요";
 "swapRecipientRouteNotAvailable" = "이 쌍에 대해 외부 수신자로 가는 경로를 사용할 수 없습니다. 수신자를 제거하거나 다른 쌍을 선택하세요.";
 "swapRecipientVerificationFailed" = "스왑이 선택한 수신자에게 전달되는지 확인할 수 없어 서명 전에 중단되었습니다. 다시 시도해 주세요.";
+"swapReferralDiscount" = "추천: %@";
 "swapRouteEta" = "~%ld초";
 "swapRouteNotAvailable" = "스왑 경로를 사용할 수 없습니다";
 "swaps" = "스왑";
@@ -1570,6 +1569,8 @@
 "swapVerifyCheckbox1Description" = "스왑 금액이 올바릅니다";
 "swapVerifyCheckbox2Description" = "받을 최소 금액에 동의합니다";
 "swapVerifyCheckbox3Description" = "정확한 스왑 금액에 대한 ERC20 허용량 제공에 동의합니다";
+"swapVultDiscount" = "VULT %@: %d%%";
+"swapVultDiscountFallback" = "VULT: %d%%";
 "switchBackToInternetMode" = "로컬을 사용하지 않으시겠습니까? 다시 전환하세요.";
 "switchToLocalMode" = "로컬 모드로 전환";
 "systemErrorMessage" = "시스템 오류입니다. 다시 시도하세요.";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1501,10 +1501,10 @@
 "swap.price_impact.good" = "양호";
 "swap.price_impact.high" = "높음";
 "swap.protocol_fee" = "프로토콜 수수료";
-"swap.referral_discount" = "추천 (-%d bps)";
+"swap.referral_discount" = "추천: %@";
 "swap.tab.limit" = "지정가";
 "swap.tab.market" = "시장";
-"swap.vult_discount" = "VULT (-%d bps)";
+"swap.vult_discount" = "VULT %@: %d%%";
 "swap.vult_waiver" = "VULT (100% 면제)";
 "swapAdvancedSettingsLockedSubtitle" = "모든 스왑에 대해 슬리피지, 가스, 경로, 수신자를 세밀하게 조정하세요.";
 "swapAdvancedSettingsLockedTitle" = "고급 스왑 설정";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1492,6 +1492,7 @@
 "support" = "Suporte";
 "supportedFileTypesUpload" = "Tipos de arquivos suportados: .bak, .vult & .zip";
 "swap" = "Troca";
+"swap.applied_discounts" = "Descontos aplicados:";
 "swap.duration.instant" = "Instantâneo";
 "swap.included_in_rate" = "incluída na taxa cotada";
 "swap.outbound_fee" = "Taxa de Saída";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1492,7 +1492,6 @@
 "support" = "Suporte";
 "supportedFileTypesUpload" = "Tipos de arquivos suportados: .bak, .vult & .zip";
 "swap" = "Troca";
-"swap.applied_discounts" = "Descontos aplicados:";
 "swap.duration.instant" = "Instantâneo";
 "swap.included_in_rate" = "incluída na taxa cotada";
 "swap.outbound_fee" = "Taxa de Saída";
@@ -1501,15 +1500,14 @@
 "swap.price_impact.good" = "Bom";
 "swap.price_impact.high" = "Alto";
 "swap.protocol_fee" = "Taxa de protocolo";
-"swap.referral_discount" = "Indicação: %@";
 "swap.tab.limit" = "Limite";
 "swap.tab.market" = "Mercado";
-"swap.vult_discount" = "VULT %@: %d%%";
 "swap.vult_waiver" = "VULT (100% isento)";
 "swapAdvancedSettingsLockedSubtitle" = "Ajuste slippage, gas, rota e destinatário em cada swap.";
 "swapAdvancedSettingsLockedTitle" = "Configurações avançadas de swap";
 "swapAmountTooSmall" = "Valor da troca muito pequeno";
 "swapAmountTooSmallRecommended" = "Valor da troca muito pequeno. Valor recomendado %@";
+"swapAppliedDiscounts" = "Descontos aplicados:";
 "swapErrorAmountTooSmallDescription" = "O valor da troca é muito pequeno. Por favor, aumente o valor.";
 "swapErrorAmountTooSmallTitle" = "Valor Muito Pequeno";
 "swapErrorInboundAddressDescription" = "O endereço de entrada é inválido. Por favor, tente novamente.";
@@ -1558,6 +1556,7 @@
 "swapOverview" = "Visão geral da troca";
 "swapRecipientRouteNotAvailable" = "Nenhuma rota para um destinatário externo está disponível para este par. Remova o destinatário ou escolha outro par.";
 "swapRecipientVerificationFailed" = "Não foi possível confirmar que a troca seria entregue ao destinatário escolhido e ela foi interrompida antes da assinatura. Tente novamente.";
+"swapReferralDiscount" = "Indicação: %@";
 "swapRouteEta" = "~%lds";
 "swapRouteNotAvailable" = "Rota de troca não disponível";
 "swaps" = "Trocas";
@@ -1570,6 +1569,8 @@
 "swapVerifyCheckbox1Description" = "O valor da troca está correto";
 "swapVerifyCheckbox2Description" = "Concordo com o valor mínimo que receberei";
 "swapVerifyCheckbox3Description" = "Concordo em fornecer permissão ERC20 para o valor exato da troca";
+"swapVultDiscount" = "VULT %@: %d%%";
+"swapVultDiscountFallback" = "VULT: %d%%";
 "switchBackToInternetMode" = "Não quer usar o modo local? Voltar.";
 "switchToLocalMode" = "Mudar para modo local";
 "systemErrorMessage" = "Erro do sistema. Tente novamente.";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1501,10 +1501,10 @@
 "swap.price_impact.good" = "Bom";
 "swap.price_impact.high" = "Alto";
 "swap.protocol_fee" = "Taxa de protocolo";
-"swap.referral_discount" = "Indicação (-%d bps)";
+"swap.referral_discount" = "Indicação: %@";
 "swap.tab.limit" = "Limite";
 "swap.tab.market" = "Mercado";
-"swap.vult_discount" = "VULT (-%d bps)";
+"swap.vult_discount" = "VULT %@: %d%%";
 "swap.vult_waiver" = "VULT (100% isento)";
 "swapAdvancedSettingsLockedSubtitle" = "Ajuste slippage, gas, rota e destinatário em cada swap.";
 "swapAdvancedSettingsLockedTitle" = "Configurações avançadas de swap";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1492,6 +1492,7 @@
 "support" = "支持";
 "supportedFileTypesUpload" = "支持的文件类型：.bak、.vult 和 .zip";
 "swap" = "交换";
+"swap.applied_discounts" = "已应用的折扣：";
 "swap.duration.instant" = "即时";
 "swap.included_in_rate" = "已包含在报价汇率中";
 "swap.outbound_fee" = "出站费用";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1492,7 +1492,6 @@
 "support" = "支持";
 "supportedFileTypesUpload" = "支持的文件类型：.bak、.vult 和 .zip";
 "swap" = "交换";
-"swap.applied_discounts" = "已应用的折扣：";
 "swap.duration.instant" = "即时";
 "swap.included_in_rate" = "已包含在报价汇率中";
 "swap.outbound_fee" = "出站费用";
@@ -1501,15 +1500,14 @@
 "swap.price_impact.good" = "良好";
 "swap.price_impact.high" = "较高";
 "swap.protocol_fee" = "协议费用";
-"swap.referral_discount" = "推荐: %@";
 "swap.tab.limit" = "限价";
 "swap.tab.market" = "市场";
-"swap.vult_discount" = "VULT %@: %d%%";
 "swap.vult_waiver" = "VULT (100% 豁免)";
 "swapAdvancedSettingsLockedSubtitle" = "为每次兑换精细调整滑点、Gas、路由和收款人。";
 "swapAdvancedSettingsLockedTitle" = "高级兑换设置";
 "swapAmountTooSmall" = "交换金额太小";
 "swapAmountTooSmallRecommended" = "交换金额太小。推荐金额 %@";
+"swapAppliedDiscounts" = "已应用的折扣：";
 "swapErrorAmountTooSmallDescription" = "交换金额太小。请增加金额。";
 "swapErrorAmountTooSmallTitle" = "金额太小";
 "swapErrorInboundAddressDescription" = "入站地址无效。请重试。";
@@ -1558,6 +1556,7 @@
 "swapOverview" = "交换概览";
 "swapRecipientRouteNotAvailable" = "此交易对没有可用的外部接收方路由。请移除接收方或选择其他交易对。";
 "swapRecipientVerificationFailed" = "无法确认此交换会发送至你选择的接收方，已在签名前停止。请重试。";
+"swapReferralDiscount" = "推荐: %@";
 "swapRouteEta" = "~%ld秒";
 "swapRouteNotAvailable" = "交换路由不可用";
 "swaps" = "兑换";
@@ -1570,6 +1569,8 @@
 "swapVerifyCheckbox1Description" = "交换金额正确";
 "swapVerifyCheckbox2Description" = "我同意我将收到的最小金额";
 "swapVerifyCheckbox3Description" = "我同意为确切的交换金额提供 ERC20 授权";
+"swapVultDiscount" = "VULT %@: %d%%";
+"swapVultDiscountFallback" = "VULT: %d%%";
 "switchBackToInternetMode" = "不想使用本地模式？切换回去。";
 "switchToLocalMode" = "切换到本地模式";
 "systemErrorMessage" = "系统错误。请重试";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1556,7 +1556,7 @@
 "swapOverview" = "交换概览";
 "swapRecipientRouteNotAvailable" = "此交易对没有可用的外部接收方路由。请移除接收方或选择其他交易对。";
 "swapRecipientVerificationFailed" = "无法确认此交换会发送至你选择的接收方，已在签名前停止。请重试。";
-"swapReferralDiscount" = "推荐: %@";
+"swapReferralDiscount" = "推荐：%@";
 "swapRouteEta" = "~%ld秒";
 "swapRouteNotAvailable" = "交换路由不可用";
 "swaps" = "兑换";
@@ -1569,8 +1569,8 @@
 "swapVerifyCheckbox1Description" = "交换金额正确";
 "swapVerifyCheckbox2Description" = "我同意我将收到的最小金额";
 "swapVerifyCheckbox3Description" = "我同意为确切的交换金额提供 ERC20 授权";
-"swapVultDiscount" = "VULT %@: %d%%";
-"swapVultDiscountFallback" = "VULT: %d%%";
+"swapVultDiscount" = "VULT %@：%d%%";
+"swapVultDiscountFallback" = "VULT：%d%%";
 "switchBackToInternetMode" = "不想使用本地模式？切换回去。";
 "switchToLocalMode" = "切换到本地模式";
 "systemErrorMessage" = "系统错误。请重试";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1501,10 +1501,10 @@
 "swap.price_impact.good" = "良好";
 "swap.price_impact.high" = "较高";
 "swap.protocol_fee" = "协议费用";
-"swap.referral_discount" = "推荐 (-%d bps)";
+"swap.referral_discount" = "推荐: %@";
 "swap.tab.limit" = "限价";
 "swap.tab.market" = "市场";
-"swap.vult_discount" = "VULT (-%d bps)";
+"swap.vult_discount" = "VULT %@: %d%%";
 "swap.vult_waiver" = "VULT (100% 豁免)";
 "swapAdvancedSettingsLockedSubtitle" = "为每次兑换精细调整滑点、Gas、路由和收款人。";
 "swapAdvancedSettingsLockedTitle" = "高级兑换设置";

--- a/VultisigApp/VultisigApp/Features/Swap/Interactor/DefaultSwapInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Interactor/DefaultSwapInteractor.swift
@@ -57,7 +57,7 @@ struct DefaultSwapInteractor: SwapInteractor {
             ? 0
             : max(
                 0,
-                THORChainSwaps.affiliateFeeRateBp
+                SwapCryptoLogic.affiliateListFeeBps
                     - THORChainSwaps.referredAffiliateFeeRateBp
                     - (Int(THORChainSwaps.referredUserFeeRateBp) ?? 0)
             )
@@ -77,8 +77,7 @@ struct DefaultSwapInteractor: SwapInteractor {
             quote: fetched.best,
             allQuotes: fetched.ranked,
             vultDiscountBps: vultDiscountBps,
-            referralDiscountBps: referralDiscountBps,
-            isReferred: !referredCode.isEmpty
+            referralDiscountBps: referralDiscountBps
         )
     }
 

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapQuoteResult.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapQuoteResult.swift
@@ -17,24 +17,15 @@ struct SwapQuoteResult: Equatable {
     let allQuotes: [SwapQuote]
     let vultDiscountBps: Int
     let referralDiscountBps: Int
-    /// Whether a referral code was active for this fetch (`!referredCode.isEmpty`).
-    /// Kept as a clean bit rather than inferred from `referralDiscountBps`, which
-    /// collapses to 0 in DEBUG (base affiliate rate is 0) even when a code is
-    /// present. Drives the route-aware affiliate-percentage label so the shown %
-    /// matches the `affiliate_bps` the request builder actually sent.
-    let isReferred: Bool
-
     init(
         quote: SwapQuote,
         allQuotes: [SwapQuote]? = nil,
         vultDiscountBps: Int,
-        referralDiscountBps: Int,
-        isReferred: Bool = false
+        referralDiscountBps: Int
     ) {
         self.quote = quote
         self.allQuotes = allQuotes ?? [quote]
         self.vultDiscountBps = vultDiscountBps
         self.referralDiscountBps = referralDiscountBps
-        self.isReferred = isReferred
     }
 }

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
@@ -79,14 +79,6 @@ struct SwapTransaction: Hashable {
     let vultDiscountBps: Int
     let referralDiscountBps: Int
 
-    /// Whether a referral code was active when this quote was fetched. Used by
-    /// the route-aware affiliate-percentage label to reproduce the exact
-    /// `affiliate_bps` the request builder sent — a clean bit, because
-    /// `referralDiscountBps` collapses to 0 in DEBUG (base rate 0) even when
-    /// referred. `var` with a default so the memberwise init stays source-
-    /// compatible; set once at construction, never mutated (immutable hand-off).
-    var isReferred: Bool = false
-
     /// Source-chain broadcast-gas ESTIMATE for a placed LIMIT order, in the fee
     /// coin's smallest units. A dedicated field — NOT the market `thorchainFee`,
     /// whose meaning is the THORChain protocol/outbound fee that feeds
@@ -162,8 +154,7 @@ extension SwapTransaction {
         gasLimit: BigInt? = nil,
         thorchainFee: BigInt? = nil,
         vultDiscountBps: Int? = nil,
-        referralDiscountBps: Int? = nil,
-        isReferred: Bool? = nil
+        referralDiscountBps: Int? = nil
     ) -> SwapTransaction {
         SwapTransaction(
             fromCoin: fromCoin,
@@ -181,7 +172,6 @@ extension SwapTransaction {
             thorchainFee: thorchainFee ?? self.thorchainFee,
             vultDiscountBps: vultDiscountBps ?? self.vultDiscountBps,
             referralDiscountBps: referralDiscountBps ?? self.referralDiscountBps,
-            isReferred: isReferred ?? self.isReferred,
             networkFeeEstimate: networkFeeEstimate,
             feeCoin: feeCoin,
             advancedSettings: advancedSettings

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
@@ -311,8 +311,8 @@ extension SwapTransaction {
 
     /// Whether an expandable fee breakdown has any itemized rows to show, so the
     /// "Total fee" chevron is only offered when expanding reveals something.
-    /// Mirrors the itemized rows the Done breakdown emits (network gas, the
-    /// Vultisig affiliate row, the protocol/outbound row).
+    /// Mirrors the itemized rows the Done breakdown emits: network gas, gross
+    /// affiliate fee, protocol fee, applied discounts, and price impact.
     var hasFeeBreakdown: Bool {
         showGas || showAffiliateFeeRow || showProtocolFeeRow || hasAppliedDiscounts || !priceImpactString.isEmpty
     }

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
@@ -314,7 +314,7 @@ extension SwapTransaction {
     /// Mirrors the itemized rows the Done breakdown emits (network gas, the
     /// Vultisig affiliate row, the protocol/outbound row).
     var hasFeeBreakdown: Bool {
-        showGas || showAffiliateFeeRow || showProtocolFeeRow
+        showGas || showAffiliateFeeRow || showProtocolFeeRow || hasAppliedDiscounts || !priceImpactString.isEmpty
     }
 
     var swapGasString: String {

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
@@ -366,14 +366,15 @@ extension SwapTransaction {
     }
 
     var baseAffiliateFee: String {
-        SwapCryptoLogic.baseAffiliateFee(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin)
+        SwapCryptoLogic.baseAffiliateFee(
+            quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin,
+            fromAmount: fromAmountString, vultDiscountBps: vultDiscountBps,
+            referralDiscountBps: referralDiscountBps
+        )
     }
 
     var swapFeeLabel: String {
-        SwapCryptoLogic.swapFeeLabel(
-            quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin,
-            fromAmount: fromAmountString, vultDiscountBps: vultDiscountBps, isReferred: isReferred
-        )
+        SwapCryptoLogic.swapFeeLabel(quote: quote)
     }
 
     var outboundFeeString: String {
@@ -401,6 +402,10 @@ extension SwapTransaction {
             fromAmount: fromAmountString, vultDiscountBps: vultDiscountBps,
             referralDiscountBps: referralDiscountBps
         )
+    }
+
+    var hasAppliedDiscounts: Bool {
+        !vultDiscount.isEmpty || !referralDiscount.isEmpty
     }
 
     var priceImpactString: String {

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
@@ -364,7 +364,10 @@ extension SwapTransaction {
     }
 
     var swapFeeLabel: String {
-        SwapCryptoLogic.swapFeeLabel(quote: quote)
+        SwapCryptoLogic.swapFeeLabel(
+            quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin,
+            vultDiscountBps: vultDiscountBps
+        )
     }
 
     var outboundFeeString: String {

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
@@ -385,7 +385,8 @@ extension SwapTransaction {
     var vultDiscount: String {
         SwapCryptoLogic.vultDiscount(
             quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin,
-            fromAmount: fromAmountString, vultDiscountBps: vultDiscountBps
+            fromAmount: fromAmountString, vultDiscountBps: vultDiscountBps,
+            referralDiscountBps: referralDiscountBps
         )
     }
 

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -409,6 +409,18 @@ enum SwapCryptoLogic {
 
     // MARK: - Display: fees
 
+    /// Public list rate shown on swap fee surfaces. This is intentionally
+    /// independent of the DEBUG-only wire affiliate configuration.
+    static let affiliateListFeeBps = 50
+
+    struct AffiliateDiscountBreakdown: Equatable {
+        let vult: Decimal
+        let referral: Decimal
+
+        var total: Decimal { vult + referral }
+        var hasDiscounts: Bool { total > 0 }
+    }
+
     static func showGas(gas: BigInt) -> Bool {
         !gas.isZero
     }
@@ -518,21 +530,35 @@ enum SwapCryptoLogic {
         return formatter.string(from: fromDate, to: toDate) ?? .empty
     }
 
-    /// Trailing value for the "Vultisig Fee" affiliate row. The affiliate
-    /// component ONLY, sourced per route from `affiliateFeeFiat` — never the
-    /// composite `fees.total`. Returns `$0.00` (not empty) for a real affiliate
-    /// route charging zero, so the Ultimate/100%-waiver user still sees the row;
-    /// SwapKit's flat 0.50% is baked into the quoted rate, so it shows an
-    /// "included in quoted rate" note instead of a separate amount. `.empty`
-    /// only when there is no quote — row visibility is gated by
-    /// `showAffiliateFeeRow`, not by this string being empty.
-    static func baseAffiliateFee(quote: SwapQuote?, fromCoin: Coin, toCoin: Coin, feeCoin: Coin) -> String {
+    /// Gross list-rate amount shown on the "Vultisig Fee" row. The quote
+    /// exposes the net charged affiliate amount, so adding the exact displayed
+    /// discounts reconstructs the undiscounted amount while `totalFeeString`
+    /// deliberately remains net. SwapKit's affiliate is embedded in the quoted
+    /// rate and therefore stays a note rather than a fabricated line-item value.
+    static func baseAffiliateFee(
+        quote: SwapQuote?,
+        fromCoin: Coin,
+        toCoin: Coin,
+        feeCoin: Coin,
+        fromAmount: String = .empty,
+        vultDiscountBps: Int = 0,
+        referralDiscountBps: Int = 0
+    ) -> String {
         guard let quote else { return .empty }
         if case .swapkit = quote {
             return "swap.included_in_rate".localized
         }
-        return affiliateFeeFiat(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin)
-            .formatToFiat(includeCurrencySymbol: true)
+        let net = affiliateFeeFiat(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin)
+        let discounts = affiliateDiscountBreakdown(
+            quote: quote,
+            fromCoin: fromCoin,
+            toCoin: toCoin,
+            feeCoin: feeCoin,
+            fromAmount: fromAmount,
+            vultDiscountBps: vultDiscountBps,
+            referralDiscountBps: referralDiscountBps
+        )
+        return (net + discounts.total).formatToFiat(includeCurrencySymbol: true)
     }
 
     /// Whether the "Vultisig Fee" affiliate row should render. Every real market
@@ -594,55 +620,11 @@ enum SwapCryptoLogic {
         }
     }
 
-    /// Label for the "Vultisig Fee (X.XX%)" affiliate row. The percentage source
-    /// depends on the route:
-    /// - Native THOR/Maya: derived from the effective affiliate bps actually sent
-    ///   on the quote request (`THORChainSwaps.effectiveAffiliateFeeBps`), so the
-    ///   shown % equals what the node charged — and reconciles with `fees.affiliate`
-    ///   by construction, rather than a lossy `fee/input` fiat division.
-    /// - SwapKit: a flat 0.50% baked into the quoted rate (no per-tx fee field).
-    /// - EVM aggregators / Jupiter: the affiliate amount comes from a route field
-    ///   (`tx.swapFee` / `platformFee`), so the % is derived from that amount and
-    ///   matches the amount shown for the route.
-    static func swapFeeLabel(
-        quote: SwapQuote?,
-        fromCoin: Coin,
-        toCoin: Coin,
-        feeCoin: Coin,
-        fromAmount: String,
-        vultDiscountBps: Int,
-        isReferred: Bool
-    ) -> String {
-        guard let quote else { return "vultisigFee".localized }
-
-        switch quote {
-        case .thorchain, .thorchainChainnet, .thorchainStagenet:
-            // All three THORChain services build affiliate params via
-            // `ThorchainService.affiliateParams`, which applies the referred
-            // split whenever a code is present.
-            let bps = THORChainSwaps.effectiveAffiliateFeeBps(
-                discountBps: vultDiscountBps,
-                isReferred: isReferred
-            )
-            return String(format: "vultisigFeePercentage".localized, Double(bps) / 100.0)
-        case .mayachain:
-            // MayaChain's affiliate params ignore the referral code entirely
-            // (`MayachainService.affiliateParams(referredCode _:)`), so it always
-            // sends the single standard rate — never the referred split.
-            let bps = THORChainSwaps.effectiveAffiliateFeeBps(
-                discountBps: vultDiscountBps,
-                isReferred: false
-            )
-            return String(format: "vultisigFeePercentage".localized, Double(bps) / 100.0)
-        case .swapkit:
-            return String(format: "vultisigFeePercentage".localized, Double(THORChainSwaps.swapKitAffiliateFeeBps) / 100.0)
-        case .oneinch, .kyberswap, .lifi, .jupiter:
-            let feeFiat = affiliateFeeFiat(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin)
-            let inputFiat = fromCoin.fiat(decimal: fromAmountDecimal(fromAmount: fromAmount))
-            guard inputFiat > 0 else { return "vultisigFee".localized }
-            let percentage = (feeFiat / inputFiat) * 100
-            return String(format: "vultisigFeePercentage".localized, NSDecimalNumber(decimal: percentage).doubleValue)
-        }
+    /// List-rate label. Discounts are itemized separately and never reduce this
+    /// percentage, regardless of the effective bps sent to a provider.
+    static func swapFeeLabel(quote: SwapQuote?) -> String {
+        guard quote != nil else { return "vultisigFee".localized }
+        return String(format: "vultisigFeePercentage".localized, Double(affiliateListFeeBps) / 100.0)
     }
 
     /// Protocol outbound-fee component in fiat (denominated in the output asset),
@@ -700,15 +682,16 @@ enum SwapCryptoLogic {
         fromAmount: String,
         vultDiscountBps: Int
     ) -> String {
-        getDiscountString(
+        let breakdown = affiliateDiscountBreakdown(
             quote: quote,
             fromCoin: fromCoin,
             toCoin: toCoin,
             feeCoin: feeCoin,
             fromAmount: fromAmount,
             vultDiscountBps: vultDiscountBps,
-            shareBps: vultDiscountBps
+            referralDiscountBps: 0
         )
+        return formatDiscount(breakdown.vult)
     }
 
     static func referralDiscount(
@@ -720,82 +703,69 @@ enum SwapCryptoLogic {
         vultDiscountBps: Int,
         referralDiscountBps: Int
     ) -> String {
-        getDiscountString(
+        let breakdown = affiliateDiscountBreakdown(
             quote: quote,
             fromCoin: fromCoin,
             toCoin: toCoin,
             feeCoin: feeCoin,
             fromAmount: fromAmount,
             vultDiscountBps: vultDiscountBps,
-            shareBps: referralDiscountBps
+            referralDiscountBps: referralDiscountBps
         )
+        return formatDiscount(breakdown.referral)
     }
 
-    private static func getDiscountString(
+    static func affiliateDiscountBreakdown(
         quote: SwapQuote?,
         fromCoin: Coin,
         toCoin: Coin,
         feeCoin: Coin,
         fromAmount: String,
         vultDiscountBps: Int,
-        shareBps: Int
-    ) -> String {
-        guard shareBps > 0 else { return .empty }
-
-        // Ultimate tier (Int.max) ⇒ 100% waiver, return total saving.
-        if shareBps == Int.max {
-            let totalSaving = calculateTotalSaving(
-                quote: quote,
-                fromCoin: fromCoin,
-                toCoin: toCoin,
-                feeCoin: feeCoin,
-                fromAmount: fromAmount
-            )
-            guard totalSaving > 0 else { return .empty }
-            return "-" + totalSaving.formatToFiat(includeCurrencySymbol: true)
+        referralDiscountBps: Int
+    ) -> AffiliateDiscountBreakdown {
+        guard let quote else { return AffiliateDiscountBreakdown(vult: 0, referral: 0) }
+        if case let .jupiter(_, _, _, feeOnInput) = quote, feeOnInput {
+            return AffiliateDiscountBreakdown(vult: 0, referral: 0)
         }
-
-        // Referral discount not applicable when Ultimate VULT tier
-        if vultDiscountBps == Int.max {
-            return .empty
-        }
-
         let inputFiat = fromCoin.fiat(decimal: fromAmountDecimal(fromAmount: fromAmount))
-        let saving = inputFiat * Decimal(shareBps) / 10000
+        guard inputFiat > 0 else { return AffiliateDiscountBreakdown(vult: 0, referral: 0) }
 
+        let vult: Decimal
+        if vultDiscountBps == Int.max {
+            let listFee = inputFiat * Decimal(affiliateListFeeBps) / 10000
+            let net = affiliateFeeFiat(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin)
+            vult = max(listFee - net, 0)
+        } else {
+            let appliedBps = max(0, min(vultDiscountBps, affiliateListFeeBps))
+            vult = inputFiat * Decimal(appliedBps) / 10000
+        }
+
+        let appliesReferralDiscount: Bool
+        switch quote {
+        case .thorchain, .thorchainChainnet, .thorchainStagenet:
+            appliesReferralDiscount = true
+        default:
+            appliesReferralDiscount = false
+        }
+
+        let referral: Decimal
+        if appliesReferralDiscount, vultDiscountBps != Int.max {
+            let appliedBps = max(0, min(referralDiscountBps, affiliateListFeeBps))
+            referral = inputFiat * Decimal(appliedBps) / 10000
+        } else {
+            referral = 0
+        }
+
+        return AffiliateDiscountBreakdown(vult: vult, referral: referral)
+    }
+
+    private static func formatDiscount(_ saving: Decimal) -> String {
         guard saving > 0 else { return .empty }
-
         if saving < 0.01 {
             return "-< " + "0.01".formatToFiat(includeCurrencySymbol: true)
         }
-
         return "-" + saving.formatToFiat(includeCurrencySymbol: true)
-    }
-
-    private static func calculateTotalSaving(
-        quote: SwapQuote?,
-        fromCoin: Coin,
-        toCoin: Coin,
-        feeCoin: Coin,
-        fromAmount: String
-    ) -> Decimal {
-        let inputFiat = fromCoin.fiat(decimal: fromAmountDecimal(fromAmount: fromAmount))
-
-        // Theoretical Base Fee (0.50%)
-        let baseFeeFiat = inputFiat * 0.0050
-
-        // Actual fee from quote
-        var actualFeeFiat = evmSwapFeeFiat(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin) ?? 0
-        if actualFeeFiat == 0, let quote {
-            switch quote {
-            case let .thorchain(q), let .thorchainChainnet(q), let .thorchainStagenet(q), let .mayachain(q):
-                let feeAmt = q.fees.affiliate.toDecimal() / pow(10, 8)
-                actualFeeFiat = toCoin.fiat(decimal: feeAmt)
-            default: break
-            }
-        }
-
-        return max(baseFeeFiat - actualFeeFiat, 0)
     }
 
     // MARK: - Price impact

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -540,9 +540,9 @@ enum SwapCryptoLogic {
         fromCoin: Coin,
         toCoin: Coin,
         feeCoin: Coin,
-        fromAmount: String = .empty,
-        vultDiscountBps: Int = 0,
-        referralDiscountBps: Int = 0
+        fromAmount: String,
+        vultDiscountBps: Int,
+        referralDiscountBps: Int
     ) -> String {
         guard let quote else { return .empty }
         if case .swapkit = quote {
@@ -731,10 +731,19 @@ enum SwapCryptoLogic {
         let inputFiat = fromCoin.fiat(decimal: fromAmountDecimal(fromAmount: fromAmount))
         guard inputFiat > 0 else { return AffiliateDiscountBreakdown(vult: 0, referral: 0) }
 
+        let net = affiliateFeeFiat(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin)
+        switch quote {
+        case .thorchain, .thorchainChainnet, .thorchainStagenet, .mayachain, .swapkit:
+            break
+        default:
+            guard net > 0 || vultDiscountBps == Int.max else {
+                return AffiliateDiscountBreakdown(vult: 0, referral: 0)
+            }
+        }
+
         let vult: Decimal
         if vultDiscountBps == Int.max {
             let listFee = inputFiat * Decimal(affiliateListFeeBps) / 10000
-            let net = affiliateFeeFiat(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin)
             vult = max(listFee - net, 0)
         } else {
             let appliedBps = max(0, min(vultDiscountBps, affiliateListFeeBps))

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -679,11 +679,11 @@ enum SwapCryptoLogic {
 
     static func vultDiscountLabel(vultDiscountBps: Int) -> String {
         guard let tier = VultDiscountTier.from(bpsDiscount: vultDiscountBps) else {
-            return "VULT: \(vultDiscountBps)%"
+            return String(format: "swapVultDiscountFallback".localized, vultDiscountBps)
         }
         let percentage = tier == .ultimate ? 100 : tier.bpsDiscount
         return String(
-            format: "swap.vult_discount".localized,
+            format: "swapVultDiscount".localized,
             tier.name.localized,
             percentage
         )
@@ -691,7 +691,7 @@ enum SwapCryptoLogic {
 
     static func referralDiscountLabel(referralDiscountBps: Int) -> String {
         String(
-            format: "swap.referral_discount".localized,
+            format: "swapReferralDiscount".localized,
             SwapSlippage.format(bps: referralDiscountBps)
         )
     }

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -678,14 +678,22 @@ enum SwapCryptoLogic {
     // MARK: - Discounts
 
     static func vultDiscountLabel(vultDiscountBps: Int) -> String {
-        if vultDiscountBps == Int.max {
-            return "swap.vult_waiver".localized
+        guard let tier = VultDiscountTier.from(bpsDiscount: vultDiscountBps) else {
+            return "VULT: \(vultDiscountBps)%"
         }
-        return String(format: "swap.vult_discount".localized, vultDiscountBps)
+        let percentage = tier == .ultimate ? 100 : tier.bpsDiscount
+        return String(
+            format: "swap.vult_discount".localized,
+            tier.name.localized,
+            percentage
+        )
     }
 
     static func referralDiscountLabel(referralDiscountBps: Int) -> String {
-        String(format: "swap.referral_discount".localized, referralDiscountBps)
+        String(
+            format: "swap.referral_discount".localized,
+            SwapSlippage.format(bps: referralDiscountBps)
+        )
     }
 
     static func vultDiscount(

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -694,7 +694,8 @@ enum SwapCryptoLogic {
         toCoin: Coin,
         feeCoin: Coin,
         fromAmount: String,
-        vultDiscountBps: Int
+        vultDiscountBps: Int,
+        referralDiscountBps: Int
     ) -> String {
         let breakdown = affiliateDiscountBreakdown(
             quote: quote,
@@ -703,7 +704,7 @@ enum SwapCryptoLogic {
             feeCoin: feeCoin,
             fromAmount: fromAmount,
             vultDiscountBps: vultDiscountBps,
-            referralDiscountBps: 0
+            referralDiscountBps: referralDiscountBps
         )
         return formatDiscount(breakdown.vult)
     }

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -418,7 +418,6 @@ enum SwapCryptoLogic {
         let referral: Decimal
 
         var total: Decimal { vult + referral }
-        var hasDiscounts: Bool { total > 0 }
     }
 
     static func showGas(gas: BigInt) -> Bool {
@@ -622,8 +621,23 @@ enum SwapCryptoLogic {
 
     /// List-rate label. Discounts are itemized separately and never reduce this
     /// percentage, regardless of the effective bps sent to a provider.
-    static func swapFeeLabel(quote: SwapQuote?) -> String {
+    static func swapFeeLabel(
+        quote: SwapQuote?,
+        fromCoin: Coin,
+        toCoin: Coin,
+        feeCoin: Coin,
+        vultDiscountBps: Int
+    ) -> String {
         guard quote != nil else { return "vultisigFee".localized }
+        switch quote {
+        case .oneinch, .kyberswap, .lifi, .jupiter:
+            let net = affiliateFeeFiat(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin)
+            if net <= 0, vultDiscountBps != Int.max {
+                return "vultisigFee".localized
+            }
+        default:
+            break
+        }
         return String(format: "vultisigFeePercentage".localized, Double(affiliateListFeeBps) / 100.0)
     }
 
@@ -741,15 +755,6 @@ enum SwapCryptoLogic {
             }
         }
 
-        let vult: Decimal
-        if vultDiscountBps == Int.max {
-            let listFee = inputFiat * Decimal(affiliateListFeeBps) / 10000
-            vult = max(listFee - net, 0)
-        } else {
-            let appliedBps = max(0, min(vultDiscountBps, affiliateListFeeBps))
-            vult = inputFiat * Decimal(appliedBps) / 10000
-        }
-
         let appliesReferralDiscount: Bool
         switch quote {
         case .thorchain, .thorchainChainnet, .thorchainStagenet:
@@ -759,11 +764,20 @@ enum SwapCryptoLogic {
         }
 
         let referral: Decimal
-        if appliesReferralDiscount, vultDiscountBps != Int.max {
+        if appliesReferralDiscount {
             let appliedBps = max(0, min(referralDiscountBps, affiliateListFeeBps))
             referral = inputFiat * Decimal(appliedBps) / 10000
         } else {
             referral = 0
+        }
+
+        let vult: Decimal
+        if vultDiscountBps == Int.max {
+            let listFee = inputFiat * Decimal(affiliateListFeeBps) / 10000
+            vult = max(listFee - net - referral, 0)
+        } else {
+            let appliedBps = max(0, min(vultDiscountBps, affiliateListFeeBps))
+            vult = inputFiat * Decimal(appliedBps) / 10000
         }
 
         return AffiliateDiscountBreakdown(vult: vult, referral: referral)

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -265,15 +265,15 @@ final class SwapDetailsViewModel {
     /// selection (`selectedQuote`) is not part of `advancedSettings`, so picking a
     /// route never reaches here — it only chooses among the quotes already fetched.
     /// No-op when nothing relevant changed (byte-identical to no interaction).
-    func advancedSettingsSheetDidClose(vault: Vault, referredCode: String) {
+    func advancedSettingsSheetDidClose(vault: Vault) {
         guard advancedSettings != advancedSettingsSnapshot else { return }
         advancedSettingsSnapshot = advancedSettings
-        fetchQuotes(vault: vault, referredCode: referredCode, immediate: true)
+        fetchQuotes(vault: vault, immediate: true)
     }
 
     // MARK: - User actions
 
-    func switchCoins(vault: Vault, referredCode: String) {
+    func switchCoins(vault: Vault) {
         // Flipping the pair is a new swap — a custom slippage / gas limit /
         // external recipient must never leak across it. In particular the
         // recipient was validated for the OLD destination chain, which is now the
@@ -287,18 +287,18 @@ final class SwapDetailsViewModel {
         // source — re-resolve so `toCoins` matches the new `fromCoin` and
         // `toCoin` lands on a valid pair before the quote fetch runs.
         updateCoinLists()
-        fetchQuotes(vault: vault, referredCode: referredCode)
+        fetchQuotes(vault: vault)
         prefetchSwapTokens()
     }
 
     /// `immediate: true` skips the keystroke debounce — used for discrete actions
     /// (percentage buttons, paste) that set a final value in one shot. Free typing
     /// stays debounced.
-    func updateFromAmount(vault: Vault, referredCode: String, immediate: Bool = false) {
-        fetchQuotes(vault: vault, referredCode: referredCode, immediate: immediate)
+    func updateFromAmount(vault: Vault, immediate: Bool = false) {
+        fetchQuotes(vault: vault, immediate: immediate)
     }
 
-    func updateFromCoin(coin: Coin, vault: Vault, referredCode: String) {
+    func updateFromCoin(coin: Coin, vault: Vault) {
         // A new source pair starts fresh — a custom slippage / gas limit /
         // recipient must never stick across swaps (Phase 5 reset semantics).
         resetAdvancedSettings()
@@ -307,18 +307,18 @@ final class SwapDetailsViewModel {
         // `toCoins` reflected the previous source's valid destinations —
         // recompute so `fetchQuotes` runs against the current valid pair.
         updateCoinLists()
-        fetchQuotes(vault: vault, referredCode: referredCode)
+        fetchQuotes(vault: vault)
         updateBalance(for: coin)
         prefetchSwapTokens()
     }
 
-    func updateToCoin(coin: Coin, vault: Vault, referredCode: String) {
+    func updateToCoin(coin: Coin, vault: Vault) {
         // A new destination invalidates a chain-specific external recipient and
         // resets the rest of the advanced settings (Phase 5 reset semantics).
         resetAdvancedSettings()
         toCoin = coin
         toChain = coin.chain
-        fetchQuotes(vault: vault, referredCode: referredCode)
+        fetchQuotes(vault: vault)
         updateBalance(for: coin)
         prefetchSwapTokens()
     }
@@ -336,24 +336,24 @@ final class SwapDetailsViewModel {
         quote != nil
     }
 
-    func updateTimer(vault: Vault, referredCode: String) {
+    func updateTimer(vault: Vault) {
         guard showRefreshCounter else {
             timer = 59
             return
         }
         timer -= 1
         if timer < 1 {
-            restartTimer(vault: vault, referredCode: referredCode)
+            restartTimer(vault: vault)
         }
     }
 
-    func restartTimer(vault: Vault, referredCode: String) {
-        refreshData(vault: vault, referredCode: referredCode)
+    func restartTimer(vault: Vault) {
+        refreshData(vault: vault)
         timer = 59
     }
 
-    func refreshData(vault: Vault, referredCode: String) {
-        fetchQuotes(vault: vault, referredCode: referredCode)
+    func refreshData(vault: Vault) {
+        fetchQuotes(vault: vault)
     }
 
     func handleFromChainUpdate(vault: Vault) {
@@ -642,7 +642,8 @@ extension SwapDetailsViewModel {
     var vultDiscount: String {
         SwapCryptoLogic.vultDiscount(
             quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin,
-            fromAmount: fromAmount, vultDiscountBps: vultDiscountBps
+            fromAmount: fromAmount, vultDiscountBps: vultDiscountBps,
+            referralDiscountBps: referralDiscountBps
         )
     }
 
@@ -688,7 +689,7 @@ private extension SwapDetailsViewModel {
         allQuotes = []
     }
 
-    func fetchQuotes(vault: Vault, referredCode: String, immediate: Bool = false) {
+    func fetchQuotes(vault: Vault, immediate: Bool = false) {
         updateQuoteTask?.cancel()
 
         // Empty or non-positive amount: drop any leftover quote/fee/discount
@@ -748,7 +749,7 @@ private extension SwapDetailsViewModel {
             // as a preview, but a fee you can't pay would surface the UTXO
             // `notEnoughUTXO` / `insufficientGas` fee errors. Insufficiency is
             // reflected only on the disabled Continue button, never as a fee error.
-            await self.updateQuotes(vault: vault, referredCode: referredCode)
+            await self.updateQuotes(vault: vault)
             if self.balanceError == nil, self.error == nil, self.quote != nil {
                 await self.updateFees(vault: vault)
             }
@@ -763,7 +764,7 @@ private extension SwapDetailsViewModel {
         }
     }
 
-    func updateQuotes(vault: Vault, referredCode: String) async {
+    func updateQuotes(vault: Vault) async {
         // Don't clear `quote` here: stale-while-revalidate keeps the previous
         // quote (and its summary) on screen until the fresh one lands. The pair
         // change in `fetchQuotes` already cleared it when it would be misleading.
@@ -791,7 +792,7 @@ private extension SwapDetailsViewModel {
                 fromCoin: fromCoin,
                 toCoin: toCoin,
                 vault: vault,
-                referredCode: referredCode,
+                referredCode: vault.referredCode?.code ?? .empty,
                 slippageBps: advancedSettings.slippage.bps,
                 recipientAddress: advancedSettings.externalRecipient
             )

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -619,14 +619,15 @@ extension SwapDetailsViewModel {
     }
 
     var baseAffiliateFee: String {
-        SwapCryptoLogic.baseAffiliateFee(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin)
+        SwapCryptoLogic.baseAffiliateFee(
+            quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin,
+            fromAmount: fromAmount, vultDiscountBps: vultDiscountBps,
+            referralDiscountBps: referralDiscountBps
+        )
     }
 
     var swapFeeLabel: String {
-        SwapCryptoLogic.swapFeeLabel(
-            quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin,
-            fromAmount: fromAmount, vultDiscountBps: vultDiscountBps, isReferred: isReferred
-        )
+        SwapCryptoLogic.swapFeeLabel(quote: quote)
     }
 
     var outboundFeeString: String {
@@ -654,6 +655,10 @@ extension SwapDetailsViewModel {
             fromAmount: fromAmount, vultDiscountBps: vultDiscountBps,
             referralDiscountBps: referralDiscountBps
         )
+    }
+
+    var hasAppliedDiscounts: Bool {
+        !vultDiscount.isEmpty || !referralDiscount.isEmpty
     }
 
     var priceImpactString: String {

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -96,11 +96,6 @@ final class SwapDetailsViewModel {
     var gasLimit: BigInt = .zero
     var vultDiscountBps: Int = 0
     var referralDiscountBps: Int = 0
-    /// Whether a referral code is active for the current quote. Route-aware
-    /// affiliate-% display keys off this clean bit (not `referralDiscountBps`,
-    /// which is 0 in DEBUG even when referred).
-    var isReferred: Bool = false
-
     // MARK: - UI state (details-screen-only)
 
     var error: Error?
@@ -422,7 +417,6 @@ final class SwapDetailsViewModel {
             thorchainFee: thorchainFee,
             vultDiscountBps: vultDiscountBps,
             referralDiscountBps: referralDiscountBps,
-            isReferred: isReferred,
             feeCoin: feeCoin,
             advancedSettings: resolvedAdvancedSettings
         )
@@ -706,7 +700,6 @@ private extension SwapDetailsViewModel {
             thorchainFee = .zero
             vultDiscountBps = 0
             referralDiscountBps = 0
-            isReferred = false
             error = nil
             isLoadingQuotes = false
             isLoadingFees = false
@@ -729,7 +722,6 @@ private extension SwapDetailsViewModel {
             thorchainFee = .zero
             vultDiscountBps = 0
             referralDiscountBps = 0
-            isReferred = false
         }
         error = nil
         isLoadingQuotes = true
@@ -787,7 +779,6 @@ private extension SwapDetailsViewModel {
             quotedAmount = fromAmount
             vultDiscountBps = 0
             referralDiscountBps = 0
-            isReferred = false
             return
         }
 
@@ -815,7 +806,6 @@ private extension SwapDetailsViewModel {
                 quotedAmount = fromAmount
                 vultDiscountBps = result.vultDiscountBps
                 referralDiscountBps = result.referralDiscountBps
-                isReferred = result.isReferred
             }
         } catch {
             // Ignore cancellation from a superseding amount edit — surfacing it

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -621,7 +621,10 @@ extension SwapDetailsViewModel {
     }
 
     var swapFeeLabel: String {
-        SwapCryptoLogic.swapFeeLabel(quote: quote)
+        SwapCryptoLogic.swapFeeLabel(
+            quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin,
+            vultDiscountBps: vultDiscountBps
+        )
     }
 
     var outboundFeeString: String {

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapVerifyViewModel.swift
@@ -113,8 +113,7 @@ final class SwapVerifyViewModel {
                     updated = updated.with(
                         quote: result.quote,
                         vultDiscountBps: result.vultDiscountBps,
-                        referralDiscountBps: result.referralDiscountBps,
-                        isReferred: result.isReferred
+                        referralDiscountBps: result.referralDiscountBps
                     )
                 }
             }

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapVerifyViewModel.swift
@@ -76,15 +76,15 @@ final class SwapVerifyViewModel {
         return !securityScannerState.shouldShowWarning
     }
 
-    func updateTimer(vault: Vault, referredCode: String) async {
+    func updateTimer(vault: Vault) async {
         timer -= 1
         if timer < 1 {
-            await refreshData(vault: vault, referredCode: referredCode)
+            await refreshData(vault: vault)
             timer = 59
         }
     }
 
-    func refreshData(vault: Vault, referredCode: String) async {
+    func refreshData(vault: Vault) async {
         // Limit orders have no market quote to refresh — fetching one here
         // would attach a market quote to a limit transaction and break the
         // `quote == nil` limit invariant (the signed artifact is the pre-built
@@ -105,7 +105,7 @@ final class SwapVerifyViewModel {
                     fromCoin: transaction.fromCoin,
                     toCoin: transaction.toCoin,
                     vault: vault,
-                    referredCode: referredCode,
+                    referredCode: vault.referredCode?.code ?? .empty,
                     slippageBps: transaction.advancedSettings.slippage.bps,
                     recipientAddress: transaction.advancedSettings.externalRecipient
                 )

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
@@ -11,7 +11,6 @@ struct SwapDetailsScreen: View {
     let vault: Vault
 
     @State private var detailsViewModel = SwapDetailsViewModel()
-    @StateObject private var referredViewModel = ReferredViewModel()
     @StateObject private var keyboardObserver = KeyboardObserver()
 
     @State private var showErrorTooltip = false
@@ -130,7 +129,7 @@ struct SwapDetailsScreen: View {
             // re-assignment afterwards or `onChange` would re-fire the quote fetch.
             detailsViewModel.load(initialFromCoin: fromCoin, initialToCoin: toCoin, vault: vault)
             detailsViewModel.warmDiscountTier(vault: vault)
-            setData()
+            setInitialChains()
         }
         .onDisappear {
             #if os(iOS)
@@ -138,13 +137,13 @@ struct SwapDetailsScreen: View {
             #endif
         }
         .swapRefreshTick {
-            detailsViewModel.updateTimer(vault: vault, referredCode: referredViewModel.savedReferredCode)
+            detailsViewModel.updateTimer(vault: vault)
         }
         .onChange(of: detailsViewModel.fromCoin) { _, _ in
-            detailsViewModel.updateFromCoin(coin: detailsViewModel.fromCoin, vault: vault, referredCode: referredViewModel.savedReferredCode)
+            detailsViewModel.updateFromCoin(coin: detailsViewModel.fromCoin, vault: vault)
         }
         .onChange(of: detailsViewModel.toCoin) { _, _ in
-            detailsViewModel.updateToCoin(coin: detailsViewModel.toCoin, vault: vault, referredCode: referredViewModel.savedReferredCode)
+            detailsViewModel.updateToCoin(coin: detailsViewModel.toCoin, vault: vault)
         }
         .onChange(of: detailsViewModel.fromChain) { _, _ in
             detailsViewModel.handleFromChainUpdate(vault: vault)
@@ -159,8 +158,7 @@ struct SwapDetailsScreen: View {
             // part of the compared settings so it never triggers a re-fetch.
             if wasPresented && !isPresented {
                 detailsViewModel.advancedSettingsSheetDidClose(
-                    vault: vault,
-                    referredCode: referredViewModel.savedReferredCode
+                    vault: vault
                 )
             }
         }
@@ -382,7 +380,7 @@ struct SwapDetailsScreen: View {
         }
         #if os(iOS)
         .refreshable {
-            detailsViewModel.refreshData(vault: vault, referredCode: referredViewModel.savedReferredCode)
+            detailsViewModel.refreshData(vault: vault)
         }
         .toolbar {
             if detailsViewModel.showPercentageButtons {
@@ -418,15 +416,14 @@ struct SwapDetailsScreen: View {
         #endif
     }
 
-    private func setData() {
-        referredViewModel.setData()
+    private func setInitialChains() {
         detailsViewModel.fromChain = detailsViewModel.fromCoin.chain
         detailsViewModel.toChain = detailsViewModel.toCoin.chain
     }
 
     private func handleSwapTap() {
         detailsViewModel.error = nil
-        detailsViewModel.switchCoins(vault: vault, referredCode: referredViewModel.savedReferredCode)
+        detailsViewModel.switchCoins(vault: vault)
         let fromChain = detailsViewModel.fromChain
         detailsViewModel.fromChain = detailsViewModel.toChain
         detailsViewModel.toChain = fromChain
@@ -444,7 +441,7 @@ extension SwapDetailsScreen {
         ) else { return }
 
         detailsViewModel.fromAmount = amount
-        detailsViewModel.updateFromAmount(vault: vault, referredCode: referredViewModel.savedReferredCode, immediate: true)
+        detailsViewModel.updateFromAmount(vault: vault, immediate: true)
     }
 
     // MARK: - Market / Limit tabs

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
@@ -11,7 +11,6 @@ struct SwapVerifyScreen: View {
     let vault: Vault
 
     @State private var verifyViewModel: SwapVerifyViewModel
-    @StateObject private var referredViewModel = ReferredViewModel()
 
     @State private var fastPasswordPresented = false
     @State private var fastVaultPassword: String = .empty
@@ -64,11 +63,10 @@ struct SwapVerifyScreen: View {
         )
         .swapRefreshTick {
             Task {
-                await verifyViewModel.updateTimer(vault: vault, referredCode: referredViewModel.savedReferredCode)
+                await verifyViewModel.updateTimer(vault: vault)
             }
         }
         .onLoad {
-            referredViewModel.setData()
             verifyViewModel.onLoad()
             Task {
                 await verifyViewModel.scan()
@@ -354,10 +352,7 @@ struct SwapVerifyScreen: View {
         retryBannerText = reason.userFacingMessage
         retrySignal.pendingRetryReason = nil
         Task {
-            await verifyViewModel.refreshData(
-                vault: vault,
-                referredCode: referredViewModel.savedReferredCode
-            )
+            await verifyViewModel.refreshData(vault: vault)
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
@@ -171,7 +171,7 @@ struct SwapVerifyScreen: View {
                     priceImpactRow
                 }
 
-                // Total Fee — reconciles to Network + Vultisig + Protocol.
+                // Net Total Fee after subtracting the applied discounts above.
                 if currentTransaction.showTotalFees {
                     separator
                     getValueCell(

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
@@ -142,9 +142,8 @@ struct SwapVerifyScreen: View {
                     .blur(radius: verifyViewModel.isLoadingFees ? 1 : 0)
                 }
 
-                // Vultisig Fee (affiliate component only). The label carries the
-                // effective affiliate %, the value the fiat amount — sourced from
-                // `fees.affiliate`, never THORChain's composite `fees.total`.
+                // Gross list-rate Vultisig fee. Applied savings are itemized in
+                // the discount group below; Total Fees remains the net charge.
                 if currentTransaction.showAffiliateFeeRow {
                     separator
                     affiliateFeeRow
@@ -161,16 +160,9 @@ struct SwapVerifyScreen: View {
                     .blur(radius: verifyViewModel.isLoadingFees ? 1 : 0)
                 }
 
-                // VULT tier saving (with the tier badge).
-                if !currentTransaction.vultDiscount.isEmpty {
+                if currentTransaction.hasAppliedDiscounts {
                     separator
-                    vultDiscountRow
-                }
-
-                // Referral saving.
-                if !currentTransaction.referralDiscount.isEmpty {
-                    separator
-                    referralDiscountRow
+                    appliedDiscountsSection
                 }
 
                 // Price Impact (only when the provider reports slippage).
@@ -449,6 +441,23 @@ struct SwapVerifyScreen: View {
                 .foregroundStyle(Theme.colors.textPrimary)
         }
         .font(Theme.fonts.bodySMedium)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var appliedDiscountsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("swap.applied_discounts".localized)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textTertiary)
+
+            if !currentTransaction.vultDiscount.isEmpty {
+                vultDiscountRow
+            }
+
+            if !currentTransaction.referralDiscount.isEmpty {
+                referralDiscountRow
+            }
+        }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
@@ -462,11 +462,6 @@ struct SwapVerifyScreen: View {
 
             Text(currentTransaction.vultDiscountLabel)
                 .foregroundStyle(Theme.colors.textTertiary)
-
-            Spacer()
-
-            Text(currentTransaction.vultDiscount)
-                .foregroundStyle(Theme.colors.textPrimary)
         }
         .font(Theme.fonts.bodySMedium)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -494,11 +489,6 @@ struct SwapVerifyScreen: View {
 
             Text(currentTransaction.referralDiscountLabel)
                 .foregroundStyle(Theme.colors.textTertiary)
-
-            Spacer()
-
-            Text(currentTransaction.referralDiscount)
-                .foregroundStyle(Theme.colors.textPrimary)
         }
         .font(Theme.fonts.bodySMedium)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
@@ -441,7 +441,7 @@ struct SwapVerifyScreen: View {
 
     private var appliedDiscountsSection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("swap.applied_discounts".localized)
+            Text("swapAppliedDiscounts".localized)
                 .font(Theme.fonts.caption12)
                 .foregroundStyle(Theme.colors.textTertiary)
 

--- a/VultisigApp/VultisigAppTests/Swap/DefaultSwapInteractorTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/DefaultSwapInteractorTests.swift
@@ -158,6 +158,23 @@ final class DefaultSwapInteractorTests: XCTestCase {
         XCTAssertEqual(quoteService.lastVultTierDiscount, VultDiscountTier.gold.bpsDiscount)
     }
 
+    func testReferralDisplayDiscountUsesShippingListRateInDebug() async throws {
+        let quoteService = MockQuoteService(stubbedResult: .success(.thorchain(makeThorQuote())))
+        let interactor = makeInteractor(quote: quoteService)
+
+        let result = try await interactor.fetchQuote(
+            amount: 1,
+            fromCoin: makeCoin(.ethereum, ticker: "ETH"),
+            toCoin: makeCoin(.bitcoin, ticker: "BTC"),
+            vault: makeVault(),
+            referredCode: "friend",
+            slippageBps: nil,
+            recipientAddress: nil
+        )
+
+        XCTAssertEqual(result?.referralDiscountBps, 5)
+    }
+
     /// The first resolution saw a VULT balance of zero — a failed or
     /// not-yet-landed fetch — and produced no tier. The tier must be re-resolved
     /// for the next quote, not pinned: a pinned nil silently overcharged the user

--- a/VultisigApp/VultisigAppTests/Swap/SwapAdvancedSettingsRefetchTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapAdvancedSettingsRefetchTests.swift
@@ -21,7 +21,7 @@ final class SwapAdvancedSettingsRefetchTests: XCTestCase {
         vm.advancedSettings.slippage = .custom(bps: 300)
 
         let before = interactor.fetchQuoteCallCount
-        vm.advancedSettingsSheetDidClose(vault: makeVault(), referredCode: "")
+        vm.advancedSettingsSheetDidClose(vault: makeVault())
         await vm.waitForQuoteTask()
 
         XCTAssertEqual(interactor.fetchQuoteCallCount, before + 1, "A slippage change must re-fetch on close")
@@ -33,7 +33,7 @@ final class SwapAdvancedSettingsRefetchTests: XCTestCase {
         vm.advancedSettings.gasLimit = 300_000
 
         let before = interactor.fetchQuoteCallCount
-        vm.advancedSettingsSheetDidClose(vault: makeVault(), referredCode: "")
+        vm.advancedSettingsSheetDidClose(vault: makeVault())
         await vm.waitForQuoteTask()
 
         XCTAssertEqual(interactor.fetchQuoteCallCount, before + 1, "A gas-limit change must re-fetch on close")
@@ -45,7 +45,7 @@ final class SwapAdvancedSettingsRefetchTests: XCTestCase {
         vm.advancedSettings.externalRecipient = "0xExternalRecipient"
 
         let before = interactor.fetchQuoteCallCount
-        vm.advancedSettingsSheetDidClose(vault: makeVault(), referredCode: "")
+        vm.advancedSettingsSheetDidClose(vault: makeVault())
         await vm.waitForQuoteTask()
 
         XCTAssertEqual(interactor.fetchQuoteCallCount, before + 1, "An external-recipient change must re-fetch on close (it changes provider eligibility)")
@@ -57,7 +57,7 @@ final class SwapAdvancedSettingsRefetchTests: XCTestCase {
         // Nothing changes while the sheet is open.
 
         let before = interactor.fetchQuoteCallCount
-        vm.advancedSettingsSheetDidClose(vault: makeVault(), referredCode: "")
+        vm.advancedSettingsSheetDidClose(vault: makeVault())
 
         // `fetchQuotes` flips `isLoadingQuotes` true synchronously before it
         // spawns its task, so a re-fetch — debounced or not — is observable
@@ -81,7 +81,7 @@ final class SwapAdvancedSettingsRefetchTests: XCTestCase {
         vm.selectProvider(alt)
 
         let before = interactor.fetchQuoteCallCount
-        vm.advancedSettingsSheetDidClose(vault: makeVault(), referredCode: "")
+        vm.advancedSettingsSheetDidClose(vault: makeVault())
 
         // Route selection isn't part of `advancedSettings`, so the close path's
         // no-change guard returns synchronously — `isLoadingQuotes` would be true

--- a/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
@@ -9,10 +9,9 @@
 //  the row-visibility gate, and the display-only invariant that none of this
 //  touches the signed keysign payload.
 //
-//  DEBUG note: `THORChainSwaps.affiliateFeeRateBp` is 0 in test builds, so
-//  non-referred native percentages read 0.00% here — that matches what the
-//  request builder sends in DEBUG. Base-50 tier math is asserted directly on
-//  the pure `discountedAffiliateBps` helper so it's independent of the build.
+//  DEBUG note: `THORChainSwaps.affiliateFeeRateBp` is 0 in test builds, while
+//  the display deliberately stays at the shipping 0.50% list rate. Wire math
+//  and Base-50 display math are therefore asserted separately.
 //
 
 import BigInt

--- a/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
@@ -59,9 +59,9 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
         XCTAssertEqual(THORChainSwaps.effectiveAffiliateFeeBps(discountBps: .max, isReferred: true), referrer)     // 10 (ultimate keeps the referrer share)
     }
 
-    // MARK: - Display bps equals the request builder's sent bps
+    // MARK: - Wire bps matches the request builder
 
-    func testDisplayBpsMatchesThorchainRequestBuilderNonReferred() {
+    func testWireBpsMatchesThorchainRequestBuilderNonReferred() {
         for discount in [0, 5, 35] {
             let (_, bpsStr) = ThorchainService.affiliateParams(referredCode: "", discountBps: discount)
             let sent = Int(bpsStr ?? "") ?? -1
@@ -69,7 +69,7 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
         }
     }
 
-    func testDisplayBpsMatchesThorchainRequestBuilderReferred() {
+    func testWireBpsMatchesThorchainRequestBuilderReferred() {
         for discount in [0, 5, 35] {
             let (_, bpsStr) = ThorchainService.affiliateParams(referredCode: "code", discountBps: discount)
             // Referred builder sends "referrer/vultisig"; the total charged is the sum.
@@ -457,6 +457,13 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
             )
         )
         XCTAssertTrue(transaction.hasAppliedDiscounts)
+
+        let undiscounted = makeNativeThorchainTransaction(
+            quote: makeThorQuote(affiliate: "500000"),
+            vultDiscountBps: 0,
+            referralDiscountBps: 0
+        )
+        XCTAssertFalse(undiscounted.hasAppliedDiscounts)
     }
 
     // MARK: - Display-only invariant: signed payload unchanged

--- a/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
@@ -514,7 +514,52 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
                 referralDiscountBps: transaction.referralDiscountBps
             )
         )
+        let breakdown = SwapCryptoLogic.affiliateDiscountBreakdown(
+            quote: wrappedQuote,
+            fromCoin: transaction.fromCoin,
+            toCoin: transaction.toCoin,
+            feeCoin: transaction.feeCoin,
+            fromAmount: transaction.fromAmount.description,
+            vultDiscountBps: transaction.vultDiscountBps,
+            referralDiscountBps: transaction.referralDiscountBps
+        )
+        XCTAssertEqual(
+            transaction.vultDiscount,
+            "-" + breakdown.vult.formatToFiat(includeCurrencySymbol: true)
+        )
+        XCTAssertEqual(
+            transaction.referralDiscount,
+            "-" + breakdown.referral.formatToFiat(includeCurrencySymbol: true)
+        )
         XCTAssertTrue(transaction.hasAppliedDiscounts)
+
+        let ultimateQuote = makeThorQuote(affiliate: "100000")
+        let ultimate = makeNativeThorchainTransaction(
+            quote: ultimateQuote,
+            vultDiscountBps: Int.max,
+            referralDiscountBps: 5
+        )
+        setPrice(1000, for: ultimate.fromCoin)
+        setPrice(1000, for: ultimate.toCoin)
+        let ultimateBreakdown = SwapCryptoLogic.affiliateDiscountBreakdown(
+            quote: .thorchain(ultimateQuote),
+            fromCoin: ultimate.fromCoin,
+            toCoin: ultimate.toCoin,
+            feeCoin: ultimate.feeCoin,
+            fromAmount: ultimate.fromAmount.description,
+            vultDiscountBps: ultimate.vultDiscountBps,
+            referralDiscountBps: ultimate.referralDiscountBps
+        )
+        XCTAssertEqual(ultimateBreakdown.vult, Decimal(string: "3.5"))
+        XCTAssertEqual(ultimateBreakdown.referral, Decimal(string: "0.5"))
+        XCTAssertEqual(
+            ultimate.vultDiscount,
+            "-" + ultimateBreakdown.vult.formatToFiat(includeCurrencySymbol: true)
+        )
+        XCTAssertEqual(
+            ultimate.referralDiscount,
+            "-" + ultimateBreakdown.referral.formatToFiat(includeCurrencySymbol: true)
+        )
 
         let undiscounted = makeNativeThorchainTransaction(
             quote: makeThorQuote(affiliate: "500000"),

--- a/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
@@ -110,6 +110,10 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
             )
         }
         XCTAssertEqual(
+            SwapCryptoLogic.vultDiscountLabel(vultDiscountBps: 15),
+            "VULT: 15%"
+        )
+        XCTAssertEqual(
             SwapCryptoLogic.referralDiscountLabel(referralDiscountBps: 5),
             "Referral: 0.05%"
         )

--- a/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
@@ -81,10 +81,16 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
     // MARK: - Gross list-rate display
 
     func testSwapFeeLabelAlwaysShowsShippingListRate() {
+        let btc = makeCoin(.bitcoin, ticker: "BTCLABEL", decimals: 8, isNative: true)
         let expected = String(format: "vultisigFeePercentage".localized, 0.50)
-        XCTAssertEqual(SwapCryptoLogic.swapFeeLabel(quote: .thorchain(makeThorQuote())), expected)
-        XCTAssertEqual(SwapCryptoLogic.swapFeeLabel(quote: .mayachain(makeThorQuote())), expected)
-        XCTAssertEqual(SwapCryptoLogic.swapFeeLabel(quote: makeSwapKitQuote()), expected)
+        func label(_ quote: SwapQuote) -> String {
+            SwapCryptoLogic.swapFeeLabel(
+                quote: quote, fromCoin: btc, toCoin: btc, feeCoin: btc, vultDiscountBps: 0
+            )
+        }
+        XCTAssertEqual(label(.thorchain(makeThorQuote())), expected)
+        XCTAssertEqual(label(.mayachain(makeThorQuote())), expected)
+        XCTAssertEqual(label(makeSwapKitQuote()), expected)
         XCTAssertEqual(SwapCryptoLogic.affiliateListFeeBps, 50)
     }
 
@@ -142,6 +148,13 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
         )
 
         XCTAssertEqual(breakdown, .init(vult: 0, referral: 0))
+        XCTAssertEqual(
+            SwapCryptoLogic.swapFeeLabel(
+                quote: quote, fromCoin: sol, toCoin: usdc, feeCoin: sol,
+                vultDiscountBps: VultDiscountTier.gold.bpsDiscount
+            ),
+            "vultisigFee".localized
+        )
         XCTAssertEqual(
             SwapCryptoLogic.baseAffiliateFee(
                 quote: quote, fromCoin: sol, toCoin: usdc, feeCoin: sol,
@@ -206,6 +219,22 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
             ),
             Decimal(5).formatToFiat(includeCurrencySymbol: true)
         )
+    }
+
+    func testUltimateReferredKeepsReferralDiscountSeparate() {
+        let btc = makeCoin(.bitcoin, ticker: "BTCULTREF", decimals: 8, isNative: true)
+        setPrice(1000, for: btc)
+        let quote = SwapQuote.thorchain(makeThorQuote(affiliate: "100000"))
+        let breakdown = SwapCryptoLogic.affiliateDiscountBreakdown(
+            quote: quote, fromCoin: btc, toCoin: btc, feeCoin: btc,
+            fromAmount: "1", vultDiscountBps: Int.max, referralDiscountBps: 5
+        )
+        let net = SwapCryptoLogic.affiliateFeeFiat(quote: quote, fromCoin: btc, toCoin: btc, feeCoin: btc)
+
+        XCTAssertEqual(net, 1)
+        XCTAssertEqual(breakdown.vult, Decimal(string: "3.5") ?? 0)
+        XCTAssertEqual(breakdown.referral, Decimal(string: "0.5") ?? 0)
+        XCTAssertEqual(net + breakdown.total, 5)
     }
 
     func testReferralDiscountOnlyAppearsOnThorchainNestedAffiliateRoutes() {
@@ -368,6 +397,27 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
         )
     }
 
+    func testLiFiSolanaGoldDiscountReconcilesGrossAndNet() {
+        let sol = makeCoin(.solana, ticker: "SOLLIFIGOLD", decimals: 9, isNative: true)
+        let usdc = makeCoin(.solana, ticker: "USDCLIFIGOLD", decimals: 6, isNative: false)
+        setPrice(100, for: sol)
+        setPrice(1, for: usdc)
+        let quote = makeLiFiSolanaQuote(
+            integratorFee: Decimal(3) / Decimal(1000),
+            dstAmount: "100000000"
+        )
+        let breakdown = SwapCryptoLogic.affiliateDiscountBreakdown(
+            quote: quote, fromCoin: sol, toCoin: usdc, feeCoin: sol,
+            fromAmount: "1", vultDiscountBps: VultDiscountTier.gold.bpsDiscount,
+            referralDiscountBps: 5
+        )
+        let net = SwapCryptoLogic.affiliateFeeFiat(quote: quote, fromCoin: sol, toCoin: usdc, feeCoin: sol)
+
+        XCTAssertEqual(net, Decimal(string: "0.3") ?? 0)
+        XCTAssertEqual(breakdown, .init(vult: Decimal(string: "0.2") ?? 0, referral: 0))
+        XCTAssertEqual(net + breakdown.total, Decimal(string: "0.5") ?? 0)
+    }
+
     func testShowProtocolFeeRowFalseForSecuredMint() {
         let btc = makeCoin(.bitcoin, ticker: "BTCPROT", decimals: 8, isNative: true)
         // Secured mint's synthetic quote reports a zero outbound that is not a
@@ -443,7 +493,16 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
         setPrice(1000, for: transaction.toCoin)
         let wrappedQuote = SwapQuote.thorchain(quote)
 
-        XCTAssertEqual(transaction.swapFeeLabel, SwapCryptoLogic.swapFeeLabel(quote: wrappedQuote))
+        XCTAssertEqual(
+            transaction.swapFeeLabel,
+            SwapCryptoLogic.swapFeeLabel(
+                quote: wrappedQuote,
+                fromCoin: transaction.fromCoin,
+                toCoin: transaction.toCoin,
+                feeCoin: transaction.feeCoin,
+                vultDiscountBps: transaction.vultDiscountBps
+            )
+        )
         XCTAssertEqual(
             transaction.baseAffiliateFee,
             SwapCryptoLogic.baseAffiliateFee(

--- a/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
@@ -3,8 +3,8 @@
 //  VultisigAppTests
 //
 //  First real coverage for the affiliate-fee display helpers exercised by the
-//  Verify / Details / Done screens: the shared effective-affiliate-bps
-//  function, the bps-derived percentage label, per-route affiliate amounts, the
+//  Verify / Details / Done screens: provider request bps, the fixed list-rate
+//  label, per-route gross/net affiliate amounts and discounts, the
 //  Total-fee reconciliation (which drops the fees.total liquidity component),
 //  the row-visibility gate, and the display-only invariant that none of this
 //  touches the signed keysign payload.
@@ -113,6 +113,45 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
         )
     }
 
+    func testAggregatorGoldGrossFeeAddsDiscountBackToNet() {
+        let eth = makeCoin(.ethereum, ticker: "ETHAGG", decimals: 6, isNative: true)
+        setPrice(1000, for: eth)
+        let quote = makeOneInchQuote(swapFee: "3000")
+        let breakdown = SwapCryptoLogic.affiliateDiscountBreakdown(
+            quote: quote, fromCoin: eth, toCoin: eth, feeCoin: eth,
+            fromAmount: "1", vultDiscountBps: VultDiscountTier.gold.bpsDiscount,
+            referralDiscountBps: 5
+        )
+        let net = SwapCryptoLogic.affiliateFeeFiat(quote: quote, fromCoin: eth, toCoin: eth, feeCoin: eth)
+
+        XCTAssertEqual(net, 3)
+        XCTAssertEqual(breakdown, .init(vult: 2, referral: 0))
+        XCTAssertEqual(net + breakdown.total, 5)
+    }
+
+    func testUnchargedAggregatorDoesNotFabricateFeeOrDiscount() {
+        let sol = makeCoin(.solana, ticker: "SOLNOFEE", decimals: 9, isNative: true)
+        let usdc = makeCoin(.solana, ticker: "USDCNOFEE", decimals: 6, isNative: false)
+        setPrice(1000, for: sol)
+        setPrice(1, for: usdc)
+        let quote = makeJupiterQuote(platformFee: 0, feeOnInput: false)
+        let breakdown = SwapCryptoLogic.affiliateDiscountBreakdown(
+            quote: quote, fromCoin: sol, toCoin: usdc, feeCoin: sol,
+            fromAmount: "1", vultDiscountBps: VultDiscountTier.gold.bpsDiscount,
+            referralDiscountBps: 5
+        )
+
+        XCTAssertEqual(breakdown, .init(vult: 0, referral: 0))
+        XCTAssertEqual(
+            SwapCryptoLogic.baseAffiliateFee(
+                quote: quote, fromCoin: sol, toCoin: usdc, feeCoin: sol,
+                fromAmount: "1", vultDiscountBps: VultDiscountTier.gold.bpsDiscount,
+                referralDiscountBps: 5
+            ),
+            Decimal(0).formatToFiat(includeCurrencySymbol: true)
+        )
+    }
+
     func testGoldAndReferralDiscountsExactlyReconcileGrossAndNet() {
         let btc = makeCoin(.bitcoin, ticker: "BTCREF", decimals: 8, isNative: true)
         setPrice(1000, for: btc)
@@ -155,7 +194,7 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
         let quote = SwapQuote.thorchain(makeThorQuote(affiliate: "0"))
         let breakdown = SwapCryptoLogic.affiliateDiscountBreakdown(
             quote: quote, fromCoin: btc, toCoin: btc, feeCoin: btc,
-            fromAmount: "1", vultDiscountBps: Int.max, referralDiscountBps: 5
+            fromAmount: "1", vultDiscountBps: Int.max, referralDiscountBps: 0
         )
 
         XCTAssertEqual(breakdown.vult, 5)
@@ -209,24 +248,34 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
         setPrice(1000, for: btc)
         // affiliate 0.01 BTC → $10; total (composite) 0.09 BTC would be $90.
         let quote = SwapQuote.thorchain(makeThorQuote(affiliate: "1000000", outbound: "0", total: "9000000"))
-        let value = SwapCryptoLogic.baseAffiliateFee(quote: quote, fromCoin: btc, toCoin: btc, feeCoin: btc)
+        let value = SwapCryptoLogic.baseAffiliateFee(
+            quote: quote, fromCoin: btc, toCoin: btc, feeCoin: btc,
+            fromAmount: "1", vultDiscountBps: 0, referralDiscountBps: 0
+        )
         XCTAssertEqual(value, Decimal(10).formatToFiat(includeCurrencySymbol: true))
         XCTAssertNotEqual(value, Decimal(90).formatToFiat(includeCurrencySymbol: true))
     }
 
-    func testBaseAffiliateFeeUltimateShowsZeroNotEmpty() {
+    func testBaseAffiliateFeeUltimateShowsGrossListFee() {
         let btc = makeCoin(.bitcoin, ticker: "BTCULT", decimals: 8, isNative: true)
         setPrice(1000, for: btc)
-        // Ultimate/100% waiver → node charges 0 affiliate; the row stays at $0.00.
+        // Ultimate/100% waiver → node charges 0 affiliate, while the gross row
+        // shows the undiscounted list amount and the discount row removes it.
         let quote = SwapQuote.thorchain(makeThorQuote(affiliate: "0", outbound: "0", total: "0"))
-        let value = SwapCryptoLogic.baseAffiliateFee(quote: quote, fromCoin: btc, toCoin: btc, feeCoin: btc)
+        let value = SwapCryptoLogic.baseAffiliateFee(
+            quote: quote, fromCoin: btc, toCoin: btc, feeCoin: btc,
+            fromAmount: "1", vultDiscountBps: Int.max, referralDiscountBps: 0
+        )
         XCTAssertFalse(value.isEmpty)
-        XCTAssertEqual(value, Decimal(0).formatToFiat(includeCurrencySymbol: true))
+        XCTAssertEqual(value, Decimal(5).formatToFiat(includeCurrencySymbol: true))
     }
 
     func testBaseAffiliateFeeSwapKitIncludedInRate() {
         let btc = makeCoin(.bitcoin, ticker: "BTCSK2", decimals: 8, isNative: true)
-        let value = SwapCryptoLogic.baseAffiliateFee(quote: makeSwapKitQuote(), fromCoin: btc, toCoin: btc, feeCoin: btc)
+        let value = SwapCryptoLogic.baseAffiliateFee(
+            quote: makeSwapKitQuote(), fromCoin: btc, toCoin: btc, feeCoin: btc,
+            fromAmount: "1", vultDiscountBps: 0, referralDiscountBps: 0
+        )
         XCTAssertEqual(value, "swap.included_in_rate".localized)
     }
 
@@ -237,7 +286,10 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
         // platformFee 0.02 USDC × $2 = $0.04 (hardcoded so a silent rate-seeding
         // failure would fail the test rather than pass at $0.00 on both sides).
         let quote = makeJupiterQuote(platformFee: Decimal(2) / Decimal(100), feeOnInput: false)
-        let value = SwapCryptoLogic.baseAffiliateFee(quote: quote, fromCoin: sol, toCoin: usdc, feeCoin: sol)
+        let value = SwapCryptoLogic.baseAffiliateFee(
+            quote: quote, fromCoin: sol, toCoin: usdc, feeCoin: sol,
+            fromAmount: "0", vultDiscountBps: 0, referralDiscountBps: 0
+        )
         XCTAssertEqual(value, (Decimal(4) / Decimal(100)).formatToFiat(includeCurrencySymbol: true))
     }
 
@@ -274,14 +326,16 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
         XCTAssertTrue(SwapCryptoLogic.showAffiliateFeeRow(quote: makeJupiterQuote(platformFee: 0, feeOnInput: false), mode: .standard))
     }
 
-    func testBaseAffiliateFeeUltimateTokenJupiterShowsZero() {
+    func testBaseAffiliateFeeUltimateTokenJupiterShowsGrossListFee() {
         let sol = makeCoin(.solana, ticker: "SOLJUP0", decimals: 9, isNative: true)
         let usdc = makeCoin(.solana, ticker: "USDCJUP0", decimals: 6, isNative: false)
+        setPrice(1000, for: sol)
         setPrice(2, for: usdc)
         let value = SwapCryptoLogic.baseAffiliateFee(
-            quote: makeJupiterQuote(platformFee: 0, feeOnInput: false), fromCoin: sol, toCoin: usdc, feeCoin: sol
+            quote: makeJupiterQuote(platformFee: 0, feeOnInput: false), fromCoin: sol, toCoin: usdc, feeCoin: sol,
+            fromAmount: "1", vultDiscountBps: Int.max, referralDiscountBps: 0
         )
-        XCTAssertEqual(value, Decimal(0).formatToFiat(includeCurrencySymbol: true))
+        XCTAssertEqual(value, Decimal(5).formatToFiat(includeCurrencySymbol: true))
     }
 
     func testAffiliateFeeFiatLifiSolanaUsesIntegratorFee() {
@@ -293,14 +347,25 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
         // row and the Total (network 0 + affiliate 0.5 + outbound 0).
         let quote = makeLiFiSolanaQuote(integratorFee: Decimal(5) / Decimal(1000), dstAmount: "100000000")
         let expected = (Decimal(5) / Decimal(10)).formatToFiat(includeCurrencySymbol: true)
-        XCTAssertEqual(SwapCryptoLogic.baseAffiliateFee(quote: quote, fromCoin: sol, toCoin: usdc, feeCoin: sol), expected)
+        XCTAssertEqual(
+            SwapCryptoLogic.baseAffiliateFee(
+                quote: quote, fromCoin: sol, toCoin: usdc, feeCoin: sol,
+                fromAmount: "0", vultDiscountBps: 0, referralDiscountBps: 0
+            ),
+            expected
+        )
         XCTAssertEqual(
             SwapCryptoLogic.totalFeeString(quote: quote, fromCoin: sol, toCoin: usdc, feeCoin: sol, fee: .zero),
             expected
         )
         // NOT $0.00 — the old evmSwapFeeBigInt-only path dropped the integrator fee.
-        XCTAssertNotEqual(SwapCryptoLogic.baseAffiliateFee(quote: quote, fromCoin: sol, toCoin: usdc, feeCoin: sol),
-                          Decimal(0).formatToFiat(includeCurrencySymbol: true))
+        XCTAssertNotEqual(
+            SwapCryptoLogic.baseAffiliateFee(
+                quote: quote, fromCoin: sol, toCoin: usdc, feeCoin: sol,
+                fromAmount: "0", vultDiscountBps: 0, referralDiscountBps: 0
+            ),
+            Decimal(0).formatToFiat(includeCurrencySymbol: true)
+        )
     }
 
     func testShowProtocolFeeRowFalseForSecuredMint() {
@@ -346,13 +411,33 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
         XCTAssertNotEqual(total, Decimal(100).formatToFiat(includeCurrencySymbol: true))
     }
 
+    func testDiscountedBreakdownKeepsTotalFeeNet() {
+        let btc = makeCoin(.bitcoin, ticker: "BTCNET", decimals: 8, isNative: true)
+        setPrice(1000, for: btc)
+        let quote = SwapQuote.thorchain(makeThorQuote(affiliate: "300000"))
+
+        XCTAssertEqual(
+            SwapCryptoLogic.baseAffiliateFee(
+                quote: quote, fromCoin: btc, toCoin: btc, feeCoin: btc,
+                fromAmount: "1", vultDiscountBps: VultDiscountTier.gold.bpsDiscount,
+                referralDiscountBps: 0
+            ),
+            Decimal(5).formatToFiat(includeCurrencySymbol: true)
+        )
+        XCTAssertEqual(
+            SwapCryptoLogic.totalFeeString(
+                quote: quote, fromCoin: btc, toCoin: btc, feeCoin: btc, fee: .zero
+            ),
+            Decimal(3).formatToFiat(includeCurrencySymbol: true)
+        )
+    }
+
     func testVerifyAndDoneTransactionUsesSharedGrossDisplayHelpers() {
         let quote = makeThorQuote(affiliate: "250000")
         let transaction = makeNativeThorchainTransaction(
             quote: quote,
             vultDiscountBps: VultDiscountTier.gold.bpsDiscount,
-            referralDiscountBps: 5,
-            isReferred: true
+            referralDiscountBps: 5
         )
         setPrice(1000, for: transaction.fromCoin)
         setPrice(1000, for: transaction.toCoin)
@@ -382,8 +467,8 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
 
         // Baseline (no tier, no referral) vs. a heavily-discounted referred user:
         // only the DISPLAY fee inputs differ — the signed artifact must not.
-        let baseline = makeNativeThorchainTransaction(quote: quote, vultDiscountBps: 0, referralDiscountBps: 0, isReferred: false)
-        let discounted = makeNativeThorchainTransaction(quote: quote, vultDiscountBps: 35, referralDiscountBps: 5, isReferred: true)
+        let baseline = makeNativeThorchainTransaction(quote: quote, vultDiscountBps: 0, referralDiscountBps: 0)
+        let discounted = makeNativeThorchainTransaction(quote: quote, vultDiscountBps: 35, referralDiscountBps: 5)
 
         let p1 = try await SwapCryptoLogic.buildSwapKeysignPayload(transaction: baseline, chainSpecific: cosmosChainSpecific(), vault: vault)
         let p2 = try await SwapCryptoLogic.buildSwapKeysignPayload(transaction: discounted, chainSpecific: cosmosChainSpecific(), vault: vault)
@@ -455,6 +540,17 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
         return .jupiter(evm, fee: nil, platformFee: platformFee, feeOnInput: feeOnInput)
     }
 
+    private func makeOneInchQuote(swapFee: String) -> SwapQuote {
+        let evm = EVMQuote(
+            dstAmount: "1000000",
+            tx: EVMQuote.Transaction(
+                from: "from", to: "to", data: "0x", value: "0", gasPrice: "0", gas: 0,
+                swapFee: swapFee, swapFeeTokenContract: ""
+            )
+        )
+        return .oneinch(evm, fee: nil)
+    }
+
     /// LiFi-Solana quote fixture: `swapFee` is "0" and the affiliate fee is
     /// carried as `integratorFee` (a fraction of the output amount), mirroring
     /// `LiFiService`'s Solana branch.
@@ -489,8 +585,7 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
     private func makeNativeThorchainTransaction(
         quote: ThorchainSwapQuote,
         vultDiscountBps: Int,
-        referralDiscountBps: Int,
-        isReferred: Bool
+        referralDiscountBps: Int
     ) -> SwapTransaction {
         let rune = makeCoin(.thorChain, ticker: "RUNE", decimals: 8, isNative: true)
         let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true)
@@ -504,7 +599,6 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
             thorchainFee: BigInt(2_000),
             vultDiscountBps: vultDiscountBps,
             referralDiscountBps: referralDiscountBps,
-            isReferred: isReferred,
             feeCoin: rune,
             advancedSettings: .default
         )

--- a/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
@@ -3,7 +3,7 @@
 //  VultisigAppTests
 //
 //  First real coverage for the affiliate-fee display helpers exercised by the
-//  Verify / Details / Done screens (#4859): the shared effective-affiliate-bps
+//  Verify / Details / Done screens: the shared effective-affiliate-bps
 //  function, the bps-derived percentage label, per-route affiliate amounts, the
 //  Total-fee reconciliation (which drops the fees.total liquidity component),
 //  the row-visibility gate, and the display-only invariant that none of this
@@ -78,55 +78,128 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
         }
     }
 
-    // MARK: - swapFeeLabel percentage per route
+    // MARK: - Gross list-rate display
 
-    func testSwapFeeLabelNativeThorchainDerivesFromBps() {
-        let btc = makeCoin(.bitcoin, ticker: "BTCLBL", decimals: 8, isNative: true)
-        let label = SwapCryptoLogic.swapFeeLabel(
-            quote: .thorchain(makeThorQuote()), fromCoin: btc, toCoin: btc, feeCoin: btc,
-            fromAmount: "1", vultDiscountBps: 0, isReferred: false
-        )
-        let expectedBps = THORChainSwaps.effectiveAffiliateFeeBps(discountBps: 0, isReferred: false)
-        XCTAssertEqual(label, String(format: "vultisigFeePercentage".localized, Double(expectedBps) / 100.0))
+    func testSwapFeeLabelAlwaysShowsShippingListRate() {
+        let expected = String(format: "vultisigFeePercentage".localized, 0.50)
+        XCTAssertEqual(SwapCryptoLogic.swapFeeLabel(quote: .thorchain(makeThorQuote())), expected)
+        XCTAssertEqual(SwapCryptoLogic.swapFeeLabel(quote: .mayachain(makeThorQuote())), expected)
+        XCTAssertEqual(SwapCryptoLogic.swapFeeLabel(quote: makeSwapKitQuote()), expected)
+        XCTAssertEqual(SwapCryptoLogic.affiliateListFeeBps, 50)
     }
 
-    func testSwapFeeLabelThorchainReferredShowsReferredSplit() {
+    func testGoldGrossFeeAddsDiscountBackToNet() {
+        let btc = makeCoin(.bitcoin, ticker: "BTCGOLD", decimals: 8, isNative: true)
+        setPrice(1000, for: btc)
+        let quote = SwapQuote.thorchain(makeThorQuote(affiliate: "300000"))
+
+        let breakdown = SwapCryptoLogic.affiliateDiscountBreakdown(
+            quote: quote, fromCoin: btc, toCoin: btc, feeCoin: btc,
+            fromAmount: "1", vultDiscountBps: VultDiscountTier.gold.bpsDiscount,
+            referralDiscountBps: 0
+        )
+        let net = SwapCryptoLogic.affiliateFeeFiat(quote: quote, fromCoin: btc, toCoin: btc, feeCoin: btc)
+
+        XCTAssertEqual(net, 3)
+        XCTAssertEqual(breakdown.vult, 2)
+        XCTAssertEqual(net + breakdown.total, 5)
+        XCTAssertEqual(
+            SwapCryptoLogic.baseAffiliateFee(
+                quote: quote, fromCoin: btc, toCoin: btc, feeCoin: btc,
+                fromAmount: "1", vultDiscountBps: VultDiscountTier.gold.bpsDiscount,
+                referralDiscountBps: 0
+            ),
+            Decimal(5).formatToFiat(includeCurrencySymbol: true)
+        )
+    }
+
+    func testGoldAndReferralDiscountsExactlyReconcileGrossAndNet() {
         let btc = makeCoin(.bitcoin, ticker: "BTCREF", decimals: 8, isNative: true)
-        let label = SwapCryptoLogic.swapFeeLabel(
-            quote: .thorchain(makeThorQuote()), fromCoin: btc, toCoin: btc, feeCoin: btc,
-            fromAmount: "1", vultDiscountBps: 0, isReferred: true
+        setPrice(1000, for: btc)
+        let quote = SwapQuote.thorchain(makeThorQuote(affiliate: "250000"))
+        let breakdown = SwapCryptoLogic.affiliateDiscountBreakdown(
+            quote: quote, fromCoin: btc, toCoin: btc, feeCoin: btc,
+            fromAmount: "1", vultDiscountBps: VultDiscountTier.gold.bpsDiscount,
+            referralDiscountBps: 5
         )
-        // 10 (referrer) + 35 (discounted base 35) = 45 bps, even in DEBUG.
-        XCTAssertEqual(label, String(format: "vultisigFeePercentage".localized, 0.45))
+        let net = SwapCryptoLogic.affiliateFeeFiat(quote: quote, fromCoin: btc, toCoin: btc, feeCoin: btc)
+
+        XCTAssertEqual(net, Decimal(string: "2.5") ?? 0)
+        XCTAssertEqual(breakdown.vult, 2)
+        XCTAssertEqual(breakdown.referral, Decimal(string: "0.5") ?? 0)
+        XCTAssertEqual(net + breakdown.total, 5)
     }
 
-    func testSwapFeeLabelMayaIgnoresReferralSplit() {
-        let btc = makeCoin(.bitcoin, ticker: "BTCMAYA", decimals: 8, isNative: true)
-        let mayaReferred = SwapCryptoLogic.swapFeeLabel(
+    func testNoDiscountKeepsGrossEqualToNet() {
+        let btc = makeCoin(.bitcoin, ticker: "BTCNONE", decimals: 8, isNative: true)
+        setPrice(1000, for: btc)
+        let quote = SwapQuote.thorchain(makeThorQuote(affiliate: "500000"))
+        let breakdown = SwapCryptoLogic.affiliateDiscountBreakdown(
+            quote: quote, fromCoin: btc, toCoin: btc, feeCoin: btc,
+            fromAmount: "1", vultDiscountBps: 0, referralDiscountBps: 0
+        )
+
+        XCTAssertEqual(breakdown, .init(vult: 0, referral: 0))
+        XCTAssertEqual(
+            SwapCryptoLogic.baseAffiliateFee(
+                quote: quote, fromCoin: btc, toCoin: btc, feeCoin: btc,
+                fromAmount: "1", vultDiscountBps: 0, referralDiscountBps: 0
+            ),
+            Decimal(5).formatToFiat(includeCurrencySymbol: true)
+        )
+    }
+
+    func testUltimateWaiverReconstructsFullListFee() {
+        let btc = makeCoin(.bitcoin, ticker: "BTCULTGROSS", decimals: 8, isNative: true)
+        setPrice(1000, for: btc)
+        let quote = SwapQuote.thorchain(makeThorQuote(affiliate: "0"))
+        let breakdown = SwapCryptoLogic.affiliateDiscountBreakdown(
+            quote: quote, fromCoin: btc, toCoin: btc, feeCoin: btc,
+            fromAmount: "1", vultDiscountBps: Int.max, referralDiscountBps: 5
+        )
+
+        XCTAssertEqual(breakdown.vult, 5)
+        XCTAssertEqual(breakdown.referral, 0)
+        XCTAssertEqual(
+            SwapCryptoLogic.baseAffiliateFee(
+                quote: quote, fromCoin: btc, toCoin: btc, feeCoin: btc,
+                fromAmount: "1", vultDiscountBps: Int.max, referralDiscountBps: 5
+            ),
+            Decimal(5).formatToFiat(includeCurrencySymbol: true)
+        )
+    }
+
+    func testReferralDiscountOnlyAppearsOnThorchainNestedAffiliateRoutes() {
+        let btc = makeCoin(.bitcoin, ticker: "BTCROUTE", decimals: 8, isNative: true)
+        setPrice(1000, for: btc)
+        let thor = SwapCryptoLogic.affiliateDiscountBreakdown(
+            quote: .thorchain(makeThorQuote()), fromCoin: btc, toCoin: btc, feeCoin: btc,
+            fromAmount: "1", vultDiscountBps: 0, referralDiscountBps: 5
+        )
+        let maya = SwapCryptoLogic.affiliateDiscountBreakdown(
             quote: .mayachain(makeThorQuote()), fromCoin: btc, toCoin: btc, feeCoin: btc,
-            fromAmount: "1", vultDiscountBps: 0, isReferred: true
+            fromAmount: "1", vultDiscountBps: 0, referralDiscountBps: 5
         )
-        let thorReferred = SwapCryptoLogic.swapFeeLabel(
-            quote: .thorchain(makeThorQuote()), fromCoin: btc, toCoin: btc, feeCoin: btc,
-            fromAmount: "1", vultDiscountBps: 0, isReferred: true
+        let swapKit = SwapCryptoLogic.affiliateDiscountBreakdown(
+            quote: makeSwapKitQuote(), fromCoin: btc, toCoin: btc, feeCoin: btc,
+            fromAmount: "1", vultDiscountBps: 0, referralDiscountBps: 5
         )
-        let thorNonReferred = SwapCryptoLogic.swapFeeLabel(
-            quote: .thorchain(makeThorQuote()), fromCoin: btc, toCoin: btc, feeCoin: btc,
-            fromAmount: "1", vultDiscountBps: 0, isReferred: false
-        )
-        // Maya never applies the referral split → it must match the standard
-        // (non-referred) rate, not the THORChain referred rate.
-        XCTAssertEqual(mayaReferred, thorNonReferred)
-        XCTAssertNotEqual(mayaReferred, thorReferred)
+
+        XCTAssertEqual(thor.referral, Decimal(string: "0.5") ?? 0)
+        XCTAssertEqual(maya.referral, 0)
+        XCTAssertEqual(swapKit.referral, 0)
     }
 
-    func testSwapFeeLabelSwapKitStaticHalfPercent() {
-        let btc = makeCoin(.bitcoin, ticker: "BTCSK", decimals: 8, isNative: true)
-        let label = SwapCryptoLogic.swapFeeLabel(
-            quote: makeSwapKitQuote(), fromCoin: btc, toCoin: btc, feeCoin: btc,
-            fromAmount: "1", vultDiscountBps: 0, isReferred: false
+    func testJupiterFeeOnInputSuppressesUnreconcilableDiscountRows() {
+        let sol = makeCoin(.solana, ticker: "SOLINPUT", decimals: 9, isNative: true)
+        let quote = makeJupiterQuote(platformFee: 0, feeOnInput: true)
+        let breakdown = SwapCryptoLogic.affiliateDiscountBreakdown(
+            quote: quote, fromCoin: sol, toCoin: sol, feeCoin: sol,
+            fromAmount: "1", vultDiscountBps: 20, referralDiscountBps: 5
         )
-        XCTAssertEqual(label, String(format: "vultisigFeePercentage".localized, 0.50))
+
+        XCTAssertEqual(breakdown, .init(vult: 0, referral: 0))
+        XCTAssertFalse(SwapCryptoLogic.showAffiliateFeeRow(quote: quote, mode: .standard))
     }
 
     // MARK: - baseAffiliateFee amount per route
@@ -271,6 +344,34 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
         XCTAssertEqual(total, Decimal(40).formatToFiat(includeCurrencySymbol: true))
         // NOT the old composite path ($10 network + $90 fees.total = $100).
         XCTAssertNotEqual(total, Decimal(100).formatToFiat(includeCurrencySymbol: true))
+    }
+
+    func testVerifyAndDoneTransactionUsesSharedGrossDisplayHelpers() {
+        let quote = makeThorQuote(affiliate: "250000")
+        let transaction = makeNativeThorchainTransaction(
+            quote: quote,
+            vultDiscountBps: VultDiscountTier.gold.bpsDiscount,
+            referralDiscountBps: 5,
+            isReferred: true
+        )
+        setPrice(1000, for: transaction.fromCoin)
+        setPrice(1000, for: transaction.toCoin)
+        let wrappedQuote = SwapQuote.thorchain(quote)
+
+        XCTAssertEqual(transaction.swapFeeLabel, SwapCryptoLogic.swapFeeLabel(quote: wrappedQuote))
+        XCTAssertEqual(
+            transaction.baseAffiliateFee,
+            SwapCryptoLogic.baseAffiliateFee(
+                quote: wrappedQuote,
+                fromCoin: transaction.fromCoin,
+                toCoin: transaction.toCoin,
+                feeCoin: transaction.feeCoin,
+                fromAmount: transaction.fromAmount.description,
+                vultDiscountBps: transaction.vultDiscountBps,
+                referralDiscountBps: transaction.referralDiscountBps
+            )
+        )
+        XCTAssertTrue(transaction.hasAppliedDiscounts)
     }
 
     // MARK: - Display-only invariant: signed payload unchanged

--- a/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
@@ -93,6 +93,28 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
         XCTAssertEqual(SwapCryptoLogic.affiliateListFeeBps, 50)
     }
 
+    func testDiscountLabelsUseFigmaPercentageFormatForEveryTier() {
+        let expectedLabels: [(VultDiscountTier, String)] = [
+            (.bronze, "VULT Bronze: 5%"),
+            (.silver, "VULT Silver: 10%"),
+            (.gold, "VULT Gold: 20%"),
+            (.platinum, "VULT Platinum: 25%"),
+            (.diamond, "VULT Diamond: 35%"),
+            (.ultimate, "VULT Ultimate: 100%")
+        ]
+
+        for (tier, expectedLabel) in expectedLabels {
+            XCTAssertEqual(
+                SwapCryptoLogic.vultDiscountLabel(vultDiscountBps: tier.bpsDiscount),
+                expectedLabel
+            )
+        }
+        XCTAssertEqual(
+            SwapCryptoLogic.referralDiscountLabel(referralDiscountBps: 5),
+            "Referral: 0.05%"
+        )
+    }
+
     func testGoldGrossFeeAddsDiscountBackToNet() {
         let btc = makeCoin(.bitcoin, ticker: "BTCGOLD", decimals: 8, isNative: true)
         setPrice(1000, for: btc)

--- a/VultisigApp/VultisigAppTests/Swap/SwapDetailsViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapDetailsViewModelTests.swift
@@ -62,7 +62,7 @@ final class SwapDetailsViewModelTests: XCTestCase {
         vm.fromAmount = "1"
 
         // First fetch: no prior quote → leading-edge skeleton should be on.
-        vm.updateFromAmount(vault: makeVault(), referredCode: "", immediate: true)
+        vm.updateFromAmount(vault: makeVault(), immediate: true)
         XCTAssertTrue(vm.showsQuoteSkeleton, "First quote of a pair must show the skeleton")
 
         await vm.waitForQuoteTask()
@@ -78,12 +78,12 @@ final class SwapDetailsViewModelTests: XCTestCase {
         vm.fromAmount = "1"
 
         // Land a firm quote first.
-        vm.updateFromAmount(vault: makeVault(), referredCode: "", immediate: true)
+        vm.updateFromAmount(vault: makeVault(), immediate: true)
         await vm.waitForQuoteTask()
         XCTAssertNotNil(vm.quote)
 
         // Auto-refresh on the same pair: the prior quote stays, so no skeleton.
-        vm.refreshData(vault: makeVault(), referredCode: "")
+        vm.refreshData(vault: makeVault())
         XCTAssertTrue(vm.isLoadingQuotes, "A refresh is in flight")
         XCTAssertFalse(
             vm.showsQuoteSkeleton,
@@ -100,7 +100,7 @@ final class SwapDetailsViewModelTests: XCTestCase {
         vm.fromAmount = "1"
 
         // Land a firm quote first.
-        vm.updateFromAmount(vault: makeVault(), referredCode: "", immediate: true)
+        vm.updateFromAmount(vault: makeVault(), immediate: true)
         await vm.waitForQuoteTask()
         XCTAssertNotNil(vm.quote)
 
@@ -109,7 +109,7 @@ final class SwapDetailsViewModelTests: XCTestCase {
         // "to" field falls back to the indicative estimate and the summary
         // shows its skeleton — stale-while-revalidate is for auto-refresh only.
         vm.fromAmount = "2"
-        vm.updateFromAmount(vault: makeVault(), referredCode: "", immediate: true)
+        vm.updateFromAmount(vault: makeVault(), immediate: true)
         XCTAssertNil(vm.quote, "Quote must clear on an amount change")
         XCTAssertTrue(vm.showsQuoteSkeleton, "An amount change must show the skeleton, not the stale summary")
         await vm.waitForQuoteTask()
@@ -122,14 +122,14 @@ final class SwapDetailsViewModelTests: XCTestCase {
         vm.toCoin = makeCoin(.bitcoin, ticker: "BTC")
         vm.fromAmount = "1"
 
-        vm.updateFromAmount(vault: makeVault(), referredCode: "", immediate: true)
+        vm.updateFromAmount(vault: makeVault(), immediate: true)
         await vm.waitForQuoteTask()
         XCTAssertNotNil(vm.quote)
 
         // Change the destination coin: the held quote is now meaningless and must
         // be cleared so a different-pair quote can't show through.
         vm.toCoin = makeCoin(.ethereum, ticker: "ETH")
-        vm.updateFromAmount(vault: makeVault(), referredCode: "", immediate: true)
+        vm.updateFromAmount(vault: makeVault(), immediate: true)
         XCTAssertNil(vm.quote, "Quote must be cleared on a pair change")
         XCTAssertTrue(vm.showsQuoteSkeleton, "A new pair with no prior quote must show the skeleton")
         await vm.waitForQuoteTask()
@@ -141,12 +141,12 @@ final class SwapDetailsViewModelTests: XCTestCase {
         vm.fromCoin = makeCoin(.thorChain, ticker: "RUNE", balance: "100000000000")
         vm.toCoin = makeCoin(.bitcoin, ticker: "BTC")
         vm.fromAmount = "1"
-        vm.updateFromAmount(vault: makeVault(), referredCode: "", immediate: true)
+        vm.updateFromAmount(vault: makeVault(), immediate: true)
         await vm.waitForQuoteTask()
         XCTAssertNotNil(vm.quote)
 
         vm.fromAmount = ""
-        vm.updateFromAmount(vault: makeVault(), referredCode: "")
+        vm.updateFromAmount(vault: makeVault())
         XCTAssertNil(vm.quote, "Emptying the amount must clear the quote")
         XCTAssertFalse(vm.showsQuoteSkeleton)
         XCTAssertFalse(vm.isLoadingQuotes)
@@ -162,7 +162,7 @@ final class SwapDetailsViewModelTests: XCTestCase {
         vm.fromAmount = "1"
 
         let start = Date()
-        vm.updateFromAmount(vault: makeVault(), referredCode: "", immediate: true)
+        vm.updateFromAmount(vault: makeVault(), immediate: true)
         await vm.waitForQuoteTask()
         let elapsed = Date().timeIntervalSince(start)
 
@@ -180,7 +180,7 @@ final class SwapDetailsViewModelTests: XCTestCase {
 
         // Default (typing) path is debounced — the network shouldn't be hit
         // before the debounce window elapses.
-        vm.updateFromAmount(vault: makeVault(), referredCode: "")
+        vm.updateFromAmount(vault: makeVault())
         try? await Task.sleep(for: .milliseconds(100))
         XCTAssertEqual(interactor.fetchQuoteCallCount, 0, "Debounced path must not fetch before the debounce")
 
@@ -197,13 +197,55 @@ final class SwapDetailsViewModelTests: XCTestCase {
 
         // Start a debounced (typing) fetch, then supersede it immediately with a
         // percentage tap — the pending one must be cancelled, only one fetch runs.
-        vm.updateFromAmount(vault: makeVault(), referredCode: "")
+        vm.updateFromAmount(vault: makeVault())
         vm.fromAmount = "2"
-        vm.updateFromAmount(vault: makeVault(), referredCode: "", immediate: true)
+        vm.updateFromAmount(vault: makeVault(), immediate: true)
         await vm.waitForQuoteTask()
 
         XCTAssertEqual(interactor.fetchQuoteCallCount, 1, "The superseded debounced fetch must be cancelled")
         XCTAssertNotNil(vm.quote)
+    }
+
+    // MARK: - Vault-owned referral code
+
+    func testDetailsQuoteUsesReferralCodeFromVault() async {
+        let interactor = MockSwapInteractor(quote: .thorchain(makeThorQuote(expectedAmountOut: "100000000")))
+        let vm = makeVM(interactor: interactor)
+        let vault = makeVault(referredCode: "FRIEND")
+        vm.fromCoin = makeCoin(.thorChain, ticker: "RUNE", balance: "100000000000")
+        vm.toCoin = makeCoin(.bitcoin, ticker: "BTC")
+        vm.fromAmount = "1"
+
+        vm.updateFromAmount(vault: vault, immediate: true)
+        await vm.waitForQuoteTask()
+
+        XCTAssertEqual(interactor.lastReferredCode, "FRIEND")
+    }
+
+    func testVerifyRefreshUsesReferralCodeFromVault() async {
+        let quote = makeThorQuote(expectedAmountOut: "100000000")
+        let interactor = MockSwapInteractor(quote: .thorchain(quote))
+        let vault = makeVault(referredCode: "FRIEND")
+        let rune = makeCoin(.thorChain, ticker: "RUNE", balance: "100000000000")
+        let btc = makeCoin(.bitcoin, ticker: "BTC")
+        let transaction = SwapTransaction(
+            fromCoin: rune,
+            toCoin: btc,
+            fromAmount: 1,
+            kind: .market(.thorchain(quote)),
+            gas: .zero,
+            gasLimit: .zero,
+            thorchainFee: .zero,
+            vultDiscountBps: 0,
+            referralDiscountBps: 0,
+            feeCoin: rune,
+            advancedSettings: .default
+        )
+        let vm = SwapVerifyViewModel(transaction: transaction, interactor: interactor)
+
+        await vm.refreshData(vault: vault)
+
+        XCTAssertEqual(interactor.lastReferredCode, "FRIEND")
     }
 
     // MARK: - Advanced-settings reset is TOKEN-driven, not chain-driven (leak prevention)
@@ -225,7 +267,7 @@ final class SwapDetailsViewModelTests: XCTestCase {
         XCTAssertNotEqual(vm.advancedSettings, .default, "Precondition: settings are non-default")
 
         // Empty amount keeps `fetchQuotes` from touching the network.
-        vm.switchCoins(vault: makeVault(), referredCode: "")
+        vm.switchCoins(vault: makeVault())
 
         XCTAssertEqual(vm.advancedSettings, .default, "Flipping the pair must reset advanced settings")
     }
@@ -240,7 +282,7 @@ final class SwapDetailsViewModelTests: XCTestCase {
         XCTAssertNotEqual(vm.advancedSettings, .default, "Precondition: settings are non-default")
 
         // Picking a new source token resets — empty amount keeps it off-network.
-        vm.updateFromCoin(coin: makeCoin(.thorChain, ticker: "RUNE"), vault: makeVault(), referredCode: "")
+        vm.updateFromCoin(coin: makeCoin(.thorChain, ticker: "RUNE"), vault: makeVault())
 
         XCTAssertEqual(vm.advancedSettings, .default, "Picking a new source token must reset advanced settings")
     }
@@ -254,7 +296,7 @@ final class SwapDetailsViewModelTests: XCTestCase {
         XCTAssertNotEqual(vm.advancedSettings, .default, "Precondition: settings are non-default")
 
         // Picking a new destination token resets.
-        vm.updateToCoin(coin: makeCoin(.thorChain, ticker: "RUNE"), vault: makeVault(), referredCode: "")
+        vm.updateToCoin(coin: makeCoin(.thorChain, ticker: "RUNE"), vault: makeVault())
 
         XCTAssertEqual(vm.advancedSettings, .default, "Picking a new destination token must reset advanced settings")
     }
@@ -338,7 +380,7 @@ final class SwapDetailsViewModelTests: XCTestCase {
         vm.toCoin = makeCoin(.bitcoin, ticker: "BTC")
         vm.fromAmount = "1"
 
-        vm.updateFromAmount(vault: makeVault(), referredCode: "", immediate: true)
+        vm.updateFromAmount(vault: makeVault(), immediate: true)
         await vm.waitForQuoteTask()
 
         XCTAssertNotNil(vm.quote, "Precondition: the quote must resolve so updateFees runs")
@@ -352,8 +394,8 @@ final class SwapDetailsViewModelTests: XCTestCase {
         SwapDetailsViewModel(interactor: interactor ?? MockSwapInteractor(quote: nil))
     }
 
-    private func makeVault() -> Vault {
-        Vault(
+    private func makeVault(referredCode: String? = nil) -> Vault {
+        let vault = Vault(
             name: "Test Vault",
             signers: [],
             pubKeyECDSA: "test-pub-ecdsa",
@@ -364,6 +406,10 @@ final class SwapDetailsViewModelTests: XCTestCase {
             resharePrefix: nil,
             libType: .DKLS
         )
+        if let referredCode {
+            vault.referredCode = ReferredCode(code: referredCode, vault: vault)
+        }
+        return vault
     }
 
     private func makeCoin(_ chain: Chain, ticker: String, balance: String = "0") -> Coin {
@@ -427,6 +473,7 @@ private final class MockSwapInteractor: SwapInteractor {
     private let stubbedQuote: SwapQuote?
     private let computeFeeError: Error?
     private(set) var fetchQuoteCallCount = 0
+    private(set) var lastReferredCode: String?
 
     init(quote: SwapQuote?, computeFeeError: Error? = nil) {
         self.stubbedQuote = quote
@@ -443,6 +490,7 @@ private final class MockSwapInteractor: SwapInteractor {
         recipientAddress: String?
     ) async throws -> SwapQuoteResult? {
         fetchQuoteCallCount += 1
+        lastReferredCode = referredCode
         guard let stubbedQuote else { return nil }
         return SwapQuoteResult(quote: stubbedQuote, vultDiscountBps: 0, referralDiscountBps: 0)
     }

--- a/VultisigApp/VultisigAppTests/Swap/SwapFeeSufficiencyValidationTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapFeeSufficiencyValidationTests.swift
@@ -37,7 +37,7 @@ final class SwapFeeSufficiencyValidationTests: XCTestCase {
         // bond (0.001) — the old order validated pre-oracle and let it pass.
         let vm = makeVerifyVM(balanceWei: "500000000000000")
 
-        await vm.refreshData(vault: makeVault(), referredCode: "")
+        await vm.refreshData(vault: makeVault())
 
         XCTAssertEqual(
             vm.error as? SwapCryptoLogic.Errors,
@@ -49,7 +49,7 @@ final class SwapFeeSufficiencyValidationTests: XCTestCase {
     func testRefreshPassesWhenBalanceCoversReconciledBond() async {
         let vm = makeVerifyVM(balanceWei: "2000000000000000") // 0.002 ETH ≥ amount + bond
 
-        await vm.refreshData(vault: makeVault(), referredCode: "")
+        await vm.refreshData(vault: makeVault())
 
         XCTAssertNil(vm.error)
         XCTAssertEqual(vm.transaction.gas, maxFeePerGasWei, "Oracle maxFeePerGas must be committed")
@@ -63,7 +63,7 @@ final class SwapFeeSufficiencyValidationTests: XCTestCase {
         // and the fetch error surfaces exactly as it used to.
         let vm = makeVerifyVM(balanceWei: "500000000000000", chainSpecificError: TestOracleError())
 
-        await vm.refreshData(vault: makeVault(), referredCode: "")
+        await vm.refreshData(vault: makeVault())
 
         XCTAssertTrue(vm.error is TestOracleError, "The oracle fetch error must surface, not a gas error")
         XCTAssertNotEqual(vm.error as? SwapCryptoLogic.Errors, .insufficientGas)
@@ -75,7 +75,7 @@ final class SwapFeeSufficiencyValidationTests: XCTestCase {
         // pre-bond gate already blocked this, and it must keep blocking.
         let vm = makeVerifyVM(balanceWei: "200000000000000", chainSpecificError: TestOracleError())
 
-        await vm.refreshData(vault: makeVault(), referredCode: "")
+        await vm.refreshData(vault: makeVault())
 
         XCTAssertEqual(vm.error as? SwapCryptoLogic.Errors, .insufficientGas)
     }

--- a/VultisigApp/VultisigAppTests/Swap/SwapProviderSelectionTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapProviderSelectionTests.swift
@@ -116,12 +116,12 @@ final class SwapProviderSelectionTests: XCTestCase {
         vm.fromCoin = makeCoin(.thorChain, ticker: "RUNE", balance: "100000000000")
         vm.toCoin = makeCoin(.bitcoin, ticker: "BTC")
         vm.fromAmount = "1"
-        vm.updateFromAmount(vault: makeVault(), referredCode: "", immediate: true)
+        vm.updateFromAmount(vault: makeVault(), immediate: true)
         await vm.waitForQuoteTask()
         vm.selectProvider(alt)
 
         vm.fromAmount = ""
-        vm.updateFromAmount(vault: makeVault(), referredCode: "")
+        vm.updateFromAmount(vault: makeVault())
 
         XCTAssertNil(vm.quote, "Emptying the amount clears the active quote")
         XCTAssertNil(vm.selectedQuote, "Emptying the amount clears the manual override")
@@ -171,7 +171,7 @@ final class SwapProviderSelectionTests: XCTestCase {
             vm.toCoin = makeCoin(.bitcoin, ticker: "BTC")
         }
         if vm.fromAmount.isEmpty { vm.fromAmount = "1" }
-        vm.updateFromAmount(vault: makeVault(), referredCode: "", immediate: true)
+        vm.updateFromAmount(vault: makeVault(), immediate: true)
         await vm.waitForQuoteTask()
     }
 


### PR DESCRIPTION
## Problem

The swap breakdown displayed the already-discounted affiliate percentage and amount on the Vultisig Fee row, then showed VULT and referral savings again as separate rows. That made the fee hierarchy misleading and prevented the expanded breakdown from clearly reconciling with the net Total Fees value.

During validation, the swap flow also read the referral code from `ReferredViewModel.savedReferredCode`. That view model was not initialized with the active vault on every swap surface, so the value could stay empty even when the vault had a referral code.

## Root cause

The shared Form/Verify/Done display helpers reused the quote-derived net affiliate component and effective provider bps for both the list-rate row and the net total. Gross price, applied savings, and provider wire values were not modeled as separate display concepts.

Referral state had two possible owners in the swap flow: the active vault and a screen-local `ReferredViewModel`. The screen-local copy could be stale or unset.

## Design

Adapted from [Figma node 78798:72683](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v?node-id=78798-72683): the expanded hierarchy now separates the gross Vultisig Fee from a conditional **Applied Discounts:** group, reusing the existing VULT tier badges, referral megaphone, typography, colors, and vertical accent treatment.

The issue acceptance criteria supersede the sample percentage in Figma: the shipping list label is **0.50%**.

## Implementation

- Adds an explicit, DEBUG-independent 50-bps display list rate.
- Reconstructs the gross fiat fee as the quote-derived net affiliate amount plus the exact displayed VULT and referral savings using `Decimal` arithmetic.
- Keeps Total Fees on the existing net affiliate amount, so gross minus discounts reconciles to the unchanged total component.
- Centralizes the label, gross amount, route-aware discount breakdown, and visibility helpers shared by Form, Verify, and Done.
- Adds the conditional localized **Applied Discounts:** heading to all three surfaces.
- Brings Done into parity by showing the VULT/referral rows and price impact in its expanded breakdown.
- Removes `ReferredViewModel` from the swap flow and reads `vault.referredCode?.code` at the quote interactor boundary in both Details and Verify.
- Passes the real referral discount through the VULT breakdown so Ultimate + referral rows reconcile with gross and net fees.
- Matches Figma discount rows across Form, Verify, and Done with icon-plus-percentage labels such as `VULT Gold: 20%` and `Referral: 0.05%`, without a trailing fiat amount.
- Adds the localization key to all eight supported locales without adding assets.

## Route-specific truth

- THORChain nested-affiliate routes show both applicable VULT and referral savings.
- Maya and aggregator routes suppress referral savings because their request builders do not apply referral bps.
- SwapKit keeps `included in quoted rate` instead of fabricating a separable fiat fee, while retaining the VULT saving its request actually applies.
- Jupiter fee-on-input continues to suppress the affiliate row and discount breakdown because no truthful output-denominated amount is available.
- Fee-less aggregator fallbacks use the plain Vultisig Fee label with `$0.00` and no fabricated savings.
- Ultimate referred THORChain swaps separate the 35-bps VULT waiver and 5-bps referral saving around the remaining 10-bps referrer charge.

## Safety

Provider fee calculations, transaction construction, signed memos, amounts, destinations, and keysign payloads are unchanged. Quote requests now consistently source the referral code from the active vault. A signed-payload invariance test pins the transaction contract.

## Verification

- `make test`: **6,936 tests, 11 skipped, 0 failures** — `** TEST SUCCEEDED **`
- Focused swap suites: **78 tests, 0 failures**
- Changed-file SwiftLint: **0 violations**
- `git diff --check`: clean
- All eight locale keys present and sorted
- Full branch independently inspected before push

Manual simulator/device UI validation was not performed in this pass; QA should visually confirm the expanded Form, Verify, and Done hierarchy across no-discount, Gold, referral, and Ultimate examples.

Closes #5311


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated swap fee summaries to show gross fees, net fees, applied Vultisig and referral discounts, and price impact.
  * Added tier indicators for eligible Vultisig discounts.
  * Standardized the displayed affiliate list rate at 0.50%.
* **Bug Fixes**
  * Improved discount calculations across supported swap routes, including zero-fee and input-fee cases.
  * Referral discounts now apply consistently to eligible THORChain swaps.
* **Localization**
  * Added “Applied Discounts” translations and fallback text for unrecognized Vultisig discount tiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
