### PR TITLE
fix(send): hide memo field for Bittensor and Polkadot sends

### DIFF
--- a/VultisigApp/VultisigApp/Components/Send/SendDetailsAddressFields.swift
+++ b/VultisigApp/VultisigApp/Components/Send/SendDetailsAddressFields.swift
@@ -79,10 +79,6 @@ struct SendDetailsAddressFields: View {
             viewModel.convertToFiat(newValue: amount)
         }
 
-        if let memo = addressResult.memo, memo.isNotEmpty {
-            viewModel.memo = memo
-        }
-
         // Attempt to detect and switch chain if address belongs to different chain
         if !viewModel.toAddress.isEmpty {
             let detectedCoin = viewModel.detectAndSwitchChain(
@@ -103,6 +99,15 @@ struct SendDetailsAddressFields: View {
                 // resolve is flagged now, so Next is disabled *with a reason*.
                 viewModel.markInvalidRecipientIfUnresolvable()
             }
+        }
+
+        // A scanned/pasted URI can carry a memo query param for a coin whose
+        // signer never encodes one. Checked after the chain-switch above so
+        // this reflects the coin actually selected once detection settles —
+        // checking before it would drop a legitimate memo when switching
+        // into a memo-supporting chain, or leak one when switching out of one.
+        if let memo = addressResult.memo, memo.isNotEmpty, viewModel.coin.supportsMemo {
+            viewModel.memo = memo
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Send/Models/SendTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Models/SendTransaction.swift
@@ -67,7 +67,11 @@ struct SendDetailsSeed: Hashable {
             lastResolvedAddress: nil,
             amount: prefilledAmount ?? "",
             amountInFiat: "",
-            memo: prefilledMemo ?? "",
+            // A deeplink can carry a memo for a coin whose signer never
+            // encodes one (see `Chain.supportsMemo`); dropping it here keeps
+            // the seed's memo consistent with the hidden field so Verify
+            // never confirms a note that would be silently discarded.
+            memo: coin.supportsMemo ? (prefilledMemo ?? "") : "",
             gas: .zero,
             fee: .zero,
             feeMode: .default,

--- a/VultisigApp/VultisigApp/Model/Chain.swift
+++ b/VultisigApp/VultisigApp/Model/Chain.swift
@@ -235,14 +235,20 @@ extension Chain {
     }
 
     /// Whether the Send flow's memo input should be exposed for this chain.
-    /// Most chains carry a memo at the protocol level. The exception is Sui:
-    /// a transaction is a Programmable Transaction Block with no memo field, so
-    /// a typed memo would be silently dropped — hiding the input avoids that.
+    /// Most chains carry a memo at the protocol level; a typed memo would be
+    /// silently dropped for the exceptions below, so hiding the input avoids
+    /// that:
+    /// - Sui: a transaction is a Programmable Transaction Block with no memo
+    ///   field.
+    /// - Polkadot and Bittensor: the signer builds only a `balances.transfer`
+    ///   extrinsic (module/method + destination + amount + signed extra) —
+    ///   there is no `system.remark`, no batch call, and no other field the
+    ///   memo could ride on.
     /// Cardano DOES support memos: they are attached on-chain as CIP-20
     /// transaction metadata (label 674) via `CardanoSigningInput.auxiliaryData`.
     var supportsMemo: Bool {
         switch self {
-        case .sui:
+        case .sui, .polkadot, .bittensor:
             return false
         default:
             return true

--- a/VultisigApp/VultisigAppTests/Model/CoinMemoSupportTests.swift
+++ b/VultisigApp/VultisigAppTests/Model/CoinMemoSupportTests.swift
@@ -25,6 +25,24 @@ final class CoinMemoSupportTests: XCTestCase {
         XCTAssertFalse(coin.supportsMemo)
     }
 
+    func testNativePolkadotCoinDoesNotSupportMemo() {
+        let coin = makeCoin(chain: .polkadot, isNativeToken: true)
+
+        XCTAssertFalse(coin.supportsMemo)
+    }
+
+    func testNativeBittensorCoinDoesNotSupportMemo() {
+        let coin = makeCoin(chain: .bittensor, isNativeToken: true)
+
+        XCTAssertFalse(coin.supportsMemo)
+    }
+
+    func testNativeCosmosCoinStillSupportsMemo() {
+        let coin = makeCoin(chain: .gaiaChain, isNativeToken: true)
+
+        XCTAssertTrue(coin.supportsMemo)
+    }
+
     private func makeCoin(chain: Chain, isNativeToken: Bool) -> Coin {
         Coin(
             asset: CoinMeta(

--- a/VultisigApp/VultisigAppTests/Send/SendTransactionTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendTransactionTests.swift
@@ -61,6 +61,50 @@ final class SendTransactionTests: XCTestCase {
         XCTAssertEqual(tx.fromAddress, coin.address)
     }
 
+    // MARK: - fromAction seed: prefilled memo respects Chain.supportsMemo
+
+    func testFromActionDropsPrefilledMemoForBittensor() throws {
+        let coin = makeCoin(.bittensor, ticker: "TAO", decimals: 9, isNative: true)
+        let seed = SendDetailsSeed.fromAction(
+            coin: coin,
+            vault: vault,
+            hasPreselectedCoin: true,
+            prefilledToAddress: "dest",
+            prefilledAmount: "1",
+            prefilledMemo: "deeplink memo"
+        )
+
+        XCTAssertEqual(seed.memo, "")
+    }
+
+    func testFromActionDropsPrefilledMemoForPolkadot() throws {
+        let coin = makeCoin(.polkadot, ticker: "DOT", decimals: 10, isNative: true)
+        let seed = SendDetailsSeed.fromAction(
+            coin: coin,
+            vault: vault,
+            hasPreselectedCoin: true,
+            prefilledToAddress: "dest",
+            prefilledAmount: "1",
+            prefilledMemo: "deeplink memo"
+        )
+
+        XCTAssertEqual(seed.memo, "")
+    }
+
+    func testFromActionKeepsPrefilledMemoForChainThatSupportsIt() throws {
+        let coin = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        let seed = SendDetailsSeed.fromAction(
+            coin: coin,
+            vault: vault,
+            hasPreselectedCoin: true,
+            prefilledToAddress: "dest",
+            prefilledAmount: "1",
+            prefilledMemo: "deeplink memo"
+        )
+
+        XCTAssertEqual(seed.memo, "deeplink memo")
+    }
+
     // MARK: - Decision 1: plain [String: String] dictionary
 
     func testMemoFunctionDictionaryIsPlainDict() throws {


### PR DESCRIPTION
## Problem

The Send screen shows a memo field for Bittensor (TAO) sends, and the Verify screen echoes the typed memo back to the user as if it will be included — but `BittensorHelper.buildCallData`/`buildSignedExtra` write exactly `[moduleIndex, methodIndex] ++ MultiAddress::Id ++ dest(32B) ++ compact(amount)` for the call and `era/nonce/tip/CheckMetadataHash` for the signed extra. There is no `system.remark`, no batch call, nowhere for a memo to live — it is silently dropped at signing time while the app affirmatively confirms it will be sent.

**Polkadot (DOT) has the identical bug**, even though the issue's parenthetical only tentatively raised it. `Polkadot.swift` has zero occurrences of "memo" across the whole file — it builds only a pinned `balanceCall.assetTransfer` (Balances module 10 / method 3). The closed Android sibling [vultisig-android#5825](https://github.com/vultisig/vultisig-android/issues/5825) fixed both chains together for exactly this reason, explicitly noting that splitting them would leave the identical bug live on one of them. This PR does the same on iOS.

## Fix

`Chain.supportsMemo` is the single predicate gating both the memo input field (`SendDetailsAdditionalSection`) and the memo row on the Verify screen (`SendCryptoVerifySummaryView`). It excluded only `.sui`, falling through `default: return true` for everything else. Added `.polkadot` and `.bittensor` alongside it, with the doc comment rewritten to explain all three exceptions.

### Scope expansion beyond the original brief — flagged prominently

Hiding the input field alone would have been **cosmetic**: two other paths can still hand a memo to the view model for a coin whose signer ignores it, bypassing the now-hidden field entirely and reproducing the exact same false confirmation on Verify (and in `KeysignPayload`):

1. **Deeplink prefill** — `SendDetailsSeed.fromAction` set `memo: prefilledMemo ?? ""` unconditionally from a `vultisig://send?...&memo=...` deeplink. Now gated: `memo: coin.supportsMemo ? (prefilledMemo ?? "") : ""`.
2. **Scanned/pasted address URI** — `SendDetailsAddressFields.handle(addressResult:)` set `viewModel.memo` unconditionally from any parsed URI's `message`/`memo` query param (`Utils.parseCryptoURI` is chain-agnostic, so this isn't Bitcoin-specific). Now gated on `viewModel.coin.supportsMemo`.

Point 2 needed care around ordering. The same `handle(addressResult:)` call can also detect that the scanned address belongs to a different chain and switch the selected coin (`detectAndSwitchChain`). The memo guard now runs **after** that chain-switch settles, evaluating the coin actually selected once detection is done — not the coin selected before it. Checking before the switch would have introduced a new bug in either direction: dropping a legitimate memo when scanning switches *into* a memo-supporting chain, or leaking one when switching *out of* one. (`SendDetailsScreen`'s existing `onChange(of: viewModel.coin)` still independently clears a stale memo on any chain switch that lands on a non-supporting coin, which covers the case where the scanned URI carried no memo of its own.)

Both guards were caught by a cross-model (Codex) review pass, not the original investigation — see the review ledger link below.

### Known, deliberately deferred (not fixed here)

The **co-signer/joiner side** of a keysign session — `KeysignMessageConfirmView` and `JoinKeysignDoneView`, both fed by `JoinKeysignViewModel.memo` — still displays an incoming `KeysignPayload`'s memo unguarded for TAO/DOT. That reproduces the same false-confirmation bug, but on the *receiving* side of a keysign ceremony rather than the initiator's Send flow this issue targets, and `JoinKeysignViewModel.memo` is shared with decoded function-call/swap memo display across three call sites — a correct fix needs its own review rather than a same-predicate reuse. Filing as a fast follow-up rather than folding into this PR.

## Verification

- Full gate: `make test DESTINATION='platform=iOS Simulator,id=E291A251-3195-481F-91C2-21508133F810'`
  ```
  ** TEST SUCCEEDED **
  Executed 7026 tests, with 11 tests skipped and 0 failures (0 unexpected) in 116.795 (119.961) seconds
  ```
  7026 = the 7020 baseline shared by three sibling branches gated in parallel, plus exactly the 6 new tests added here (`CoinMemoSupportTests` 3→6, `SendTransactionTests` +3) — confirmed by per-suite name, not just the total, and the count moving is itself the disk-pressure corroboration (free space dropped to 8.8 GB mid-run; a stale/cached pass would have reported the unchanged 7020).
- Cross-model review: two rounds of per-commit Codex review (`--sandbox read-only`) plus a whole-branch pass, all findings verified against source, ledger recorded — round 1 found the two missing prefill guards (fixed), round 2 found the ordering bug above (fixed) and the co-signer-side gap (deferred, see above). Whole-branch pass: no findings.
- SwiftLint: 0 violations on all changed files.
- This branch was test-merged against three sibling Bittensor/Polkadot-adjacent branches (#5330, #5331, #5332) with no conflicts — this is the only one of the four touching `Chain.swift`.

## Flag for human review

This touches a Send-form path feeding MPC signing (`Chain.supportsMemo` → `SendDetailsSeed`/`SendDetailsAddressFields` → `SendTransaction` → `KeysignPayload`). No signing logic changed — this only prevents a memo from being collected/displayed for two chains whose signers already ignored it — but flagging per repo convention for human + on-device review before merge.

Closes #5326


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Memo fields are now shown and preserved only for networks that support memo encoding.
  - Memo input is disabled for Polkadot and Bittensor, while remaining available for supported networks such as Cosmos and Ethereum.
  - Prefilled memos are cleared when sending on unsupported networks.

- **Tests**
  - Added coverage to verify memo support and preservation behavior across supported and unsupported networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->