### PR TITLE
fix: stabilize vault navigation and scroll state

### DIFF
--- a/VultisigApp/VultisigApp/App/ContentView.swift
+++ b/VultisigApp/VultisigApp/App/ContentView.swift
@@ -10,7 +10,7 @@ import SwiftData
 
 private let logger = Log.app.other
 
-enum RootRoute {
+enum RootRoute: Equatable {
     case home(showingVaultSelector: Bool)
     case createVault
 }
@@ -198,10 +198,8 @@ struct ContentView: View {
                 BackgroundTransactionPoller.shared.resumePendingTransactions()
             }
         }
-        .onChange(of: appViewModel.selectedVault) { _, _ in
-            guard appViewModel.restartNavigation else { return }
-            navigateToHome()
-        }
+        // A selection and its restart request change together. Observe the
+        // request once; observing the selection too resets the stack twice.
         .onChange(of: appViewModel.restartNavigation) { _, newValue in
             guard newValue else { return }
             navigateToHome()
@@ -334,9 +332,14 @@ struct ContentView: View {
     }
 
     func navigateToHome() {
-        appViewModel.showSplashView = false
-        rootRoute = .home(showingVaultSelector: appViewModel.showingVaultSelector)
-        navigationRouter.navPath = NavigationPath()
+        if appViewModel.showSplashView {
+            appViewModel.showSplashView = false
+        }
+        let homeRoute = RootRoute.home(showingVaultSelector: appViewModel.showingVaultSelector)
+        if rootRoute != homeRoute {
+            rootRoute = homeRoute
+        }
+        navigationRouter.navigateToRoot()
     }
 
     @ViewBuilder

--- a/VultisigApp/VultisigApp/Components/ScrollView/OffsetObservingScrollView.swift
+++ b/VultisigApp/VultisigApp/Components/ScrollView/OffsetObservingScrollView.swift
@@ -53,6 +53,7 @@ struct OffsetObservingScrollView<Content: View>: View {
         }
         .coordinateSpace(name: coordinateSpaceName)
         .onPreferenceChange(ScrollOffsetPreferenceKey.self) { value in
+            guard scrollOffset != value else { return }
             scrollOffset = value
         }
     }
@@ -90,22 +91,14 @@ private extension OffsetObservingScrollView {
     }
 }
 
-private struct ScrollOffsetPreferenceKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-
-    private static var lastUpdateTime: CFTimeInterval = 0
-    private static let targetFrameRate: Double = 30
-    private static var frameInterval: CFTimeInterval { 1.0 / targetFrameRate }
+struct ScrollOffsetPreferenceKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
 
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        let newValue = nextValue()
-        let currentTime = CACurrentMediaTime()
-
-        // Only update if enough time has passed since the last update
-        if currentTime - lastUpdateTime >= frameInterval {
-            value += newValue
-            lastUpdateTime = currentTime
-        }
-        // If not enough time has passed, keep the previous value (don't update)
+        // Reduction combines one preference tree at a time. A shared clock here
+        // drops values from unrelated scroll views and can replace an offset
+        // with the default value. Keep reduction independent of time/instances;
+        // the picker handles scroll-settle debouncing after receiving offsets.
+        value += nextValue()
     }
 }

--- a/VultisigApp/VultisigApp/Components/TabBar/VultiTabBar.swift
+++ b/VultisigApp/VultisigApp/Components/TabBar/VultiTabBar.swift
@@ -41,7 +41,14 @@ struct VultiTabBar<Item: TabBarItem, Content: View>: View {
                 legacyTabBar
             }
 #endif
-        }.onChange(of: selectedItem) { oldValue, newValue in
+        }
+        .onChange(of: items) { _, newItems in
+            // TabView can display a fallback without updating its selection
+            // binding. Keep the screen's header on the tab that still exists.
+            guard !newItems.contains(selectedItem), let firstItem = newItems.first else { return }
+            selectedItem = firstItem
+        }
+        .onChange(of: selectedItem) { oldValue, newValue in
             if newValue == accessory {
                 selectedItem = oldValue
                 onAccessory?()

--- a/VultisigApp/VultisigApp/Core/Navigation/NavigationRouter.swift
+++ b/VultisigApp/VultisigApp/Core/Navigation/NavigationRouter.swift
@@ -47,7 +47,10 @@ final class NavigationRouter: ObservableObject {
     }
 
     func navigateToRoot() {
-        navPath.removeLast(navPath.count)
+        // An empty-path mutation still publishes and invalidates NavigationStack.
+        if !navPath.isEmpty {
+            navPath.removeLast(navPath.count)
+        }
         history.removeAll()
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiMain/DefiMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiMain/DefiMainScreen.swift
@@ -55,6 +55,9 @@ struct DefiMainScreen: View {
                     scrollProxy = proxy
                 }
             }
+            // A different vault starts at its balance, without retaining the
+            // previous vault's scroll position or cached lazy-stack layout.
+            .id(vault.id)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             .background(MainBackgroundWithNotification())
             .onChange(of: showSearchHeader) { _, showSearchHeader in
@@ -77,6 +80,11 @@ struct DefiMainScreen: View {
         }
         .throttledOnAppear(interval: 15.0, action: refresh)
         .onChange(of: vault) { _, _ in
+            // A new vault opens at its balance, without the old search filter
+            // or a focused field competing with the reset scroll position.
+            if focusSearch { focusSearch = false }
+            if showSearchHeader { showSearchHeader = false }
+            if !viewModel.searchText.isEmpty { viewModel.searchText = "" }
             refresh()
         }
         .onReceive(NotificationCenter.default.publisher(for: .defiPositionsDidChange)) { _ in

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
@@ -71,6 +71,9 @@ struct VaultMainScreen: View {
                         scrollProxy = proxy
                     }
                 }
+                // A different vault starts at its balance, without retaining the
+                // previous vault's scroll position or cached lazy-stack layout.
+                .id(vault.id)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                 .background(MainBackgroundWithNotification())
                 .onAppear {
@@ -116,6 +119,11 @@ struct VaultMainScreen: View {
             refresh()
         }
         .onChange(of: vault) { _, _ in
+            // A new vault opens at its balance, without the old search filter
+            // or a focused field competing with the reset scroll position.
+            if focusSearch { focusSearch = false }
+            if showSearchHeader { showSearchHeader = false }
+            if !viewModel.searchText.isEmpty { viewModel.searchText = "" }
             refresh()
         }
         .onChange(of: shouldRefresh) { _, newValue in

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/VaultMainScreenScrollView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/VaultMainScreenScrollView.swift
@@ -50,7 +50,9 @@ struct VaultMainScreenScrollView<Content: View>: View {
                     .background(
                         GeometryReader { proxy in
                             Color.clear
-                                .onChange(of: preferenceValue(proxy: proxy)) { _, newValue in
+                                // A new vault's viewport must also replace the
+                                // old header progress before the first scroll.
+                                .onChange(of: preferenceValue(proxy: proxy), initial: true) { _, newValue in
                                     onOffsetChange(newValue)
                                 }
                         }

--- a/VultisigApp/VultisigAppTests/Features/Home/VaultSwitchScrollTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/Home/VaultSwitchScrollTests.swift
@@ -1,0 +1,346 @@
+import Combine
+import SwiftData
+import SwiftUI
+import UIKit
+import XCTest
+
+@testable import VultisigApp
+
+/// Hosts the production scroll views: value-only collapse tests cannot detect
+/// a retained UIScrollView offset or a missing initial geometry callback.
+@MainActor
+final class VaultSwitchScrollTests: XCTestCase {
+    private var token: TestContextToken?
+    private var window: UIWindow?
+    private weak var previousKeyWindow: UIWindow?
+    private let collapse = HomeHeaderCollapse()
+
+    override func setUpWithError() throws {
+        let installed = try TestStore.installInMemoryContainer()
+        token = installed
+        // The DeFi screen starts unstructured refresh work across suspension.
+        TestStore.retain(installed.container)
+    }
+
+    override func tearDownWithError() throws {
+        window?.isHidden = true
+        window?.rootViewController = nil
+        window = nil
+        previousKeyWindow?.makeKey()
+        TestStore.restore(token)
+        token = nil
+    }
+
+    func testWalletSwitchReturnsToTopAndExpandsBalance() async throws {
+        let selection = VaultSelection(vault: makeVault("first"))
+        try hostWallet(selection)
+        let original = try await scrollDown(tab: .wallet)
+
+        selection.vault = makeVault("second")
+        try await settleLayout()
+
+        let current = try verticalScrollView()
+        XCTAssertFalse(current === original)
+        assertAtTop(current, tab: .wallet)
+    }
+
+    func testWalletSwitchBetweenShortAndLongContentStaysAtTop() async throws {
+        let long = makeVault("long")
+        let short = TestStore.makeVault(pubKey: "short")
+        let selection = VaultSelection(vault: long)
+        try hostWallet(selection)
+        try await settleLayout()
+
+        for vault in [short, long, short] {
+            selection.vault = vault
+            try await settleLayout()
+            assertAtTop(try verticalScrollView(), tab: .wallet)
+        }
+    }
+
+    func testSameVaultRefreshPreservesScrollPosition() async throws {
+        let selection = VaultSelection(vault: makeVault("refresh"))
+        let model = LocalWalletModel()
+        try hostWallet(selection, model: model)
+        let original = try await scrollDown(tab: .wallet)
+        let offset = original.contentOffset.y
+
+        model.updateBalance(vault: selection.vault)
+        try await settleLayout()
+
+        let current = try verticalScrollView()
+        XCTAssertTrue(current === original)
+        XCTAssertEqual(current.contentOffset.y, offset, accuracy: 1)
+        XCTAssertEqual(collapse.wallet.value, 1)
+    }
+
+    func testDefiSwitchReturnsToTopAndExpandsBalance() async throws {
+        // Empty vaults avoid network balance work. The compact viewport makes
+        // the real balance banner and customize-chains content scrollable.
+        let selection = VaultSelection(vault: TestStore.makeVault(pubKey: "defi-first"))
+        try host(DefiContent(selection: selection, collapse: collapse).frame(height: 300))
+        let original = try await scrollDown(tab: .defi)
+
+        selection.vault = TestStore.makeVault(pubKey: "defi-second")
+        try await settleLayout()
+
+        let current = try verticalScrollView()
+        XCTAssertFalse(current === original)
+        assertAtTop(current, tab: .defi)
+    }
+
+    func testInitialGeometryExpandsPreviouslyCollapsedHeader() async throws {
+        collapse.update(tab: .wallet, offset: -200, restingOffset: 78)
+        try host(
+            VaultMainScreenScrollView(topInset: 78, onOffsetChange: { [collapse] offset in
+                collapse.update(tab: .wallet, offset: offset, restingOffset: 78)
+            }, content: {
+                Color.clear.frame(height: 1_200)
+            })
+        )
+        try await settleLayout()
+        assertAtTop(try verticalScrollView(), tab: .wallet)
+    }
+
+    func testVaultSwitchClearsOpenWalletSearch() async throws {
+        let selection = VaultSelection(vault: makeVault("search-first"))
+        let model = LocalWalletModel()
+        model.searchText = "bitcoin"
+        try hostWallet(selection, model: model, startsInSearch: true)
+        try await settleLayout()
+        XCTAssertFalse(visibleTextFields(in: try XCTUnwrap(window)).isEmpty)
+
+        selection.vault = makeVault("search-second")
+        try await settleLayout()
+
+        XCTAssertTrue(visibleTextFields(in: try XCTUnwrap(window)).isEmpty)
+        XCTAssertEqual(model.searchText, "")
+        assertAtTop(try verticalScrollView(), tab: .wallet)
+    }
+
+    func testVaultSwitchClearsOpenDefiSearch() async throws {
+        let selection = VaultSelection(vault: TestStore.makeVault(pubKey: "defi-search-first"))
+        let model = DefiMainViewModel()
+        model.searchText = "bitcoin"
+        try host(DefiSearchContent(selection: selection, collapse: collapse, model: model))
+        try await settleLayout()
+        XCTAssertFalse(visibleTextFields(in: try XCTUnwrap(window)).isEmpty)
+
+        selection.vault = TestStore.makeVault(pubKey: "defi-search-second")
+        try await settleLayout()
+
+        XCTAssertTrue(visibleTextFields(in: try XCTUnwrap(window)).isEmpty)
+        XCTAssertEqual(model.searchText, "")
+        assertAtTop(try verticalScrollView(), tab: .defi)
+    }
+
+    func testRemovingSelectedDefiTabRestoresWallet() async throws {
+        let tabs = TabSelection()
+        tabs.selected = .defi
+        try host(TabSelectionContent(model: tabs))
+        try await settleLayout()
+        XCTAssertEqual(tabs.selected, .defi)
+
+        tabs.items = [.wallet]
+        try await settleLayout()
+
+        XCTAssertEqual(tabs.selected, .wallet)
+    }
+
+    func testTabbedVaultSwitchDoesNotTemporarilyCollapseBalances() async throws {
+        let selection = VaultSelection(vault: TestStore.makeVault(pubKey: "tabs-first"))
+        let tabs = TabSelection()
+        var values: [Double] = []
+        let wallet = collapse.$wallet.sink { values.append($0.value) }
+        let defi = collapse.$defi.sink { values.append($0.value) }
+        defer { wallet.cancel(); defi.cancel() }
+        try host(TabbedVaultContent(selection: selection, tabs: tabs, collapse: collapse)
+            .environmentObject(LocalWalletModel() as VaultDetailViewModel)
+            .environmentObject(CoinSelectionViewModel()))
+        try await settleLayout()
+        tabs.selected = .defi
+        try await settleLayout()
+        selection.vault = TestStore.makeVault(pubKey: "tabs-second")
+        try await settleLayout()
+        XCTAssertEqual(tabs.selected, .defi)
+        tabs.selected = .wallet
+        try await settleLayout()
+        tabs.selected = .defi
+        try await settleLayout()
+
+        XCTAssertTrue(values.allSatisfy { $0 == 0 }, "Unexpected collapse during tab layout: \(values)")
+    }
+
+    private func visibleTextFields(in view: UIView) -> [UITextField] {
+        // Lazy containers may retain a removed field in an invisible subtree.
+        guard !view.isHidden, view.alpha > 0 else { return [] }
+        if let field = view as? UITextField { return [field] }
+        return view.subviews.flatMap { visibleTextFields(in: $0) }
+    }
+
+    private func makeVault(_ name: String) -> Vault {
+        let vault = TestStore.makeVault(pubKey: name)
+        let chains: [Chain] = [
+            .bitcoin, .ethereum, .solana, .thorChain, .litecoin,
+            .dogecoin, .avalanche, .base, .arbitrum, .polygon
+        ]
+        vault.coins = chains.map { chain in
+            let asset = CoinMeta(
+                chain: chain, ticker: chain.ticker, logo: "", decimals: 8,
+                priceProviderId: "", contractAddress: "", isNativeToken: true
+            )
+            return Coin(asset: asset, address: "fixture-\(name)-\(chain.name)", hexPublicKey: "")
+        }
+        return vault
+    }
+
+    private func hostWallet(
+        _ selection: VaultSelection, model: LocalWalletModel? = nil, startsInSearch: Bool = false
+    ) throws {
+        try host(WalletContent(selection: selection, collapse: collapse, startsInSearch: startsInSearch)
+            .environmentObject((model ?? LocalWalletModel()) as VaultDetailViewModel)
+            .environmentObject(CoinSelectionViewModel()))
+    }
+
+    private func host(_ content: some View) throws {
+        let token = try XCTUnwrap(token)
+        let scene = try XCTUnwrap(UIApplication.shared.connectedScenes.first as? UIWindowScene)
+        previousKeyWindow = scene.windows.first(where: \.isKeyWindow)
+        let controller = UIHostingController(rootView: NavigationStack {
+            content
+                .frame(width: 390, height: 600)
+                .customNavigationBarHidden()
+        }
+        .modelContainer(token.container)
+        .environmentObject(HomeViewModel())
+        .environmentObject(SettingsViewModel.shared)
+        .environmentObject(PushNotificationManager.shared)
+        .environmentObject(AppViewModel.shared)
+        .environmentObject(DeeplinkViewModel())
+        .environmentObject(PhoneCheckUpdateViewModel())
+        .environmentObject(SheetPresentedCounterManager()))
+        let window = UIWindow(windowScene: scene)
+        window.rootViewController = controller
+        self.window = window
+        window.makeKeyAndVisible()
+    }
+
+    private func scrollDown(tab: HomeTab) async throws -> UIScrollView {
+        try await settleLayout()
+        let scroll = try verticalScrollView()
+        let distance = HeaderCollapseProgress.distance(for: tab)
+        let target = distance + 20
+        let scrollableDistance = scroll.contentSize.height - scroll.bounds.height
+            + scroll.adjustedContentInset.top + scroll.adjustedContentInset.bottom
+        XCTAssertGreaterThan(scrollableDistance, target)
+        scroll.setContentOffset(CGPoint(x: 0, y: target - scroll.adjustedContentInset.top), animated: false)
+        try await settleLayout()
+        XCTAssertGreaterThan(scroll.contentOffset.y + scroll.adjustedContentInset.top, distance)
+        XCTAssertEqual(collapse.progress(for: tab).value, 1)
+        return scroll
+    }
+
+    private func verticalScrollView() throws -> UIScrollView {
+        let window = try XCTUnwrap(window)
+        return try XCTUnwrap(scrollViews(in: window).first)
+    }
+
+    private func scrollViews(in view: UIView) -> [UIScrollView] {
+        if let scroll = view as? UIScrollView { return [scroll] }
+        return view.subviews.flatMap { scrollViews(in: $0) }
+    }
+
+    private func assertAtTop(_ scroll: UIScrollView, tab: HomeTab, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(scroll.contentOffset.y + scroll.adjustedContentInset.top, 0, accuracy: 1, file: file, line: line)
+        XCTAssertEqual(collapse.progress(for: tab).value, 0, file: file, line: line)
+    }
+
+    private func settleLayout() async throws {
+        // Let SwiftUI's lazy layout and the carousel's entrance animation settle.
+        try await Task.sleep(for: .milliseconds(600))
+        window?.layoutIfNeeded()
+    }
+}
+
+@MainActor
+private final class VaultSelection: ObservableObject {
+    @Published var vault: Vault
+    init(vault: Vault) { self.vault = vault }
+}
+
+private struct WalletContent: View {
+    @ObservedObject var selection: VaultSelection
+    let collapse: HomeHeaderCollapse
+    var startsInSearch = false
+
+    var body: some View {
+        VaultMainScreen(
+            vault: selection.vault, routeToPresent: .constant(nil), addressToCopy: .constant(nil),
+            showUpgradeVaultSheet: .constant(false), showBackupNow: .constant(false),
+            collapse: collapse, shouldRefresh: .constant(false), onCamera: {},
+            showSearchHeader: startsInSearch, focusSearch: startsInSearch
+        )
+    }
+}
+
+private struct DefiContent: View {
+    @ObservedObject var selection: VaultSelection
+    let collapse: HomeHeaderCollapse
+
+    var body: some View {
+        DefiMainScreen(vault: selection.vault, collapse: collapse)
+    }
+}
+
+/// Keep actual rows and banners but replace remote refreshes with local projections.
+@MainActor
+private final class LocalWalletModel: VaultDetailViewModel {
+    override func updateBalance(vault: Vault) { groupChains(vault: vault) }
+    override func setupBanners(for _: Vault) { vaultBanners = [.followVultisig] }
+    override func getGroupAsync(_: CoinSelectionViewModel) {}
+}
+
+@MainActor
+private final class TabSelection: ObservableObject {
+    @Published var selected: HomeTab = .wallet
+    @Published var items: [HomeTab] = [.wallet, .defi]
+}
+
+private struct TabSelectionContent: View {
+    @ObservedObject var model: TabSelection
+
+    var body: some View {
+        VultiTabBar(selectedItem: $model.selected, items: model.items, accessory: .camera) { tab in
+            Text(tab.name)
+        } onAccessory: {}
+    }
+}
+
+private struct TabbedVaultContent: View {
+    @ObservedObject var selection: VaultSelection
+    @ObservedObject var tabs: TabSelection
+    let collapse: HomeHeaderCollapse
+
+    var body: some View {
+        VultiTabBar(selectedItem: $tabs.selected, items: tabs.items, accessory: .camera) { tab in
+            switch tab {
+            case .wallet: WalletContent(selection: selection, collapse: collapse)
+            case .defi: DefiContent(selection: selection, collapse: collapse)
+            case .camera: EmptyView()
+            }
+        } onAccessory: {}
+    }
+}
+
+private struct DefiSearchContent: View {
+    @ObservedObject var selection: VaultSelection
+    let collapse: HomeHeaderCollapse
+    let model: DefiMainViewModel
+
+    var body: some View {
+        DefiMainScreen(
+            vault: selection.vault, collapse: collapse,
+            showSearchHeader: true, focusSearch: true, viewModel: model
+        )
+    }
+}

--- a/VultisigApp/VultisigAppTests/Navigation/NavigationRouterTests.swift
+++ b/VultisigApp/VultisigAppTests/Navigation/NavigationRouterTests.swift
@@ -1,0 +1,53 @@
+import Combine
+import SwiftUI
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class NavigationRouterTests: XCTestCase {
+    func testReturningToEmptyRootDoesNotPublish() {
+        let router = NavigationRouter()
+        var updates = 0
+        let subscription = router.$navPath.dropFirst().sink { _ in updates += 1 }
+        defer { subscription.cancel() }
+
+        router.navigateToRoot()
+        router.navigateToRoot()
+
+        XCTAssertTrue(router.navPath.isEmpty)
+        XCTAssertEqual(updates, 0)
+    }
+
+    func testReturningToRootPublishesOnceAndClearsThePath() {
+        let router = NavigationRouter()
+        router.navigate(to: "first")
+        router.navigate(to: "second")
+        var updates = 0
+        let subscription = router.$navPath.dropFirst().sink { _ in updates += 1 }
+        defer { subscription.cancel() }
+
+        router.navigateToRoot()
+        router.navigateToRoot()
+
+        XCTAssertTrue(router.navPath.isEmpty)
+        XCTAssertEqual(updates, 1)
+    }
+
+    func testReturningToRootClearsMatchingNavigationHistory() {
+        let router = NavigationRouter()
+        router.navigate(to: "oldRoute")
+        router.navigate(to: "oldDetail")
+        router.navigateToRoot()
+        router.navigate(to: "newRoute")
+        router.navigate(to: "newDetail")
+
+        // A retired route must use the no-match fallback, going back one step.
+        // Stale history would calculate a removal count larger than the path.
+        router.navigateBack { ($0 as? String) == "oldRoute" }
+
+        XCTAssertEqual(router.navPath.count, 1)
+        router.navigateBack()
+        XCTAssertTrue(router.navPath.isEmpty)
+    }
+
+}

--- a/VultisigApp/VultisigAppTests/Navigation/ScrollOffsetPreferenceKeyTests.swift
+++ b/VultisigApp/VultisigAppTests/Navigation/ScrollOffsetPreferenceKeyTests.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+import XCTest
+@testable import VultisigApp
+
+final class ScrollOffsetPreferenceKeyTests: XCTestCase {
+    func testIdenticalLayoutPassesKeepTheSameOffset() {
+        for _ in 0..<20 {
+            var value = ScrollOffsetPreferenceKey.defaultValue
+            ScrollOffsetPreferenceKey.reduce(value: &value) { -80 }
+            XCTAssertEqual(value, -80)
+        }
+    }
+
+    func testIndependentScrollViewsDoNotSuppressEachOther() {
+        var first = ScrollOffsetPreferenceKey.defaultValue
+        var second = ScrollOffsetPreferenceKey.defaultValue
+
+        ScrollOffsetPreferenceKey.reduce(value: &first) { -80 }
+        ScrollOffsetPreferenceKey.reduce(value: &second) { 125 }
+
+        XCTAssertEqual(first, -80)
+        XCTAssertEqual(second, 125)
+    }
+
+    func testDefaultValueDoesNotChangeAnExistingOffset() {
+        var value: CGFloat = -80
+
+        ScrollOffsetPreferenceKey.reduce(value: &value) { ScrollOffsetPreferenceKey.defaultValue }
+
+        XCTAssertEqual(value, -80)
+    }
+
+    func testSiblingOffsetsAreCombinedWithoutDroppingValues() {
+        var value = ScrollOffsetPreferenceKey.defaultValue
+
+        ScrollOffsetPreferenceKey.reduce(value: &value) { 12 }
+        ScrollOffsetPreferenceKey.reduce(value: &value) { -5 }
+        ScrollOffsetPreferenceKey.reduce(value: &value) { 9 }
+
+        XCTAssertEqual(value, 16)
+    }
+}


### PR DESCRIPTION
## Description

Switching vaults could retain Home's previous scroll position and collapsed header, hiding the new vault's large balance. Give each vault its own Wallet/DeFi scroll viewport, publish its initial geometry, and clear the previous vault's open search and query. If the new vault has no DeFi tab, select the remaining Wallet tab so the header follows the displayed content. Same-vault refreshes preserve scrolling, and a still-available DeFi selection stays selected.

Selecting a vault with a navigation-restart request also changed two observed signals, resetting Home twice. Consume only the restart request, avoid unchanged root-state writes, and leave an empty navigation path untouched while always clearing route history.

The chain-picker offset reducer used one shared clock across every scroll view and reduction pass: identical inputs could produce `-80` followed by `0`. Use deterministic additive reduction with a zero identity, and skip unchanged offset-binding writes.

Related to #4470. These correct independently measured defects. The original macOS layout hang remains unlocalized, so the issue should stay open.

## Which feature is affected?

- Home Wallet/DeFi tabs, vault selection, and navigation back to Home.
- [x] Swap — chain-picker scrolling only; transaction construction and signing are unchanged. No swap transaction was submitted for these UI corrections.

## Parity

- Android: n/a — SwiftUI navigation, scroll-view lifecycle, and preference reduction.
- Windows + extension: n/a — SwiftUI navigation, scroll-view lifecycle, and preference reduction.
- SDK: n/a — app UI only; no shared transaction, signing, or fee behavior changed.

## Validation

Verified at `bdd4d6fd78deff2db45e762803b92ff5ad52a699`:

- Full iOS suite: **7,036 tests; 7,024 passed, 1 expected failure, 11 skipped, 0 unexpected failures**. iPhone 17 simulator, iOS 26.5, English/en_US. Fresh xcresult reports Passed.
- 16 new regression tests: seven navigation/reducer tests and nine hosted runtime tests using actual Wallet/DeFi/TabBar views with isolated in-memory fixtures.
- Hosted tests cover switching while scrolled, short/long content from the top, same-vault refresh preservation, initial header geometry, clearing Wallet/DeFi search, removing the selected DeFi tab, and every collapse publication across tab/vault transitions.
- Before/after: original scroll code fails the Wallet, DeFi, and initial-geometry tests; the added search/tab cases reproduced both review findings before their corrections. All nine current runtime tests pass.
- Native macOS scroll-component probe: switching retains a 220-point offset before the correction and returns to 0 afterward. Earlier native navigation/picker probes confirm two Home resets become one and identical `-80` reductions remain `-80`.
- macOS build and static analysis passed. SwiftLint matches the 27-warning baseline, with no new warnings or warnings in changed files.
- Per-commit and whole-branch read-only Claude reviews completed; findings verified and triaged, with search/tab corrections covered by runtime tests.

These isolated runtime checks do not reproduce the original app hang.

**Remaining manual check:** physical 120 Hz iPhone picker scrolling, haptic feel, and performance before release, including per-offset work-item allocation/cancellation. The existing 150 ms debounce covers scroll settlement, not all per-offset processing.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Agent Metadata

- **Agent**: Codex; read-only cross-model review by Claude
- **Issue**: Related to #4470; remains open
- **Confidence**: High for the measured navigation, picker, and vault-switch defects; the original hang's cause remains unknown
- **Needs human review for**: 120 Hz iPhone picker scrolling, haptics, and performance before release


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved navigation reset behavior when returning to the home screen.
  - Fixed tab selection so it falls back to the first available tab when the current tab is no longer present.
  - Improved scroll position and header behavior when switching between vaults.
  - Search state now clears appropriately when changing vaults.
  - Improved initial scroll and header positioning for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->