### PR TITLE
test(cardano): add CNT send golden vector for native-token support

### DIFF
--- a/VultisigApp/VultisigAppTests/Chains/ChainHelperTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/ChainHelperTests.swift
@@ -148,7 +148,7 @@ enum ChainHelperFixture: String, CaseIterable {
         case .arb: return 1
         case .bittensor: return 1
         case .bsc: return 2
-        case .cardano: return 2
+        case .cardano: return 3
         case .cosmos: return 4
         case .cosmosChainMatrix: return 5
         case .cosmosSdkSignAmino: return 2

--- a/VultisigApp/VultisigAppTests/Chains/KeysignPayloadCodable.swift
+++ b/VultisigApp/VultisigAppTests/Chains/KeysignPayloadCodable.swift
@@ -627,17 +627,40 @@ extension VSTronTransferAssetContractPayload: @retroactive Codable {
     }
 }
 
+extension VSCardanoTokenAsset: @retroactive Codable {
+    enum CodingKeys: String, CodingKey {
+        case policyID = "policy_id"
+        case assetNameHex = "asset_name_hex"
+        case amount
+    }
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(policyID, forKey: .policyID)
+        try container.encode(assetNameHex, forKey: .assetNameHex)
+        try container.encode(amount, forKey: .amount)
+    }
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init()
+        policyID = try container.decode(String.self, forKey: .policyID)
+        assetNameHex = try container.decode(String.self, forKey: .assetNameHex)
+        amount = try container.decode(String.self, forKey: .amount)
+    }
+}
+
 extension VSUtxoInfo: @retroactive Codable {
     enum CodingKeys: String, CodingKey {
         case hash
         case amount
         case index
+        case cardanoTokens = "cardano_tokens"
     }
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(hash, forKey: .hash)
         try container.encode(amount, forKey: .amount)
         try container.encode(index, forKey: .index)
+        try container.encode(cardanoTokens, forKey: .cardanoTokens)
     }
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -645,6 +668,7 @@ extension VSUtxoInfo: @retroactive Codable {
         hash = try container.decode(String.self, forKey: .hash)
         amount = try container.decode(Int64.self, forKey: .amount)
         index = try container.decode(UInt32.self, forKey: .index)
+        cardanoTokens = try container.decodeIfPresent([VSCardanoTokenAsset].self, forKey: .cardanoTokens) ?? []
     }
 }
 

--- a/VultisigApp/VultisigAppTests/TestData/cardano.json
+++ b/VultisigApp/VultisigAppTests/TestData/cardano.json
@@ -68,5 +68,48 @@
       "lib_type": "DKLS"
     },
     "expected_image_hash": ["c2a0b05a7a8cc1746555b54d136810f10d4c1609c6897f70a009a1807fc7c9b9"]
+  },
+  {
+    "name": "Send SNEK - native token",
+    "keysign_payload": {
+      "coin": {
+        "chain": "Cardano",
+        "ticker": "SNEK",
+        "address": "addr1v9g9wnzsutrxt7vcg4efdfwhagwh3x2f6hjwykk7acdpsfgyt4h2j",
+        "decimals": 0,
+        "price_provider_id": "snek",
+        "contract_address": "279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f.534e454b",
+        "is_native_token": false,
+        "hex_public_key": "75be85178816db3bc71a4f3e64e5c89866d8b7daae827ba9cf4ecd1ed9e645d5",
+        "logo": "snek.png"
+      },
+      "to_address": "addr1v9g9wnzsutrxt7vcg4efdfwhagwh3x2f6hjwykk7acdpsfgyt4h2j",
+      "to_amount": "1000000",
+      "BlockchainSpecific": {
+        "Cardano": {
+          "byte_fee": 200000,
+          "send_max_amount": false,
+          "ttl": 190000000
+        }
+      },
+      "utxo_info": [
+        {
+          "hash": "f074134aabbfb13b8aec7cf5465b1e5a862d1cadc175d431c1d9339150db8a1d",
+          "amount": 10000000,
+          "index": 0,
+          "cardano_tokens": [
+            {
+              "policy_id": "279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f",
+              "asset_name_hex": "534e454b",
+              "amount": "2500000"
+            }
+          ]
+        }
+      ],
+      "SwapPayload": null,
+      "vault_public_key_ecdsa": "75be85178816db3bc71a4f3e64e5c89866d8b7daae827ba9cf4ecd1ed9e645d5",
+      "lib_type": "DKLS"
+    },
+    "expected_image_hash": ["5ad62be071e80c4e617487831d35be6f1fc0fff46aeca43b41164ccc36190c8a"]
   }
 ]


### PR DESCRIPTION
## Summary
- Ports vultisig-android#5818's "Send SNEK - native token" golden vector into `cardano.json`, adding CNT (Cardano native token) send coverage to the cross-platform signing corpus
- Fixes a bug uncovered while adding it: the test target's hand-written `VSUtxoInfo: Codable` shim predates the `cardano_tokens` proto field and silently dropped it, so `CardanoHelper` never saw the per-UTXO token bundle and WalletCore's planner failed with `errorLowBalance`
- Adds `VSCardanoTokenAsset: Codable` and wires `cardano_tokens` through `VSUtxoInfo`'s coding keys/init/encode

## Test Plan
- [x] `ChainHelperTests.testCardanoFixture` passes and produces `5ad62be071e80c4e617487831d35be6f1fc0fff46aeca43b41164ccc36190c8a` — byte-identical to Android's expected hash for the same vector
- [x] Full `ChainHelperTests` suite (33 tests) passes
- [x] `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — no new violations

https://claude.ai/code/session_01BezMJRbtBC81d5dB4XBuQJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for serializing and deserializing Cardano native-token details in transaction data.
  - Added Cardano token transaction coverage, including SNEK asset information and related UTXO data.

- **Tests**
  - Expanded Cardano fixture coverage to include an additional token transaction scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->