### PR TITLE
fix(bittensor): require SS58 prefix + checksum on the sign path

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Bittensor/Signing/BittensorHelper.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Bittensor/Signing/BittensorHelper.swift
@@ -152,7 +152,7 @@ enum BittensorHelper {
         let payload = Data(decoded[0..<(prefixByteCount + 32)])
         let checksum = Data(decoded[(prefixByteCount + 32)..<expectedLength])
 
-        let ss58PrefixData = "SS58PRE".data(using: .utf8)!
+        let ss58PrefixData = Data("SS58PRE".utf8)
         let hash = Hash.blake2b(data: ss58PrefixData + payload, size: 64)
         guard hash.prefix(2) == checksum else { return nil }
 

--- a/VultisigApp/VultisigApp/Blockchain/Bittensor/Signing/BittensorHelper.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Bittensor/Signing/BittensorHelper.swift
@@ -114,22 +114,49 @@ enum BittensorHelper {
 
     // MARK: - SS58 Address Encoding/Decoding
 
-    /// Decode an SS58 address to its raw public key bytes (32 bytes for ed25519)
-    static func ss58Decode(_ address: String) -> Data? {
-        guard let decoded = Base58.decodeNoCheck(string: address) else {
+    /// Decode an SS58 address to its raw public key bytes (32 bytes for ed25519),
+    /// requiring an exact prefix + checksum match against `expectedPrefix`.
+    /// This is the single decode both the form (`isValidAddress`) and the sign
+    /// path (`buildCallData`) use, so they can never accept different addresses.
+    static func ss58Decode(_ address: String, expectedPrefix: UInt16 = ss58Prefix) -> Data? {
+        guard let decoded = Base58.decodeNoCheck(string: address), !decoded.isEmpty else {
             return nil
         }
 
-        // Simple prefix (1 byte) + 32 byte key + 2 byte checksum = 35 bytes
-        // Full prefix (2 bytes) + 32 byte key + 2 byte checksum = 36 bytes
-        if decoded.count == 35 {
-            // Single byte prefix
-            return Data(decoded[1..<33])
-        } else if decoded.count == 36 {
-            // Two byte prefix
-            return Data(decoded[2..<34])
+        let prefixByteCount: Int
+        let decodedPrefix: UInt16
+
+        if decoded[0] < 64 {
+            prefixByteCount = 1
+            decodedPrefix = UInt16(decoded[0])
+        } else if decoded[0] <= 127 {
+            // The SS58 two-byte prefix indicator is 64...127; 128...255 is
+            // reserved (not a valid full-identifier prefix at all), and the
+            // low-6-bits-only formula below would otherwise alias several
+            // reserved first bytes onto the same prefix as a canonical one.
+            guard decoded.count >= 2 else { return nil }
+            prefixByteCount = 2
+            let first = decoded[0]
+            let second = decoded[1]
+            decodedPrefix = UInt16((first & 0x3F) << 2) | UInt16(second >> 6) | (UInt16(second & 0x3F) << 8)
+        } else {
+            return nil
         }
-        return nil
+
+        guard decodedPrefix == expectedPrefix else { return nil }
+
+        // Exact length only: prefix + 32-byte key + 2-byte checksum, no trailing bytes.
+        let expectedLength = prefixByteCount + 32 + 2
+        guard decoded.count == expectedLength else { return nil }
+
+        let payload = Data(decoded[0..<(prefixByteCount + 32)])
+        let checksum = Data(decoded[(prefixByteCount + 32)..<expectedLength])
+
+        let ss58PrefixData = "SS58PRE".data(using: .utf8)!
+        let hash = Hash.blake2b(data: ss58PrefixData + payload, size: 64)
+        guard hash.prefix(2) == checksum else { return nil }
+
+        return Data(decoded[prefixByteCount..<(prefixByteCount + 32)])
     }
 
     /// Encode raw public key bytes to SS58 address with given prefix
@@ -154,40 +181,11 @@ enum BittensorHelper {
         return Base58.encodeNoCheck(data: payload + checksum)
     }
 
-    /// Validate a Bittensor SS58 address (prefix 42)
+    /// Validate a Bittensor SS58 address (prefix 42). Thin wrapper over
+    /// `ss58Decode` so the form can never accept an address the sign path
+    /// would reject, or vice versa.
     static func isValidAddress(_ address: String) -> Bool {
-        guard let decoded = Base58.decodeNoCheck(string: address) else {
-            return false
-        }
-
-        // Check minimum length: prefix(1-2) + pubkey(32) + checksum(2) = 35 or 36
-        guard decoded.count >= 35 else { return false }
-
-        let prefixByteCount: Int
-        let decodedPrefix: UInt16
-
-        if decoded[0] < 64 {
-            prefixByteCount = 1
-            decodedPrefix = UInt16(decoded[0])
-        } else {
-            guard decoded.count >= 36 else { return false }
-            prefixByteCount = 2
-            let first = decoded[0]
-            let second = decoded[1]
-            decodedPrefix = UInt16((first & 0x3F) << 2) | UInt16(second >> 6) | (UInt16(second & 0x3F) << 8)
-        }
-
-        guard decodedPrefix == ss58Prefix else { return false }
-
-        let pubkey = Data(decoded[prefixByteCount..<(prefixByteCount + 32)])
-        let checksum = Data(decoded[(prefixByteCount + 32)..<(prefixByteCount + 34)])
-
-        // Verify checksum
-        let ss58PrefixData = "SS58PRE".data(using: .utf8)!
-        let payload = Data(decoded[0..<(prefixByteCount + 32)])
-        let hash = Hash.blake2b(data: ss58PrefixData + payload, size: 64)
-
-        return hash.prefix(2) == checksum && pubkey.count == 32
+        ss58Decode(address) != nil
     }
 
     // MARK: - Pre-signed Image Hash (for MPC signing)

--- a/VultisigApp/VultisigAppTests/Blockchain/SigningGolden/SigningGoldenFixtures.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/SigningGolden/SigningGoldenFixtures.swift
@@ -72,7 +72,19 @@ enum SigningGoldenFactory {
     /// Canonical destination address for `chain`, derived from a fixed key so
     /// it is a real, chain-valid address (never a placeholder string).
     static func recipient(_ chain: Chain) -> String {
-        chain.coinType.deriveAddress(privateKey: recipientKey)
+        switch chain {
+        case .bittensor:
+            // WalletCore has no CoinType.Bittensor; `chain.coinType` aliases
+            // Polkadot, whose SS58 prefix is 0, not Bittensor's 42. Mirror
+            // `CoinFactory`'s override so this is a real, checksummed SS58-42
+            // address — the strict sign-path decode rejects anything else.
+            return BittensorHelper.ss58Encode(
+                publicKey: recipientKey.getPublicKeyEd25519().data,
+                prefix: BittensorHelper.ss58Prefix
+            )
+        default:
+            return chain.coinType.deriveAddress(privateKey: recipientKey)
+        }
     }
 
     /// A signing coin whose `address` + `hexPublicKey` both derive from the

--- a/VultisigApp/VultisigAppTests/Chains/BittensorHelperTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/BittensorHelperTests.swift
@@ -1,0 +1,153 @@
+//
+//  BittensorHelperTests.swift
+//  VultisigApp
+//
+//  Pins BittensorHelper's SS58 decode as the single strict parser the form
+//  (`isValidAddress`) and the sign path (`buildCallData`, via
+//  `getPreSignedImageHash`/`getSignedTransaction`) share: prefix 42 + a valid
+//  checksum + an exact byte length, or the address is rejected outright —
+//  never a byte offset carved out of an unvalidated string.
+//
+
+@testable import VultisigApp
+import BigInt
+import Tss
+import WalletCore
+import XCTest
+
+final class BittensorHelperTests: XCTestCase {
+
+    // MARK: - Fixtures (mirrors TestData/bittensor.json)
+
+    /// Real, checksummed SS58-42 Bittensor address.
+    private let validAddress = "5DtJMgqtYZg6NyCM1KDkmgZ6nW7pKgL1fneDHQtwPjBrQuXG"
+    /// The 32-byte ed25519 public key `validAddress` encodes.
+    private let validAddressPubKeyHex = "5088e7e9faef052bbf655fe91f9a9effb421d4fd68a1597645918803d84c660c"
+
+    /// Same 32-byte public key as `validAddress`, but SS58-encoded with the
+    /// Polkadot mainnet prefix (0) instead of Bittensor's (42) — a real,
+    /// checksummed, otherwise-valid Substrate address on the wrong network.
+    private let polkadotPrefixAddress = "12pbW26xQLwZpWCrxxGkuqPFe87U1yt9kHNhShtHwpDNb5Tp"
+
+    /// `validAddress` with the final checksum byte flipped, re-encoded.
+    private let checksumCorruptedAddress = "5DtJMgqtYZg6NyCM1KDkmgZ6nW7pKgL1fneDHQtwPjBrQuWb"
+
+    /// `validAddress`'s decoded bytes (prefix + pubkey + checksum) with one
+    /// extra trailing byte appended before re-encoding: the checksum still
+    /// verifies against the leading 33 bytes, but the payload is 36 bytes
+    /// instead of the 35 a single-byte prefix requires.
+    private let trailingGarbageAddress = "KdsRcJrnWKDYjy35JPRJCDagXqX5sSauxCTFDSUF5KCu6WpcA"
+
+    /// Same public key + second byte as the canonical two-byte encoding of
+    /// prefix 42, but with first byte 0x8A (138) instead of the canonical
+    /// 0x4A (74) — SS58's two-byte prefix indicator is 64...127, so 138 is
+    /// reserved, not a valid prefix byte at all. The prefix-decode formula
+    /// only reads the low 6 bits of the first byte, so without an explicit
+    /// upper bound this reserved byte aliases onto prefix 42 anyway, with a
+    /// checksum that verifies (it's computed over these exact bytes).
+    private let malformedTwoBytePrefixAddress = "23zq2QKhC35xn5Vjvca3cuJYonkEMHz1EmqhZy8xRcjWr74t8y"
+
+    // MARK: - ss58Decode
+
+    func testSs58DecodeValidAddressReturnsExpectedPublicKey() throws {
+        let decoded = try XCTUnwrap(BittensorHelper.ss58Decode(validAddress))
+        XCTAssertEqual(decoded, try XCTUnwrap(Data(hexString: validAddressPubKeyHex)))
+    }
+
+    func testSs58DecodeRejectsPrefixZeroPolkadotAddress() {
+        XCTAssertNil(BittensorHelper.ss58Decode(polkadotPrefixAddress))
+    }
+
+    func testSs58DecodeRejectsChecksumCorruption() {
+        XCTAssertNil(BittensorHelper.ss58Decode(checksumCorruptedAddress))
+    }
+
+    func testSs58DecodeRejectsTrailingGarbageAfterChecksum() {
+        XCTAssertNil(BittensorHelper.ss58Decode(trailingGarbageAddress))
+    }
+
+    func testSs58DecodeRejectsReservedTwoBytePrefixByte() {
+        XCTAssertNil(BittensorHelper.ss58Decode(malformedTwoBytePrefixAddress))
+    }
+
+    // MARK: - isValidAddress (must agree with ss58Decode)
+
+    func testIsValidAddressAcceptsRealBittensorAddress() {
+        XCTAssertTrue(BittensorHelper.isValidAddress(validAddress))
+    }
+
+    func testIsValidAddressRejectsPrefixZeroPolkadotAddress() {
+        XCTAssertFalse(BittensorHelper.isValidAddress(polkadotPrefixAddress))
+    }
+
+    func testIsValidAddressRejectsChecksumCorruption() {
+        XCTAssertFalse(BittensorHelper.isValidAddress(checksumCorruptedAddress))
+    }
+
+    // MARK: - Sign path: same rejections must throw, never silently sign
+
+    func testGetPreSignedImageHashThrowsForPrefixZeroAddress() throws {
+        let payload = try makePayload(toAddress: polkadotPrefixAddress)
+        assertThrowsInvalidDestinationAddress(try BittensorHelper.getPreSignedImageHash(keysignPayload: payload))
+    }
+
+    func testGetPreSignedImageHashThrowsForChecksumCorruptedAddress() throws {
+        let payload = try makePayload(toAddress: checksumCorruptedAddress)
+        assertThrowsInvalidDestinationAddress(try BittensorHelper.getPreSignedImageHash(keysignPayload: payload))
+    }
+
+    func testGetSignedTransactionThrowsForPrefixZeroAddress() throws {
+        let payload = try makePayload(toAddress: polkadotPrefixAddress)
+        assertThrowsInvalidDestinationAddress(try BittensorHelper.getSignedTransaction(keysignPayload: payload, signatures: [:]))
+    }
+
+    func testGetSignedTransactionThrowsForChecksumCorruptedAddress() throws {
+        let payload = try makePayload(toAddress: checksumCorruptedAddress)
+        assertThrowsInvalidDestinationAddress(try BittensorHelper.getSignedTransaction(keysignPayload: payload, signatures: [:]))
+    }
+
+    func testGetPreSignedImageHashSucceedsForValidAddress() throws {
+        let payload = try makePayload(toAddress: validAddress)
+        XCTAssertNoThrow(try BittensorHelper.getPreSignedImageHash(keysignPayload: payload))
+    }
+
+    // MARK: - Fixtures
+
+    /// Asserts the expression throws specifically `buildCallData`'s rejection,
+    /// not merely "some error" — an unrelated downstream throw (e.g. signature
+    /// verification failing on empty test signatures) would let a regression
+    /// that silently accepts an invalid address pass this test for the wrong
+    /// reason.
+    private func assertThrowsInvalidDestinationAddress<T>(
+        _ expression: @autoclosure () throws -> T,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertThrowsError(try expression(), file: file, line: line) { error in
+            guard case HelperError.runtimeError(let message) = error else {
+                XCTFail("expected HelperError.runtimeError, got \(error)", file: file, line: line)
+                return
+            }
+            XCTAssertEqual(message, "Invalid Bittensor destination address", file: file, line: line)
+        }
+    }
+
+    private func makePayload(toAddress: String) throws -> KeysignPayload {
+        let coin = SigningGoldenFactory.coin(chain: .bittensor, ticker: "TAO", decimals: 9, curve: .ed25519)
+        return SigningGoldenFactory.payload(
+            coin: coin,
+            toAddress: toAddress,
+            toAmount: BigInt(1_000_000_000),
+            chainSpecific: .Polkadot(
+                recentBlockHash: Self.polkadotGenesis,
+                nonce: 0,
+                currentBlockNumber: BigInt(5_234_567),
+                specVersion: 260,
+                transactionVersion: 5,
+                genesisHash: Self.polkadotGenesis
+            )
+        )
+    }
+
+    private static let polkadotGenesis = "91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3"
+}


### PR DESCRIPTION
## Problem

`BittensorHelper.buildCallData` decoded the destination SS58 address with `ss58Decode`, a lax parser that branched on **decoded-byte length alone** — no SS58 prefix check, no checksum verification — while `isValidAddress` (the form's validation gate) checked both `prefix == 42` and the blake2b-512 `SS58PRE` checksum. A co-sign payload could therefore carry an address the form never validated, and the sign path would still encode whatever 32 raw bytes fell out of a fixed byte offset straight into the extrinsic.

Invariant this closes (per the epic, vultisig-sdk#2333): **the pubkey that lands in the call data must be the checksummed SS58-42 the user saw.**

## Evidence the bug was real, found while fixing it

`SigningGoldenFixtures.recipient(_:)` derives every chain's fixture destination via `chain.coinType.deriveAddress(privateKey:)`. Bittensor's `ChainConfig.coinType` is WalletCore's `.polkadot` (WalletCore has no native Bittensor coin type — `CoinFactory` overrides address derivation for `.bittensor` to call `BittensorHelper.ss58Encode(..., prefix: 42)` directly). So `recipient(.bittensor)` was silently producing a **prefix-0 Polkadot address**, and the *old* lax `ss58Decode` accepted it without complaint — the `bittensor_send` golden vector has been signing to a non-Bittensor-prefixed address and reporting green the whole time. That's the issue's exact failure mode, sitting in our own test suite. Fixed by special-casing `.bittensor` in `recipient(_:)` to SS58-encode with prefix 42, the same way `CoinFactory` does for real coins.

## Fix

Collapsed the two parsers into one: `ss58Decode(_ address: String, expectedPrefix: UInt16 = ss58Prefix) -> Data?` now validates prefix, checksum, **and exact byte length** (35 for a 1-byte prefix, 36 for a 2-byte prefix — no trailing-garbage tolerance, closing a gap where the old `isValidAddress`'s `>= 35` check let a payload with bytes appended after a valid checksum still validate). `isValidAddress` is now a one-line wrapper over it.

`buildCallData`'s call site is **unchanged** — same function name, same default argument — so the form and the sign path can never accept different addresses again by construction, and this also means a sibling PR (#5328, an unrelated zero/burn `AccountId` guard landing a few lines below the decode call in the same function) rebases against this branch with no conflict.

A second Codex review round additionally caught and fixed: the two-byte SS58 prefix indicator is only valid for first bytes 64...127; the prefix-decode formula reads only the low 6 bits of the first byte, so without an explicit upper bound, reserved first bytes 128...255 aliased onto a valid prefix (with a checksum that trivially verifies, since it's computed over those same non-canonical bytes). Now explicitly rejected.

## Tests

New `Chains/BittensorHelperTests.swift` (13 tests): a real address decodes to its known 32-byte pubkey; a real prefix-0 Polkadot address encoding the *same* public key is rejected (both by `ss58Decode` and `isValidAddress`); a checksum-corrupted address is rejected; a trailing-garbage-after-checksum address is rejected; a reserved-range two-byte-prefix address is rejected; `getPreSignedImageHash`/`getSignedTransaction` throw the specific `HelperError.runtimeError("Invalid Bittensor destination address")` — not just "some error" — for the rejected cases, so a future regression that silently re-accepts an invalid address can't hide behind an unrelated downstream throw.

Existing Bittensor coverage (`ChainHelperTests.testBittensorFixture`, `SigningGoldenTests.testSigningGoldens`'s `bittensor_send` vector) still passes unmodified against the same recorded golden hash — confirmed by running the gate, not assumed: SS58-encoding the same 32-byte public key with prefix 42 instead of prefix 0 only changes the prefix/checksum bytes, not the decoded destination pubkey, so the signed bytes are provably unchanged.

## Verification

- Cross-model review (Codex, `gpt-5.5-high`, read-only): round 1 on the initial commit found 1 MAJOR + 1 MINOR (both above); fixed and amended. Round 2 on the amended commit and a separate whole-branch pass: **No findings** on both.
- Full gate: `make test DESTINATION='platform=iOS Simulator,id=66B04510-3DF9-4A0B-956D-A02D1C7D318F'` → `** TEST SUCCEEDED **`, `Executed 7033 tests, with 11 tests skipped and 0 failures (0 unexpected)`. All 13 new `BittensorHelperTests` cases confirmed present and passing by name in the log (not just an aggregate count), and `SigningGoldenTests.testSigningGoldens` (which includes `bittensor_send`) passed against the unmodified recorded golden JSON.
- `df -h /System/Volumes/Data`: 28Gi free before the gate → 15Gi free after (three sibling agents were gating in parallel on the same volume). Did not hit zero, and the result is corroborated independently of the disk margin — the new test names and their pass/fail results could not come from a stale build, since this test file didn't exist before this branch.
- SwiftLint on changed files: 0 violations.

## Scope / not done here

- iOS-only. Android/Windows carry their own clones of `BittensorHelper` and are not touched (tracked by the epic, vultisig-sdk#2333 / SDK sibling vultisig-sdk#2335).
- Left the non-canonical two-byte encoding of prefix 42 (0x4A 0x80, distinct from the reserved-range fix above) accepted, matching prior shipped behavior — not a form/sign-path parity question now that both paths share one function by construction.
- No on-device acceptance test was performed.

## Review

**This is a signing-path change touching fund destinations — please have a human review it, and treat the on-device signing flow as unverified until someone runs it on a real device/simulator pair.**

Plan: `wiki/pages/projects/vultisig/ios-bugs/tao-ss58-strict-5327-plan.md`

Closes #5327


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bittensor address validation by enforcing valid network prefixes, address lengths, checksums, and reserved-prefix rules.
  * Ensured invalid Bittensor destination addresses are rejected before signing.
  * Aligned address validation with signing behavior for more consistent results.

* **Tests**
  * Added coverage for valid and invalid Bittensor addresses, decoding, validation, and pre-signing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->