### PR TITLE
fix(swap): carry the native swap fee to the co-signer

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
@@ -220,10 +220,11 @@ extension ERC20ApprovePayload {
     }
 }
 
-/// Receivers read an absent or empty `fee` as "legacy sender, render no row",
-/// so a nil or a zero must leave the field unset rather than write `"0"`.
+/// `fee` has implicit presence, so an unset field and a `"0"` are distinguishable
+/// on the wire and mean different things: unknown versus a route that charges
+/// nothing. Only a nil leaves the field unset; `"0"` is written like any value.
 private func writeNativeSwapFee(_ fee: String?, to proto: inout VSTHORChainSwapPayload) {
-    guard let fee = fee?.nilIfEmpty, fee != "0" else { return }
+    guard let fee = fee?.nilIfEmpty else { return }
     proto.fee = fee
 }
 

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
@@ -220,10 +220,8 @@ extension ERC20ApprovePayload {
     }
 }
 
-/// Explicit presence for the native swap fee: receivers read an absent or empty
-/// `fee` as "legacy sender → render no fee row", so a nil or a zero must leave
-/// the field untouched rather than write `"0"`. That is also what stops a
-/// relayed legacy payload from gaining a fee its sender never stated.
+/// Receivers read an absent or empty `fee` as "legacy sender, render no row",
+/// so a nil or a zero must leave the field unset rather than write `"0"`.
 private func writeNativeSwapFee(_ fee: String?, to proto: inout VSTHORChainSwapPayload) {
     guard let fee = fee?.nilIfEmpty, fee != "0" else { return }
     proto.fee = fee

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
@@ -220,6 +220,15 @@ extension ERC20ApprovePayload {
     }
 }
 
+/// Explicit presence for the native swap fee: receivers read an absent or empty
+/// `fee` as "legacy sender → render no fee row", so a nil or a zero must leave
+/// the field untouched rather than write `"0"`. That is also what stops a
+/// relayed legacy payload from gaining a fee its sender never stated.
+private func writeNativeSwapFee(_ fee: String?, to proto: inout VSTHORChainSwapPayload) {
+    guard let fee = fee?.nilIfEmpty, fee != "0" else { return }
+    proto.fee = fee
+}
+
 extension SwapPayload {
     init(proto: VSKeysignPayload.OneOf_SwapPayload) throws {
         switch proto {
@@ -236,7 +245,8 @@ extension SwapPayload {
                 streamingInterval: value.streamingInterval,
                 streamingQuantity: value.streamingQuantity,
                 expirationTime: value.expirationTime,
-                isAffiliate: value.isAffiliate
+                isAffiliate: value.isAffiliate,
+                fee: value.fee.nilIfEmpty
             ))
         case .mayachainSwapPayload(let value):
             self = .mayachain(THORChainSwapPayload(
@@ -251,7 +261,8 @@ extension SwapPayload {
                 streamingInterval: value.streamingInterval,
                 streamingQuantity: value.streamingQuantity,
                 expirationTime: value.expirationTime,
-                isAffiliate: value.isAffiliate
+                isAffiliate: value.isAffiliate,
+                fee: value.fee.nilIfEmpty
             ))
         case .oneinchSwapPayload(let value):
             // `has*` guards distinguish "legacy sender, context unknown"
@@ -335,6 +346,7 @@ extension SwapPayload {
                 $0.streamingQuantity = payload.streamingQuantity
                 $0.expirationTime = payload.expirationTime
                 $0.isAffiliate = payload.isAffiliate
+                writeNativeSwapFee(payload.fee, to: &$0)
             })
         case .mayachain(let payload):
             return .mayachainSwapPayload(.with {
@@ -350,6 +362,7 @@ extension SwapPayload {
                 $0.streamingQuantity = payload.streamingQuantity
                 $0.expirationTime = payload.expirationTime
                 $0.isAffiliate = payload.isAffiliate
+                writeNativeSwapFee(payload.fee, to: &$0)
             })
         case .generic(let payload):
             return .oneinchSwapPayload(.with {

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/THORChainSwapPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/THORChainSwapPayload.swift
@@ -45,13 +45,10 @@ struct THORChainSwapPayload: Codable, Hashable {
     let streamingQuantity: String
     let expirationTime: UInt64
     let isAffiliate: Bool
-    /// Provider-side swap fee, so a co-signer holding only this payload can show
-    /// what the swap costs instead of the network fee alone. A raw integer in the
-    /// destination coin's native-swap fixed point (`toCoin.thorswapMultiplier`) —
-    /// native routes charge in the output asset, so `toCoin` is the fee coin and
-    /// no separate coin context has to travel. `nil` from a sender that quotes no
-    /// fee (limit orders, synthesized deposits) or pre-dates the field; consumers
-    /// render no row rather than a definite zero. Display only: no signer reads it.
+    /// Provider-side swap fee, for a co-signer that holds no quote. A raw integer
+    /// in the destination coin's native-swap fixed point (`toCoin.thorswapMultiplier`):
+    /// native routes charge in the output asset, so `toCoin` is the fee coin and no
+    /// coin context travels. `nil` means unknown, and renders no row. Display only.
     var fee: String? = nil
 
     var toAddress: String {

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/THORChainSwapPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/THORChainSwapPayload.swift
@@ -48,7 +48,9 @@ struct THORChainSwapPayload: Codable, Hashable {
     /// Provider-side swap fee, for a co-signer that holds no quote. A raw integer
     /// in the destination coin's native-swap fixed point (`toCoin.thorswapMultiplier`):
     /// native routes charge in the output asset, so `toCoin` is the fee coin and no
-    /// coin context travels. `nil` means unknown, and renders no row. Display only.
+    /// coin context travels. `"0"` is a route that charges nothing and renders
+    /// `$0.00`; `nil` is a sender that stated nothing and renders no row.
+    /// Display only.
     var fee: String? = nil
 
     var toAddress: String {

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/THORChainSwapPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/THORChainSwapPayload.swift
@@ -45,6 +45,14 @@ struct THORChainSwapPayload: Codable, Hashable {
     let streamingQuantity: String
     let expirationTime: UInt64
     let isAffiliate: Bool
+    /// Provider-side swap fee, so a co-signer holding only this payload can show
+    /// what the swap costs instead of the network fee alone. A raw integer in the
+    /// destination coin's native-swap fixed point (`toCoin.thorswapMultiplier`) —
+    /// native routes charge in the output asset, so `toCoin` is the fee coin and
+    /// no separate coin context has to travel. `nil` from a sender that quotes no
+    /// fee (limit orders, synthesized deposits) or pre-dates the field; consumers
+    /// render no row rather than a definite zero. Display only: no signer reads it.
+    var fee: String? = nil
 
     var toAddress: String {
         return toCoin.address

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignGasViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignGasViewModel.swift
@@ -28,9 +28,15 @@ struct JoinKeysignGasViewModel {
 
     /// `nil` when nothing prices the fee coin, so a caller summing this never
     /// absorbs an unpriced leg as free.
-    func networkFeeFiat(payload: KeysignPayload) -> Decimal? {
+    func networkFeeFiat(payload: KeysignPayload, vault: Vault? = nil) -> Decimal? {
         guard let resolved = resolveNetworkFee(payload: payload) else { return nil }
-        return feeFiat(coin: payload.coin, fee: resolved.amount)
+        // Gas is always paid in the native coin. A priced source token cannot
+        // stand in for an unavailable native rate, even on the same chain.
+        let feeCoin = vault?.nativeCoin(for: payload.coin.chain)?.toCoinMeta()
+            ?? (payload.coin.isNativeToken ? payload.coin.toCoinMeta() : resolved.nativeToken)
+        guard let rate = RateProvider.shared.rate(for: feeCoin) else { return nil }
+        let amount = Decimal(resolved.amount) / pow(10, resolved.nativeToken.decimals)
+        return RateProvider.shared.fiatBalance(value: amount, rate: rate)
     }
 
     private func resolveNetworkFee(payload: KeysignPayload) -> ResolvedNetworkFee? {
@@ -110,18 +116,6 @@ struct JoinKeysignGasViewModel {
         let feeDecimal = coin.decimal(for: fee)
         // Use fee-specific formatting with more decimal places (5 instead of 2)
         return RateProvider.shared.fiatFeeString(value: feeDecimal, coin: coin)
-    }
-
-    /// Unformatted twin of `feesInReadable`, same coin preference, but `nil`
-    /// rather than a `$0.00` when neither coin has a rate.
-    private func feeFiat(coin: Coin, fee: BigInt) -> Decimal? {
-        if let vaultNativeCoin = AppViewModel.shared.selectedVault?.nativeCoin(for: coin.chain),
-           let rate = RateProvider.shared.rate(for: vaultNativeCoin) {
-            return RateProvider.shared.fiatBalance(value: vaultNativeCoin.decimal(for: fee), rate: rate)
-        }
-
-        guard let rate = RateProvider.shared.rate(for: coin) else { return nil }
-        return RateProvider.shared.fiatBalance(value: coin.decimal(for: fee), rate: rate)
     }
 
     private func calculateUTXOTotalFee(payload: KeysignPayload) -> BigInt? {

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignGasViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignGasViewModel.swift
@@ -11,8 +11,6 @@ import BigInt
 // TODO: - Extend and reuse for both on-device and co-pairing signing
 struct JoinKeysignGasViewModel {
 
-    /// The network fee a payload resolves to, before formatting: the amount in
-    /// the fee coin's smallest units plus the coin that names and prices it.
     private struct ResolvedNetworkFee {
         let amount: BigInt
         let nativeToken: CoinMeta
@@ -28,11 +26,8 @@ struct JoinKeysignGasViewModel {
         return ("\(gasInReadable) \(resolved.nativeToken.ticker)", feeInReadable)
     }
 
-    /// Fiat value of the same fee `getCalculatedNetworkFee` formats, as a
-    /// `Decimal` so a caller can add it to another fee. `nil` when nothing
-    /// prices the fee coin: a total that silently absorbed an unpriced leg
-    /// would understate the transaction, which is the failure a total row
-    /// exists to prevent.
+    /// `nil` when nothing prices the fee coin, so a caller summing this never
+    /// absorbs an unpriced leg as free.
     func networkFeeFiat(payload: KeysignPayload) -> Decimal? {
         guard let resolved = resolveNetworkFee(payload: payload) else { return nil }
         return feeFiat(coin: payload.coin, fee: resolved.amount)
@@ -117,11 +112,8 @@ struct JoinKeysignGasViewModel {
         return RateProvider.shared.fiatFeeString(value: feeDecimal, coin: coin)
     }
 
-    /// Unformatted twin of `feesInReadable`, for callers that have to sum the
-    /// fee rather than print it. Same coin preference — the vault's own coin
-    /// first for its up-to-date price data, the payload coin as the fallback —
-    /// but `nil` instead of a `$0.00` when neither has a rate, so an unpriced
-    /// fee is dropped from a total rather than counted as free.
+    /// Unformatted twin of `feesInReadable`, same coin preference, but `nil`
+    /// rather than a `$0.00` when neither coin has a rate.
     private func feeFiat(coin: Coin, fee: BigInt) -> Decimal? {
         if let vaultNativeCoin = AppViewModel.shared.selectedVault?.nativeCoin(for: coin.chain),
            let rate = RateProvider.shared.rate(for: vaultNativeCoin) {

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignGasViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignGasViewModel.swift
@@ -10,11 +10,39 @@ import BigInt
 
 // TODO: - Extend and reuse for both on-device and co-pairing signing
 struct JoinKeysignGasViewModel {
+
+    /// The network fee a payload resolves to, before formatting: the amount in
+    /// the fee coin's smallest units plus the coin that names and prices it.
+    private struct ResolvedNetworkFee {
+        let amount: BigInt
+        let nativeToken: CoinMeta
+    }
+
     func getCalculatedNetworkFee(payload: KeysignPayload) -> (feeCrypto: String, feeFiat: String) {
+        guard let resolved = resolveNetworkFee(payload: payload) else {
+            return (.empty, .empty)
+        }
+        let gasAmount = Decimal(resolved.amount) / pow(10, resolved.nativeToken.decimals)
+        let gasInReadable = gasAmount.formatToDecimal(digits: resolved.nativeToken.decimals)
+        let feeInReadable = feesInReadable(coin: payload.coin, fee: resolved.amount)
+        return ("\(gasInReadable) \(resolved.nativeToken.ticker)", feeInReadable)
+    }
+
+    /// Fiat value of the same fee `getCalculatedNetworkFee` formats, as a
+    /// `Decimal` so a caller can add it to another fee. `nil` when nothing
+    /// prices the fee coin: a total that silently absorbed an unpriced leg
+    /// would understate the transaction, which is the failure a total row
+    /// exists to prevent.
+    func networkFeeFiat(payload: KeysignPayload) -> Decimal? {
+        guard let resolved = resolveNetworkFee(payload: payload) else { return nil }
+        return feeFiat(coin: payload.coin, fee: resolved.amount)
+    }
+
+    private func resolveNetworkFee(payload: KeysignPayload) -> ResolvedNetworkFee? {
         guard let nativeToken = TokensStore.TokenSelectionAssets.first(where: {
             $0.isNativeToken && $0.chain == payload.coin.chain
         }) else {
-            return (.empty, .empty)
+            return nil
         }
 
         // When the dApp supplied explicit fee data via signAmino (e.g. Rujira
@@ -23,11 +51,7 @@ struct JoinKeysignGasViewModel {
         // non-zero network fee when the chain actually charges nothing.
         // Parity with vultisig-windows PR #3843.
         if let dappFee = payload.dappSuppliedCosmosFee() {
-            let dappFeeBigInt = BigInt(dappFee)
-            let gasAmount = Decimal(dappFee) / pow(10, nativeToken.decimals)
-            let gasInReadable = gasAmount.formatToDecimal(digits: nativeToken.decimals)
-            let feeInReadable = feesInReadable(coin: payload.coin, fee: dappFeeBigInt)
-            return ("\(gasInReadable) \(nativeToken.ticker)", feeInReadable)
+            return ResolvedNetworkFee(amount: BigInt(dappFee), nativeToken: nativeToken)
         }
 
         if payload.coin.chainType == .EVM {
@@ -49,13 +73,7 @@ struct JoinKeysignGasViewModel {
                     gasLimit: gasLimit
                 ).feeWei
             }
-            let gasAmount = Decimal(totalFeeWei) / pow(10, nativeToken.decimals)
-            let gasInReadable = gasAmount.formatToDecimal(digits: nativeToken.decimals)
-
-            var feeInReadable = feesInReadable(coin: payload.coin, fee: totalFeeWei)
-            feeInReadable = feeInReadable.nilIfEmpty.map { $0 } ?? ""
-
-            return ("\(gasInReadable) \(nativeToken.ticker)", feeInReadable)
+            return ResolvedNetworkFee(amount: totalFeeWei, nativeToken: nativeToken)
         }
 
         // A Solana payload carrying an injected ComputeBudget pair costs
@@ -68,9 +86,7 @@ struct JoinKeysignGasViewModel {
            case .Solana(_, let priorityFee, let priorityLimit, _, _, _) = payload.chainSpecific,
            priorityFee > 0, priorityLimit > 0,
            let total = PrebuiltPayloadFee.fee(for: payload) {
-            let gasAmount = Decimal(total) / pow(10, nativeToken.decimals)
-            let gasInReadable = gasAmount.formatToDecimal(digits: nativeToken.decimals)
-            return ("\(gasInReadable) \(nativeToken.ticker)", feesInReadable(coin: payload.coin, fee: total))
+            return ResolvedNetworkFee(amount: total, nativeToken: nativeToken)
         }
 
         // For UTXO and Cardano chains, calculate total fee using WalletCore (like first device)
@@ -81,15 +97,7 @@ struct JoinKeysignGasViewModel {
             feeToUse = calculateCardanoTotalFee(payload: payload) ?? payload.chainSpecific.gas
         }
 
-        // Use the same fee for both crypto and fiat display for UTXO and Cardano chains
-        let gasAmountToDisplay = (payload.coin.chainType == .UTXO || payload.coin.chainType == .Cardano) ? feeToUse : payload.chainSpecific.gas
-        let gasAmount = Decimal(gasAmountToDisplay) / pow(10, nativeToken.decimals)
-        let gasInReadable = gasAmount.formatToDecimal(digits: nativeToken.decimals)
-
-        var feeInReadable = feesInReadable(coin: payload.coin, fee: feeToUse)
-        feeInReadable = feeInReadable.nilIfEmpty.map { $0 } ?? ""
-
-        return ("\(gasInReadable) \(nativeToken.ticker)", feeInReadable)
+        return ResolvedNetworkFee(amount: feeToUse, nativeToken: nativeToken)
     }
 
     func feesInReadable(coin: Coin, fee: BigInt) -> String {
@@ -107,6 +115,21 @@ struct JoinKeysignGasViewModel {
         let feeDecimal = coin.decimal(for: fee)
         // Use fee-specific formatting with more decimal places (5 instead of 2)
         return RateProvider.shared.fiatFeeString(value: feeDecimal, coin: coin)
+    }
+
+    /// Unformatted twin of `feesInReadable`, for callers that have to sum the
+    /// fee rather than print it. Same coin preference — the vault's own coin
+    /// first for its up-to-date price data, the payload coin as the fallback —
+    /// but `nil` instead of a `$0.00` when neither has a rate, so an unpriced
+    /// fee is dropped from a total rather than counted as free.
+    private func feeFiat(coin: Coin, fee: BigInt) -> Decimal? {
+        if let vaultNativeCoin = AppViewModel.shared.selectedVault?.nativeCoin(for: coin.chain),
+           let rate = RateProvider.shared.rate(for: vaultNativeCoin) {
+            return RateProvider.shared.fiatBalance(value: vaultNativeCoin.decimal(for: fee), rate: rate)
+        }
+
+        guard let rate = RateProvider.shared.rate(for: coin) else { return nil }
+        return RateProvider.shared.fiatBalance(value: coin.decimal(for: fee), rate: rate)
     }
 
     private func calculateUTXOTotalFee(payload: KeysignPayload) -> BigInt? {

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignSwapFeeViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignSwapFeeViewModel.swift
@@ -48,18 +48,14 @@ struct JoinKeysignSwapFeeViewModel {
         case let .generic(payload):
             return resolveGenericSwapFee(payload: payload, vault: vault)
         case .swapkit, .none:
-            // SwapKit's transfer routes keep their fee in a group of their own
-            // on the wire, which this payload shape does not carry yet.
+            // SwapKit keeps its fee in a wire group this payload shape lacks.
             return nil
         }
     }
 
-    /// Native THORChain/MayaChain routes charge in the destination asset, so the
-    /// payload's own `toCoin` is the fee coin — no coin context has to travel and
-    /// none has to be guessed. The amount is scaled by the same
-    /// `thorswapMultiplier` the rest of the native path reads quote amounts with
-    /// (1e8 for THORChain, the coin's own decimals for MayaChain), which is the
-    /// denomination every platform writes this field in.
+    /// Native routes charge in the destination asset, so `toCoin` is the fee coin.
+    /// Not `SwapCryptoLogic.swapFeeCoin`: native quotes carry no
+    /// `swapFeeTokenContract`, so it would fall through to the source gas coin.
     private func resolveNativeSwapFee(payload: THORChainSwapPayload) -> ResolvedSwapFee? {
         guard let rawFee = payload.fee?.nilIfEmpty,
               let amount = Decimal(string: rawFee),

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignSwapFeeViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignSwapFeeViewModel.swift
@@ -57,9 +57,11 @@ struct JoinKeysignSwapFeeViewModel {
     /// Not `SwapCryptoLogic.swapFeeCoin`: native quotes carry no
     /// `swapFeeTokenContract`, so it would fall through to the source gas coin.
     private func resolveNativeSwapFee(payload: THORChainSwapPayload) -> ResolvedSwapFee? {
+        // `>= 0`, not `> 0`: a stated zero renders a `$0.00` row to match the
+        // initiator. Only an absent fee hides the row.
         guard let rawFee = payload.fee?.nilIfEmpty,
               let amount = Decimal(string: rawFee),
-              amount > 0 else { return nil }
+              amount >= 0 else { return nil }
         let multiplier = payload.toCoin.thorswapMultiplier
         guard multiplier > 0 else { return nil }
         return ResolvedSwapFee(amount: amount / multiplier, coin: payload.toCoin.toCoinMeta())

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignSwapFeeViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignSwapFeeViewModel.swift
@@ -41,9 +41,35 @@ struct JoinKeysignSwapFeeViewModel {
     }
 
     func resolveSwapFee(swapPayload: SwapPayload?, vault: Vault?) -> ResolvedSwapFee? {
-        // Only general (1inch-shaped) swaps carry a bare swap-fee amount;
-        // other payload variants encode fees elsewhere.
-        guard case let .generic(payload) = swapPayload else { return nil }
+        switch swapPayload {
+        case let .thorchain(payload), let .thorchainChainnet(payload),
+             let .thorchainStagenet(payload), let .mayachain(payload):
+            return resolveNativeSwapFee(payload: payload)
+        case let .generic(payload):
+            return resolveGenericSwapFee(payload: payload, vault: vault)
+        case .swapkit, .none:
+            // SwapKit's transfer routes keep their fee in a group of their own
+            // on the wire, which this payload shape does not carry yet.
+            return nil
+        }
+    }
+
+    /// Native THORChain/MayaChain routes charge in the destination asset, so the
+    /// payload's own `toCoin` is the fee coin — no coin context has to travel and
+    /// none has to be guessed. The amount is scaled by the same
+    /// `thorswapMultiplier` the rest of the native path reads quote amounts with
+    /// (1e8 for THORChain, the coin's own decimals for MayaChain), which is the
+    /// denomination every platform writes this field in.
+    private func resolveNativeSwapFee(payload: THORChainSwapPayload) -> ResolvedSwapFee? {
+        guard let rawFee = payload.fee?.nilIfEmpty,
+              let amount = Decimal(string: rawFee),
+              amount > 0 else { return nil }
+        let multiplier = payload.toCoin.thorswapMultiplier
+        guard multiplier > 0 else { return nil }
+        return ResolvedSwapFee(amount: amount / multiplier, coin: payload.toCoin.toCoinMeta())
+    }
+
+    private func resolveGenericSwapFee(payload: GenericSwapPayload, vault: Vault?) -> ResolvedSwapFee? {
         guard let fee = BigInt(payload.quote.tx.swapFee), fee > 0 else { return nil }
 
         // Pre-context senders omit chain/decimals — render no row rather

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
@@ -799,14 +799,10 @@ class JoinKeysignViewModel: ObservableObject {
         swapFeeViewModel.getSwapFee(swapPayload: keysignPayload?.swapPayload, vault: vault)
     }
 
-    /// Total-fee row for the swap confirm screen — network fee plus swap fee, the
-    /// figure the initiator totals on its own verify screen. Formatted like the
-    /// initiator's (standard fiat precision), not like the itemized fee rows.
-    ///
-    /// nil unless BOTH legs price. A total that quietly dropped the swap fee is
-    /// the very number this row exists to correct, and a legacy payload carrying
-    /// no fee is indistinguishable from a route that charges none — so no row is
-    /// shown rather than one that understates the swap.
+    /// Network fee plus swap fee, formatted like the initiator's total rather
+    /// than like the itemized fee rows. `nil` unless BOTH legs price: a legacy
+    /// payload carrying no fee is indistinguishable from a route charging none,
+    /// so no row beats one that understates the swap.
     func getSwapTotalFee() -> String? {
         guard let keysignPayload,
               let networkFeeFiat = gasViewModel.networkFeeFiat(payload: keysignPayload),

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
@@ -809,11 +809,18 @@ class JoinKeysignViewModel: ObservableObject {
               let swapFee = swapFeeViewModel.resolveSwapFee(
                 swapPayload: keysignPayload.swapPayload,
                 vault: vault
-              ),
-              let rate = RateProvider.shared.rate(for: swapFee.coin) else {
+              ) else {
             return nil
         }
-        let swapFeeFiat = RateProvider.shared.fiatBalance(value: swapFee.amount, rate: rate)
+        // A stated zero is worth zero at any price, so it needs no rate. Only a
+        // non-zero leg has to be priced before it can enter a total.
+        let swapFeeFiat: Decimal
+        if swapFee.amount.isZero {
+            swapFeeFiat = .zero
+        } else {
+            guard let rate = RateProvider.shared.rate(for: swapFee.coin) else { return nil }
+            swapFeeFiat = RateProvider.shared.fiatBalance(value: swapFee.amount, rate: rate)
+        }
         return (networkFeeFiat + swapFeeFiat).formatToFiat(includeCurrencySymbol: true)
     }
 

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
@@ -808,7 +808,7 @@ class JoinKeysignViewModel: ObservableObject {
     /// row: nothing was claimed, so nothing can be totalled.
     func getSwapTotalFee() -> String? {
         guard let keysignPayload,
-              let networkFeeFiat = gasViewModel.networkFeeFiat(payload: keysignPayload),
+              let networkFeeFiat = gasViewModel.networkFeeFiat(payload: keysignPayload, vault: vault),
               let swapFee = swapFeeViewModel.resolveSwapFee(
                 swapPayload: keysignPayload.swapPayload,
                 vault: vault

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
@@ -799,6 +799,28 @@ class JoinKeysignViewModel: ObservableObject {
         swapFeeViewModel.getSwapFee(swapPayload: keysignPayload?.swapPayload, vault: vault)
     }
 
+    /// Total-fee row for the swap confirm screen — network fee plus swap fee, the
+    /// figure the initiator totals on its own verify screen. Formatted like the
+    /// initiator's (standard fiat precision), not like the itemized fee rows.
+    ///
+    /// nil unless BOTH legs price. A total that quietly dropped the swap fee is
+    /// the very number this row exists to correct, and a legacy payload carrying
+    /// no fee is indistinguishable from a route that charges none — so no row is
+    /// shown rather than one that understates the swap.
+    func getSwapTotalFee() -> String? {
+        guard let keysignPayload,
+              let networkFeeFiat = gasViewModel.networkFeeFiat(payload: keysignPayload),
+              let swapFee = swapFeeViewModel.resolveSwapFee(
+                swapPayload: keysignPayload.swapPayload,
+                vault: vault
+              ),
+              let rate = RateProvider.shared.rate(for: swapFee.coin) else {
+            return nil
+        }
+        let swapFeeFiat = RateProvider.shared.fiatBalance(value: swapFee.amount, rate: rate)
+        return (networkFeeFiat + swapFeeFiat).formatToFiat(includeCurrencySymbol: true)
+    }
+
     func getFromFiatAmount() -> String {
         guard let payload = keysignPayload?.swapPayload else { return .empty }
         let amount = payload.fromCoin.decimal(for: payload.fromAmount)

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
@@ -800,9 +800,12 @@ class JoinKeysignViewModel: ObservableObject {
     }
 
     /// Network fee plus swap fee, formatted like the initiator's total rather
-    /// than like the itemized fee rows. `nil` unless BOTH legs price: a legacy
-    /// payload carrying no fee is indistinguishable from a route charging none,
-    /// so no row beats one that understates the swap.
+    /// than like the itemized fee rows.
+    ///
+    /// The network leg must price, and so must a non-zero swap leg — a total that
+    /// absorbed an unpriced fee would understate the swap. A STATED zero is worth
+    /// zero at any price and needs no rate. An ABSENT fee still suppresses the
+    /// row: nothing was claimed, so nothing can be totalled.
     func getSwapTotalFee() -> String? {
         guard let keysignPayload,
               let networkFeeFiat = gasViewModel.networkFeeFiat(payload: keysignPayload),

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignSwapConfirmView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignSwapConfirmView.swift
@@ -53,6 +53,11 @@ struct KeysignSwapConfirmView: View {
 
             separator
             getNetworkFeeCell()
+
+            if let totalFee = viewModel.getSwapTotalFee() {
+                separator
+                getValueCell(for: "totalFee", with: totalFee)
+            }
         }
         .padding(16)
         .background(Theme.colors.bgSurface1)

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
@@ -198,8 +198,35 @@ extension SwapCryptoLogic {
             streamingInterval: memoTerms.streamingInterval,
             streamingQuantity: memoTerms.streamingQuantity,
             expirationTime: UInt64(expirationTime.timeIntervalSince1970),
-            isAffiliate: SwapCryptoLogic.isAffiliate
+            isAffiliate: SwapCryptoLogic.isAffiliate,
+            fee: nativeSwapPayloadFee(quote: quote)
         )
+    }
+
+    /// The provider-side swap fee to carry on the keysign payload, as a raw
+    /// integer in the units the quote already reports it in — the destination
+    /// coin's native-swap fixed point (`toCoin.thorswapMultiplier`). Native
+    /// routes charge in the output asset, so the payload's `toCoin` is the fee
+    /// coin and no separate coin context has to travel.
+    ///
+    /// Sums exactly the two components the verify screens itemize
+    /// (`affiliateFeeFiat` + `outboundFeeFiat`), so a co-signer rendering off
+    /// the payload arrives at the initiator's figure by construction. The
+    /// quote's own `fees.total` is deliberately not used: it folds in the
+    /// liquidity/slippage component, which is already reflected in the quoted
+    /// output amount, so carrying it would double-count against the total this
+    /// device displays.
+    ///
+    /// `nil` when nothing chargeable is itemized, or when either component is
+    /// malformed — a receiver shows no row rather than a partial figure that
+    /// reads as authoritative.
+    static func nativeSwapPayloadFee(quote: ThorchainSwapQuote) -> String? {
+        guard let affiliate = BigInt(quote.fees.affiliate),
+              let outbound = BigInt(quote.fees.outbound) else {
+            return nil
+        }
+        let total = affiliate + outbound
+        return total > 0 ? String(total) : nil
     }
 
     /// Assemble the final `KeysignPayload` for a swap given a finalised

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
@@ -203,23 +203,13 @@ extension SwapCryptoLogic {
         )
     }
 
-    /// The provider-side swap fee to carry on the keysign payload, as a raw
-    /// integer in the units the quote already reports it in — the destination
-    /// coin's native-swap fixed point (`toCoin.thorswapMultiplier`). Native
-    /// routes charge in the output asset, so the payload's `toCoin` is the fee
-    /// coin and no separate coin context has to travel.
+    /// Sums exactly the two components the verify screens itemize, so a co-signer
+    /// reaches the initiator's figure by construction. Deliberately NOT the quote's
+    /// `fees.total`: that folds in the liquidity component, which the quoted output
+    /// amount already reflects, so carrying it would double-count.
     ///
-    /// Sums exactly the two components the verify screens itemize
-    /// (`affiliateFeeFiat` + `outboundFeeFiat`), so a co-signer rendering off
-    /// the payload arrives at the initiator's figure by construction. The
-    /// quote's own `fees.total` is deliberately not used: it folds in the
-    /// liquidity/slippage component, which is already reflected in the quoted
-    /// output amount, so carrying it would double-count against the total this
-    /// device displays.
-    ///
-    /// `nil` when nothing chargeable is itemized, or when either component is
-    /// malformed — a receiver shows no row rather than a partial figure that
-    /// reads as authoritative.
+    /// `nil` when nothing is charged or either component is malformed — a partial
+    /// sum would still read as authoritative.
     static func nativeSwapPayloadFee(quote: ThorchainSwapQuote) -> String? {
         guard let affiliate = BigInt(quote.fees.affiliate),
               let outbound = BigInt(quote.fees.outbound) else {

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
@@ -208,15 +208,17 @@ extension SwapCryptoLogic {
     /// `fees.total`: that folds in the liquidity component, which the quoted output
     /// amount already reflects, so carrying it would double-count.
     ///
-    /// `nil` when nothing is charged or either component is malformed — a partial
-    /// sum would still read as authoritative.
+    /// A route that charges nothing returns `"0"`, NOT `nil`: the receiver has to
+    /// tell a known zero (render `$0.00`, as the initiator does) from a sender that
+    /// stated nothing (render no row). `nil` is reserved for the second case —
+    /// here, a component too malformed to sum.
     static func nativeSwapPayloadFee(quote: ThorchainSwapQuote) -> String? {
         guard let affiliate = BigInt(quote.fees.affiliate),
               let outbound = BigInt(quote.fees.outbound) else {
             return nil
         }
         let total = affiliate + outbound
-        return total > 0 ? String(total) : nil
+        return total >= 0 ? String(total) : nil
     }
 
     /// Assemble the final `KeysignPayload` for a swap given a finalised

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
@@ -213,12 +213,13 @@ extension SwapCryptoLogic {
     /// stated nothing (render no row). `nil` is reserved for the second case —
     /// here, a component too malformed to sum.
     static func nativeSwapPayloadFee(quote: ThorchainSwapQuote) -> String? {
-        guard let affiliate = BigInt(quote.fees.affiliate),
-              let outbound = BigInt(quote.fees.outbound) else {
+        // Each component is checked, not just the sum: a negative offsetting a
+        // positive would otherwise launder a malformed quote into a stated zero.
+        guard let affiliate = BigInt(quote.fees.affiliate), affiliate >= 0,
+              let outbound = BigInt(quote.fees.outbound), outbound >= 0 else {
             return nil
         }
-        let total = affiliate + outbound
-        return total >= 0 ? String(total) : nil
+        return String(affiliate + outbound)
     }
 
     /// Assemble the final `KeysignPayload` for a swap given a finalised

--- a/VultisigApp/VultisigAppTests/Keysign/NativeSwapFeeProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/NativeSwapFeeProtoMappingTests.swift
@@ -11,12 +11,28 @@
 //
 
 import BigInt
+import SwiftData
 import XCTest
 import VultisigCommonData
 @testable import VultisigApp
 
 @MainActor
 final class NativeSwapFeeProtoMappingTests: XCTestCase {
+
+    /// Rate fixtures are written through `Storage.shared.modelContext`, so this
+    /// class installs its own in-memory container rather than persisting into
+    /// whatever store a previous test class left installed — which in a
+    /// simulator can be the app's real one.
+    private var token: TestContextToken!
+
+    override func setUpWithError() throws {
+        token = try TestStore.installInMemoryContainer()
+    }
+
+    override func tearDown() {
+        TestStore.restore(token)
+        token = nil
+    }
 
     // MARK: - Proto round-trip
 
@@ -131,12 +147,19 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
         XCTAssertEqual(SwapCryptoLogic.nativeSwapPayloadFee(quote: quote), "48000000")
     }
 
-    func testNativeSwapPayloadFeeExcludesTheLiquidityComponent() {
+    func testNativeSwapPayloadFeeIgnoresTheQuotesTotal() {
         // `fees.total` folds in the liquidity/slippage charge, which the quoted
-        // output amount already reflects. Carrying it would make the co-signer's
-        // total exceed the initiator's for the same swap.
-        let quote = makeThorQuote(affiliate: "1000000", outbound: "47000000", total: "60000000")
-        XCTAssertNotEqual(SwapCryptoLogic.nativeSwapPayloadFee(quote: quote), quote.fees.total)
+        // output amount already reflects. Carrying it would put the co-signer's
+        // total above the initiator's for one swap. Varying ONLY `total` and
+        // pinning the exact result asserts independence, where a `!=` check
+        // would also be satisfied by an implementation that returned nil.
+        for total in ["60000000", "48000000", "0", "not-a-number"] {
+            let quote = makeThorQuote(affiliate: "1000000", outbound: "47000000", total: total)
+            XCTAssertEqual(
+                SwapCryptoLogic.nativeSwapPayloadFee(quote: quote), "48000000",
+                "fees.total = \(total) must not move the carried fee"
+            )
+        }
     }
 
     func testNativeSwapPayloadFeeIsNilWhenNothingIsCharged() {
@@ -226,8 +249,12 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
             toAmountDecimal: 3000,
             quote: quote
         )
+        // Serialize and parse back: the co-signer's figure has to survive the
+        // wire, not just the in-memory struct, or this proves nothing about the
+        // device that actually renders it.
+        let decoded = try SwapPayload(proto: SwapPayload.thorchain(payload).mapToProtobuff())
         let resolved = try XCTUnwrap(
-            JoinKeysignSwapFeeViewModel().resolveSwapFee(swapPayload: .thorchain(payload), vault: nil)
+            JoinKeysignSwapFeeViewModel().resolveSwapFee(swapPayload: decoded, vault: nil)
         )
 
         XCTAssertGreaterThan(initiatorFiat, 0, "Seeded rate should make the comparison meaningful")
@@ -249,11 +276,61 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
         let viewModel = JoinKeysignViewModel()
         viewModel.keysignPayload = keysignPayload
 
-        let networkFiat = try XCTUnwrap(JoinKeysignGasViewModel().networkFeeFiat(payload: keysignPayload))
-        let expected = (networkFiat + toCoin.fiat(decimal: Decimal(string: "0.48") ?? 0))
-            .formatToFiat(includeCurrencySymbol: true)
+        // Both legs are derived from the fixture by hand rather than from the
+        // code under test, so a wrong gas amount, decimals, coin or rate moves
+        // the actual without moving the expectation.
+        //   network: 21_000 gas x 1 gwei = 0.000021 ETH @ $2000 = $0.042
+        //   swap:    0.48 TRX @ $0.25                            = $0.12
+        XCTAssertEqual(
+            JoinKeysignGasViewModel().networkFeeFiat(payload: keysignPayload),
+            Decimal(string: "0.042"),
+            "Network leg must price the transmitted gas through the payload's own coin"
+        )
+        XCTAssertEqual(
+            viewModel.getSwapTotalFee(),
+            Decimal(string: "0.162")?.formatToFiat(includeCurrencySymbol: true)
+        )
+    }
 
-        XCTAssertEqual(viewModel.getSwapTotalFee(), expected)
+    func testTotalFeeRowHiddenWhenTheSwapFeeCoinHasNoRate() throws {
+        let sourceCoin = makeEthSource()
+        setPrice(2000, for: sourceCoin)
+        // Destination coin deliberately left unpriced.
+        let viewModel = JoinKeysignViewModel()
+        viewModel.keysignPayload = makeKeysignPayload(
+            coin: sourceCoin,
+            swapPayload: .thorchain(makeNativePayload(fee: "48000000", toCoin: makeUnpricedTRX()))
+        )
+
+        XCTAssertNotNil(
+            JoinKeysignGasViewModel().networkFeeFiat(payload: try XCTUnwrap(viewModel.keysignPayload)),
+            "Only the swap leg should be unpriced here, or this asserts the wrong branch"
+        )
+        XCTAssertNil(
+            viewModel.getSwapTotalFee(),
+            "An unpriced swap leg must drop the row, not be absorbed into the total as free"
+        )
+    }
+
+    func testTotalFeeRowHiddenWhenTheNetworkFeeCoinHasNoRate() {
+        // Source coin deliberately left unpriced.
+        setPrice(0.25, for: makeTRX())
+        let viewModel = JoinKeysignViewModel()
+        viewModel.keysignPayload = makeKeysignPayload(
+            coin: makeUnpricedEthSource(),
+            swapPayload: .thorchain(makeNativePayload(fee: "48000000"))
+        )
+
+        XCTAssertNotNil(
+            JoinKeysignSwapFeeViewModel().resolveSwapFee(
+                swapPayload: viewModel.keysignPayload?.swapPayload, vault: nil
+            ),
+            "Only the network leg should be unpriced here, or this asserts the wrong branch"
+        )
+        XCTAssertNil(
+            viewModel.getSwapTotalFee(),
+            "An unpriced network leg must drop the row for the same reason"
+        )
     }
 
     func testTotalFeeRowHiddenWhenTheSenderCarriedNoFee() {
@@ -364,31 +441,64 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
         makeCoin(.mayaChain, ticker: "CACAO", decimals: 10, isNative: true)
     }
 
-    /// A distinct ticker (and so a distinct price-provider id) keeps the source
-    /// coin's seeded rate independent of whatever another test class priced ETH at.
     private func makeEthSource() -> Coin {
-        makeCoin(.ethereum, ticker: "ETHNATIVEFEE", decimals: 18, isNative: true)
+        makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
     }
 
-    private func makeCoin(_ chain: Chain, ticker: String, decimals: Int, isNative: Bool, contract: String = "") -> Coin {
+    /// Same shape as the priced fixtures but under an id nothing seeds, so the
+    /// fail-closed branches are exercised by a genuinely absent rate.
+    private func makeUnpricedTRX() -> Coin {
+        makeCoin(.tron, ticker: "TRX", decimals: 6, isNative: true, priceScope: "unpriced")
+    }
+
+    private func makeUnpricedEthSource() -> Coin {
+        makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true, priceScope: "unpriced")
+    }
+
+    /// `RateProvider` is a process-wide singleton keyed by `priceProviderId`, so
+    /// fixtures scope theirs to this class. Sharing a generic id ("eth", "trx")
+    /// would let this class's seeded prices leak into other test classes and let
+    /// theirs leak in here, making both order-dependent.
+    private func makeCoin(
+        _ chain: Chain,
+        ticker: String,
+        decimals: Int,
+        isNative: Bool,
+        contract: String = "",
+        priceScope: String = "5340"
+    ) -> Coin {
         let asset = CoinMeta(
             chain: chain,
             ticker: ticker,
             logo: "logo",
             decimals: decimals,
-            priceProviderId: ticker.lowercased(),
+            priceProviderId: "native-swap-fee-\(priceScope)-\(ticker.lowercased())",
             contractAddress: contract,
             isNativeToken: isNative
         )
         return Coin(asset: asset, address: "native-swap-fee-\(ticker)", hexPublicKey: "")
     }
 
-    private func setPrice(_ value: Double, for coin: Coin) {
+    private func setPrice(
+        _ value: Double,
+        for coin: Coin,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
         let cryptoId = RateProvider.cryptoId(for: coin.toCoinMeta()).id
         // In-memory rates update before the storage write, so a storage failure
-        // in the test harness doesn't invalidate the assertion.
+        // does not by itself invalidate the assertion. What the tests actually
+        // depend on is that the rate reads back, so that is what is asserted —
+        // a silent seeding failure surfaces here rather than as a confusing nil
+        // fiat several lines later.
         try? RateProvider.shared.save(rates: [
             Rate(fiat: SettingsCurrency.current.rawValue, crypto: cryptoId, value: value)
         ])
+        XCTAssertNotNil(
+            RateProvider.shared.rate(for: coin),
+            "Seeded rate for \(coin.ticker) must be readable",
+            file: file,
+            line: line
+        )
     }
 }

--- a/VultisigApp/VultisigAppTests/Keysign/NativeSwapFeeProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/NativeSwapFeeProtoMappingTests.swift
@@ -71,12 +71,37 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
         XCTAssertNil(decoded.fee, "Empty on the wire normalizes back to nil, not \"\"")
     }
 
-    func testZeroFeeStaysOffTheWire() {
+    func testKnownZeroFeeTravelsOnTheWire() throws {
+        // A route that charges nothing is a statement, and the initiator renders
+        // it as $0.00. Dropping it here is what left the co-signer with no row.
         let proto = SwapPayload.thorchain(makeNativePayload(fee: "0")).mapToProtobuff()
         guard case let .thorchainSwapPayload(value) = proto else {
             XCTFail("Expected .thorchainSwapPayload"); return
         }
-        XCTAssertTrue(value.fee.isEmpty, "A zero is indistinguishable from unknown; never claim it")
+        XCTAssertEqual(value.fee, "0")
+
+        guard case let .thorchain(decoded) = try SwapPayload(proto: proto) else {
+            XCTFail("Expected .thorchain"); return
+        }
+        XCTAssertEqual(decoded.fee, "0", "A stated zero must survive as a zero, not decay to nil")
+    }
+
+    /// `fee` has implicit presence, so unset and `"0"` are different bytes and must
+    /// stay different UI. A change that rendered everything, or nothing, fails here.
+    func testAbsentAndKnownZeroAreDistinguishableEndToEnd() throws {
+        let model = JoinKeysignSwapFeeViewModel()
+
+        let absent = try SwapPayload(proto: SwapPayload.thorchain(makeNativePayload(fee: nil)).mapToProtobuff())
+        let zero = try SwapPayload(proto: SwapPayload.thorchain(makeNativePayload(fee: "0")).mapToProtobuff())
+
+        XCTAssertNil(
+            model.resolveSwapFee(swapPayload: absent, vault: nil),
+            "A sender that stated nothing must render no row"
+        )
+        XCTAssertEqual(
+            model.resolveSwapFee(swapPayload: zero, vault: nil)?.amount, 0,
+            "A sender that stated zero must render a zero row, matching the initiator"
+        )
     }
 
     func testLegacyWireBytesDecodeToNoFeeAndNoRow() throws {
@@ -154,9 +179,11 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
         }
     }
 
-    func testNativeSwapPayloadFeeIsNilWhenNothingIsCharged() {
+    func testNativeSwapPayloadFeeIsZeroWhenNothingIsCharged() {
+        // Same-chain routes (RUNE -> RUJI) have no outbound leg and can round the
+        // affiliate cut to nothing. That is a fee of zero, not an absent fee.
         let quote = makeThorQuote(affiliate: "0", outbound: "0", total: "0")
-        XCTAssertNil(SwapCryptoLogic.nativeSwapPayloadFee(quote: quote))
+        XCTAssertEqual(SwapCryptoLogic.nativeSwapPayloadFee(quote: quote), "0")
     }
 
     func testNativeSwapPayloadFeeIsNilForAMalformedComponent() {
@@ -199,11 +226,23 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
         XCTAssertEqual(resolved?.coin.ticker, "CACAO")
     }
 
-    func testNativeResolverYieldsNoRowForZeroOrAbsentFee() {
+    func testNativeResolverYieldsNoRowOnlyForAnAbsentFee() {
         let model = JoinKeysignSwapFeeViewModel()
         XCTAssertNil(model.resolveSwapFee(swapPayload: .thorchain(makeNativePayload(fee: nil)), vault: nil))
-        XCTAssertNil(model.resolveSwapFee(swapPayload: .thorchain(makeNativePayload(fee: "0")), vault: nil))
         XCTAssertNil(model.resolveSwapFee(swapPayload: .thorchain(makeNativePayload(fee: "")), vault: nil))
+        XCTAssertNil(
+            model.resolveSwapFee(swapPayload: .thorchain(makeNativePayload(fee: "not-a-number")), vault: nil),
+            "A malformed fee is unstatable, not zero"
+        )
+    }
+
+    func testNativeResolverRendersAStatedZero() {
+        let resolved = JoinKeysignSwapFeeViewModel().resolveSwapFee(
+            swapPayload: .thorchain(makeNativePayload(fee: "0")),
+            vault: nil
+        )
+        XCTAssertEqual(resolved?.amount, 0)
+        XCTAssertEqual(resolved?.coin.ticker, "TRX")
     }
 
     func testChainnetAndStagenetVariantsResolveTheSameFee() {
@@ -275,6 +314,26 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
         XCTAssertEqual(
             viewModel.getSwapTotalFee(),
             Decimal(string: "0.162")?.formatToFiat(includeCurrencySymbol: true)
+        )
+    }
+
+    func testTotalFeeRowPresentForAStatedZeroSwapFee() {
+        // The RUNE -> RUJI shape: network fee only, but the row must still render
+        // rather than vanish, because the initiator shows a total here.
+        let sourceCoin = makeEthSource()
+        setPrice(2000, for: sourceCoin)
+        let viewModel = JoinKeysignViewModel()
+        viewModel.keysignPayload = makeKeysignPayload(
+            coin: sourceCoin,
+            // Destination deliberately unpriced: a zero leg is worth zero at any
+            // price, so it must not need a rate to enter the total.
+            swapPayload: .thorchain(makeNativePayload(fee: "0", toCoin: makeUnpricedTRX()))
+        )
+
+        XCTAssertEqual(
+            viewModel.getSwapTotalFee(),
+            Decimal(string: "0.042")?.formatToFiat(includeCurrencySymbol: true),
+            "A zero swap fee contributes zero; the total is the network fee alone"
         )
     }
 

--- a/VultisigApp/VultisigAppTests/Keysign/NativeSwapFeeProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/NativeSwapFeeProtoMappingTests.swift
@@ -1,0 +1,394 @@
+//
+//  NativeSwapFeeProtoMappingTests.swift
+//  VultisigAppTests
+//
+//  Coverage for the native (THORChain / MayaChain) swap fee on
+//  `THORChainSwapPayload.fee`: what the builder puts on the wire, that a
+//  legacy or zero fee stays off it, and that a co-signer rendering off the
+//  payload alone lands on the initiator's own figure. A joiner holds no
+//  quote, so this field is the only statement it gets of what the swap
+//  costs — without it the confirm screen totals the network fee alone.
+//
+
+import BigInt
+import XCTest
+import VultisigCommonData
+@testable import VultisigApp
+
+@MainActor
+final class NativeSwapFeeProtoMappingTests: XCTestCase {
+
+    // MARK: - Proto round-trip
+
+    func testThorchainProtoRoundTripCarriesFee() throws {
+        let proto = SwapPayload.thorchain(makeNativePayload(fee: "48000000")).mapToProtobuff()
+        guard case let .thorchainSwapPayload(value) = proto else {
+            XCTFail("Expected .thorchainSwapPayload"); return
+        }
+        XCTAssertEqual(value.fee, "48000000")
+
+        guard case let .thorchain(decoded) = try SwapPayload(proto: proto) else {
+            XCTFail("Expected .thorchain"); return
+        }
+        XCTAssertEqual(decoded.fee, "48000000")
+    }
+
+    func testMayachainProtoRoundTripCarriesFee() throws {
+        let payload = makeNativePayload(fee: "125000000000", toCoin: makeCacao())
+        let proto = SwapPayload.mayachain(payload).mapToProtobuff()
+        guard case let .mayachainSwapPayload(value) = proto else {
+            XCTFail("Expected .mayachainSwapPayload"); return
+        }
+        XCTAssertEqual(value.fee, "125000000000")
+
+        guard case let .mayachain(decoded) = try SwapPayload(proto: proto) else {
+            XCTFail("Expected .mayachain"); return
+        }
+        XCTAssertEqual(decoded.fee, "125000000000")
+    }
+
+    func testNilFeeStaysOffTheWire() throws {
+        let proto = SwapPayload.thorchain(makeNativePayload(fee: nil)).mapToProtobuff()
+        guard case let .thorchainSwapPayload(value) = proto else {
+            XCTFail("Expected .thorchainSwapPayload"); return
+        }
+        XCTAssertTrue(value.fee.isEmpty, "A sender with no quoted fee must leave the field unset")
+
+        guard case let .thorchain(decoded) = try SwapPayload(proto: proto) else {
+            XCTFail("Expected .thorchain"); return
+        }
+        XCTAssertNil(decoded.fee, "Empty on the wire normalizes back to nil, not \"\"")
+    }
+
+    func testZeroFeeStaysOffTheWire() {
+        let proto = SwapPayload.thorchain(makeNativePayload(fee: "0")).mapToProtobuff()
+        guard case let .thorchainSwapPayload(value) = proto else {
+            XCTFail("Expected .thorchainSwapPayload"); return
+        }
+        XCTAssertTrue(value.fee.isEmpty, "A zero is indistinguishable from unknown; never claim it")
+    }
+
+    func testLegacyWireBytesDecodeToNoFeeAndNoRow() throws {
+        // A sender that predates field 13 serializes fields 1-12 only.
+        var legacy = VSTHORChainSwapPayload()
+        legacy.fromAddress = "bc1qsender"
+        legacy.fromCoin = ProtoCoinResolver.proto(from: makeBTC())
+        legacy.toCoin = ProtoCoinResolver.proto(from: makeTRX())
+        legacy.vaultAddress = "bc1qasgard"
+        legacy.fromAmount = "100000"
+        legacy.toAmountDecimal = "3000"
+        legacy.toAmountLimit = "0"
+        legacy.streamingInterval = "1"
+        legacy.streamingQuantity = "0"
+        legacy.expirationTime = 1_757_000_000
+        legacy.isAffiliate = true
+
+        let bytes = try legacy.serializedData()
+        let reparsed = try VSTHORChainSwapPayload(serializedBytes: bytes)
+        let decoded = try SwapPayload(proto: .thorchainSwapPayload(reparsed))
+
+        guard case let .thorchain(payload) = decoded else {
+            XCTFail("Expected .thorchain"); return
+        }
+        XCTAssertNil(payload.fee)
+        XCTAssertNil(
+            JoinKeysignSwapFeeViewModel().resolveSwapFee(swapPayload: decoded, vault: nil),
+            "Legacy sender → render no row, never a definite $0.00"
+        )
+    }
+
+    func testReEncodingALegacyPayloadLeavesTheFeeUnset() throws {
+        var legacy = VSTHORChainSwapPayload()
+        legacy.fromAddress = "bc1qsender"
+        legacy.fromCoin = ProtoCoinResolver.proto(from: makeBTC())
+        legacy.toCoin = ProtoCoinResolver.proto(from: makeTRX())
+        legacy.vaultAddress = "bc1qasgard"
+        legacy.fromAmount = "100000"
+        legacy.toAmountDecimal = "3000"
+        legacy.toAmountLimit = "0"
+        legacy.streamingInterval = "1"
+        legacy.streamingQuantity = "0"
+        legacy.expirationTime = 1_757_000_000
+        legacy.isAffiliate = true
+
+        let decoded = try SwapPayload(proto: .thorchainSwapPayload(
+            try VSTHORChainSwapPayload(serializedBytes: try legacy.serializedData())
+        ))
+        guard case let .thorchainSwapPayload(reEncoded) = decoded.mapToProtobuff() else {
+            XCTFail("Expected .thorchainSwapPayload"); return
+        }
+
+        XCTAssertTrue(
+            reEncoded.fee.isEmpty,
+            "Relaying a legacy payload must not invent a fee the original sender never stated"
+        )
+    }
+
+    // MARK: - What the builder puts on the wire
+
+    func testNativeSwapPayloadFeeSumsAffiliateAndOutbound() {
+        let quote = makeThorQuote(affiliate: "1000000", outbound: "47000000", total: "60000000")
+        XCTAssertEqual(SwapCryptoLogic.nativeSwapPayloadFee(quote: quote), "48000000")
+    }
+
+    func testNativeSwapPayloadFeeExcludesTheLiquidityComponent() {
+        // `fees.total` folds in the liquidity/slippage charge, which the quoted
+        // output amount already reflects. Carrying it would make the co-signer's
+        // total exceed the initiator's for the same swap.
+        let quote = makeThorQuote(affiliate: "1000000", outbound: "47000000", total: "60000000")
+        XCTAssertNotEqual(SwapCryptoLogic.nativeSwapPayloadFee(quote: quote), quote.fees.total)
+    }
+
+    func testNativeSwapPayloadFeeIsNilWhenNothingIsCharged() {
+        let quote = makeThorQuote(affiliate: "0", outbound: "0", total: "0")
+        XCTAssertNil(SwapCryptoLogic.nativeSwapPayloadFee(quote: quote))
+    }
+
+    func testNativeSwapPayloadFeeIsNilForAMalformedComponent() {
+        let quote = makeThorQuote(affiliate: "1000000", outbound: "not-a-number", total: "60000000")
+        XCTAssertNil(
+            SwapCryptoLogic.nativeSwapPayloadFee(quote: quote),
+            "A partial sum reads as authoritative; report nothing instead"
+        )
+    }
+
+    func testBuiltThorchainPayloadCarriesTheQuoteFee() {
+        let payload = SwapCryptoLogic.buildThorchainSwapPayload(
+            fromCoin: makeBTC(),
+            toCoin: makeTRX(),
+            fromAmountInCoin: BigInt(100_000),
+            toAmountDecimal: 3000,
+            quote: makeThorQuote(affiliate: "1000000", outbound: "47000000", total: "60000000")
+        )
+        XCTAssertEqual(payload.fee, "48000000")
+    }
+
+    // MARK: - What the co-signer reads back
+
+    func testNativeResolverScalesByThorchainFixedPoint() {
+        // 48_000_000 @ 1e8 is 0.48 TRX — the destination asset, which is where
+        // a native route charges. Reading it as raw units would be 1e8x off.
+        let resolved = JoinKeysignSwapFeeViewModel().resolveSwapFee(
+            swapPayload: .thorchain(makeNativePayload(fee: "48000000")),
+            vault: nil
+        )
+        XCTAssertEqual(resolved?.amount, Decimal(string: "0.48"))
+        XCTAssertEqual(resolved?.coin.ticker, "TRX", "Native fees are denominated in the destination coin")
+    }
+
+    func testNativeResolverScalesMayaDestinationByItsOwnDecimals() {
+        // CACAO is 10-decimal, so MayaChain quotes it at 1e10, not THORChain's 1e8.
+        let resolved = JoinKeysignSwapFeeViewModel().resolveSwapFee(
+            swapPayload: .mayachain(makeNativePayload(fee: "125000000000", toCoin: makeCacao())),
+            vault: nil
+        )
+        XCTAssertEqual(resolved?.amount, Decimal(string: "12.5"))
+        XCTAssertEqual(resolved?.coin.ticker, "CACAO")
+    }
+
+    func testNativeResolverYieldsNoRowForZeroOrAbsentFee() {
+        let model = JoinKeysignSwapFeeViewModel()
+        XCTAssertNil(model.resolveSwapFee(swapPayload: .thorchain(makeNativePayload(fee: nil)), vault: nil))
+        XCTAssertNil(model.resolveSwapFee(swapPayload: .thorchain(makeNativePayload(fee: "0")), vault: nil))
+        XCTAssertNil(model.resolveSwapFee(swapPayload: .thorchain(makeNativePayload(fee: "")), vault: nil))
+    }
+
+    func testChainnetAndStagenetVariantsResolveTheSameFee() {
+        let model = JoinKeysignSwapFeeViewModel()
+        let payload = makeNativePayload(fee: "48000000")
+        XCTAssertEqual(
+            model.resolveSwapFee(swapPayload: .thorchainChainnet(payload), vault: nil)?.amount,
+            Decimal(string: "0.48")
+        )
+        XCTAssertEqual(
+            model.resolveSwapFee(swapPayload: .thorchainStagenet(payload), vault: nil)?.amount,
+            Decimal(string: "0.48")
+        )
+    }
+
+    /// The point of the whole change: the fiat the co-signer shows is the fiat
+    /// the initiator itemizes, arrived at from the payload alone.
+    func testCoSignerSwapFeeFiatMatchesTheInitiatorItemization() throws {
+        let fromCoin = makeBTC()
+        let toCoin = makeTRX()
+        setPrice(0.25, for: toCoin)
+        let quote = makeThorQuote(affiliate: "1000000", outbound: "47000000", total: "60000000")
+        let swapQuote = SwapQuote.thorchain(quote)
+
+        let initiatorFiat = SwapCryptoLogic.affiliateFeeFiat(
+            quote: swapQuote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: fromCoin
+        ) + SwapCryptoLogic.outboundFeeFiat(quote: swapQuote, toCoin: toCoin)
+
+        let payload = SwapCryptoLogic.buildThorchainSwapPayload(
+            fromCoin: fromCoin,
+            toCoin: toCoin,
+            fromAmountInCoin: BigInt(100_000),
+            toAmountDecimal: 3000,
+            quote: quote
+        )
+        let resolved = try XCTUnwrap(
+            JoinKeysignSwapFeeViewModel().resolveSwapFee(swapPayload: .thorchain(payload), vault: nil)
+        )
+
+        XCTAssertGreaterThan(initiatorFiat, 0, "Seeded rate should make the comparison meaningful")
+        XCTAssertEqual(toCoin.fiat(decimal: resolved.amount), initiatorFiat)
+    }
+
+    // MARK: - Total-fee row on the co-signer's confirm screen
+
+    func testTotalFeeRowSumsNetworkAndSwapFee() throws {
+        let sourceCoin = makeEthSource()
+        setPrice(2000, for: sourceCoin)
+        let toCoin = makeTRX()
+        setPrice(0.25, for: toCoin)
+
+        let keysignPayload = makeKeysignPayload(
+            coin: sourceCoin,
+            swapPayload: .thorchain(makeNativePayload(fee: "48000000", toCoin: toCoin))
+        )
+        let viewModel = JoinKeysignViewModel()
+        viewModel.keysignPayload = keysignPayload
+
+        let networkFiat = try XCTUnwrap(JoinKeysignGasViewModel().networkFeeFiat(payload: keysignPayload))
+        let expected = (networkFiat + toCoin.fiat(decimal: Decimal(string: "0.48") ?? 0))
+            .formatToFiat(includeCurrencySymbol: true)
+
+        XCTAssertEqual(viewModel.getSwapTotalFee(), expected)
+    }
+
+    func testTotalFeeRowHiddenWhenTheSenderCarriedNoFee() {
+        let sourceCoin = makeEthSource()
+        setPrice(2000, for: sourceCoin)
+        setPrice(0.25, for: makeTRX())
+
+        let viewModel = JoinKeysignViewModel()
+        viewModel.keysignPayload = makeKeysignPayload(
+            coin: sourceCoin,
+            swapPayload: .thorchain(makeNativePayload(fee: nil))
+        )
+
+        XCTAssertNil(
+            viewModel.getSwapTotalFee(),
+            "A legacy payload is indistinguishable from a free route; a network-fee-only total is the bug"
+        )
+    }
+
+    // MARK: - Fixtures
+
+    private func makeNativePayload(fee: String?, toCoin: Coin? = nil) -> THORChainSwapPayload {
+        THORChainSwapPayload(
+            fromAddress: "bc1qsender",
+            fromCoin: makeBTC(),
+            toCoin: toCoin ?? makeTRX(),
+            vaultAddress: "bc1qasgard",
+            routerAddress: nil,
+            fromAmount: BigInt(100_000),
+            toAmountDecimal: 3000,
+            toAmountLimit: "0",
+            streamingInterval: "1",
+            streamingQuantity: "0",
+            expirationTime: 1_757_000_000,
+            isAffiliate: true,
+            fee: fee
+        )
+    }
+
+    private func makeKeysignPayload(coin: Coin, swapPayload: SwapPayload) -> KeysignPayload {
+        KeysignPayload(
+            coin: coin,
+            toAddress: "0xasgard",
+            toAmount: BigInt("1000000000000000000"),
+            chainSpecific: .Ethereum(
+                maxFeePerGasWei: BigInt(1_000_000_000),
+                priorityFeeWei: 0,
+                nonce: 0,
+                gasLimit: BigInt(21_000)
+            ),
+            utxos: [],
+            memo: "=:TRX.TRX:addr",
+            swapPayload: swapPayload,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "",
+            vaultLocalPartyID: "",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: nil
+        )
+    }
+
+    private func makeThorQuote(affiliate: String, outbound: String, total: String) -> ThorchainSwapQuote {
+        ThorchainSwapQuote(
+            dustThreshold: nil,
+            expectedAmountOut: "300000000000",
+            expiry: 1_757_000_000,
+            fees: Fees(
+                affiliate: affiliate,
+                asset: "TRX.TRX",
+                outbound: outbound,
+                total: total,
+                liquidity: nil,
+                slippageBps: nil,
+                totalBps: nil
+            ),
+            inboundAddress: "bc1qasgard",
+            inboundConfirmationBlocks: nil,
+            inboundConfirmationSeconds: nil,
+            memo: "=:TRX.TRX:addr:0/1/0",
+            notes: "",
+            outboundDelayBlocks: 0,
+            outboundDelaySeconds: 0,
+            recommendedMinAmountIn: "0",
+            slippageBps: nil,
+            totalSwapSeconds: nil,
+            warning: "",
+            router: nil,
+            maxStreamingQuantity: nil
+        )
+    }
+
+    private func makeBTC() -> Coin {
+        makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true)
+    }
+
+    private func makeTRX() -> Coin {
+        makeCoin(.tron, ticker: "TRX", decimals: 6, isNative: true)
+    }
+
+    private func makeCacao() -> Coin {
+        makeCoin(.mayaChain, ticker: "CACAO", decimals: 10, isNative: true)
+    }
+
+    /// A distinct ticker (and so a distinct price-provider id) keeps the source
+    /// coin's seeded rate independent of whatever another test class priced ETH at.
+    private func makeEthSource() -> Coin {
+        makeCoin(.ethereum, ticker: "ETHNATIVEFEE", decimals: 18, isNative: true)
+    }
+
+    private func makeCoin(_ chain: Chain, ticker: String, decimals: Int, isNative: Bool, contract: String = "") -> Coin {
+        let asset = CoinMeta(
+            chain: chain,
+            ticker: ticker,
+            logo: "logo",
+            decimals: decimals,
+            priceProviderId: ticker.lowercased(),
+            contractAddress: contract,
+            isNativeToken: isNative
+        )
+        return Coin(asset: asset, address: "native-swap-fee-\(ticker)", hexPublicKey: "")
+    }
+
+    private func setPrice(_ value: Double, for coin: Coin) {
+        let cryptoId = RateProvider.cryptoId(for: coin.toCoinMeta()).id
+        // In-memory rates update before the storage write, so a storage failure
+        // in the test harness doesn't invalidate the assertion.
+        try? RateProvider.shared.save(rates: [
+            Rate(fiat: SettingsCurrency.current.rawValue, crypto: cryptoId, value: value)
+        ])
+    }
+}

--- a/VultisigApp/VultisigAppTests/Keysign/NativeSwapFeeProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/NativeSwapFeeProtoMappingTests.swift
@@ -413,6 +413,62 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
         )
     }
 
+    func testTokenRateCannotPriceAnUnpricedNativeNetworkFee() throws {
+        let tokenCoin = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false, contract: "0xusdc")
+        setPrice(1, for: tokenCoin)
+        let nativeCoin = makeUnpricedEthSource()
+        XCTAssertNil(RateProvider.shared.rate(for: nativeCoin))
+        let vault = TestStore.makeVault()
+        vault.coins = [tokenCoin, nativeCoin]
+        let viewModel = JoinKeysignViewModel()
+        viewModel.vault = vault
+        viewModel.keysignPayload = makeKeysignPayload(
+            coin: tokenCoin,
+            swapPayload: .thorchain(makeNativePayload(fee: "0", toCoin: makeUnpricedTRX()))
+        )
+
+        XCTAssertNil(JoinKeysignGasViewModel().networkFeeFiat(payload: try XCTUnwrap(viewModel.keysignPayload), vault: vault))
+        XCTAssertNil(viewModel.getSwapTotalFee(), "A priced token must not make an unpriced gas leg look known")
+    }
+
+    func testTokenSwapNetworkFeeUsesNativeDecimalsAndRate() {
+        let tokenCoin = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false, contract: "0xusdc")
+        setPrice(1, for: tokenCoin)
+        let nativeCoin = makeEthSource()
+        setPrice(2000, for: nativeCoin)
+        let vault = TestStore.makeVault()
+        vault.coins = [tokenCoin, nativeCoin]
+        let payload = makeKeysignPayload(
+            coin: tokenCoin,
+            swapPayload: .thorchain(makeNativePayload(fee: "0", toCoin: makeUnpricedTRX()))
+        )
+        let viewModel = JoinKeysignViewModel()
+        viewModel.vault = vault
+        viewModel.keysignPayload = payload
+
+        // 21,000 gas at 1 gwei = 0.000021 ETH; at $2,000/ETH this is $0.042.
+        XCTAssertEqual(JoinKeysignGasViewModel().networkFeeFiat(payload: payload, vault: vault), Decimal(string: "0.042"))
+        XCTAssertEqual(viewModel.getSwapTotalFee(), Decimal(string: "0.042")?.formatToFiat(includeCurrencySymbol: true))
+    }
+
+    func testTokenSwapWithoutVaultNativeUsesCatalogNativeRate() throws {
+        let tokenCoin = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false, contract: "0xusdc")
+        setPrice(1, for: tokenCoin)
+        let vault = TestStore.makeVault()
+        vault.coins = [tokenCoin]
+        XCTAssertNil(vault.nativeCoin(for: .ethereum))
+        let native = try XCTUnwrap(TokensStore.TokenSelectionAssets.first { $0.chain == .ethereum && $0.isNativeToken })
+        let payload = makeKeysignPayload(
+            coin: tokenCoin,
+            swapPayload: .thorchain(makeNativePayload(fee: "0", toCoin: makeUnpricedTRX()))
+        )
+
+        // Do not seed a shared catalog rate: another test may have loaded it.
+        // Either cache state must value 0.000021 ETH, never 21 million USDC.
+        let expected = RateProvider.shared.rate(for: native).map { Decimal(21) / 1_000_000 * Decimal($0.value) }
+        XCTAssertEqual(JoinKeysignGasViewModel().networkFeeFiat(payload: payload, vault: vault), expected)
+    }
+
     func testTotalFeeRowHiddenWhenTheSenderCarriedNoFee() {
         let sourceCoin = makeEthSource()
         setPrice(2000, for: sourceCoin)

--- a/VultisigApp/VultisigAppTests/Keysign/NativeSwapFeeProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/NativeSwapFeeProtoMappingTests.swift
@@ -71,19 +71,31 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
         XCTAssertNil(decoded.fee, "Empty on the wire normalizes back to nil, not \"\"")
     }
 
-    func testKnownZeroFeeTravelsOnTheWire() throws {
+    func testKnownZeroFeeSurvivesSerialization() throws {
         // A route that charges nothing is a statement, and the initiator renders
         // it as $0.00. Dropping it here is what left the co-signer with no row.
-        let proto = SwapPayload.thorchain(makeNativePayload(fee: "0")).mapToProtobuff()
-        guard case let .thorchainSwapPayload(value) = proto else {
-            XCTFail("Expected .thorchainSwapPayload"); return
-        }
-        XCTAssertEqual(value.fee, "0")
+        // Asserted through real bytes: checking the in-memory property alone
+        // would still pass if proto3 elided the field on the way out.
+        let zero = try XCTUnwrap(nativeProto(fee: "0")).serializedData()
+        let absent = try XCTUnwrap(nativeProto(fee: nil)).serializedData()
 
-        guard case let .thorchain(decoded) = try SwapPayload(proto: proto) else {
-            XCTFail("Expected .thorchain"); return
-        }
-        XCTAssertEqual(decoded.fee, "0", "A stated zero must survive as a zero, not decay to nil")
+        // Field 13, wire type 2, length 1, ASCII "0".
+        XCTAssertNotNil(
+            zero.range(of: Data([0x6a, 0x01, 0x30])),
+            "A stated zero must occupy field 13 on the wire"
+        )
+        XCTAssertNotEqual(zero, absent, "The two states must not serialize identically")
+
+        // Reparsed rather than byte-matched for the absent case: a lone 0x6a can
+        // legitimately appear as another field's length or payload byte.
+        XCTAssertTrue(
+            try VSTHORChainSwapPayload(serializedBytes: absent).fee.isEmpty,
+            "An absent fee must reparse as unset"
+        )
+        XCTAssertEqual(
+            try VSTHORChainSwapPayload(serializedBytes: zero).fee, "0",
+            "A stated zero must reparse as a zero, not decay to unset"
+        )
     }
 
     /// `fee` has implicit presence, so unset and `"0"` are different bytes and must
@@ -91,17 +103,25 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
     func testAbsentAndKnownZeroAreDistinguishableEndToEnd() throws {
         let model = JoinKeysignSwapFeeViewModel()
 
-        let absent = try SwapPayload(proto: SwapPayload.thorchain(makeNativePayload(fee: nil)).mapToProtobuff())
-        let zero = try SwapPayload(proto: SwapPayload.thorchain(makeNativePayload(fee: "0")).mapToProtobuff())
+        // Through serialized bytes, and all the way to `getSwapFee` — the
+        // accessor the confirm screen actually binds its row to.
+        let absent = try SwapPayload(proto: .thorchainSwapPayload(
+            try VSTHORChainSwapPayload(serializedBytes: try XCTUnwrap(nativeProto(fee: nil)).serializedData())
+        ))
+        let zero = try SwapPayload(proto: .thorchainSwapPayload(
+            try VSTHORChainSwapPayload(serializedBytes: try XCTUnwrap(nativeProto(fee: "0")).serializedData())
+        ))
 
         XCTAssertNil(
-            model.resolveSwapFee(swapPayload: absent, vault: nil),
+            model.getSwapFee(swapPayload: absent, vault: nil),
             "A sender that stated nothing must render no row"
         )
-        XCTAssertEqual(
-            model.resolveSwapFee(swapPayload: zero, vault: nil)?.amount, 0,
-            "A sender that stated zero must render a zero row, matching the initiator"
+        let zeroRow = try XCTUnwrap(
+            model.getSwapFee(swapPayload: zero, vault: nil),
+            "A sender that stated zero must render a row, matching the initiator's $0.00"
         )
+        XCTAssertTrue(zeroRow.feeCrypto.contains("TRX"))
+        XCTAssertEqual(model.resolveSwapFee(swapPayload: zero, vault: nil)?.amount, 0)
     }
 
     func testLegacyWireBytesDecodeToNoFeeAndNoRow() throws {
@@ -186,6 +206,17 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
         XCTAssertEqual(SwapCryptoLogic.nativeSwapPayloadFee(quote: quote), "0")
     }
 
+    func testNativeSwapPayloadFeeIsNilForANegativeComponent() {
+        // A negative offsetting a positive sums to zero, which would otherwise
+        // be stated as a confident "this route is free".
+        XCTAssertNil(SwapCryptoLogic.nativeSwapPayloadFee(
+            quote: makeThorQuote(affiliate: "-1", outbound: "1", total: "0")
+        ))
+        XCTAssertNil(SwapCryptoLogic.nativeSwapPayloadFee(
+            quote: makeThorQuote(affiliate: "1", outbound: "-1", total: "0")
+        ))
+    }
+
     func testNativeSwapPayloadFeeIsNilForAMalformedComponent() {
         let quote = makeThorQuote(affiliate: "1000000", outbound: "not-a-number", total: "60000000")
         XCTAssertNil(
@@ -233,6 +264,10 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
         XCTAssertNil(
             model.resolveSwapFee(swapPayload: .thorchain(makeNativePayload(fee: "not-a-number")), vault: nil),
             "A malformed fee is unstatable, not zero"
+        )
+        XCTAssertNil(
+            model.resolveSwapFee(swapPayload: .thorchain(makeNativePayload(fee: "-1")), vault: nil),
+            "A negative fee from a peer is nonsense, not a discount"
         )
     }
 
@@ -396,6 +431,13 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
     }
 
     // MARK: - Fixtures
+
+    /// The generated proto for a native payload, for tests that need real bytes.
+    private func nativeProto(fee: String?) -> VSTHORChainSwapPayload? {
+        guard case let .thorchainSwapPayload(value) =
+            SwapPayload.thorchain(makeNativePayload(fee: fee)).mapToProtobuff() else { return nil }
+        return value
+    }
 
     private func makeNativePayload(fee: String?, toCoin: Coin? = nil) -> THORChainSwapPayload {
         THORChainSwapPayload(

--- a/VultisigApp/VultisigAppTests/Keysign/NativeSwapFeeProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/NativeSwapFeeProtoMappingTests.swift
@@ -2,12 +2,9 @@
 //  NativeSwapFeeProtoMappingTests.swift
 //  VultisigAppTests
 //
-//  Coverage for the native (THORChain / MayaChain) swap fee on
-//  `THORChainSwapPayload.fee`: what the builder puts on the wire, that a
-//  legacy or zero fee stays off it, and that a co-signer rendering off the
-//  payload alone lands on the initiator's own figure. A joiner holds no
-//  quote, so this field is the only statement it gets of what the swap
-//  costs — without it the confirm screen totals the network fee alone.
+//  Native (THORChain / MayaChain) swap fee on `THORChainSwapPayload.fee`:
+//  what reaches the wire, and that a co-signer reading only the payload
+//  lands on the initiator's figure.
 //
 
 import BigInt
@@ -19,10 +16,8 @@ import VultisigCommonData
 @MainActor
 final class NativeSwapFeeProtoMappingTests: XCTestCase {
 
-    /// Rate fixtures are written through `Storage.shared.modelContext`, so this
-    /// class installs its own in-memory container rather than persisting into
-    /// whatever store a previous test class left installed — which in a
-    /// simulator can be the app's real one.
+    /// Rate fixtures write through `Storage.shared.modelContext`, which in a
+    /// simulator can be the app's real store unless a container is installed.
     private var token: TestContextToken!
 
     override func setUpWithError() throws {
@@ -148,11 +143,8 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
     }
 
     func testNativeSwapPayloadFeeIgnoresTheQuotesTotal() {
-        // `fees.total` folds in the liquidity/slippage charge, which the quoted
-        // output amount already reflects. Carrying it would put the co-signer's
-        // total above the initiator's for one swap. Varying ONLY `total` and
-        // pinning the exact result asserts independence, where a `!=` check
-        // would also be satisfied by an implementation that returned nil.
+        // Varying ONLY `total` and pinning the exact result asserts independence;
+        // a `!=` check would also be satisfied by an always-nil implementation.
         for total in ["60000000", "48000000", "0", "not-a-number"] {
             let quote = makeThorQuote(affiliate: "1000000", outbound: "47000000", total: total)
             XCTAssertEqual(
@@ -189,8 +181,6 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
     // MARK: - What the co-signer reads back
 
     func testNativeResolverScalesByThorchainFixedPoint() {
-        // 48_000_000 @ 1e8 is 0.48 TRX — the destination asset, which is where
-        // a native route charges. Reading it as raw units would be 1e8x off.
         let resolved = JoinKeysignSwapFeeViewModel().resolveSwapFee(
             swapPayload: .thorchain(makeNativePayload(fee: "48000000")),
             vault: nil
@@ -229,8 +219,6 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
         )
     }
 
-    /// The point of the whole change: the fiat the co-signer shows is the fiat
-    /// the initiator itemizes, arrived at from the payload alone.
     func testCoSignerSwapFeeFiatMatchesTheInitiatorItemization() throws {
         let fromCoin = makeBTC()
         let toCoin = makeTRX()
@@ -249,9 +237,8 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
             toAmountDecimal: 3000,
             quote: quote
         )
-        // Serialize and parse back: the co-signer's figure has to survive the
-        // wire, not just the in-memory struct, or this proves nothing about the
-        // device that actually renders it.
+        // Through the wire, not the in-memory struct: otherwise this still passes
+        // when the proto writer stops writing the field.
         let decoded = try SwapPayload(proto: SwapPayload.thorchain(payload).mapToProtobuff())
         let resolved = try XCTUnwrap(
             JoinKeysignSwapFeeViewModel().resolveSwapFee(swapPayload: decoded, vault: nil)
@@ -276,11 +263,10 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
         let viewModel = JoinKeysignViewModel()
         viewModel.keysignPayload = keysignPayload
 
-        // Both legs are derived from the fixture by hand rather than from the
-        // code under test, so a wrong gas amount, decimals, coin or rate moves
+        // Derived by hand, not from the code under test, so a wrong amount moves
         // the actual without moving the expectation.
         //   network: 21_000 gas x 1 gwei = 0.000021 ETH @ $2000 = $0.042
-        //   swap:    0.48 TRX @ $0.25                            = $0.12
+        //   swap:    0.48 TRX @ $0.25                           = $0.12
         XCTAssertEqual(
             JoinKeysignGasViewModel().networkFeeFiat(payload: keysignPayload),
             Decimal(string: "0.042"),
@@ -445,8 +431,7 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
         makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
     }
 
-    /// Same shape as the priced fixtures but under an id nothing seeds, so the
-    /// fail-closed branches are exercised by a genuinely absent rate.
+    /// Under an id nothing seeds, so the fail-closed branches see a real absence.
     private func makeUnpricedTRX() -> Coin {
         makeCoin(.tron, ticker: "TRX", decimals: 6, isNative: true, priceScope: "unpriced")
     }
@@ -456,9 +441,7 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
     }
 
     /// `RateProvider` is a process-wide singleton keyed by `priceProviderId`, so
-    /// fixtures scope theirs to this class. Sharing a generic id ("eth", "trx")
-    /// would let this class's seeded prices leak into other test classes and let
-    /// theirs leak in here, making both order-dependent.
+    /// a generic id ("eth", "trx") would make this class and others order-dependent.
     private func makeCoin(
         _ chain: Chain,
         ticker: String,
@@ -486,11 +469,8 @@ final class NativeSwapFeeProtoMappingTests: XCTestCase {
         line: UInt = #line
     ) {
         let cryptoId = RateProvider.cryptoId(for: coin.toCoinMeta()).id
-        // In-memory rates update before the storage write, so a storage failure
-        // does not by itself invalidate the assertion. What the tests actually
-        // depend on is that the rate reads back, so that is what is asserted —
-        // a silent seeding failure surfaces here rather than as a confusing nil
-        // fiat several lines later.
+        // In-memory rates update before the storage write, so assert what the
+        // tests depend on — that the rate reads back — not that the save landed.
         try? RateProvider.shared.save(rates: [
             Rate(fiat: SettingsCurrency.current.rawValue, crypto: cryptoId, value: value)
         ])


### PR DESCRIPTION
## Problem

A device **joining** a keysign renders its swap confirm screen entirely from the serialized `KeysignPayload` — it holds no quote. Two gaps meant it could not state what a swap costs:

1. **The swap-fee row existed only for 1inch-shaped payloads.** On `main`, `JoinKeysignSwapFeeViewModel.resolveSwapFee` opens with `guard case let .generic(payload) = swapPayload else { return nil }`, so a native THORChain/MayaChain swap resolved no fee at all. iOS also wrote 12 of `THORChainSwapPayload`'s 13 fields, omitting `fee`, so there was nothing to resolve even in principle.
2. **There was no Total Fee row at all** on that screen — provider, an optional swap fee, and the network fee, nothing more.

So on a native swap the joiner showed the network fee alone while the initiator itemized a protocol fee and a product fee on top of it. Measured on Windows, BTC → TRX, both devices on the same build:

| Row | Initiator | Joiner |
|---|---|---|
| Network Fee | 0.00001035 BTC / $0.80 | 0.00001035 BTC / $0.80 |
| Swap Fee | Protocol Fee $0.47 (+$0.01 product fee) | **absent** |
| Max. Total Fee | **$1.28** | **absent** |

A co-signer was approving a swap it had been told cost $0.48 less than it does, on the screen whose only purpose is for both parties to confirm the same swap.

**No commondata pin bump is needed or included.** `string fee = 13` already exists at the pinned revision (`VultisigApp/project.yml:88` → `63a65c37c…`) and was simply never written.

## Change

Two additions, not a correction of an existing row:

- **Native THORChain/MayaChain routes gain a swap-fee row the co-signer never had.** `THORChainSwapPayload` gains `fee`, written and read in both proto branches; the builder populates it from the quote; the resolver gains a native branch.
- **The Total Fee row is new** on the confirm screen, for every payload shape that can produce one — not native-only. Hidden unless the network leg prices and a non-zero swap leg prices, so an unpriced fee is never absorbed as free.

The fee is resolved against the payload's own `toCoin`, scaled by the same `thorswapMultiplier` the rest of the native path uses (1e8 for THORChain, the coin's own decimals for MayaChain) — the denomination `vultisig-sdk` writes and `vultisig-windows` reads. `totalFee` already ships in all 8 locales: **no new strings, no locale files touched.**

`JoinKeysignGasViewModel.getCalculatedNetworkFee` was restructured around a private `resolveNetworkFee` so the fee's fiat is available as a `Decimal` to sum. Behaviour-preserving across every branch (dApp-supplied Cosmos fee, EVM incl. the `EVMSwapFee` reconciliation, Solana ComputeBudget, UTXO, Cardano, default) — the dropped `gasAmountToDisplay` ternary always selected the same value as `feeToUse`.

## Found on device: a stated zero is not an absent one

Testing a real two-device **RUNE → RUJI** swap, the co-signer showed *neither* row. RUJI is same-chain THORChain, so `fees.outbound` is 0 and the affiliate cut rounds to 0 — and the initiator still renders both rows at `$0.00`, deliberately (`showAffiliateFeeRow` is unconditional for a market route; `showProtocolFeeRow` tests the *formatted* string, and `"$0.00"` is non-empty).

The first iteration collapsed three states into two. `fee` has implicit presence, so unset and `"0"` are different bytes and always were distinguishable — Codex verified the encoding against the generated source: unset omits field 13, `"0"` serializes as `6a 01 30`. Four sites threw the distinction away, and all four are fixed: the builder returns `"0"` rather than `nil` when nothing is charged (reserving `nil` for a component too malformed to sum, each component checked so a negative can't offset a positive into a false zero); the writer no longer strips `"0"`; the resolver accepts `>= 0`; and `getSwapTotalFee` treats a zero leg as worth zero at any price, so it no longer demands a rate for the destination coin — which alone would still have suppressed the total on exactly this swap, since a co-signer that doesn't hold RUJI has no rate for it.

## Decision: `affiliate + outbound`, not `fees.total`

Deliberate, and a **known divergence from `vultisig-sdk` / `vultisig-windows`**, which write `quote.fees.total`.

iOS's initiator itemizes `affiliateFeeFiat` + `outboundFeeFiat` and sums exactly those into `totalFeeString`, excluding the liquidity component of `fees.total` on purpose — the quoted output already reflects it, so folding it in double-counts. Windows makes the opposite call (`protocol = total - affiliate`, so its rows sum to `fees.total`). The issue forbids changing the initiator and requires the joiner to match it, so iOS carries what the iOS initiator shows. Consequence: a Windows joiner on an iOS-initiated swap sees the iOS initiator's figure — the guarantee that matters — but not what a Windows initiator would have shown.

## Correction: the fee coin is `toCoin`, not `swapFeeCoin`

The issue text says to resolve the fee coin with `SwapCryptoLogic.swapFeeCoin`. **That is wrong for native routes and is not used.** `swapFeeCoin` disambiguates via `quote.swapFeeTokenContract`, which returns `nil` for every `.thorchain*`/`.mayachain` case (`SwapQuote.swift:226-233`), so it falls through to `feeCoin` — the *source-chain gas coin* (BTC on a BTC → TRX swap) — while a native route charges in the *destination* asset. Using it would have produced exactly the disagreement it was meant to prevent. Native fees need no coin context on the wire: the fee coin **is** `toCoin`, which already travels on the payload.

## Signing safety — display only

**`fee` cannot enter any pre-signing hash. Verified twice, independently.** A repo-wide search by the cross-model reviewer found no signer reading `swapPayload.fee`; separately I grepped `Blockchain/` and `Features/Keysign/` and the only consumers are the two proto writers and the display resolver (the `TransactionHistoryRecording` `payload.fee.crypto`/`.fiat` hits a naive grep surfaces are a *different type's* pair).

Native pre-sign inputs are built from `KeysignPayload` (`coin`, `toAddress`, `toAmount`, `memo`, `chainSpecific`) via `THORChainSwaps.getPreSignedInputData`; the swap payload supplies only `fromCoin.chain` for routing and `fromCoin`/`fromAmount` for the `MsgDeposit` asset. `KeysignMessage.payloadID` is a relay content hash the joiner downloads by id, not a signing input.

## Known adjacent instance, deliberately not widened into

The **1inch/generic path has the same zero-collapse** (`KeysignMessage+ProtoMappable.swift:381` writes only when `swapFee != "0"`), and it is pre-existing on `main` — it predates this PR. An EVM swap by a user on the Ultimate tier shows `$0.00` on the initiator and nothing on the co-signer.

It is **not** fixable by relaxing that guard. `EVMQuote.Transaction.init(from:)` decodes a missing `swap_fee` as `?? "0"`, so the initiator cannot tell a stated zero from an unmentioned one before it writes; relaxing the guard would make the app assert a zero the provider never quoted, which is worse than showing nothing. The fix belongs at the quote model (`swapFee` as `String?`) and ripples through `evmSwapFeeBigInt`, `swapFeeString`, `affiliateFeeFiat` and the LiFi/Kyber branches. Filed separately.

Two further wrinkles for that work: **LiFi Solana** hard-codes `swapFee: "0"` and charges via `integratorFee` as a fraction of output, so a stated zero there would be a lie — the amount is not expressible in `swap_fee`; and **Jupiter / SwapKit-generic** never populate the fee coin context at all in `SwapPayloadBuilder`, so their fees reach no co-signer regardless.

## Verification

Full gate on a dedicated `en_US` simulator (since deleted), against the exact pushed commit:

```
HEAD:      c018d66940ca48bc1eb57392629367b4e95151b5
DF_BEFORE: /dev/disk3s5  460Gi  406Gi   25Gi   95%
** TEST SUCCEEDED **
Executed 7102 tests, with 11 tests skipped and 0 failures (0 unexpected) in 130.533 seconds
GATE_EXIT=0
DF_AFTER:  /dev/disk3s5  460Gi  406Gi   24Gi   95%
```

0 failed cases; all 24 new cases named individually as `passed`; free space never approached zero, so the marker is not a stale-run artifact. SwiftLint: 0 violations across the changed files.

Cross-model review (`codex exec --sandbox read-only`) at every step: no P0/P1 and no Critical/High/Medium at any stage. The original production commit drew zero findings. Later passes raised test-quality issues — a circular total-fee expectation, a parity test that bypassed the wire, an `XCTAssertNotEqual` satisfiable by an always-`nil` implementation, process-wide rate state, incomplete negative validation, and a serialization test that never serialized — all fixed.

## Tests

`VultisigAppTests/Keysign/NativeSwapFeeProtoMappingTests.swift`, 24 cases. Two carry the load:

- `testCoSignerSwapFeeFiatMatchesTheInitiatorItemization` builds the payload from a live quote, **serializes and parses it back**, and asserts the co-signer's fiat equals `affiliateFeeFiat + outboundFeeFiat` from that quote.
- `testKnownZeroFeeSurvivesSerialization` and `testAbsentAndKnownZeroAreDistinguishableEndToEnd` assert the *distinction* through real bytes — field 13 present as `6a 01 30` for a stated zero, reparsing to unset when absent — and run through `getSwapFee`, the accessor the confirm screen binds to. A regression that rendered everything, or nothing, fails both.

Also covered: round-trip on both branches; pre-field-13 wire bytes parse and relay without gaining a fee; destination-coin denomination on both networks (1e8 THORChain, CACAO's own 1e10); negative and malformed components rejected; and the Total Fee row present for a stated zero on an unpriced destination coin, absent when either leg is genuinely unknown.

### The review pattern worth carrying forward

Three separate findings across this branch turned out to be one defect: **an assertion whose name claimed a boundary its body never crossed.** A parity test named for the wire that stayed in memory; a total named for correctness that recomputed its expectation through the function under test; a serialization test named for bytes that read an in-memory property. Each was individually plausible and collectively a blind spot.

The name is where the claim lives, so the name is what should be checked against the body. That is reviewable in a way "write better tests" is not.

## Review flags

- ⚠️ **Touches a keysign payload on a signing path — needs human review and on-device acceptance.** **On-device acceptance was NOT performed by me.** The stated-zero bug was found by Gaston on a real two-device RUNE → RUJI swap; re-running that is the acceptance test. A green gate only proves unit-level semantics.
- **The co-signer shows one row where the initiator shows two** (Swap Fee = affiliate, Protocol Fee = outbound). That mismatch survives this PR for non-zero routes and may need a second commondata field. Note it is *invisible* on the RUNE → RUJI retest, since both components are zero there — a non-zero native swap is needed to see it.
- Pre-existing, **not** fixed here: `affiliateFeeFiat`/`outboundFeeFiat` hard-code `pow(10, 8)` where `thorswapMultiplier` uses the coin's own decimals, so the *initiator* misprices a MayaChain-destination fee. Filed as #5351. The wire denomination here is the cross-platform-correct one.
- Out of scope by design: the commondata pin, and `OneInchSwapPayload` / `SwapKitSwapPayload` (#5341).

Closes #5340

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqdXT9XtXkN4XMwjXyqjND



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Swap confirmations now show combined network and swap fees in fiat when pricing is available.
  - Native THORChain and MayaChain swap fees are included in fee calculations.
  - Network fees across supported chains use consistent crypto and fiat values.
  - Affiliate and outbound charges are included in applicable swap fee calculations.
  - Explicit zero-fee routes display as $0.00, while unavailable fees remain hidden.

- **Bug Fixes**
  - Fee handling now distinguishes valid zero fees from missing, malformed, or negative data.
  - Legacy swap payloads preserve absent fee information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->