### PR TITLE
fix(blockaid): net complete Solana asset diffs

### DIFF
--- a/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidSimulationParser.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidSimulationParser.swift
@@ -102,15 +102,11 @@ enum BlockaidSimulationParser {
 
     // MARK: - Solana
 
-    /// Parses a Solana simulation response. Mirrors `parseBlockaidSolanaSimulation`:
-    /// when three diffs come back and one is native SOL, the SOL diff is
-    /// filtered out as "likely the transaction fee". One remaining diff maps to
-    /// `.transfer`, two remaining diffs map to `.swap` (or `.transfer` if only
-    /// the out side has a value).
-    ///
-    /// Diverges from the extension in one place: a two-diff pair that resolves
-    /// to the same mint is netted rather than reported as a swap — see
-    /// `netSameMint(outCoin:outAmount:inCoin:inAmount:)`.
+    /// Parses every Solana balance leg into complete per-mint net changes.
+    /// Native SOL and WSOL share the wrapped-SOL mint sentinel, so wrapping
+    /// noise is netted while distinct assets remain independent. A hero is
+    /// emitted only when the complete result is one transfer/receive or one
+    /// unambiguous swap; multi-spend shapes fail closed.
     static func parseSolana(
         response: BlockaidSolanaSimulationResponseJson
     ) -> BlockaidSimulationInfo? {
@@ -119,164 +115,122 @@ enum BlockaidSimulationParser {
             return nil
         }
 
-        let relevant: [BlockaidSolanaSimulationJson.AccountAssetDiff]
-        if diffs.count == 3,
-           let solIndex = diffs.firstIndex(where: { $0.asset.type == "SOL" || $0.assetType == "SOL" }) {
-            var filtered = diffs
-            filtered.remove(at: solIndex)
-            relevant = filtered
-        } else {
-            relevant = diffs
-        }
-
-        if relevant.count == 1 {
-            return parseSolanaTransfer(diff: relevant[0])
-        }
-
-        return parseSolanaSwap(diffs: relevant)
+        return parseSolanaNetChanges(diffs: diffs)
     }
 
-    private static func parseSolanaTransfer(
-        diff: BlockaidSolanaSimulationJson.AccountAssetDiff
-    ) -> BlockaidSimulationInfo? {
-        guard let rawValue = diff.out?.rawValue,
-              let amount = parseRawAmount(rawValue),
-              let coin = buildSolanaCoin(from: diff.asset) else {
-            return nil
-        }
-        return .transfer(fromCoin: coin, fromAmount: amount)
+    private struct SolanaMintBalance {
+        let decimals: Int
+        var incoming: BigInt = 0
+        var outgoing: BigInt = 0
+        var incomingCoin: BlockaidSimulationCoin?
+        var outgoingCoin: BlockaidSimulationCoin?
     }
 
-    private static func parseSolanaSwap(
+    private struct SolanaNetChange {
+        let coin: BlockaidSimulationCoin
+        let amount: BigInt
+    }
+
+    private static func parseSolanaNetChanges(
         diffs: [BlockaidSolanaSimulationJson.AccountAssetDiff]
     ) -> BlockaidSimulationInfo? {
-        // Mirror the extension's positional destructuring: first diff is the
-        // out side, second is the in side. Fall back to .transfer when only
-        // one side carries a value (matches the extension's `else if` branch).
-        let outIndex = diffs[0].out != nil ? 0 : 1
-        let inIndex = diffs[1].`in` != nil ? 1 : 0
-        let outSource = diffs[outIndex]
-        let inSource = diffs[inIndex]
+        guard let balances = solanaMintBalances(diffs: diffs) else { return nil }
 
-        if let outRaw = outSource.out?.rawValue,
-           let inRaw = inSource.`in`?.rawValue,
-           let outAmount = parseRawAmount(outRaw),
-           let inAmount = parseRawAmount(inRaw),
-           let fromCoin = buildSolanaCoin(from: outSource.asset),
-           let toCoin = buildSolanaCoin(from: inSource.asset) {
-            if let outMint = fromCoin.address,
-               let inMint = toCoin.address,
-               outMint == inMint {
-                // The netting reads exactly two legs: one diff's out side and
-                // one diff's in side, which can collapse onto the same diff.
-                // Every other leg the response states goes unread, so netting
-                // past one would have the hero state an authoritative net
-                // having never looked at a balance change the transaction
-                // makes. Decline and let the caller fall back to the generic
-                // title.
-                guard readsEveryLeg(diffs, outIndex: outIndex, inIndex: inIndex) else {
-                    return nil
-                }
-                return netSameMint(
-                    outCoin: fromCoin,
-                    outAmount: outAmount,
-                    inCoin: toCoin,
-                    inAmount: inAmount
+        var incomingChanges: [SolanaNetChange] = []
+        var outgoingChanges: [SolanaNetChange] = []
+
+        for balance in balances.values {
+            if balance.outgoing > balance.incoming,
+               let coin = balance.outgoingCoin {
+                outgoingChanges.append(
+                    SolanaNetChange(coin: coin, amount: balance.outgoing - balance.incoming)
+                )
+            } else if balance.incoming > balance.outgoing,
+                      let coin = balance.incomingCoin {
+                incomingChanges.append(
+                    SolanaNetChange(coin: coin, amount: balance.incoming - balance.outgoing)
                 )
             }
-            return .swap(fromCoin: fromCoin, toCoin: toCoin, fromAmount: outAmount, toAmount: inAmount)
         }
 
-        if let outRaw = outSource.out?.rawValue,
-           let outAmount = parseRawAmount(outRaw),
-           let fromCoin = buildSolanaCoin(from: outSource.asset) {
-            return .transfer(fromCoin: fromCoin, fromAmount: outAmount)
+        if outgoingChanges.count == 1, incomingChanges.isEmpty,
+           let outgoing = outgoingChanges.first {
+            return .transfer(fromCoin: outgoing.coin, fromAmount: outgoing.amount)
+        }
+
+        if outgoingChanges.isEmpty, incomingChanges.count == 1,
+           let incoming = incomingChanges.first {
+            return .receive(coin: incoming.coin, amount: incoming.amount)
+        }
+
+        if outgoingChanges.count == 1, incomingChanges.count == 1,
+           let outgoing = outgoingChanges.first,
+           let incoming = incomingChanges.first {
+            return .swap(
+                fromCoin: outgoing.coin,
+                toCoin: incoming.coin,
+                fromAmount: outgoing.amount,
+                toAmount: incoming.amount
+            )
         }
 
         return nil
     }
 
-    /// Collapses an out/in pair that resolves to a single mint into the net
-    /// movement of that mint.
-    ///
-    /// Nothing was exchanged, so a swap hero would name a destination asset the
-    /// user is not receiving. Wrapping SOL and spending it in the same
-    /// transaction is the common source: the wrap-in and the spend-out cancel
-    /// and never surface as diffs of their own, leaving only the wSOL account's
-    /// rent-exempt residual as a small incoming diff beside the real native-SOL
-    /// out leg. `buildSolanaCoin` maps native SOL onto the wrapped-SOL mint, so
-    /// both legs arrive here carrying the same mint and are directly netted.
-    ///
-    /// The direction is decided by the net, not by which leg is which: the same
-    /// pair arrives reversed when a transaction unwraps wSOL back into native
-    /// SOL (a Kamino wrapped-SOL withdraw closes its payout account, which is
-    /// what unwraps it), where the out leg is only the residual being returned
-    /// and the in leg is the amount the user actually receives. The coin comes
-    /// from whichever leg the net follows, so the ticker stays truthful —
-    /// native SOL reads "SOL" even though it shares WSOL's mint here.
-    ///
-    /// An exact cancellation nets to zero. There is no honest hero for "your
-    /// balance does not change", so it returns nil and the caller falls back to
-    /// the generic title.
-    ///
-    /// Mints are compared exactly. Solana addresses are base58 and
-    /// case-sensitive, unlike the EVM path's checksummed hex.
-    ///
-    /// Both legs must be non-negative. Blockaid states each side's magnitude
-    /// and puts the direction in the field name, but `raw_value` decodes a
-    /// signed integer, and a negative reaching the subtraction would flip the
-    /// direction of an approval headline. Fail closed instead.
-    private static func netSameMint(
-        outCoin: BlockaidSimulationCoin,
-        outAmount: BigInt,
-        inCoin: BlockaidSimulationCoin,
-        inAmount: BigInt
-    ) -> BlockaidSimulationInfo? {
-        guard outAmount >= 0, inAmount >= 0 else { return nil }
+    private static func solanaMintBalances(
+        diffs: [BlockaidSolanaSimulationJson.AccountAssetDiff]
+    ) -> [String: SolanaMintBalance]? {
+        var balances: [String: SolanaMintBalance] = [:]
 
-        if outAmount > inAmount {
-            return .transfer(fromCoin: outCoin, fromAmount: outAmount - inAmount)
+        for diff in diffs {
+            let isNativeSol = diff.asset.type == "SOL" || diff.assetType == "SOL"
+            guard let incoming = parseSolanaLeg(diff.`in`),
+                  let outgoing = parseSolanaLeg(diff.out) else {
+                return nil
+            }
+            guard incoming != 0 || outgoing != 0 else { continue }
+            guard let coin = buildSolanaCoin(from: diff.asset, assetType: diff.assetType),
+                  let mint = coin.address else {
+                return nil
+            }
+
+            if var balance = balances[mint] {
+                guard balance.decimals == coin.decimals else { return nil }
+                balance.incoming += incoming
+                balance.outgoing += outgoing
+                if incoming > 0, balance.incomingCoin == nil || isNativeSol {
+                    balance.incomingCoin = coin
+                }
+                if outgoing > 0, balance.outgoingCoin == nil || isNativeSol {
+                    balance.outgoingCoin = coin
+                }
+                balances[mint] = balance
+            } else {
+                balances[mint] = SolanaMintBalance(
+                    decimals: coin.decimals,
+                    incoming: incoming,
+                    outgoing: outgoing,
+                    incomingCoin: incoming > 0 ? coin : nil,
+                    outgoingCoin: outgoing > 0 ? coin : nil
+                )
+            }
         }
-        if inAmount > outAmount {
-            return .receive(coin: inCoin, amount: inAmount - outAmount)
-        }
-        return nil
+
+        return balances
     }
 
-    /// Whether the netting's two legs are the only balance changes the
-    /// response states.
-    ///
-    /// The netting subtracts `diffs[inIndex].in` from `diffs[outIndex].out`
-    /// and reads nothing else — not the out leg of any other diff, nor the in
-    /// leg of any other diff, and not the opposite leg of either source when
-    /// the two indices differ. Any of those carrying a balance means the net
-    /// on screen would be missing an amount the transaction moves, which is
-    /// worse than no net at all.
-    private static func readsEveryLeg(
-        _ diffs: [BlockaidSolanaSimulationJson.AccountAssetDiff],
-        outIndex: Int,
-        inIndex: Int
-    ) -> Bool {
-        diffs.indices.allSatisfy { index in
-            (index == outIndex || !carriesBalance(diffs[index].out))
-                && (index == inIndex || !carriesBalance(diffs[index].`in`))
-        }
-    }
-
-    /// Whether a single leg states a balance change.
-    ///
-    /// A leg that decodes to zero moves nothing, so it is not a change the
-    /// netting has to account for — declining over one would drop a net the
-    /// hero could state honestly. A leg that is present but whose magnitude
-    /// does not decode is not provably zero (`BalanceChange` keeps a
-    /// `raw_value` it cannot read as nil), so it counts as a change and the
-    /// netting fails closed.
-    private static func carriesBalance(
+    /// Missing legs are zero; present legs must decode to a non-negative
+    /// magnitude because direction is carried by the `in`/`out` field itself.
+    private static func parseSolanaLeg(
         _ leg: BlockaidSolanaSimulationJson.BalanceChange?
-    ) -> Bool {
-        guard let leg else { return false }
-        guard let raw = leg.rawValue, let amount = parseRawAmount(raw) else { return true }
-        return amount != 0
+    ) -> BigInt? {
+        guard let leg else { return 0 }
+        guard let raw = leg.rawValue,
+              let amount = parseRawAmount(raw),
+              amount >= 0 else {
+            return nil
+        }
+        return amount
     }
 
     /// Builds a `BlockaidSimulationCoin` from a Solana asset, substituting the
@@ -284,9 +238,10 @@ enum BlockaidSimulationParser {
     /// falls back to `TokensStore` and finally to a truncated mint when symbol
     /// is missing. Decimals must come from one of Blockaid or TokensStore.
     private static func buildSolanaCoin(
-        from asset: BlockaidSolanaSimulationJson.Asset
+        from asset: BlockaidSolanaSimulationJson.Asset,
+        assetType: String?
     ) -> BlockaidSimulationCoin? {
-        let isNative = asset.type == "SOL"
+        let isNative = asset.type == "SOL" || assetType == "SOL"
         let mint = isNative ? wrappedSolMint : asset.address
         guard let mint, !mint.isEmpty else { return nil }
 

--- a/VultisigApp/VultisigAppTests/Services/BlockaidSolanaSimulationParserTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/BlockaidSolanaSimulationParserTests.swift
@@ -153,6 +153,27 @@ final class BlockaidSolanaSimulationParserTests: XCTestCase {
         XCTAssertEqual(amount, BigInt("2000000000"))
     }
 
+    func testParseSolanaTransferRecognizesNativeSolFromDiffAssetType() {
+        let asset = BlockaidSolanaSimulationJson.Asset(
+            type: nil,
+            name: "Solana",
+            symbol: "SOL",
+            address: nil,
+            decimals: 9,
+            logo: nil
+        )
+        let info = BlockaidSimulationParser.parseSolana(
+            response: response(with: [diff(asset: asset, assetType: "SOL", out: balance("2000000000"))])
+        )
+
+        guard case let .transfer(coin, amount) = info else {
+            return XCTFail("expected native SOL transfer, got \(String(describing: info))")
+        }
+        XCTAssertEqual(coin.ticker, "SOL")
+        XCTAssertEqual(coin.address, BlockaidSimulationParser.wrappedSolMint)
+        XCTAssertEqual(amount, BigInt("2000000000"))
+    }
+
     /// Native SOL must render the chain's own logo, not the wrapped-SOL
     /// (WSOL) metadata that `TokensStore` returns for the wrapped-SOL mint,
     /// and not the Blockaid per-request CDN URL (which isn't hot-linkable).
@@ -221,10 +242,10 @@ final class BlockaidSolanaSimulationParserTests: XCTestCase {
         XCTAssertEqual(toAmount, BigInt("5000000000"))
     }
 
-    /// When Blockaid returns three diffs and one is native SOL, the parser
-    /// filters the SOL diff (treated as tx fee) and parses the remaining two as
-    /// a swap. Regression guard for parity with `parseBlockaidSolanaSimulation`.
-    func test_parseSolana_swap_withNativeSolFee_filtersSolDiff() {
+    /// The response does not identify which outflow is the transaction fee.
+    /// Dropping the smaller/native leg by shape or magnitude could instead
+    /// hide a real principal spend, so two net outflows fail closed.
+    func testParseSolanaThreeDiffsWithTwoNetOutflowsReturnsNil() {
         let usdc = token(symbol: "USDC", address: "Usdc1111", decimals: 6)
         let bonk = token(symbol: "BONK", address: "Bonk1111", decimals: 5)
         let sol = native(symbol: "SOL", decimals: 9)
@@ -234,13 +255,80 @@ final class BlockaidSolanaSimulationParserTests: XCTestCase {
             diff(asset: sol, out: balance("5000")), // fee leg
             diff(asset: bonk, in: balance("5000000000"))
         ]
+
+        XCTAssertNil(BlockaidSimulationParser.parseSolana(response: response(with: diffs)))
+    }
+
+    /// A wrapped-SOL withdrawal can report native SOL in, a WSOL residual out,
+    /// and a receipt token out. Native SOL and WSOL must net together; deleting
+    /// the native leg would reverse the approval direction into a WSOL send.
+    func testParseSolanaThreeDiffWithdrawKeepsNativeSolAsDestination() {
+        let receipt = token(symbol: "kSOL", address: "ReceiptMint1111", decimals: 6)
+        let diffs = [
+            diff(asset: native(symbol: "SOL", decimals: 9), in: balance("61474280")),
+            diff(
+                asset: token(symbol: "WSOL", address: BlockaidSimulationParser.wrappedSolMint, decimals: 9),
+                out: balance("2039280")
+            ),
+            diff(asset: receipt, out: balance("50000000"))
+        ]
+
         let info = BlockaidSimulationParser.parseSolana(response: response(with: diffs))
 
-        guard case let .swap(fromCoin, toCoin, _, _) = info else {
-            return XCTFail("expected .swap after SOL-fee filter, got \(String(describing: info))")
+        guard case let .swap(fromCoin, toCoin, fromAmount, toAmount) = info else {
+            return XCTFail("expected receipt-to-SOL swap, got \(String(describing: info))")
         }
-        XCTAssertEqual(fromCoin.ticker, "USDC")
-        XCTAssertEqual(toCoin.ticker, "BONK")
+        XCTAssertEqual(fromCoin.ticker, "kSOL")
+        XCTAssertEqual(toCoin.ticker, "SOL")
+        XCTAssertEqual(fromAmount, BigInt("50000000"))
+        XCTAssertEqual(toAmount, BigInt("59435000"), "61474280 in - 2039280 out")
+    }
+
+    /// The reverse shape is a deposit: native SOL out, a WSOL residual in, and
+    /// the receipt token in. The same complete netting must preserve the actual
+    /// destination while removing only same-mint wrapping noise.
+    func testParseSolanaThreeDiffDepositKeepsReceiptAsDestination() {
+        let receipt = token(symbol: "kSOL", address: "ReceiptMint1111", decimals: 6)
+        let diffs = [
+            diff(asset: receipt, in: balance("50000000")),
+            diff(
+                asset: token(symbol: "WSOL", address: BlockaidSimulationParser.wrappedSolMint, decimals: 9),
+                in: balance("2039280")
+            ),
+            diff(asset: native(symbol: "SOL", decimals: 9), out: balance("61474280"))
+        ]
+
+        let info = BlockaidSimulationParser.parseSolana(response: response(with: diffs))
+
+        guard case let .swap(fromCoin, toCoin, fromAmount, toAmount) = info else {
+            return XCTFail("expected SOL-to-receipt swap, got \(String(describing: info))")
+        }
+        XCTAssertEqual(fromCoin.ticker, "SOL")
+        XCTAssertEqual(toCoin.ticker, "kSOL")
+        XCTAssertEqual(fromAmount, BigInt("59435000"), "61474280 out - 2039280 in")
+        XCTAssertEqual(toAmount, BigInt("50000000"))
+    }
+
+    func testParseSolanaThreeDiffWithdrawIsIndependentOfDiffOrder() {
+        let receipt = token(symbol: "kSOL", address: "ReceiptMint1111", decimals: 6)
+        let diffs = [
+            diff(asset: receipt, out: balance("50000000")),
+            diff(
+                asset: token(symbol: "WSOL", address: BlockaidSimulationParser.wrappedSolMint, decimals: 9),
+                out: balance("2039280")
+            ),
+            diff(asset: native(symbol: "SOL", decimals: 9), in: balance("61474280"))
+        ]
+
+        let info = BlockaidSimulationParser.parseSolana(response: response(with: diffs))
+
+        guard case let .swap(fromCoin, toCoin, fromAmount, toAmount) = info else {
+            return XCTFail("expected receipt-to-SOL swap, got \(String(describing: info))")
+        }
+        XCTAssertEqual(fromCoin.ticker, "kSOL")
+        XCTAssertEqual(toCoin.ticker, "SOL")
+        XCTAssertEqual(fromAmount, BigInt("50000000"))
+        XCTAssertEqual(toAmount, BigInt("59435000"))
     }
 
     /// A genuine swap out of native SOL must survive the same-mint netting:
@@ -357,10 +445,10 @@ final class BlockaidSolanaSimulationParserTests: XCTestCase {
         XCTAssertNil(BlockaidSimulationParser.parseSolana(response: response(with: diffs)))
     }
 
-    /// The three-diff native-SOL fee filter runs first, so a same-mint pair can
-    /// still be what is left afterwards — here two wSOL accounts either side of
-    /// a separate native-SOL fee leg. The netting must apply to the survivors.
-    func test_parseSolana_threeDiffs_afterSolFeeFilter_netsSameMintPair() {
+    /// Every same-mint leg participates in the total, including a native-SOL
+    /// outflow. This avoids silently treating a small principal movement as a
+    /// fee while preserving the canonical SOL/WSOL net.
+    func testParseSolanaThreeDiffsNetEverySameMintLeg() {
         let wsol = token(symbol: "WSOL", address: BlockaidSimulationParser.wrappedSolMint, decimals: 9)
         let diffs = [
             diff(asset: wsol, out: balance("5000000")),
@@ -373,8 +461,8 @@ final class BlockaidSolanaSimulationParserTests: XCTestCase {
         guard case let .transfer(coin, amount) = info else {
             return XCTFail("expected netted .transfer, got \(String(describing: info))")
         }
-        XCTAssertEqual(coin.ticker, "WSOL")
-        XCTAssertEqual(amount, BigInt("4000000"), "5000000 out - 1000000 in")
+        XCTAssertEqual(coin.ticker, "SOL")
+        XCTAssertEqual(amount, BigInt("4005000"), "5000000 + 5000 out - 1000000 in")
     }
 
     /// `raw_value` decodes a signed integer even though Blockaid states each
@@ -413,18 +501,24 @@ final class BlockaidSolanaSimulationParserTests: XCTestCase {
         XCTAssertEqual(amount, BigInt("3000000"), "5000000 out - 2000000 in")
     }
 
-    /// The same collapse, but the skipped diff spends a second asset. Netting
-    /// here would headline an authoritative inflow while never looking at the
-    /// USDC leaving, so the parser declines and the caller falls back to the
-    /// generic title.
-    func test_parseSolana_sameMint_collapsedSources_returnsNil_whenOtherDiffCarriesBalance() {
+    /// Complete aggregation accounts for both the same-mint net inflow and the
+    /// second asset outflow, so the result is an honest USDC-to-WSOL swap.
+    func testParseSolanaSameMintNetAndOtherSpendBecomeSwap() {
         let wsol = token(symbol: "WSOL", address: BlockaidSimulationParser.wrappedSolMint, decimals: 9)
         let diffs = [
             diff(asset: wsol, in: balance("61474280"), out: balance("2039280")),
             diff(asset: token(symbol: "USDC", address: "Usdc1111", decimals: 6), out: balance("100000000"))
         ]
 
-        XCTAssertNil(BlockaidSimulationParser.parseSolana(response: response(with: diffs)))
+        let info = BlockaidSimulationParser.parseSolana(response: response(with: diffs))
+
+        guard case let .swap(fromCoin, toCoin, fromAmount, toAmount) = info else {
+            return XCTFail("expected USDC-to-WSOL swap, got \(String(describing: info))")
+        }
+        XCTAssertEqual(fromCoin.ticker, "USDC")
+        XCTAssertEqual(toCoin.ticker, "WSOL")
+        XCTAssertEqual(fromAmount, BigInt("100000000"))
+        XCTAssertEqual(toAmount, BigInt("59435000"))
     }
 
     /// An explicit zero leg moves nothing, so it is not a balance change the
@@ -499,13 +593,9 @@ final class BlockaidSolanaSimulationParserTests: XCTestCase {
         XCTAssertNil(BlockaidSimulationParser.parseSolana(response: response(with: diffs)))
     }
 
-    /// The legs need not collapse onto one diff for a leg to go unread. Here
-    /// the netting takes its out side from the SOL diff and its in side from
-    /// the WSOL diff, so the WSOL diff's own out leg is never looked at: the
-    /// hero would headline 57395720 (59435000 - 2039280) when the true net is
-    /// 57895720, understating what leaves the vault by the ignored 500000.
-    /// Decline instead.
-    func testParseSolanaSameMintDistinctSourcesReturnsNilWhenInSourceAlsoSpends() {
+    /// Both sides of every diff participate in the group total. The extra WSOL
+    /// outflow therefore increases the displayed net instead of being ignored.
+    func testParseSolanaSameMintDistinctSourcesIncludesInSourceOutflow() {
         let diffs = [
             diff(asset: native(symbol: "SOL", decimals: 9), out: balance("59435000")),
             diff(
@@ -515,13 +605,17 @@ final class BlockaidSolanaSimulationParserTests: XCTestCase {
             )
         ]
 
-        XCTAssertNil(BlockaidSimulationParser.parseSolana(response: response(with: diffs)))
+        let info = BlockaidSimulationParser.parseSolana(response: response(with: diffs))
+
+        guard case let .transfer(coin, amount) = info else {
+            return XCTFail("expected complete net transfer, got \(String(describing: info))")
+        }
+        XCTAssertEqual(coin.ticker, "SOL")
+        XCTAssertEqual(amount, BigInt("57895720"), "59435000 + 500000 out - 2039280 in")
     }
 
-    /// The mirror: the out-side diff carries an in leg of its own, which the
-    /// netting drops because the in side is taken from the other diff. The
-    /// same understatement, in the receive direction.
-    func testParseSolanaSameMintDistinctSourcesReturnsNilWhenOutSourceAlsoReceives() {
+    /// The mirror includes the extra incoming leg in the receive total.
+    func testParseSolanaSameMintDistinctSourcesIncludesOutSourceInflow() {
         let diffs = [
             diff(
                 asset: token(symbol: "WSOL", address: BlockaidSimulationParser.wrappedSolMint, decimals: 9),
@@ -529,6 +623,33 @@ final class BlockaidSolanaSimulationParserTests: XCTestCase {
                 out: balance("2039280")
             ),
             diff(asset: native(symbol: "SOL", decimals: 9), in: balance("61474280"))
+        ]
+
+        let info = BlockaidSimulationParser.parseSolana(response: response(with: diffs))
+
+        guard case let .receive(coin, amount) = info else {
+            return XCTFail("expected complete net receive, got \(String(describing: info))")
+        }
+        XCTAssertEqual(coin.ticker, "SOL")
+        XCTAssertEqual(amount, BigInt("59935000"), "61474280 + 500000 in - 2039280 out")
+    }
+
+    func testParseSolanaSameMintWithInconsistentDecimalsReturnsNil() {
+        let diffs = [
+            diff(asset: native(symbol: "SOL", decimals: 9), out: balance("59435000")),
+            diff(
+                asset: token(symbol: "WSOL", address: BlockaidSimulationParser.wrappedSolMint, decimals: 8),
+                in: balance("2039280")
+            )
+        ]
+
+        XCTAssertNil(BlockaidSimulationParser.parseSolana(response: response(with: diffs)))
+    }
+
+    func testParseSolanaMultipleDistinctNetSpendsReturnNil() {
+        let diffs = [
+            diff(asset: token(symbol: "USDC", address: "Usdc1111", decimals: 6), out: balance("1000000")),
+            diff(asset: token(symbol: "BONK", address: "Bonk1111", decimals: 5), out: balance("500000"))
         ]
 
         XCTAssertNil(BlockaidSimulationParser.parseSolana(response: response(with: diffs)))
@@ -572,12 +693,13 @@ private extension BlockaidSolanaSimulationParserTests {
 
     func diff(
         asset: BlockaidSolanaSimulationJson.Asset,
+        assetType: String? = nil,
         in inBalance: BlockaidSolanaSimulationJson.BalanceChange? = nil,
         out: BlockaidSolanaSimulationJson.BalanceChange? = nil
     ) -> BlockaidSolanaSimulationJson.AccountAssetDiff {
         BlockaidSolanaSimulationJson.AccountAssetDiff(
             asset: asset,
-            assetType: asset.type,
+            assetType: assetType ?? asset.type,
             in: inBalance,
             out: out
         )


### PR DESCRIPTION
## Summary

- replace the positional three-diff native-SOL deletion heuristic with complete per-mint balance aggregation
- canonicalize native SOL and WSOL to the same mint, net every incoming and outgoing leg, and prefer native SOL metadata when it participates in a displayed direction
- fail closed to the generic approval title when the complete result has multiple net spends or malformed/inconsistent data
- add regressions for withdrawal and deposit direction, shuffled diff order, complete same-mint totals, ambiguous fee/principal shapes, and invalid legs

## Why

Blockaid can return a Solana withdrawal as native SOL in, a WSOL residual out, and a receipt token out. The old exactly-three-diffs heuristic deleted the native SOL leg unconditionally, then interpreted the remaining entries positionally. That could reverse the approval headline into a WSOL outflow even though the vault receives SOL.

This implementation does not guess whether a native movement is a fee from its magnitude. If the response contains two independent net outflows, the parser declines to produce a specialized hero instead of hiding a possible principal spend.

This changes approval presentation only; transaction construction and signing bytes are untouched.

## Linked work

- `vultisig-sdk#2091` remains open. SDK PR `#2108` remains open with an unresolved review noting that an absolute fee ceiling can still discard a small principal spend; PR `#2203` was closed without merge.
- `vultisig-android#5683` is closed by merged PR `#5730`; Android was already structurally immune and added the direction regression.
- `vultisig-windows#4728` remains open and depends on the SDK parser.
- iOS PR `#5190` introduced same-mint SOL/WSOL netting; this PR generalizes it across the full diff set.

## Verification

- `swiftlint lint --no-cache --config VultisigApp/.swiftlint.yml <changed files>` — 0 violations
- focused `BlockaidSolanaSimulationParserTests` — 35 tests, 0 failures
- `make test` — 6,970 tests, 11 skipped, 0 failures (`** TEST SUCCEEDED **`)
- Claude review skipped at the request of the maintainer

Closes #5195


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solana transaction simulation results by accurately netting incoming and outgoing asset movements.
  * Preserved native SOL details when processing SOL and wrapped SOL activity.
  * Prevented ambiguous, invalid, unsupported, or zero-value balance changes from being reported as transfers or swaps.
  * Improved handling of multi-leg transactions, inconsistent decimals, and multiple outgoing movements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->