### PR TITLE
fix(bittensor): guard against burn/zero-account TAO destinations

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Bittensor/Signing/BittensorHelper.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Bittensor/Signing/BittensorHelper.swift
@@ -190,6 +190,19 @@ enum BittensorHelper {
         return hash.prefix(2) == checksum && pubkey.count == 32
     }
 
+    /// The Substrate burn/zero AccountId (32 zero bytes) — SS58-42-encodes to
+    /// `5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM`, a syntactically
+    /// valid Bittensor address with no known private key, so anything sent
+    /// there is unspendable.
+    private static let burnAccountId = Data(repeating: 0, count: 32)
+
+    /// True when `address` SS58-decodes to the burn AccountId. Independent of
+    /// prefix/checksum validity by design, so it also catches malformed
+    /// variants that happen to decode to all-zero key bytes.
+    static func isBurnAddress(_ address: String) -> Bool {
+        ss58Decode(address) == burnAccountId
+    }
+
     // MARK: - Pre-signed Image Hash (for MPC signing)
 
     static func getPreSignedImageHash(keysignPayload: KeysignPayload) throws -> [String] {
@@ -263,6 +276,7 @@ enum BittensorHelper {
         guard let destPubkey = ss58Decode(keysignPayload.toAddress) else {
             throw HelperError.runtimeError("Invalid Bittensor destination address")
         }
+        try assertNotBurnAccount(destPubkey)
 
         var data = Data()
         data.append(moduleIndex) // Balances pallet
@@ -272,6 +286,16 @@ enum BittensorHelper {
         data.append(compactEncode(keysignPayload.toAmount)) // compact encoded amount
 
         return data
+    }
+
+    /// Fail-closed guard so a keysign payload never builds a call to the burn
+    /// AccountId even if it bypassed this device's send-form validation — a
+    /// co-signer that only sees the payload at keysign time still routes
+    /// through here before anything gets signed.
+    private static func assertNotBurnAccount(_ pubkey: Data) throws {
+        guard pubkey != burnAccountId else {
+            throw HelperError.runtimeError("Bittensor destination is the burn/zero account")
+        }
     }
 
     /// Build signed extra: mortal_era(2B) ++ compact(nonce) ++ compact(tip=0) ++ 0x00(CheckMetadataHash:Disabled)

--- a/VultisigApp/VultisigApp/Blockchain/Bittensor/Signing/BittensorHelper.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Bittensor/Signing/BittensorHelper.swift
@@ -196,9 +196,11 @@ enum BittensorHelper {
     /// there is unspendable.
     private static let burnAccountId = Data(repeating: 0, count: 32)
 
-    /// True when `address` SS58-decodes to the burn AccountId. Independent of
-    /// prefix/checksum validity by design, so it also catches malformed
-    /// variants that happen to decode to all-zero key bytes.
+    /// True when `address` SS58-decodes to the burn AccountId. The
+    /// byte-level `assertNotBurnAccount` guard in `buildCallData` is the
+    /// one that does not depend on how strict `ss58Decode` is — this
+    /// string-level check is only ever reached from the form, after
+    /// `isValidAddress` has already required a well-formed address.
     static func isBurnAddress(_ address: String) -> Bool {
         ss58Decode(address) == burnAccountId
     }

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "broadcastRetryStaleBlockhash" = "Transaktion abgelaufen. Bitte erneut versuchen.";
 "broadcastRetryStaleNonce" = "Transaktions-Nonce veraltet — Details aktualisiert. Bitte erneut versuchen.";
 "broadcastRetryStaleQuote" = "Angebot abgelaufen — Details aktualisiert. Bitte erneut versuchen.";
+"burnAddressError" = "Dies ist eine Verbrennungsadresse. Hierher gesendete Gelder können nicht wiederhergestellt werden.";
 "buy" = "Kaufen";
 "buyVultBannerSubtitle" = "Und spare bei Swap-Gebühren";
 "buyVultBannerTitle" = "$VULT kaufen";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "broadcastRetryStaleBlockhash" = "Transaction expired. Please try again.";
 "broadcastRetryStaleNonce" = "Transaction nonce outdated — details refreshed. Please try again.";
 "broadcastRetryStaleQuote" = "Quote expired — details refreshed. Please try again.";
+"burnAddressError" = "This is a burn address. Funds sent here can never be recovered.";
 "buy" = "Buy";
 "buyVultBannerSubtitle" = "And save on swap fees";
 "buyVultBannerTitle" = "Buy $VULT";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "broadcastRetryStaleBlockhash" = "Transacción expirada. Por favor, inténtalo de nuevo.";
 "broadcastRetryStaleNonce" = "Nonce de transacción desactualizado — detalles actualizados. Por favor, inténtalo de nuevo.";
 "broadcastRetryStaleQuote" = "Cotización expirada — detalles actualizados. Por favor, inténtalo de nuevo.";
+"burnAddressError" = "Esta es una dirección de quema. Los fondos enviados aquí no se pueden recuperar.";
 "buy" = "Comprar";
 "buyVultBannerSubtitle" = "Y ahorra en comisiones de swap";
 "buyVultBannerTitle" = "Comprar $VULT";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "broadcastRetryStaleBlockhash" = "Transakcija istekla. Molimo pokušajte ponovno.";
 "broadcastRetryStaleNonce" = "Nonce transakcije zastario — detalji ažurirani. Molimo pokušajte ponovno.";
 "broadcastRetryStaleQuote" = "Ponuda istekla — detalji ažurirani. Molimo pokušajte ponovno.";
+"burnAddressError" = "Ovo je adresa za spaljivanje. Sredstva poslana na ovu adresu ne mogu se povratiti.";
 "buy" = "Kupi";
 "buyVultBannerSubtitle" = "I uštedi na naknadama za swap";
 "buyVultBannerTitle" = "Kupi $VULT";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "broadcastRetryStaleBlockhash" = "Transazione scaduta. Riprova.";
 "broadcastRetryStaleNonce" = "Nonce della transazione obsoleto — dettagli aggiornati. Riprova.";
 "broadcastRetryStaleQuote" = "Quotazione scaduta — dettagli aggiornati. Riprova.";
+"burnAddressError" = "Questo è un indirizzo di combustione. I fondi inviati qui non possono essere recuperati.";
 "buy" = "Acquista";
 "buyVultBannerSubtitle" = "E risparmia sulle commissioni di swap";
 "buyVultBannerTitle" = "Compra $VULT";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "broadcastRetryStaleBlockhash" = "트랜잭션이 만료되었습니다. 다시 시도해 주세요.";
 "broadcastRetryStaleNonce" = "트랜잭션 nonce가 오래되었습니다 — 세부 정보가 새로 고쳐졌습니다. 다시 시도해 주세요.";
 "broadcastRetryStaleQuote" = "견적이 만료되었습니다 — 세부 정보가 새로 고쳐졌습니다. 다시 시도해 주세요.";
+"burnAddressError" = "이것은 소각 주소입니다. 이 주소로 보낸 자금은 복구할 수 없습니다.";
 "buy" = "구매";
 "buyVultBannerSubtitle" = "스왑 수수료 절약";
 "buyVultBannerTitle" = "$VULT 구매";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "broadcastRetryStaleBlockhash" = "Transação expirada. Por favor, tente novamente.";
 "broadcastRetryStaleNonce" = "Nonce da transação desatualizado — detalhes atualizados. Por favor, tente novamente.";
 "broadcastRetryStaleQuote" = "Cotação expirada — detalhes atualizados. Por favor, tente novamente.";
+"burnAddressError" = "Este é um endereço de queima. Os fundos enviados aqui não podem ser recuperados.";
 "buy" = "Comprar";
 "buyVultBannerSubtitle" = "E economize nas taxas de swap";
 "buyVultBannerTitle" = "Comprar $VULT";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "broadcastRetryStaleBlockhash" = "交易已过期。请重试。";
 "broadcastRetryStaleNonce" = "交易 nonce 已过期 — 详情已刷新。请重试。";
 "broadcastRetryStaleQuote" = "报价已过期 — 详情已刷新。请重试。";
+"burnAddressError" = "这是一个销毁地址，发送到这里的资金将永远无法找回。";
 "buy" = "购买";
 "buyVultBannerSubtitle" = "并节省兑换手续费";
 "buyVultBannerTitle" = "购买 $VULT";

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -1161,17 +1161,33 @@ final class SendDetailsViewModel {
         return true
     }
 
-    /// TRON self-send guard (parity with android DefaultSendStrategy): a plain
+    /// Self-send guard (parity with android DefaultSendStrategy): a plain
     /// transfer whose destination is the sender's own address just burns fees.
-    /// Staking ops (freeze/unfreeze) are self-directed by design, so they're
-    /// excluded via the existing `isStakingOperation` flag. Compares against
-    /// `fromAddress` — the sender `makeTransaction()` actually signs with, which
-    /// a hydrated seed can decouple from `coin.address` — so the guard tracks the
-    /// real sender rather than an assumed-equal default.
+    /// TRON staking ops (freeze/unfreeze) are self-directed by design, so
+    /// they're excluded via the existing `isStakingOperation` flag. Bittensor
+    /// shares the same self-send-wastes-fees shape as TRON, so it reuses this
+    /// guard rather than growing a second one. Compares against `fromAddress`
+    /// — the sender `makeTransaction()` actually signs with, which a hydrated
+    /// seed can decouple from `coin.address` — so the guard tracks the real
+    /// sender rather than an assumed-equal default.
     func validateNotSelfSend() -> Bool {
-        guard coin.chain == .tron, !isStakingOperation else { return true }
+        guard [.tron, .bittensor].contains(coin.chain), !isStakingOperation else { return true }
         guard toAddress == fromAddress else { return true }
         setAddressError(message: "sameAddressError")
+        return false
+    }
+
+    /// Blocks a send to the Substrate burn/zero AccountId — form-level only,
+    /// so the failure is actionable while the destination field is still on
+    /// screen. `BittensorHelper.buildCallData` carries the fail-closed
+    /// counterpart for a keysign payload that bypasses this form (e.g. built
+    /// on a co-signer device). Bittensor-scoped: Polkadot shares the same
+    /// zero-AccountId concept but resolves addresses through a different path
+    /// (WalletCore `AnyAddress` in `Polkadot.swift`), which is left as
+    /// follow-up rather than folded into this check.
+    func validateBurnDestination() -> Bool {
+        guard coin.chain == .bittensor, BittensorHelper.isBurnAddress(toAddress) else { return true }
+        setAddressError(message: "burnAddressError")
         return false
     }
 
@@ -1306,6 +1322,7 @@ final class SendDetailsViewModel {
         // through the screen's format check.
         guard await validateAddressResolved() else { return false }
         guard validateNotSelfSend() else { return false }
+        guard validateBurnDestination() else { return false }
         guard validateRippleTagAndMemo() else { return false }
         guard await validateRippleRequireDest() else { return false }
         guard validateBalance() else { return false }

--- a/VultisigApp/VultisigAppTests/Chains/BittensorDestinationGuardTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/BittensorDestinationGuardTests.swift
@@ -1,0 +1,114 @@
+//
+//  BittensorDestinationGuardTests.swift
+//  VultisigAppTests
+//
+//  Pins the burn/zero-AccountId guard: the all-zero 32-byte AccountId
+//  SS58-42-encodes to a checksum-valid Bittensor address with no known
+//  private key, so `isBurnAddress` must catch it and `buildCallData`
+//  (exercised via `getPreSignedImageHash`) must fail closed rather than
+//  build a signable call to it.
+//
+
+@testable import VultisigApp
+import BigInt
+import XCTest
+
+final class BittensorDestinationGuardTests: XCTestCase {
+
+    /// The well-known Substrate burn address: SS58-42-encoding of the
+    /// all-zero AccountId. Independently verified against
+    /// `BittensorHelper.ss58Encode`'s own algorithm (Blake2b-512 checksum,
+    /// base58, no leading-zero collapsing) rather than trusted as a fixture.
+    private let burnAddress = "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM"
+    private let normalAddress = "5DtJMgqtYZg6NyCM1KDkmgZ6nW7pKgL1fneDHQtwPjBrQuXG"
+
+    // MARK: - Encoding sanity
+
+    func testSS58EncodeOfZeroPubkeyProducesKnownBurnAddress() {
+        let zeroPubkey = Data(repeating: 0, count: 32)
+        let encoded = BittensorHelper.ss58Encode(publicKey: zeroPubkey, prefix: BittensorHelper.ss58Prefix)
+        XCTAssertEqual(encoded, burnAddress)
+    }
+
+    func testIsValidAddressAcceptsTheBurnAddress() {
+        // Documents the trap this guard exists for: the burn address is a
+        // syntactically valid, checksum-passing Bittensor address, so
+        // `isValidAddress` alone does not protect against it.
+        XCTAssertTrue(BittensorHelper.isValidAddress(burnAddress))
+    }
+
+    // MARK: - isBurnAddress
+
+    func testIsBurnAddressTrueForZeroAccountId() {
+        XCTAssertTrue(BittensorHelper.isBurnAddress(burnAddress))
+    }
+
+    func testIsBurnAddressFalseForNormalAddress() {
+        XCTAssertFalse(BittensorHelper.isBurnAddress(normalAddress))
+    }
+
+    func testIsBurnAddressFalseForUndecodableAddress() {
+        XCTAssertFalse(BittensorHelper.isBurnAddress("not-an-ss58-address"))
+    }
+
+    // MARK: - buildCallData fail-closed guard (exercised via getPreSignedImageHash)
+
+    func testGetPreSignedImageHashThrowsForBurnDestination() throws {
+        let payload = makeKeysignPayload(toAddress: burnAddress)
+        XCTAssertThrowsError(try BittensorHelper.getPreSignedImageHash(keysignPayload: payload)) { error in
+            guard case HelperError.runtimeError = error else {
+                XCTFail("Expected HelperError.runtimeError, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testGetPreSignedImageHashBuildsForNormalDestination() throws {
+        let payload = makeKeysignPayload(toAddress: normalAddress)
+        let hashes = try BittensorHelper.getPreSignedImageHash(keysignPayload: payload)
+        XCTAssertFalse(hashes.isEmpty)
+    }
+
+    // MARK: - Fixture
+
+    private func makeKeysignPayload(toAddress: String) -> KeysignPayload {
+        let meta = CoinMeta.make(chain: .bittensor, ticker: "TAO", decimals: 9, isNativeToken: true)
+        let coin = Coin(
+            asset: meta,
+            address: "5Ej64CJQSZFsPK4byPVCZhNWiYeRXnELwYw4KYQBq6yfvaQ3",
+            hexPublicKey: "75be85178816db3bc71a4f3e64e5c89866d8b7daae827ba9cf4ecd1ed9e645d5"
+        )
+
+        let chainSpecific = BlockChainSpecific.Polkadot(
+            recentBlockHash: "0xe3b45c86765f382bf3df23251099c2eb8f253cb6f962738a559db79ba90c3c79",
+            nonce: 0,
+            currentBlockNumber: BigInt(5234567),
+            specVersion: 260,
+            transactionVersion: 5,
+            genesisHash: "0xc41ec96637a215f4ea0505043f6055c8de087bf1d526b860990f340ea25d155d",
+            gas: BigInt(200_000)
+        )
+
+        return KeysignPayload(
+            coin: coin,
+            toAddress: toAddress,
+            toAmount: BigInt(1_000_000_000),
+            chainSpecific: chainSpecific,
+            utxos: [],
+            memo: nil,
+            swapPayload: nil,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+            vaultLocalPartyID: "party",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: nil
+        )
+    }
+}

--- a/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelValidationTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelValidationTests.swift
@@ -338,6 +338,72 @@ final class SendDetailsViewModelValidationTests: XCTestCase {
         XCTAssertTrue(vm.showAddressAlert)
     }
 
+    // MARK: - Bittensor self-send guard (validateNotSelfSend)
+
+    func testValidateNotSelfSendFailsForBittensorSameAddress() {
+        let tao = SendFormFixture.makeTAO()
+        let vm = SendFormFixture.make(coin: tao)
+        vm.toAddress = tao.address
+
+        XCTAssertFalse(vm.validateNotSelfSend())
+        XCTAssertEqual(vm.errorMessage, "sameAddressError")
+    }
+
+    func testValidateNotSelfSendPassesForBittensorDifferentAddress() {
+        let tao = SendFormFixture.makeTAO()
+        let vm = SendFormFixture.make(coin: tao)
+        vm.toAddress = "5DtJMgqtYZg6NyCM1KDkmgZ6nW7pKgL1fneDHQtwPjBrQuXG"
+
+        XCTAssertTrue(vm.validateNotSelfSend())
+    }
+
+    // MARK: - Bittensor burn/zero-account guard (validateBurnDestination)
+
+    /// SS58-42 encoding of the all-zero AccountId — a syntactically valid,
+    /// checksum-passing Bittensor address with no known private key.
+    private let bittensorBurnAddress = "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM"
+
+    func testValidateBurnDestinationFailsForBurnAddress() {
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeTAO())
+        vm.toAddress = bittensorBurnAddress
+
+        XCTAssertFalse(vm.validateBurnDestination())
+        XCTAssertEqual(vm.errorMessage, "burnAddressError")
+        XCTAssertTrue(vm.showAddressAlert)
+    }
+
+    func testValidateBurnDestinationPassesForNormalBittensorAddress() {
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeTAO())
+        vm.toAddress = "5DtJMgqtYZg6NyCM1KDkmgZ6nW7pKgL1fneDHQtwPjBrQuXG"
+
+        XCTAssertTrue(vm.validateBurnDestination())
+    }
+
+    func testValidateBurnDestinationPassesForNonBittensorChainEvenWithBurnAddress() {
+        // Guard is Bittensor-scoped — the same 32-zero-byte pattern encoded
+        // under a different chain's address scheme is not this guard's concern.
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeETH())
+        vm.toAddress = bittensorBurnAddress
+
+        XCTAssertTrue(vm.validateBurnDestination())
+    }
+
+    /// End-to-end: a TAO send to the burn address is rejected by
+    /// `validateForm()` with `burnAddressError`. A passthrough address
+    /// resolver isolates the burn-destination guard from `AddressService`'s
+    /// resolution behavior in unit tests.
+    func testValidateFormBlocksBittensorBurnDestination() async {
+        let tao = SendFormFixture.makeTAO()
+        let vm = SendFormFixture.make(coin: tao, addressResolver: { input, _ in input })
+        vm.toAddress = bittensorBurnAddress
+        vm.amount = "1"
+
+        let isValid = await vm.validateForm()
+
+        XCTAssertFalse(isValid)
+        XCTAssertEqual(vm.errorMessage, "burnAddressError")
+    }
+
     func testValidateFormStopsAtFirstFailure() async {
         // Cosmos chain + pending tx + empty amount + bad address: only the
         // first failure (pending) should fire its setter.

--- a/VultisigApp/VultisigAppTests/Send/SendFormFixture.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendFormFixture.swift
@@ -70,6 +70,10 @@ enum SendFormFixture {
         makeCoin(.tron, ticker: "TRX", decimals: 6, isNative: true, rawBalance: rawBalance)
     }
 
+    static func makeTAO(rawBalance: String = "1000000000") -> Coin {
+        makeCoin(.bittensor, ticker: "TAO", decimals: 9, isNative: true, rawBalance: rawBalance)
+    }
+
     static func makeXRP(rawBalance: String = "20000000") -> Coin {
         makeCoin(.ripple, ticker: "XRP", decimals: 6, isNative: true, rawBalance: rawBalance)
     }


### PR DESCRIPTION
## Problem

A TAO (Bittensor) send to the Substrate burn/zero AccountId — 32 zero bytes, which SS58-42-encodes to `5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM`, a syntactically valid, checksum-passing Bittensor address with no known private key — passed `BittensorHelper.isValidAddress` and built a signable call with no warning. Funds sent there are permanently unrecoverable. Verified this independently (Python blake2b-512 + base58, matching `ss58Encode`'s own algorithm) rather than trusting the issue's claim.

There was no dangerous-address registry anywhere on iOS to extend — this repo has no `assertSafeDestination`/`burnAddress`/`dangerousAddress` precedent (that's the SDK's, a separate project). `BittensorHelper.buildCallData` decoded the destination and appended its 32 raw bytes straight into the call with no safety check.

## Fix

Two layers, because the send-form guard alone doesn't protect a keysign payload built on a co-signer device that never saw this device's form:

1. **Form validator** (`SendDetailsViewModel.validateBurnDestination()`) — Bittensor-scoped, backed by a new `BittensorHelper.isBurnAddress(_:)`, wired into `validateForm()` right after the self-send guard. Makes the rejection actionable while the destination field is still on screen.
2. **Fail-closed guard in the signing path** — `BittensorHelper.buildCallData` now calls a small `assertNotBurnAccount(_:)` on its own line, right after the existing SS58 decode, comparing the already-decoded 32 bytes against the all-zero AccountId. This is the layer a co-signer's keysign payload cannot route around, since it never touches the send form at all.

Both share one source of truth, `BittensorHelper.burnAccountId`.

**Self-send**: `validateNotSelfSend()` already guarded TRON (a plain transfer to the sender's own address just wastes fees); this PR extends it to `.bittensor` too, reusing the existing `sameAddressError` string rather than growing a second guard. Kept form-level only, matching TRON — self-send wastes fees, it doesn't destroy funds the way the burn account does, so it doesn't need the `buildCallData`-level guard.

**Scope decision — Bittensor only, not Polkadot**: Polkadot shares the same zero-AccountId burn concept, but resolves and encodes addresses through a completely different path — WalletCore's `AnyAddress` in `Polkadot.swift` — not `BittensorHelper`'s hand-rolled SS58 codec. Extending this guard to Polkadot means either duplicating it against WalletCore's address type or introducing a shared cross-chain check, which is its own design decision the source issue doesn't ask for. Left as an explicit follow-up, not a silent omission. Recorded in the wiki plan.

**Localization**: new `burnAddressError` key added to all 8 shipping locales (en/de/es/it/pt/hr/ko/zh-Hans included), inserted in sorted position, real translations for every locale (not English placeholders).

## Coordination note

A sibling PR (#5327, strict SS58 prefix/checksum decode) touches the same `buildCallData`'s `ss58Decode(...)` line. This PR's guard is a separate line/helper call rather than a rewrite of the decode, so the two rebase mechanically regardless of merge order. One doc comment on `isBurnAddress` was worded to stay accurate whichever PR lands first — it no longer claims to independently catch malformed variants (true only against the current lenient decode); it now points at `assertNotBurnAccount` in `buildCallData` as the guard whose fail-closed behavior is independent of decode strictness, since it compares already-decoded bytes, not the string.

## Tests

13 new tests, all passing in the full gate run:
- `BittensorDestinationGuardTests.swift` (new file) — `ss58Encode` of the zero pubkey against the known burn address (corroborates the manual verification), documents that `isValidAddress` accepts the burn address today (the exact trap this guard exists for), `isBurnAddress` true/false/undecodable, and `getPreSignedImageHash` (which routes through `buildCallData`) throwing for the burn destination while still building unchanged for a normal one.
- `SendDetailsViewModelValidationTests.swift` additions — Bittensor self-send guard, the burn-destination form validator in isolation and its Bittensor-only scoping, and the full `validateForm()` pipeline end to end with a passthrough address resolver.

## Verification

- Cross-model review: 4 local commits, each gated by `codex exec --sandbox read-only` (one round each, no findings requiring fixes beyond one doc-comment reword requested for cross-branch accuracy), plus a whole-branch pass — **No findings**.
- Full gate: `make test` on a dedicated simulator — `** TEST SUCCEEDED **`, `Executed 7033 tests, with 11 tests skipped and 0 failures (0 unexpected)`. All 13 new tests individually confirmed passed in the log.
- Disk: `df -h /System/Volumes/Data` — 26G free before, 15G free after (three other gates running in parallel on the same volume; never approached zero).
- SwiftLint: 0 violations on all changed files.
- **No on-device verification was performed by this agent.**

## Review flag

This touches a signing path (`BittensorHelper.buildCallData`) and a send-form validator directly upstream of a keysign ceremony. Flagging for human review given the fund-safety nature of the change, per this repo's HIGH security tier for anything near signing.

Closes #5328

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Bittensor transactions now block burn and zero addresses to help prevent irreversible fund loss.
  - Self-send validation now applies to Bittensor transfers while continuing to allow staking operations.
  - Transaction signing fails safely when a burn destination is detected.

- **User Experience**
  - Added localized burn-address warnings in English, German, Spanish, Croatian, Italian, Korean, Portuguese, and Simplified Chinese.

- **Tests**
  - Added coverage for burn-address detection, self-send validation, safe transaction handling, and valid Bittensor destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->