### PR TITLE
feat(history): swap/limit rows show FROM → TO pair and both amounts

### DIFF
--- a/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryCardView.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryCardView.swift
@@ -482,7 +482,11 @@ struct TransactionHistoryCardView: View {
 
     private var collapsedContent: some View {
         HStack(spacing: 12) {
-            coinIcon
+            if showsSwapLegs {
+                swapPairIcon
+            } else {
+                coinIcon
+            }
 
             if transaction.type == .trustLineActivation {
                 trustLineColumn
@@ -530,6 +534,44 @@ struct TransactionHistoryCardView: View {
             ticker: transaction.coinTicker,
             tokenChainLogo: transaction.coinChainLogo
         )
+    }
+
+    /// A completed swap/limit row's icon: the FROM token's left half against
+    /// the TO token's right half, meeting as one 24pt circle split down the
+    /// middle — so the row names both assets before the eye reaches the
+    /// amounts. Send/receive rows keep the single `coinIcon` above.
+    private var swapPairIcon: some View {
+        HStack(spacing: 0) {
+            iconHalf(
+                logo: transaction.coinLogo,
+                ticker: transaction.coinTicker,
+                keeping: .leading
+            )
+            iconHalf(
+                logo: transaction.toCoinLogo ?? "",
+                ticker: transaction.toCoinTicker ?? "",
+                keeping: .trailing
+            )
+        }
+        .frame(width: 24, height: 24)
+    }
+
+    /// One half of `swapPairIcon`. The logo renders at its FULL 24pt inside a
+    /// 12pt-wide clip, so it keeps its own circular mask and true proportions
+    /// rather than being squashed to half width; `keeping` selects which side
+    /// survives the clip.
+    ///
+    /// No chain badge here: at 12pt it would be sliced down the middle, and
+    /// the `FROM → TO` pill already names both assets.
+    private func iconHalf(logo: String, ticker: String, keeping: Alignment) -> some View {
+        AsyncImageView(
+            logo: logo,
+            size: CGSize(width: 24, height: 24),
+            ticker: ticker,
+            tokenChainLogo: nil
+        )
+        .frame(width: 12, height: 24, alignment: keeping)
+        .clipped()
     }
 
     private var amountColumn: some View {

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryCardView.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryCardView.swift
@@ -25,6 +25,27 @@ struct TransactionHistoryCardView: View {
         TransactionHistoryFailureReasonPresentation.displayText(for: transaction.errorMessage)
     }
 
+    /// Whether the collapsed row shows the completed-swap layout (two amount
+    /// legs + a `FROM → TO` pill) instead of today's single fiat/crypto
+    /// amount. See the static twin below for the routing rule.
+    private var showsSwapLegs: Bool {
+        Self.showsSwapLegs(
+            type: transaction.type,
+            toAmountCrypto: transaction.toAmountCrypto,
+            toCoinTicker: transaction.toCoinTicker
+        )
+    }
+
+    /// Whether the "via {provider}" badge belongs on this row. See the
+    /// static twin below for the routing rule.
+    private var showsViaBadge: Bool {
+        Self.showsViaBadge(
+            hasProvider: transaction.swapProvider != nil,
+            isExpanded: isExpanded,
+            showsSwapLegs: showsSwapLegs
+        )
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             topRow
@@ -38,7 +59,7 @@ struct TransactionHistoryCardView: View {
             }
         }
         .padding(16)
-        .padding(.bottom, transaction.swapProvider != nil ? 20 : 0)
+        .padding(.bottom, showsViaBadge ? 20 : 0)
         .cornerRadius(Theme.radius.xl)
         .background(
             Theme.radius.xl.shape
@@ -47,7 +68,9 @@ struct TransactionHistoryCardView: View {
                 .stroke(Theme.colors.border, lineWidth: 1)
         )
         .overlay(alignment: .bottomTrailing) {
-            viaBadge
+            if showsViaBadge {
+                viaBadge
+            }
         }
         .animation(.spring(response: 0.4, dampingFraction: 0.8), value: isExpanded)
         .onAppear {
@@ -71,6 +94,38 @@ struct TransactionHistoryCardView: View {
     /// put in those slots.
     static func shouldExpand(status: TransactionHistoryStatus, type: TransactionHistoryType) -> Bool {
         status == .inProgress && type != .approve && type != .trustLineActivation
+    }
+
+    // MARK: - Completed Swap/Limit Legs Routing
+
+    /// Whether this row shows the completed-swap layout: two amount legs
+    /// (`+to` / `-from`) plus a `FROM → TO` pill, replacing today's single
+    /// fiat/crypto amount. Requires the to-side to actually be known — a
+    /// limit order placed from a native source (`recordLimitOrder`) never
+    /// resolves `toCoinTicker`/`toAmountCrypto` (the co-signer only sees the
+    /// `=<` memo, never a real `Coin`), so that row keeps the old layout
+    /// rather than claiming a pair it cannot show.
+    static func showsSwapLegs(
+        type: TransactionHistoryType,
+        toAmountCrypto: String?,
+        toCoinTicker: String?
+    ) -> Bool {
+        guard type == .swap || type == .limit else { return false }
+        guard let toAmountCrypto, !toAmountCrypto.isEmpty else { return false }
+        guard let toCoinTicker, !toCoinTicker.isEmpty else { return false }
+        return true
+    }
+
+    /// Whether the "via {provider}" badge belongs on this row.
+    ///
+    /// Gone only on a COMPLETED row already showing the swap legs — the
+    /// `FROM → TO` pill takes over naming the route there. Every other
+    /// swap-provider row keeps it: an in-progress row's `expandedContent`
+    /// names both coins but not the provider, and a to-side-less limit
+    /// order still needs the badge to say what it routed through.
+    static func showsViaBadge(hasProvider: Bool, isExpanded: Bool, showsSwapLegs: Bool) -> Bool {
+        guard hasProvider else { return false }
+        return isExpanded || !showsSwapLegs
     }
 
     // MARK: - Top Row
@@ -431,6 +486,8 @@ struct TransactionHistoryCardView: View {
 
             if transaction.type == .trustLineActivation {
                 trustLineColumn
+            } else if showsSwapLegs {
+                swapLegsColumn
             } else {
                 amountColumn
             }
@@ -439,6 +496,8 @@ struct TransactionHistoryCardView: View {
 
             if transaction.type == .send {
                 addressPill
+            } else if showsSwapLegs {
+                swapPairPill
             }
         }
     }
@@ -482,6 +541,59 @@ struct TransactionHistoryCardView: View {
 
             cryptoAmountText(transaction.amountCrypto, ticker: transaction.coinTicker)
         }
+    }
+
+    /// The completed row's two legs: `+{toAmount} {toTicker}` in primary
+    /// above `-{fromAmount} {fromTicker}` in tertiary, same size
+    /// (`priceFootnote`) — confirmed against the Figma frame, which uses one
+    /// size for both lines and only the colour to demote the from-side.
+    ///
+    /// Rebuilds the ticker from `toCoinTicker`/`coinTicker` via
+    /// `Self.stripTicker` rather than trusting `toAmountCrypto`/
+    /// `amountCrypto` to already carry it: the `SwapDoneScreen` path
+    /// pre-formats `"\(amount) \(ticker)"`, but the co-signer's
+    /// `TransactionHistoryRecorder.recordFromKeysignPayload` records
+    /// `toAmountCrypto` as a bare number — the exact reason
+    /// `cryptoAmountText` strips defensively instead of assuming the ticker
+    /// is there.
+    ///
+    /// ⚠️ `toAmountCrypto` is the quote's EXPECTED output, frozen when the
+    /// row was recorded and never refreshed with what actually landed
+    /// (`TransactionHistoryViewModel.updateStatus`,
+    /// `SwapKitTrackingService.applyResponseToTx` both carry it forward
+    /// verbatim). The in-progress row labels the same value "expectedPayout"
+    /// for exactly this reason; this completed row has no such label and
+    /// reads as fact — a known, accepted property of the data.
+    private var swapLegsColumn: some View {
+        let toTicker = transaction.toCoinTicker ?? ""
+        let toAmount = Self.stripTicker(from: transaction.toAmountCrypto ?? "", ticker: toTicker)
+        let fromAmount = Self.stripTicker(from: transaction.amountCrypto, ticker: transaction.coinTicker)
+
+        return VStack(alignment: .leading, spacing: 2) {
+            Text("+\(toAmount) \(toTicker)")
+                .foregroundStyle(Theme.colors.textPrimary)
+            Text("-\(fromAmount) \(transaction.coinTicker)")
+                .foregroundStyle(Theme.colors.textTertiary)
+        }
+        .font(Theme.fonts.priceFootnote)
+        .lineLimit(1)
+    }
+
+    /// `FROM → TO`, in the same pill geometry `addressPill` uses for a send
+    /// row's `to 0x…` — the slot a completed swap/limit row fills instead.
+    private var swapPairPill: some View {
+        Text("\(transaction.coinTicker) → \(transaction.toCoinTicker ?? "")")
+            .font(Theme.fonts.caption12)
+            .foregroundStyle(Theme.colors.textPrimary)
+            .lineLimit(1)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(Theme.colors.bgSurface2)
+            .cornerRadius(Theme.radius.pill)
+            .overlay(
+                Theme.radius.pill.shape
+                    .stroke(Theme.colors.border, lineWidth: 1)
+            )
     }
 
     private var addressPill: some View {
@@ -529,9 +641,7 @@ struct TransactionHistoryCardView: View {
     // MARK: - Helpers
 
     private func cryptoAmountText(_ crypto: String, ticker: String) -> some View {
-        let amount = crypto.hasSuffix(ticker)
-            ? String(crypto.dropLast(ticker.count)).trimmingCharacters(in: .whitespaces)
-            : crypto
+        let amount = Self.stripTicker(from: crypto, ticker: ticker)
 
         return HStack(spacing: 4) {
             Text(amount)
@@ -541,6 +651,19 @@ struct TransactionHistoryCardView: View {
         }
         .font(Theme.fonts.priceFootnote)
         .lineLimit(1)
+    }
+
+    /// Bare numeric amount from a pre-formatted `"{amount} {ticker}"` string
+    /// that may or may not actually carry the suffix — not every recorder
+    /// path appends one (see `swapLegsColumn`). A no-op when the ticker
+    /// isn't present, so callers can always safely re-append it themselves.
+    static func stripTicker(from crypto: String, ticker: String) -> String {
+        // Matches the SPACE-delimited suffix, not a bare `hasSuffix(ticker)`
+        // — a custom token can carry a numeric-looking ticker (e.g. "50"),
+        // which would otherwise chew digits off an amount like "200.50"
+        // that merely ends in the same characters.
+        let suffix = " \(ticker)"
+        return crypto.hasSuffix(suffix) ? String(crypto.dropLast(suffix.count)) : crypto
     }
 
     private func truncatedAddress(_ address: String) -> String {

--- a/VultisigApp/VultisigAppTests/Features/TransactionHistory/TransactionHistoryCardViewTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/TransactionHistory/TransactionHistoryCardViewTests.swift
@@ -85,6 +85,128 @@ final class TransactionHistoryCardViewTests: XCTestCase {
         XCTAssertEqual(display.kind, .failed)
     }
 
+    // MARK: - Ticker stripping (shared by cryptoAmountText and swapLegsColumn)
+
+    /// The `SwapDoneScreen` path pre-formats `"{amount} {ticker}"`; stripping
+    /// isolates the bare number so it can be re-styled separately from the
+    /// ticker.
+    func testStripTickerRemovesASuffixThatIsPresent() {
+        XCTAssertEqual(
+            TransactionHistoryCardView.stripTicker(from: "200.50 SOL", ticker: "SOL"),
+            "200.50"
+        )
+    }
+
+    /// The co-signer's `TransactionHistoryRecorder.recordFromKeysignPayload`
+    /// records `toAmountCrypto` as a bare number with no ticker suffix at
+    /// all — the exact case that regressed the swap-legs ticker. Stripping
+    /// must be a no-op here, not eat digits off the amount.
+    func testStripTickerIsANoOpWhenTheSuffixIsAbsent() {
+        XCTAssertEqual(
+            TransactionHistoryCardView.stripTicker(from: "200.50", ticker: "SOL"),
+            "200.50"
+        )
+    }
+
+    /// A custom token's ticker can look like the tail of a decimal amount
+    /// (e.g. a ticker of "50"). Matching only the SPACE-delimited suffix
+    /// keeps this a no-op instead of chewing digits off the amount.
+    func testStripTickerDoesNotEatDigitsFromAnAmbiguousNumericTicker() {
+        XCTAssertEqual(
+            TransactionHistoryCardView.stripTicker(from: "200.50", ticker: "50"),
+            "200.50"
+        )
+    }
+
+    // MARK: - Completed swap/limit legs routing
+
+    /// A completed swap or limit row with both amounts known gets the
+    /// two-leg layout.
+    func testShowsSwapLegsForCompleteSwapOrLimitData() {
+        for type in [TransactionHistoryType.swap, .limit] {
+            XCTAssertTrue(
+                TransactionHistoryCardView.showsSwapLegs(
+                    type: type,
+                    toAmountCrypto: "200.50 SOL",
+                    toCoinTicker: "SOL"
+                ),
+                "\(type) with a known to-side must show the legs"
+            )
+        }
+    }
+
+    /// Send, approve, and trust-line rows never get the swap legs — they
+    /// have nothing to pair.
+    func testShowsSwapLegsFalseForNonSwapTypes() {
+        for type in [TransactionHistoryType.send, .approve, .trustLineActivation] {
+            XCTAssertFalse(
+                TransactionHistoryCardView.showsSwapLegs(
+                    type: type,
+                    toAmountCrypto: "200.50 SOL",
+                    toCoinTicker: "SOL"
+                ),
+                "\(type) must never show the swap legs"
+            )
+        }
+    }
+
+    /// A native-source limit order (`recordLimitOrder`) never resolves the
+    /// to-side, so it keeps today's single fiat/crypto amount instead of
+    /// claiming a pair it cannot show.
+    func testShowsSwapLegsFalseWithoutAKnownToSide() {
+        XCTAssertFalse(
+            TransactionHistoryCardView.showsSwapLegs(type: .limit, toAmountCrypto: nil, toCoinTicker: nil)
+        )
+        XCTAssertFalse(
+            TransactionHistoryCardView.showsSwapLegs(type: .limit, toAmountCrypto: "", toCoinTicker: "SOL")
+        )
+        XCTAssertFalse(
+            TransactionHistoryCardView.showsSwapLegs(type: .limit, toAmountCrypto: "1 SOL", toCoinTicker: "")
+        )
+    }
+
+    // MARK: - Via badge routing
+
+    /// The badge disappears only once a COMPLETED row is already showing
+    /// the swap legs — the `FROM → TO` pill takes over naming the route.
+    func testShowsViaBadgeFalseOnlyForACompletedRowWithSwapLegs() {
+        XCTAssertFalse(
+            TransactionHistoryCardView.showsViaBadge(hasProvider: true, isExpanded: false, showsSwapLegs: true)
+        )
+    }
+
+    /// An in-progress swap row keeps the badge even though it will show the
+    /// legs once it completes — `expandedContent` names both coins but not
+    /// the provider.
+    func testShowsViaBadgeTrueWhileInProgressEvenWithSwapLegs() {
+        XCTAssertTrue(
+            TransactionHistoryCardView.showsViaBadge(hasProvider: true, isExpanded: true, showsSwapLegs: true)
+        )
+    }
+
+    /// A completed row that can't show the legs (no known to-side) still
+    /// needs the badge to say what it routed through.
+    func testShowsViaBadgeTrueForACompletedRowWithoutSwapLegs() {
+        XCTAssertTrue(
+            TransactionHistoryCardView.showsViaBadge(hasProvider: true, isExpanded: false, showsSwapLegs: false)
+        )
+    }
+
+    /// No provider, no badge, regardless of everything else.
+    func testShowsViaBadgeFalseWithoutAProvider() {
+        for isExpanded in [true, false] {
+            for showsSwapLegs in [true, false] {
+                XCTAssertFalse(
+                    TransactionHistoryCardView.showsViaBadge(
+                        hasProvider: false,
+                        isExpanded: isExpanded,
+                        showsSwapLegs: showsSwapLegs
+                    )
+                )
+            }
+        }
+    }
+
     // MARK: - Helpers
 
     private func makeLimitDetails(status: LimitOrderStatus) -> LimitOrderDetails {


### PR DESCRIPTION
## Problem

Completed swap and limit rows in Transaction History showed only the from-side amount plus a `via {provider}` corner badge — no destination ticker, no From → To pair (send rows already have a `to 0x…` pill; swaps didn't get the equivalent). Figma review flagged the mismatch: [Transaction History - Swaps](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=74765-110319) (frame `74765-110319`).

## Fix

- `collapsedContent` (the completed-row layout) now branches to a `swapLegsColumn` (`+toAmount` primary / `-fromAmount` tertiary, same size, differing only by colour — confirmed against the Figma node) and a `swapPairPill` (`FROM → TO`, in the same pill slot/geometry `addressPill` already uses for a send row's `to 0x…`) whenever the row is a completed `.swap`/`.limit` with a known to-side.
- The `via {provider}` badge and its reserved bottom padding are now conditional (`showsViaBadge`), not unconditional on `swapProvider != nil`. It's **gone only** on a completed row already showing the new legs — every other swap-provider row keeps it exactly as before:
  - An **in-progress** swap/limit row (still on `expandedContent`, the from→to diagram) keeps the badge — that layout names both coins but never the provider, and the issue/Figma only cover completed rows.
  - A **native-source limit order** (`TransactionHistoryRecorder.recordLimitOrder` — an order placed from RUNE/BTC/etc. rather than via the swap screen) never resolves `toCoinTicker`/`toAmountCrypto` at all (the co-signer only sees the `=<` memo, never a real `Coin` — see the doc comment on that recorder), so it keeps the old single-amount layout *and* the badge, since it can't show a pair it doesn't have.
- Two static routing functions, `showsSwapLegs`/`showsViaBadge`, carry these decisions so they're pinnable by unit tests without rendering SwiftUI — matching the file's existing `shouldExpand`/`isLimitTerminal` pattern.
- The two legs rebuild their ticker from `toCoinTicker`/`coinTicker` via a shared `stripTicker` helper rather than trusting `toAmountCrypto`/`amountCrypto` to already carry it: the co-signer path (`TransactionHistoryRecorder.recordFromKeysignPayload`) records `toAmountCrypto` as a **bare number with no ticker suffix**, unlike `SwapDoneScreen`'s pre-formatted `"{amount} {ticker}"` — caught by cross-model review, fixed, and pinned by a test (`testStripTickerIsANoOpWhenTheSuffixIsAbsent`). `stripTicker` matches only the space-delimited suffix (not a bare `hasSuffix`) so a numeric-looking custom-token ticker (e.g. `"50"`) can't chew digits off an amount like `"200.50"`.

## Known caveats (not fixed here — flagging for follow-up / reviewer awareness)

- **`toAmountCrypto` is the swap quote's *expected* output**, frozen once at record time (`TransactionHistoryRecorder`/`SwapDoneScreen`) and never refreshed with what actually landed — `TransactionHistoryViewModel.updateStatus` and `SwapKitTrackingService.applyResponseToTx` both carry it forward verbatim. The in-progress row labels this same value "expectedPayout" for exactly this reason; the completed row this PR adds has no such label and reads as fact. Built as the issue specifies (the detail sheet already renders the same value) — **worth its own follow-up issue**, not addressed here.
- **Type pill wording**: the Figma frame reads "Swapped"/"Limit"; the code renders `"swap".localized` (currently "Swapped" in en, presumably matching, but not verified across all wording) via `TransactionHistoryTypePill.swift`. Pre-existing, unrelated to this issue's change list — left alone for a reviewer to decide.
- **Deferred (cross-model review, MINOR)**: `showsSwapLegs`/`showsViaBadge` route off `isExpanded` (the coarse `transaction.status`), while a limit order's top-right status line routes off the authoritative `isLimitTerminal` (`LimitOrderStatusDisplay.effectiveUiStatus`). These two signals were already independent before this PR (`body`'s `isExpanded`-gated layout choice vs `topRow`'s `isLimitTerminal`-gated status line) and can diverge in a narrow, pre-existing window — on the initiating device, if `THORChainLimitTrackingService.write()`'s row mirror (`storage.updateSwapTrackingStatus`) fails after the authoritative `LimitOrder` write already succeeded (the two are atomic on a co-signer, which holds no local order). This PR reuses `isExpanded` specifically because that's the same signal that already decides `collapsedContent` vs `expandedContent` — routing the badge/legs off `isLimitTerminal` instead would introduce a *new* mismatch within the collapsed layout itself. Fixing the underlying divergence means changing what drives the in-progress limit card, which is out of scope for this issue and has no Figma coverage here. Worth its own issue if the mirror-failure window is judged worth designing for.

## Out of scope (explicitly, per the issue)

Detail sheet, `expandedContent` (in-progress diagram), send/receive/approve/trust-line rows, tab filtering.

## Testing

- Unit tests: `VultisigAppTests/Features/TransactionHistory/TransactionHistoryCardViewTests.swift` — 10 new camelCase tests covering `showsSwapLegs`, `showsViaBadge`, and `stripTicker` (including the bare-number and ambiguous-numeric-ticker regressions caught by cross-model review). File pre-existed so no `make generate` was needed for registration; ran anyway as a safety check.
- Cross-model review (`codex-review-loop`): round 1 found 1 MAJOR (ticker dropped on the co-signer path — fixed), round 2 found 1 MINOR (over-strip on an ambiguous numeric ticker — fixed), whole-branch pass found 1 MINOR (deferred, see above).
- Full gate: `make test DESTINATION='platform=iOS Simulator,id=D63D0F2D-8734-43F5-A630-53982AADC558'` — `** TEST SUCCEEDED **`, `Executed 7030 tests, with 11 tests skipped and 0 failures (0 unexpected)` (17 in `TransactionHistoryCardViewTests`, up from 7 — the new tests actually ran). `df -h /System/Volumes/Data`: 34G free before, 17G free after — never approached zero.
- **Visual acceptance against the Figma frame in the simulator was NOT performed** — this PR is verified by unit tests and the Figma `get_design_context` token/geometry data only. A reviewer should eyeball a real completed swap and limit row before merge.

Closes #5325

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Completed swap and limit transactions now show separate FROM and TO amounts with a clear “FROM → TO” indicator when destination details are available.
  - Provider badges are hidden for these completed layouts, while remaining visible for other applicable transaction history entries.
- **Bug Fixes**
  - Ticker labels now remove only a space-delimited suffix, preserving ambiguous or unaffected labels.
  - Transaction history display is more consistent across completed, incomplete, expanded, and provider-related states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->