### PR TITLE
fix(polkadot): cache zero balance for never-funded accounts

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Polkadot/Service/PolkadotService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Polkadot/Service/PolkadotService.swift
@@ -59,7 +59,11 @@ class PolkadotService: RpcService {
             return hex
         }
 
+        // An empty result means the account has never held a balance on-chain
+        // (no `System.Account` entry). Cache the zero so a never-funded address
+        // doesn't bypass the cache and re-hit the RPC on every balance refresh.
         guard !result.isEmpty else {
+            self.cachePolkadotBalance.set(cacheKey, (data: BigInt.zero, timestamp: Date()))
             return BigInt.zero
         }
 
@@ -70,7 +74,10 @@ class PolkadotService: RpcService {
         // the misc_frozen/fee_frozen -> frozen/flags runtime migration since
         // `free` is always the first AccountData field.
         let hex = result.stripHexPrefix()
-        guard hex.count >= 64 else { return BigInt.zero }
+        guard hex.count >= 64 else {
+            self.cachePolkadotBalance.set(cacheKey, (data: BigInt.zero, timestamp: Date()))
+            return BigInt.zero
+        }
 
         // free balance at bytes 16-31 (hex chars 32-63), u128 little-endian
         let freeHex = String(hex[hex.index(hex.startIndex, offsetBy: 32)..<hex.index(hex.startIndex, offsetBy: 64)])


### PR DESCRIPTION
## Summary
- The macOS app was repeatedly hitting `https://api.vultisig.com/dot/` for Polkadot balance checks. Root cause: `PolkadotService.fetchBalance` only wrote to its 60s cache on the success path — any address with no on-chain `System.Account` entry (never funded) or a malformed/short SCALE response returned `BigInt.zero` without caching, so it re-hit the RPC on every balance refresh (`VaultMainScreen`'s `throttledOnAppear` fires every 15s, and `onAppear` recurs often on macOS due to window focus changes).
- Both early-return paths now cache the zero balance for 60s like the success path, bringing a never-funded DOT account's request rate in line with every other case.

## Test Plan
- [x] `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — no new violations (file lints clean)
- [ ] Manual: add a Polkadot chain with a never-funded address, confirm requests to `api.vultisig.com/dot/` stop repeating within the 60s cache window

https://claude.ai/code/session_01XL4YcWGr7QgaXbT9hGKVre

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved balance handling for accounts with no funds or incomplete account data.
  - Prevented repeated network requests when a zero balance is confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->