### PR TITLE
fix(settings): reuse VultiToggle for App Lock controls

### DIFF
--- a/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/ManagePasscodeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/ManagePasscodeScreen.swift
@@ -182,10 +182,8 @@ struct ManagePasscodeScreen: View {
 
             Spacer()
 
-            Toggle("", isOn: isOn)
+            VultiToggle(isOn: isOn)
                 .labelsHidden()
-                .tint(Theme.colors.primaryAccent4)
-                .fixedSize()
         }
         .padding(16)
         .contentShape(Rectangle())


### PR DESCRIPTION
## Description

Closes #5336.

Replace the plain `Toggle` in `ManagePasscodeScreen.toggleRow` with the existing `VultiToggle`. Both App Lock Passcode and biometric unlock now share the app's switch styling, accent tint, and sizing instead of macOS's default checkbox.

The existing bindings, hidden labels, and biometric accessibility identifier are retained. No changes to setup/disable confirmation, biometric authentication, backup, or encryption logic. The shared screen uses the component on both iOS and macOS.

## Verification

- macOS build: passed (`make build-check BUILD_DESTINATION='platform=macOS'`).
- Full iOS unit suite: passed (`make test DESTINATION='platform=iOS Simulator,id=8BDE8B65-F137-466A-B070-A34B9FDBB807'`): 7,020 tests, 11 skipped, 0 failures.
- Full SwiftLint: 27 existing warnings, 0 serious violations; no new warnings.
- Isolated macOS runtime probe compiled the production `VultiToggle`: confirmed the old control renders as a button/checkbox and the shared control as a native switch, in both off/on states. Programmatic clicks verified that enable/disable requests reach a gated binding without committing the underlying state. The probe used a stand-in theme and did not access wallet data; this was not an end-to-end Security flow test.
- `git diff --check`: passed.
- Disk check: 17 GiB free before the gate sequence, 12 GiB after (lowest observed 9.2 GiB).

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Existing full tests and focused runtime verification cover this UI-only replacement

## Agent Metadata

- **Agent**: Codex
- **Issue**: #5336
- **Confidence**: high
- **Needs human review for**: final macOS visual acceptance
- Claude review omitted as requested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the passcode management screen’s toggle control to use the app’s standard toggle styling.
  * Removed custom accent color and fixed sizing so the control follows the shared design system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->