### PR TITLE
fix(send): reject non-plain-decimal amounts at every external boundary

### DIFF
--- a/VultisigApp/VultisigApp/Components/Validators/AmountBalanceValidator.swift
+++ b/VultisigApp/VultisigApp/Components/Validators/AmountBalanceValidator.swift
@@ -35,10 +35,8 @@ struct AmountBalanceValidator: FormFieldValidator {
     }
 
     func validate(value: String) throws {
-        // `formatter` is a plain `.decimal` NumberFormatter, which reads scientific
-        // notation: "1e5" would validate as 100000 and ride into the transaction
-        // builder. The balance ceiling below is not a backstop for that — a large
-        // enough balance, or a small exponent, clears it.
+        // `formatter` reads scientific notation, and the balance ceiling below is no
+        // backstop for it: a large enough balance clears the expanded value.
         guard value.isValidDecimal() else {
             throw ValidationError.invalidAmount
         }

--- a/VultisigApp/VultisigApp/Components/Validators/AmountBalanceValidator.swift
+++ b/VultisigApp/VultisigApp/Components/Validators/AmountBalanceValidator.swift
@@ -35,6 +35,14 @@ struct AmountBalanceValidator: FormFieldValidator {
     }
 
     func validate(value: String) throws {
+        // `formatter` is a plain `.decimal` NumberFormatter, which reads scientific
+        // notation: "1e5" would validate as 100000 and ride into the transaction
+        // builder. The balance ceiling below is not a backstop for that — a large
+        // enough balance, or a small exponent, clears it.
+        guard value.isValidDecimal() else {
+            throw ValidationError.invalidAmount
+        }
+
         guard
             let number = Self.formatter.number(from: value),
             let amount = Decimal(string: number.stringValue)

--- a/VultisigApp/VultisigApp/Core/Extensions/StringExtension.swift
+++ b/VultisigApp/VultisigApp/Core/Extensions/StringExtension.swift
@@ -254,6 +254,41 @@ extension String {
         return number >= 0
     }
 
+    /// Normalizes an amount that arrived from outside the app — a deeplink query
+    /// item, a payment URI's `amount=` — into the representation everything
+    /// downstream reads back, or nil when it is not a plain dot-decimal number.
+    ///
+    /// The shape is checked with fixed ASCII semantics, never the device locale.
+    /// An external amount is dot-decimal by specification, and a locale-aware
+    /// parse of one is actively wrong: under `pt_BR` or `de_DE`, `NumberFormatter`
+    /// reads the `.` in `0.005` as a grouping separator and yields 5 — a
+    /// thousandfold error on a value heading for a signature, larger than the
+    /// scientific-notation case this guard was first written for.
+    ///
+    /// The accepted digits are then re-rendered with the locale's decimal
+    /// separator, because the send form and `toDecimal()` parse with
+    /// `Locale.current`: handing `0.005` to a `pt_BR` device unchanged would just
+    /// move the same misparse one step later.
+    func externalAmount(locale: Locale = .current) -> String? {
+        let candidate = trimmingCharacters(in: .whitespaces)
+        let parts = candidate.split(separator: ".", omittingEmptySubsequences: false)
+        guard !candidate.isEmpty,
+              parts.count <= 2,
+              parts.allSatisfy({ !$0.isEmpty && $0.allSatisfy { $0.isASCII && $0.isNumber } })
+        else {
+            return nil
+        }
+
+        guard let separator = locale.decimalSeparator, separator != "." else {
+            return candidate
+        }
+
+        let localized = candidate.replacingOccurrences(of: ".", with: separator)
+        // The form applies its own gate to whatever is prefilled; a value that
+        // could not pass it must not be staged in the first place.
+        return localized.isValidDecimal(locale: locale) ? localized : nil
+    }
+
     var isValidEmail: Bool {
         let regex = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
         let predicate = NSPredicate(format: "SELF MATCHES %@", regex)

--- a/VultisigApp/VultisigApp/Core/Extensions/StringExtension.swift
+++ b/VultisigApp/VultisigApp/Core/Extensions/StringExtension.swift
@@ -258,34 +258,41 @@ extension String {
     /// item, a payment URI's `amount=` — into the representation everything
     /// downstream reads back, or nil when it is not a plain dot-decimal number.
     ///
-    /// The shape is checked with fixed ASCII semantics, never the device locale.
-    /// An external amount is dot-decimal by specification, and a locale-aware
-    /// parse of one is actively wrong: under `pt_BR` or `de_DE`, `NumberFormatter`
-    /// reads the `.` in `0.005` as a grouping separator and yields 5 — a
-    /// thousandfold error on a value heading for a signature, larger than the
-    /// scientific-notation case this guard was first written for.
+    /// The shape is BIP-321's amount grammar, `*digit [ "." *digit ]`, read with
+    /// fixed ASCII semantics rather than the device locale. The spec mandates a
+    /// period and forbids commas, and a locale-aware parse of such a value is
+    /// actively wrong: under `pt_BR` or `de_DE`, `NumberFormatter` reads the `.`
+    /// in `0.005` as a grouping separator and returns 5 — a thousandfold error on
+    /// a value heading for a signature, larger than the scientific-notation case
+    /// this guard was first written for. `1.` and `.5` are accepted because the
+    /// grammar admits them; `""` and `"."` are not, since they name no amount.
     ///
-    /// The accepted digits are then re-rendered with the locale's decimal
-    /// separator, because the send form and `toDecimal()` parse with
-    /// `Locale.current`: handing `0.005` to a `pt_BR` device unchanged would just
-    /// move the same misparse one step later.
+    /// The accepted digits are re-rendered with the locale's decimal separator,
+    /// because the send form and `toDecimal()` parse with `Locale.current`:
+    /// handing `0.005` to a `pt_BR` device unchanged would just move the same
+    /// misparse one step later.
     func externalAmount(locale: Locale = .current) -> String? {
-        let candidate = trimmingCharacters(in: .whitespaces)
-        let parts = candidate.split(separator: ".", omittingEmptySubsequences: false)
-        guard !candidate.isEmpty,
-              parts.count <= 2,
-              parts.allSatisfy({ !$0.isEmpty && $0.allSatisfy { $0.isASCII && $0.isNumber } })
-        else {
-            return nil
+        var seenSeparator = false
+        var digits = 0
+        for character in self {
+            if character == "." {
+                guard !seenSeparator else { return nil }
+                seenSeparator = true
+            } else if character.isASCII, character.isNumber {
+                digits += 1
+            } else {
+                return nil
+            }
         }
+        guard digits > 0 else { return nil }
 
-        guard let separator = locale.decimalSeparator, separator != "." else {
-            return candidate
-        }
+        let separator = locale.decimalSeparator ?? "."
+        let localized = separator == "." ? self : replacingOccurrences(of: ".", with: separator)
 
-        let localized = candidate.replacingOccurrences(of: ".", with: separator)
-        // The form applies its own gate to whatever is prefilled; a value that
-        // could not pass it must not be staged in the first place.
+        // Every path ends here, including the one where no re-rendering was
+        // needed: the form applies its own gate to whatever is prefilled, so a
+        // value it would refuse must never be staged — and a value too large for
+        // `Decimal` must not depend on which separator the device happens to use.
         return localized.isValidDecimal(locale: locale) ? localized : nil
     }
 

--- a/VultisigApp/VultisigApp/Core/Extensions/StringExtension.swift
+++ b/VultisigApp/VultisigApp/Core/Extensions/StringExtension.swift
@@ -139,18 +139,19 @@ extension String {
         return nil
     }
 
-    /// Whether every character belongs to a numeric amount: an ASCII digit or a
+    /// Whether every character belongs to a numeric amount: a decimal digit or a
     /// decimal / grouping separator (the current locale's, plus `.`/`,` so a value
     /// pasted from another locale still validates). An empty string is valid (it
     /// clears the field).
     ///
-    /// Used to gate entry on macOS, which has no decimal keypad: a numeric field
-    /// rejects any edit that introduces a letter or symbol, rather than silently
-    /// stripping it — stripping would turn a mixed paste like `"12abc34"` into a
-    /// real-looking `"1234"`, and collapse a grouped `pt_BR` `"1.234,56"` toward a
-    /// wrong value. This only validates the character SET; `parseInput` remains the
-    /// numeric validator (so an in-progress `"1."` or a stray second separator is
-    /// still allowed as text and simply parses to its own value / zero).
+    /// Gates entry on macOS, which has no decimal keypad: a numeric field rejects
+    /// any edit that introduces a letter or symbol, rather than silently stripping
+    /// it — stripping would turn a mixed paste like `"12abc34"` into a real-looking
+    /// `"1234"`, and collapse a grouped `pt_BR` `"1.234,56"` toward a wrong value.
+    /// Also the character-set half of `isValidDecimal`. This only validates the
+    /// character SET; `parseInput` remains the numeric validator (so an in-progress
+    /// `"1."` or a stray second separator is still allowed as text and simply parses
+    /// to its own value / zero).
     func isDecimalInput(locale: Locale = .current) -> Bool {
         var allowed: Set<Character> = [".", ","]
         if let decimal = locale.decimalSeparator, decimal.count == 1 {
@@ -159,7 +160,20 @@ extension String {
         if let grouping = locale.groupingSeparator, grouping.count == 1 {
             allowed.insert(Character(grouping))
         }
-        return allSatisfy { ($0.isASCII && $0.isNumber) || allowed.contains($0) }
+        return allSatisfy { $0.isDecimalDigit || allowed.contains($0) }
+    }
+}
+
+private extension Character {
+    /// A Unicode decimal digit, not just `0`-`9`. `NumberFormatter` renders in the
+    /// locale's numbering system — `ar_EG` formats 1234.5 as `١٢٣٤٫٥`, `ne_NP` as
+    /// `१२३४.५` — so an amount the app formatted for the user has to validate again
+    /// under that same locale.
+    ///
+    /// Narrower than `isNumber` / `isWholeNumber` on purpose: those also accept
+    /// `²`, `½`, `Ⅷ` and `②`, none of which belong in an amount field.
+    var isDecimalDigit: Bool {
+        unicodeScalars.count == 1 && unicodeScalars.first?.properties.numericType == .decimal
     }
 }
 
@@ -222,8 +236,18 @@ extension String {
         return self.toDecimal().truncated(toPlaces: decimals).description.toBigInt()
     }
 
-    func isValidDecimal() -> Bool {
-        guard let number = parseInput() else {
+    /// Whether this is a plain decimal amount: the character set `isDecimalInput`
+    /// allows, parsing to a non-negative value.
+    ///
+    /// The character-set half is what stops `NumberFormatter` expanding scientific
+    /// notation — it reads `"1e5"` as 100000, so an amount arriving from outside the
+    /// app would otherwise sign five orders of magnitude above the string the Verify
+    /// screen displays. Surrounding whitespace is trimmed for that half only:
+    /// `parseInput` still rules on the untrimmed value, so it keeps tolerating the
+    /// spaces it always did and keeps rejecting embedded newlines.
+    func isValidDecimal(locale: Locale = .current) -> Bool {
+        guard trimmingCharacters(in: .whitespaces).isDecimalInput(locale: locale),
+              let number = parseInput(locale: locale) else {
             return false
         }
 

--- a/VultisigApp/VultisigApp/Core/Extensions/StringExtension.swift
+++ b/VultisigApp/VultisigApp/Core/Extensions/StringExtension.swift
@@ -144,14 +144,13 @@ extension String {
     /// pasted from another locale still validates). An empty string is valid (it
     /// clears the field).
     ///
-    /// Gates entry on macOS, which has no decimal keypad: a numeric field rejects
-    /// any edit that introduces a letter or symbol, rather than silently stripping
-    /// it — stripping would turn a mixed paste like `"12abc34"` into a real-looking
-    /// `"1234"`, and collapse a grouped `pt_BR` `"1.234,56"` toward a wrong value.
-    /// Also the character-set half of `isValidDecimal`. This only validates the
-    /// character SET; `parseInput` remains the numeric validator (so an in-progress
-    /// `"1."` or a stray second separator is still allowed as text and simply parses
-    /// to its own value / zero).
+    /// Used to gate entry on macOS, which has no decimal keypad: a numeric field
+    /// rejects any edit that introduces a letter or symbol, rather than silently
+    /// stripping it — stripping would turn a mixed paste like `"12abc34"` into a
+    /// real-looking `"1234"`, and collapse a grouped `pt_BR` `"1.234,56"` toward a
+    /// wrong value. This only validates the character SET; `parseInput` remains the
+    /// numeric validator (so an in-progress `"1."` or a stray second separator is
+    /// still allowed as text and simply parses to its own value / zero).
     func isDecimalInput(locale: Locale = .current) -> Bool {
         var allowed: Set<Character> = [".", ","]
         if let decimal = locale.decimalSeparator, decimal.count == 1 {
@@ -165,13 +164,9 @@ extension String {
 }
 
 private extension Character {
-    /// A Unicode decimal digit, not just `0`-`9`. `NumberFormatter` renders in the
-    /// locale's numbering system — `ar_EG` formats 1234.5 as `١٢٣٤٫٥`, `ne_NP` as
-    /// `१२३४.५` — so an amount the app formatted for the user has to validate again
-    /// under that same locale.
-    ///
-    /// Narrower than `isNumber` / `isWholeNumber` on purpose: those also accept
-    /// `²`, `½`, `Ⅷ` and `②`, none of which belong in an amount field.
+    /// A Unicode decimal digit, so an amount `NumberFormatter` rendered in a
+    /// non-Latin numbering system validates back. Narrower than `isNumber` /
+    /// `isWholeNumber`, which also accept `²`, `½`, `Ⅷ` and `②`.
     var isDecimalDigit: Bool {
         unicodeScalars.count == 1 && unicodeScalars.first?.properties.numericType == .decimal
     }
@@ -236,15 +231,8 @@ extension String {
         return self.toDecimal().truncated(toPlaces: decimals).description.toBigInt()
     }
 
-    /// Whether this is a plain decimal amount: the character set `isDecimalInput`
-    /// allows, parsing to a non-negative value.
-    ///
     /// The character-set half is what stops `NumberFormatter` expanding scientific
-    /// notation — it reads `"1e5"` as 100000, so an amount arriving from outside the
-    /// app would otherwise sign five orders of magnitude above the string the Verify
-    /// screen displays. Surrounding whitespace is trimmed for that half only:
-    /// `parseInput` still rules on the untrimmed value, so it keeps tolerating the
-    /// spaces it always did and keeps rejecting embedded newlines.
+    /// notation. Whitespace is trimmed for that half only.
     func isValidDecimal(locale: Locale = .current) -> Bool {
         guard trimmingCharacters(in: .whitespaces).isDecimalInput(locale: locale),
               let number = parseInput(locale: locale) else {
@@ -254,23 +242,10 @@ extension String {
         return number >= 0
     }
 
-    /// Normalizes an amount that arrived from outside the app — a deeplink query
-    /// item, a payment URI's `amount=` — into the representation everything
-    /// downstream reads back, or nil when it is not a plain dot-decimal number.
-    ///
-    /// The shape is BIP-321's amount grammar, `*digit [ "." *digit ]`, read with
-    /// fixed ASCII semantics rather than the device locale. The spec mandates a
-    /// period and forbids commas, and a locale-aware parse of such a value is
-    /// actively wrong: under `pt_BR` or `de_DE`, `NumberFormatter` reads the `.`
-    /// in `0.005` as a grouping separator and returns 5 — a thousandfold error on
-    /// a value heading for a signature, larger than the scientific-notation case
-    /// this guard was first written for. `1.` and `.5` are accepted because the
-    /// grammar admits them; `""` and `"."` are not, since they name no amount.
-    ///
-    /// The accepted digits are re-rendered with the locale's decimal separator,
-    /// because the send form and `toDecimal()` parse with `Locale.current`:
-    /// handing `0.005` to a `pt_BR` device unchanged would just move the same
-    /// misparse one step later.
+    /// An amount supplied by a link or QR, in this device's representation, or nil
+    /// if it is not BIP-321's `*digit [ "." *digit ]`. Read with fixed semantics,
+    /// never the device locale, which would take the `.` for a grouping separator;
+    /// re-rendered after, because everything downstream parses `Locale.current`.
     func externalAmount(locale: Locale = .current) -> String? {
         var seenSeparator = false
         var digits = 0
@@ -289,10 +264,7 @@ extension String {
         let separator = locale.decimalSeparator ?? "."
         let localized = separator == "." ? self : replacingOccurrences(of: ".", with: separator)
 
-        // Every path ends here, including the one where no re-rendering was
-        // needed: the form applies its own gate to whatever is prefilled, so a
-        // value it would refuse must never be staged — and a value too large for
-        // `Decimal` must not depend on which separator the device happens to use.
+        // Every path ends here, so validity never depends on the device separator.
         return localized.isValidDecimal(locale: locale) ? localized : nil
     }
 

--- a/VultisigApp/VultisigApp/Core/Platform/macOS/Native/MacAddressScannerView+macOS.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/macOS/Native/MacAddressScannerView+macOS.swift
@@ -18,7 +18,7 @@ struct AddressResult {
         self.amount = amount
     }
 
-    static func fromURI(_ uri: String) -> AddressResult {
+    static func fromURI(_ uri: String, locale: Locale = .current) -> AddressResult {
         guard URLComponents(string: uri) != nil else {
             // Validate up
             return .init(address: uri)
@@ -27,13 +27,13 @@ struct AddressResult {
         let (address, amount, message) = Utils.parseCryptoURI(uri)
 
         // A scanned URI is untrusted text, and the send form assigns this amount
-        // straight into the field. `NumberFormatter` reads scientific notation, so
-        // a `?amount=1e5` would fill it with a value that signs as 100000 — carry
-        // only a plain decimal through.
+        // straight into the field. A payment URI is dot-decimal by specification,
+        // so it goes through the same fixed-semantics read as a deeplink rather
+        // than the device locale.
         return AddressResult(
             address: address,
             memo: message,
-            amount: amount.isValidDecimal() ? amount : nil
+            amount: amount.externalAmount(locale: locale)
         )
     }
 }

--- a/VultisigApp/VultisigApp/Core/Platform/macOS/Native/MacAddressScannerView+macOS.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/macOS/Native/MacAddressScannerView+macOS.swift
@@ -26,10 +26,7 @@ struct AddressResult {
 
         let (address, amount, message) = Utils.parseCryptoURI(uri)
 
-        // A scanned URI is untrusted text, and the send form assigns this amount
-        // straight into the field. A payment URI is dot-decimal by specification,
-        // so it goes through the same fixed-semantics read as a deeplink rather
-        // than the device locale.
+        // Untrusted, and dot-decimal like a deeplink: same fixed-semantics read.
         return AddressResult(
             address: address,
             memo: message,

--- a/VultisigApp/VultisigApp/Core/Platform/macOS/Native/MacAddressScannerView+macOS.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/macOS/Native/MacAddressScannerView+macOS.swift
@@ -26,7 +26,15 @@ struct AddressResult {
 
         let (address, amount, message) = Utils.parseCryptoURI(uri)
 
-        return AddressResult(address: address, memo: message, amount: amount)
+        // A scanned URI is untrusted text, and the send form assigns this amount
+        // straight into the field. `NumberFormatter` reads scientific notation, so
+        // a `?amount=1e5` would fill it with a value that signs as 100000 — carry
+        // only a plain decimal through.
+        return AddressResult(
+            address: address,
+            memo: message,
+            amount: amount.isValidDecimal() ? amount : nil
+        )
     }
 }
 

--- a/VultisigApp/VultisigApp/Core/ViewModels/DeeplinkViewModel.swift
+++ b/VultisigApp/VultisigApp/Core/ViewModels/DeeplinkViewModel.swift
@@ -98,6 +98,14 @@ class DeeplinkViewModel: ObservableObject {
 }
 
 struct DeeplinkLogic {
+    /// Locale used to render an accepted `amount` for this device. The link's own
+    /// digits are always read as dot-decimal, independent of it.
+    let locale: Locale
+
+    init(locale: Locale = .current) {
+        self.locale = locale
+    }
+
     struct DeeplinkResult {
         var type: DeeplinkFlowType?
         var selectedVault: Vault?
@@ -191,15 +199,17 @@ struct DeeplinkLogic {
         result.assetChain = queryItems?.first(where: { $0.name == "assetChain" })?.value?.removingPercentEncoding
         result.assetTicker = queryItems?.first(where: { $0.name == "assetTicker" })?.value?.removingPercentEncoding
         result.address = queryItems?.first(where: { $0.name == "toAddress" })?.value?.removingPercentEncoding
-        // `NumberFormatter` reads scientific notation, so an `amount=1e5` carried
-        // through here would stage — and sign — 100000 while Verify displayed the
-        // string it came from. A link is attacker-supplied text: only a plain
-        // decimal is prefilled, anything else leaves the field empty for the user.
+        // A link is attacker-supplied text, and two different misreads of it end in
+        // a wrong signed amount: `NumberFormatter` expands `1e5` to 100000, and a
+        // locale-aware parse turns a canonical `0.005` into 5 under a
+        // comma-decimal locale. `externalAmount` settles both — dot-decimal in,
+        // this device's representation out — and anything else leaves the field
+        // empty for the user to fill.
         result.sendAmount = queryItems?
             .first(where: { $0.name == "amount" })?
             .value?
             .removingPercentEncoding
-            .flatMap { $0.isValidDecimal() ? $0 : nil }
+            .flatMap { $0.externalAmount(locale: locale) }
         result.sendMemo = queryItems?.first(where: { $0.name == "memo" })?.value?.removingPercentEncoding
         result.pendingSendDeeplink = true
 

--- a/VultisigApp/VultisigApp/Core/ViewModels/DeeplinkViewModel.swift
+++ b/VultisigApp/VultisigApp/Core/ViewModels/DeeplinkViewModel.swift
@@ -191,7 +191,15 @@ struct DeeplinkLogic {
         result.assetChain = queryItems?.first(where: { $0.name == "assetChain" })?.value?.removingPercentEncoding
         result.assetTicker = queryItems?.first(where: { $0.name == "assetTicker" })?.value?.removingPercentEncoding
         result.address = queryItems?.first(where: { $0.name == "toAddress" })?.value?.removingPercentEncoding
-        result.sendAmount = queryItems?.first(where: { $0.name == "amount" })?.value?.removingPercentEncoding
+        // `NumberFormatter` reads scientific notation, so an `amount=1e5` carried
+        // through here would stage — and sign — 100000 while Verify displayed the
+        // string it came from. A link is attacker-supplied text: only a plain
+        // decimal is prefilled, anything else leaves the field empty for the user.
+        result.sendAmount = queryItems?
+            .first(where: { $0.name == "amount" })?
+            .value?
+            .removingPercentEncoding
+            .flatMap { $0.isValidDecimal() ? $0 : nil }
         result.sendMemo = queryItems?.first(where: { $0.name == "memo" })?.value?.removingPercentEncoding
         result.pendingSendDeeplink = true
 

--- a/VultisigApp/VultisigApp/Core/ViewModels/DeeplinkViewModel.swift
+++ b/VultisigApp/VultisigApp/Core/ViewModels/DeeplinkViewModel.swift
@@ -98,8 +98,7 @@ class DeeplinkViewModel: ObservableObject {
 }
 
 struct DeeplinkLogic {
-    /// Locale used to render an accepted `amount` for this device. The link's own
-    /// digits are always read as dot-decimal, independent of it.
+    /// Renders an accepted `amount`; the link itself is always read as dot-decimal.
     let locale: Locale
 
     init(locale: Locale = .current) {
@@ -199,12 +198,8 @@ struct DeeplinkLogic {
         result.assetChain = queryItems?.first(where: { $0.name == "assetChain" })?.value?.removingPercentEncoding
         result.assetTicker = queryItems?.first(where: { $0.name == "assetTicker" })?.value?.removingPercentEncoding
         result.address = queryItems?.first(where: { $0.name == "toAddress" })?.value?.removingPercentEncoding
-        // A link is attacker-supplied text, and two different misreads of it end in
-        // a wrong signed amount: `NumberFormatter` expands `1e5` to 100000, and a
-        // locale-aware parse turns a canonical `0.005` into 5 under a
-        // comma-decimal locale. `externalAmount` settles both — dot-decimal in,
-        // this device's representation out — and anything else leaves the field
-        // empty for the user to fill.
+        // Attacker-supplied: anything that would not stage the number the link names
+        // leaves the field empty.
         result.sendAmount = queryItems?
             .first(where: { $0.name == "amount" })?
             .value?

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -1144,6 +1144,20 @@ final class SendDetailsViewModel {
         return true
     }
 
+    /// Rejects an amount that is not a plain decimal. `parseInput` is backed by
+    /// `NumberFormatter`, which expands scientific notation ("1e5" -> 100000),
+    /// and Verify renders the raw string — so an expanded value would be signed
+    /// behind a figure the user never agreed to. The boundaries that can carry one
+    /// in are guarded at their source; this is the backstop for anything that
+    /// reaches `amount` without passing them.
+    func validateAmountFormat() -> Bool {
+        guard amount.isValidDecimal() else {
+            setAmountError(message: "decimalAmountError")
+            return false
+        }
+        return true
+    }
+
     /// Rejects malformed addresses for the current coin's chain.
     func validateAddressFormat() -> Bool {
         guard isValidAddressFormat() else {
@@ -1315,6 +1329,7 @@ final class SendDetailsViewModel {
 
         guard validatePendingTransaction() else { return false }
         guard validateAmountNonZero() else { return false }
+        guard validateAmountFormat() else { return false }
         // Address resolution runs BEFORE the XRP tag/memo rule: it hosts the
         // X-address normalization seam, which can autofill the tag field —
         // validating the tag first would let an autofilled value (e.g. an

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -1144,12 +1144,7 @@ final class SendDetailsViewModel {
         return true
     }
 
-    /// Rejects an amount that is not a plain decimal. `parseInput` is backed by
-    /// `NumberFormatter`, which expands scientific notation ("1e5" -> 100000),
-    /// and Verify renders the raw string — so an expanded value would be signed
-    /// behind a figure the user never agreed to. The boundaries that can carry one
-    /// in are guarded at their source; this is the backstop for anything that
-    /// reaches `amount` without passing them.
+    /// Backstop: Verify renders the raw string, so an expanded one signs behind it.
     func validateAmountFormat() -> Bool {
         guard amount.isValidDecimal() else {
             setAmountError(message: "decimalAmountError")

--- a/VultisigApp/VultisigAppTests/Core/ExternalAmountGuardTests.swift
+++ b/VultisigApp/VultisigAppTests/Core/ExternalAmountGuardTests.swift
@@ -128,12 +128,44 @@ final class ExternalAmountGuardTests: XCTestCase {
 
     func testExternalAmountRejectsEverythingNotPlainDotDecimal() {
         for locale in [Locale(identifier: "en_US"), Locale(identifier: "pt_BR")] {
-            for candidate in ["1e5", "1E5", "2.5e3", "1e-3", "0x1F", "1,5", "1.", ".5", "1.2.3", "-5", "1 234", "abc", ""] {
+            for candidate in ["1e5", "1E5", "2.5e3", "1e-3", "0x1F", "1,5", "1.2.3", "-5", "1 234", "abc", "", ".", "  0.5  "] {
                 XCTAssertNil(
                     candidate.externalAmount(locale: locale),
                     "\(locale.identifier) must reject \(candidate.isEmpty ? "(empty)" : candidate)"
                 )
             }
+        }
+    }
+
+    /// BIP-321's amount grammar is `*digit [ "." *digit ]`, which admits a
+    /// trailing and a leading separator, and `parseInput` reads both ("1." -> 1,
+    /// ".5" -> 0.5). Rejecting them would drop a spec-legal QR amount. `""` and
+    /// `"."` stay rejected — they carry no digit, so they name no amount.
+    func testExternalAmountAcceptsTheGrammarsBareSeparatorForms() {
+        for identifier in ["en_US", "pt_BR", "de_DE"] {
+            let locale = Locale(identifier: identifier)
+
+            XCTAssertEqual("1.".externalAmount(locale: locale)?.parseInput(locale: locale), Decimal(1), identifier)
+            XCTAssertEqual(
+                ".5".externalAmount(locale: locale)?.parseInput(locale: locale),
+                Decimal(string: "0.5"), identifier
+            )
+        }
+    }
+
+    /// An amount too large for `Decimal` must be refused identically everywhere.
+    /// It previously slipped through on dot-decimal locales only, because the
+    /// no-re-rendering-needed path returned early without the final check — so
+    /// the form then rejected a value the boundary had already staged, and which
+    /// of the two happened depended on the device's separator.
+    func testExternalAmountRejectsOversizedAmountOnEveryLocale() {
+        let oversized = String(repeating: "9", count: 309)
+
+        for identifier in ["en_US", "pt_BR", "de_DE", "ko_KR"] {
+            XCTAssertNil(
+                oversized.externalAmount(locale: Locale(identifier: identifier)),
+                "\(identifier) staged an amount its own parser cannot read"
+            )
         }
     }
 

--- a/VultisigApp/VultisigAppTests/Core/ExternalAmountGuardTests.swift
+++ b/VultisigApp/VultisigAppTests/Core/ExternalAmountGuardTests.swift
@@ -2,10 +2,8 @@
 //  ExternalAmountGuardTests.swift
 //  VultisigAppTests
 //
-//  Amounts that reach the send form from outside the app — a `vultisig://send`
-//  deeplink and a scanned `bitcoin:` / `ton://` URI — must be plain decimals
-//  before they can be prefilled. `NumberFormatter` expands scientific notation,
-//  so an unguarded `amount=1e5` stages 100000.
+//  The two paths that prefill the send form from outside the app: a
+//  `vultisig://send` deeplink and a scanned `bitcoin:` / `ton://` URI.
 //
 
 import XCTest
@@ -16,10 +14,7 @@ final class ExternalAmountGuardTests: XCTestCase {
 
     // MARK: - Why the guard rejects rather than normalises
 
-    /// Verify renders the amount string verbatim — `SendVerifyScreen` hands
-    /// `tx.amount` to `CoinAmountFiatLabel`, which is a plain `Text(amount)` with
-    /// no formatting hop — while everything signed derives from `amountDecimal`.
-    /// For scientific notation those two disagree by five orders of magnitude.
+    /// Verify renders `tx.amount`; the signed value comes from `amountDecimal`.
     func testScientificNotationDisplaysAndSignsDifferentValues() {
         let coin = SendFormFixture.makeBTC()
         let displayed = "1e5"
@@ -52,15 +47,10 @@ final class ExternalAmountGuardTests: XCTestCase {
         XCTAssertEqual(try sendAmount(from: "amount=100000"), "100000")
     }
 
-    /// A link with no amount at all is unchanged by the guard — the form opens
-    /// with an empty field, exactly as a rejected one now does.
     func testDeeplinkWithoutAmountStaysNil() throws {
         XCTAssertNil(try sendAmount(from: "memo=hello"))
     }
 
-    /// The rest of the send deeplink keeps working when the amount is dropped:
-    /// the address still routes, so the user lands on a prefilled form and types
-    /// the amount themselves.
     func testDeeplinkWithRejectedAmountStillCarriesAddress() throws {
         let url = URL(string: "vultisig://send?assetChain=ethereum&assetTicker=ETH&toAddress=0xdead&amount=1e5")!
 
@@ -84,7 +74,6 @@ final class ExternalAmountGuardTests: XCTestCase {
         XCTAssertEqual(AddressResult.fromURI("ton://transfer/EQabc?amount=12.25").amount, "12.25")
     }
 
-    /// Dropping the amount must not drop the address or the memo riding with it.
     func testScannedURIWithRejectedAmountKeepsAddressAndMessage() {
         let result = AddressResult.fromURI("bitcoin:bc1qexampleaddress?amount=1e5&message=coffee")
 
@@ -93,13 +82,10 @@ final class ExternalAmountGuardTests: XCTestCase {
         XCTAssertNil(result.amount)
     }
 
-    // MARK: - Comma-decimal locales (the misparse that outranks 1e5)
+    // MARK: - Comma-decimal locales
 
-    /// An external amount is dot-decimal by specification, but `parseInput` is
-    /// locale-aware: under a comma-decimal locale it reads the `.` in `0.005` as a
-    /// grouping separator and returns 5. Five of the eight shipping locales do
-    /// this, so a canonical payment link was staging a thousandfold overpayment —
-    /// a larger error than the scientific notation this guard started from.
+    /// A locale-aware parse reads the `.` in a machine-supplied `0.005` as a
+    /// grouping separator and returns 5, in five of the eight shipping locales.
     func testExternalAmountSurvivesCommaDecimalLocales() {
         for identifier in ["en_US", "de_DE", "zh_Hans_CN", "es_ES", "ko_KR", "it_IT", "pt_BR", "hr_HR"] {
             let locale = Locale(identifier: identifier)
@@ -115,8 +101,6 @@ final class ExternalAmountGuardTests: XCTestCase {
         }
     }
 
-    /// The same misread with the digits the other way round: `1.234` is one and a
-    /// bit, never one thousand two hundred and thirty four.
     func testExternalAmountDoesNotPromoteFractionToThousands() {
         for identifier in ["pt_BR", "de_DE"] {
             let locale = Locale(identifier: identifier)
@@ -137,10 +121,8 @@ final class ExternalAmountGuardTests: XCTestCase {
         }
     }
 
-    /// BIP-321's amount grammar is `*digit [ "." *digit ]`, which admits a
-    /// trailing and a leading separator, and `parseInput` reads both ("1." -> 1,
-    /// ".5" -> 0.5). Rejecting them would drop a spec-legal QR amount. `""` and
-    /// `"."` stay rejected — they carry no digit, so they name no amount.
+    /// BIP-321 admits a bare separator on either side, so rejecting `1.` / `.5`
+    /// would drop a spec-legal QR amount. `""` and `"."` carry no digit.
     func testExternalAmountAcceptsTheGrammarsBareSeparatorForms() {
         for identifier in ["en_US", "pt_BR", "de_DE"] {
             let locale = Locale(identifier: identifier)
@@ -153,11 +135,8 @@ final class ExternalAmountGuardTests: XCTestCase {
         }
     }
 
-    /// An amount too large for `Decimal` must be refused identically everywhere.
-    /// It previously slipped through on dot-decimal locales only, because the
-    /// no-re-rendering-needed path returned early without the final check — so
-    /// the form then rejected a value the boundary had already staged, and which
-    /// of the two happened depended on the device's separator.
+    /// Previously slipped through on dot-decimal locales, where the early return
+    /// skipped the final check.
     func testExternalAmountRejectsOversizedAmountOnEveryLocale() {
         let oversized = String(repeating: "9", count: 309)
 
@@ -169,7 +148,6 @@ final class ExternalAmountGuardTests: XCTestCase {
         }
     }
 
-    /// End to end through the deeplink, not just the helper.
     func testDeeplinkStagesCommaLocaleAmountThatReadsBackCorrectly() throws {
         for identifier in ["pt_BR", "de_DE"] {
             let locale = Locale(identifier: identifier)
@@ -189,9 +167,7 @@ final class ExternalAmountGuardTests: XCTestCase {
 
     // MARK: - The live function-call / DeFi amount gate
 
-    /// `AmountBalanceValidator` is the validator on ~19 function-call and DeFi
-    /// amount fields, and its `NumberFormatter` read scientific notation. The
-    /// balance ceiling is not a backstop: a large enough balance clears it.
+    /// The live gate on ~19 function-call and DeFi amount fields.
     func testAmountBalanceValidatorRejectsScientificNotation() {
         let validator = AmountBalanceValidator(balance: Decimal(1_000_000))
 

--- a/VultisigApp/VultisigAppTests/Core/ExternalAmountGuardTests.swift
+++ b/VultisigApp/VultisigAppTests/Core/ExternalAmountGuardTests.swift
@@ -1,0 +1,95 @@
+//
+//  ExternalAmountGuardTests.swift
+//  VultisigAppTests
+//
+//  Amounts that reach the send form from outside the app — a `vultisig://send`
+//  deeplink and a scanned `bitcoin:` / `ton://` URI — must be plain decimals
+//  before they can be prefilled. `NumberFormatter` expands scientific notation,
+//  so an unguarded `amount=1e5` stages 100000.
+//
+
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class ExternalAmountGuardTests: XCTestCase {
+
+    // MARK: - Why the guard rejects rather than normalises
+
+    /// Verify renders the amount string verbatim — `SendVerifyScreen` hands
+    /// `tx.amount` to `CoinAmountFiatLabel`, which is a plain `Text(amount)` with
+    /// no formatting hop — while everything signed derives from `amountDecimal`.
+    /// For scientific notation those two disagree by five orders of magnitude.
+    func testScientificNotationDisplaysAndSignsDifferentValues() {
+        let coin = SendFormFixture.makeBTC()
+        let displayed = "1e5"
+
+        let signed = SendCryptoLogic.amountDecimal(coin: coin, amount: displayed)
+
+        XCTAssertEqual(signed, Decimal(100_000))
+        XCTAssertNotEqual(displayed, "\(signed)")
+        XCTAssertFalse(displayed.isValidDecimal(), "the form must refuse it before Verify can show it")
+    }
+
+    // MARK: - Deeplink boundary
+
+    private func sendAmount(from query: String) throws -> String? {
+        let url = URL(string: "vultisig://send?assetChain=ethereum&assetTicker=ETH&toAddress=0xdead&\(query)")!
+        return try DeeplinkLogic().extractParameters(url, vaults: []).sendAmount
+    }
+
+    func testDeeplinkDropsScientificNotationAmount() throws {
+        XCTAssertNil(try sendAmount(from: "amount=1e5"))
+        XCTAssertNil(try sendAmount(from: "amount=1E5"))
+        XCTAssertNil(try sendAmount(from: "amount=2.5e3"))
+        XCTAssertNil(try sendAmount(from: "amount=1e-3"))
+        XCTAssertNil(try sendAmount(from: "amount=0x1F"))
+    }
+
+    func testDeeplinkKeepsPlainDecimalAmount() throws {
+        XCTAssertEqual(try sendAmount(from: "amount=1.5"), "1.5")
+        XCTAssertEqual(try sendAmount(from: "amount=0.00000001"), "0.00000001")
+        XCTAssertEqual(try sendAmount(from: "amount=100000"), "100000")
+    }
+
+    /// A link with no amount at all is unchanged by the guard — the form opens
+    /// with an empty field, exactly as a rejected one now does.
+    func testDeeplinkWithoutAmountStaysNil() throws {
+        XCTAssertNil(try sendAmount(from: "memo=hello"))
+    }
+
+    /// The rest of the send deeplink keeps working when the amount is dropped:
+    /// the address still routes, so the user lands on a prefilled form and types
+    /// the amount themselves.
+    func testDeeplinkWithRejectedAmountStillCarriesAddress() throws {
+        let url = URL(string: "vultisig://send?assetChain=ethereum&assetTicker=ETH&toAddress=0xdead&amount=1e5")!
+
+        let result = try DeeplinkLogic().extractParameters(url, vaults: [])
+
+        XCTAssertEqual(result.address, "0xdead")
+        XCTAssertEqual(result.type, .Send)
+        XCTAssertNil(result.sendAmount)
+    }
+
+    // MARK: - Scanned crypto-URI boundary
+
+    func testScannedURIDropsScientificNotationAmount() {
+        XCTAssertNil(AddressResult.fromURI("bitcoin:bc1qexampleaddress?amount=1e5").amount)
+        XCTAssertNil(AddressResult.fromURI("bitcoin:bc1qexampleaddress?amount=2.5e3").amount)
+        XCTAssertNil(AddressResult.fromURI("ton://transfer/EQabc?amount=1e5").amount)
+    }
+
+    func testScannedURIKeepsPlainDecimalAmount() {
+        XCTAssertEqual(AddressResult.fromURI("bitcoin:bc1qexampleaddress?amount=0.5").amount, "0.5")
+        XCTAssertEqual(AddressResult.fromURI("ton://transfer/EQabc?amount=12.25").amount, "12.25")
+    }
+
+    /// Dropping the amount must not drop the address or the memo riding with it.
+    func testScannedURIWithRejectedAmountKeepsAddressAndMessage() {
+        let result = AddressResult.fromURI("bitcoin:bc1qexampleaddress?amount=1e5&message=coffee")
+
+        XCTAssertEqual(result.address, "bc1qexampleaddress")
+        XCTAssertEqual(result.memo, "coffee")
+        XCTAssertNil(result.amount)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Core/ExternalAmountGuardTests.swift
+++ b/VultisigApp/VultisigAppTests/Core/ExternalAmountGuardTests.swift
@@ -33,9 +33,9 @@ final class ExternalAmountGuardTests: XCTestCase {
 
     // MARK: - Deeplink boundary
 
-    private func sendAmount(from query: String) throws -> String? {
+    private func sendAmount(from query: String, locale: Locale = Locale(identifier: "en_US")) throws -> String? {
         let url = URL(string: "vultisig://send?assetChain=ethereum&assetTicker=ETH&toAddress=0xdead&\(query)")!
-        return try DeeplinkLogic().extractParameters(url, vaults: []).sendAmount
+        return try DeeplinkLogic(locale: locale).extractParameters(url, vaults: []).sendAmount
     }
 
     func testDeeplinkDropsScientificNotationAmount() throws {
@@ -64,7 +64,7 @@ final class ExternalAmountGuardTests: XCTestCase {
     func testDeeplinkWithRejectedAmountStillCarriesAddress() throws {
         let url = URL(string: "vultisig://send?assetChain=ethereum&assetTicker=ETH&toAddress=0xdead&amount=1e5")!
 
-        let result = try DeeplinkLogic().extractParameters(url, vaults: [])
+        let result = try DeeplinkLogic(locale: Locale(identifier: "en_US")).extractParameters(url, vaults: [])
 
         XCTAssertEqual(result.address, "0xdead")
         XCTAssertEqual(result.type, .Send)
@@ -91,5 +91,87 @@ final class ExternalAmountGuardTests: XCTestCase {
         XCTAssertEqual(result.address, "bc1qexampleaddress")
         XCTAssertEqual(result.memo, "coffee")
         XCTAssertNil(result.amount)
+    }
+
+    // MARK: - Comma-decimal locales (the misparse that outranks 1e5)
+
+    /// An external amount is dot-decimal by specification, but `parseInput` is
+    /// locale-aware: under a comma-decimal locale it reads the `.` in `0.005` as a
+    /// grouping separator and returns 5. Five of the eight shipping locales do
+    /// this, so a canonical payment link was staging a thousandfold overpayment —
+    /// a larger error than the scientific notation this guard started from.
+    func testExternalAmountSurvivesCommaDecimalLocales() {
+        for identifier in ["en_US", "de_DE", "zh_Hans_CN", "es_ES", "ko_KR", "it_IT", "pt_BR", "hr_HR"] {
+            let locale = Locale(identifier: identifier)
+
+            guard let staged = "0.005".externalAmount(locale: locale) else {
+                return XCTFail("\(identifier) rejected a canonical dot-decimal amount")
+            }
+
+            XCTAssertEqual(
+                staged.parseInput(locale: locale), Decimal(string: "0.005"),
+                "\(identifier) staged \(staged), which its own parser must read back as 0.005"
+            )
+        }
+    }
+
+    /// The same misread with the digits the other way round: `1.234` is one and a
+    /// bit, never one thousand two hundred and thirty four.
+    func testExternalAmountDoesNotPromoteFractionToThousands() {
+        for identifier in ["pt_BR", "de_DE"] {
+            let locale = Locale(identifier: identifier)
+            let staged = "1.234".externalAmount(locale: locale)
+
+            XCTAssertEqual(staged?.parseInput(locale: locale), Decimal(string: "1.234"), identifier)
+        }
+    }
+
+    func testExternalAmountRejectsEverythingNotPlainDotDecimal() {
+        for locale in [Locale(identifier: "en_US"), Locale(identifier: "pt_BR")] {
+            for candidate in ["1e5", "1E5", "2.5e3", "1e-3", "0x1F", "1,5", "1.", ".5", "1.2.3", "-5", "1 234", "abc", ""] {
+                XCTAssertNil(
+                    candidate.externalAmount(locale: locale),
+                    "\(locale.identifier) must reject \(candidate.isEmpty ? "(empty)" : candidate)"
+                )
+            }
+        }
+    }
+
+    /// End to end through the deeplink, not just the helper.
+    func testDeeplinkStagesCommaLocaleAmountThatReadsBackCorrectly() throws {
+        for identifier in ["pt_BR", "de_DE"] {
+            let locale = Locale(identifier: identifier)
+            let staged = try sendAmount(from: "amount=0.005", locale: locale)
+
+            XCTAssertEqual(staged?.parseInput(locale: locale), Decimal(string: "0.005"), identifier)
+            XCTAssertNil(try sendAmount(from: "amount=1e5", locale: locale), identifier)
+        }
+    }
+
+    func testScannedURIStagesCommaLocaleAmountThatReadsBackCorrectly() {
+        let locale = Locale(identifier: "pt_BR")
+        let staged = AddressResult.fromURI("bitcoin:bc1qexampleaddress?amount=0.005", locale: locale).amount
+
+        XCTAssertEqual(staged?.parseInput(locale: locale), Decimal(string: "0.005"))
+    }
+
+    // MARK: - The live function-call / DeFi amount gate
+
+    /// `AmountBalanceValidator` is the validator on ~19 function-call and DeFi
+    /// amount fields, and its `NumberFormatter` read scientific notation. The
+    /// balance ceiling is not a backstop: a large enough balance clears it.
+    func testAmountBalanceValidatorRejectsScientificNotation() {
+        let validator = AmountBalanceValidator(balance: Decimal(1_000_000))
+
+        for candidate in ["1e5", "1E5", "2.5e3", "0x1F"] {
+            XCTAssertThrowsError(try validator.validate(value: candidate), candidate)
+        }
+    }
+
+    func testAmountBalanceValidatorStillAcceptsPlainAmounts() {
+        let validator = AmountBalanceValidator(balance: Decimal(1_000_000))
+
+        XCTAssertNoThrow(try validator.validate(value: "0.5"))
+        XCTAssertNoThrow(try validator.validate(value: "1000"))
     }
 }

--- a/VultisigApp/VultisigAppTests/Extensions/StringExtensionTests.swift
+++ b/VultisigApp/VultisigAppTests/Extensions/StringExtensionTests.swift
@@ -147,9 +147,6 @@ final class StringExtensionsTests: XCTestCase {
 
     // MARK: - isValidDecimal
 
-    /// `NumberFormatter` reads scientific notation, so before the character-set
-    /// half was folded in, an `amount=1e5` reaching the send form from a deeplink
-    /// or a scanned `bitcoin:` URI validated and then signed as 100000.
     func testIsValidDecimalRejectsScientificNotationAndHex() {
         let locale = Locale(identifier: "en_US")
 
@@ -159,8 +156,7 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertFalse("1e-3".isValidDecimal(locale: locale))
         XCTAssertFalse("0x1F".isValidDecimal(locale: locale))
 
-        // The expansion `parseInput` performs is unchanged — the guard is on the
-        // notation, not on the value it would reach.
+        // The guard is on the notation; `parseInput`'s expansion is unchanged.
         XCTAssertEqual("1e5".parseInput(locale: locale), Decimal(100_000))
         XCTAssertTrue("100000".isValidDecimal(locale: locale))
     }
@@ -172,7 +168,6 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertTrue("0".isValidDecimal(locale: enUS))
         XCTAssertTrue("0.00000001".isValidDecimal(locale: enUS))
         XCTAssertTrue("1,234.56".isValidDecimal(locale: enUS))
-        // Surrounding spaces stay tolerated, as `parseInput` always has.
         XCTAssertTrue("   1,234.56   ".isValidDecimal(locale: enUS))
 
         let ptBR = Locale(identifier: "pt_BR")
@@ -190,11 +185,7 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertFalse("\n\t1,234.56\t\n".isValidDecimal(locale: locale))
     }
 
-    /// `NumberFormatter` renders digits in the locale's numbering system, so an
-    /// amount the app formatted for the user has to validate again under that same
-    /// locale. Every shipping locale is Latin-digit, but the two sides must agree
-    /// for any effective locale — a rejected Max amount would block sending
-    /// outright, a worse failure than the one the guard exists to prevent.
+    /// An amount the app formatted must validate back, or Max would block sending.
     func testIsValidDecimalAcceptsEveryLocaleNumberingSystem() {
         let identifiers = [
             "en_US", "de_DE", "zh_Hans_CN", "es_ES", "ko_KR", "it_IT", "pt_BR", "hr_HR",
@@ -203,8 +194,7 @@ final class StringExtensionsTests: XCTestCase {
 
         for identifier in identifiers {
             let locale = Locale(identifier: identifier)
-            // Mirrors `SendCryptoLogic.formatAmountInput`, which fills the amount
-            // field from Max / percentage presets.
+            // Mirrors `SendCryptoLogic.formatAmountInput`.
             let formatter = NumberFormatter()
             formatter.numberStyle = .decimal
             formatter.locale = locale
@@ -222,8 +212,6 @@ final class StringExtensionsTests: XCTestCase {
         }
     }
 
-    /// The digit test is Unicode decimal digits (Nd) — deliberately narrower than
-    /// `isNumber`, which also accepts exponents, fractions and numeral letters.
     func testIsDecimalInputAcceptsOnlyDecimalDigits() {
         let locale = Locale(identifier: "en_US")
 

--- a/VultisigApp/VultisigAppTests/Extensions/StringExtensionTests.swift
+++ b/VultisigApp/VultisigAppTests/Extensions/StringExtensionTests.swift
@@ -145,6 +145,97 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertFalse("abc12,5".isDecimalInput(locale: locale))
     }
 
+    // MARK: - isValidDecimal
+
+    /// `NumberFormatter` reads scientific notation, so before the character-set
+    /// half was folded in, an `amount=1e5` reaching the send form from a deeplink
+    /// or a scanned `bitcoin:` URI validated and then signed as 100000.
+    func testIsValidDecimalRejectsScientificNotationAndHex() {
+        let locale = Locale(identifier: "en_US")
+
+        XCTAssertFalse("1e5".isValidDecimal(locale: locale))
+        XCTAssertFalse("1E5".isValidDecimal(locale: locale))
+        XCTAssertFalse("2.5e3".isValidDecimal(locale: locale))
+        XCTAssertFalse("1e-3".isValidDecimal(locale: locale))
+        XCTAssertFalse("0x1F".isValidDecimal(locale: locale))
+
+        // The expansion `parseInput` performs is unchanged — the guard is on the
+        // notation, not on the value it would reach.
+        XCTAssertEqual("1e5".parseInput(locale: locale), Decimal(100_000))
+        XCTAssertTrue("100000".isValidDecimal(locale: locale))
+    }
+
+    func testIsValidDecimalAcceptsPlainAndGroupedAmounts() {
+        let enUS = Locale(identifier: "en_US")
+
+        XCTAssertTrue("1".isValidDecimal(locale: enUS))
+        XCTAssertTrue("0".isValidDecimal(locale: enUS))
+        XCTAssertTrue("0.00000001".isValidDecimal(locale: enUS))
+        XCTAssertTrue("1,234.56".isValidDecimal(locale: enUS))
+        // Surrounding spaces stay tolerated, as `parseInput` always has.
+        XCTAssertTrue("   1,234.56   ".isValidDecimal(locale: enUS))
+
+        let ptBR = Locale(identifier: "pt_BR")
+        XCTAssertTrue("1.234,56".isValidDecimal(locale: ptBR))
+        XCTAssertEqual("1.234,56".parseInput(locale: ptBR), Decimal(string: "1234.56"))
+    }
+
+    func testIsValidDecimalRejectsEmptyMalformedAndNegative() {
+        let locale = Locale(identifier: "en_US")
+
+        XCTAssertFalse("".isValidDecimal(locale: locale))
+        XCTAssertFalse("abc".isValidDecimal(locale: locale))
+        XCTAssertFalse("1.8.3".isValidDecimal(locale: locale))
+        XCTAssertFalse("-5".isValidDecimal(locale: locale))
+        XCTAssertFalse("\n\t1,234.56\t\n".isValidDecimal(locale: locale))
+    }
+
+    /// `NumberFormatter` renders digits in the locale's numbering system, so an
+    /// amount the app formatted for the user has to validate again under that same
+    /// locale. Every shipping locale is Latin-digit, but the two sides must agree
+    /// for any effective locale — a rejected Max amount would block sending
+    /// outright, a worse failure than the one the guard exists to prevent.
+    func testIsValidDecimalAcceptsEveryLocaleNumberingSystem() {
+        let identifiers = [
+            "en_US", "de_DE", "zh_Hans_CN", "es_ES", "ko_KR", "it_IT", "pt_BR", "hr_HR",
+            "ar_EG", "fa_IR", "ne_NP"
+        ]
+
+        for identifier in identifiers {
+            let locale = Locale(identifier: identifier)
+            // Mirrors `SendCryptoLogic.formatAmountInput`, which fills the amount
+            // field from Max / percentage presets.
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .decimal
+            formatter.locale = locale
+            formatter.maximumFractionDigits = 8
+            formatter.minimumFractionDigits = 0
+            formatter.usesGroupingSeparator = false
+            formatter.decimalSeparator = locale.decimalSeparator ?? "."
+            let formatted = formatter.string(from: NSDecimalNumber(decimal: Decimal(string: "1234.5")!)) ?? ""
+
+            XCTAssertTrue(
+                formatted.isValidDecimal(locale: locale),
+                "\(identifier) formats 1234.5 as \(formatted), which it must accept back"
+            )
+            XCTAssertFalse("1e5".isValidDecimal(locale: locale), "\(identifier) must still reject 1e5")
+        }
+    }
+
+    /// The digit test is Unicode decimal digits (Nd) — deliberately narrower than
+    /// `isNumber`, which also accepts exponents, fractions and numeral letters.
+    func testIsDecimalInputAcceptsOnlyDecimalDigits() {
+        let locale = Locale(identifier: "en_US")
+
+        XCTAssertTrue("١٢٣".isDecimalInput(locale: Locale(identifier: "ar_EG")))
+        XCTAssertTrue("१२३".isDecimalInput(locale: Locale(identifier: "ne_NP")))
+
+        XCTAssertFalse("1²".isDecimalInput(locale: locale))
+        XCTAssertFalse("½".isDecimalInput(locale: locale))
+        XCTAssertFalse("Ⅷ".isDecimalInput(locale: locale))
+        XCTAssertFalse("②".isDecimalInput(locale: locale))
+    }
+
     // MARK: - toBigInt(decimals:)
 
     /// The whole point of the exact path: past `Int64` — about 9.223 on an

--- a/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelValidationTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelValidationTests.swift
@@ -209,6 +209,62 @@ final class SendDetailsViewModelValidationTests: XCTestCase {
         XCTAssertFalse(vm.showAmountAlert)
     }
 
+    // MARK: - Amount format
+
+    func testValidateAmountFormatRejectsScientificNotation() {
+        for candidate in ["1e5", "1E5", "2.5e3", "1e-3", "0x1F"] {
+            let vm = SendFormFixture.make()
+            vm.amount = candidate
+            XCTAssertFalse(vm.validateAmountFormat(), "\(candidate) must be rejected")
+            XCTAssertEqual(vm.errorMessage, "decimalAmountError")
+            XCTAssertTrue(vm.showAmountAlert)
+        }
+    }
+
+    func testValidateAmountFormatAcceptsPlainDecimal() {
+        let vm = SendFormFixture.make()
+        vm.amount = "0.5"
+        XCTAssertTrue(vm.validateAmountFormat())
+        XCTAssertFalse(vm.showAmountAlert)
+    }
+
+    /// `1e5` is non-zero once expanded, so the non-zero rule waves it through —
+    /// the format rule is what stops it, and it has to run before the address is
+    /// resolved so the failure is about the amount, not the recipient.
+    func testValidateFormRejectsScientificNotationAmount() async {
+        let vm = SendFormFixture.make()
+        vm.toAddress = "addr"
+        vm.amount = "1e5"
+
+        let isValid = await vm.validateForm()
+
+        XCTAssertFalse(isValid)
+        XCTAssertEqual(vm.errorMessage, "decimalAmountError")
+        XCTAssertTrue(vm.showAmountAlert)
+    }
+
+    /// An empty amount keeps reporting the zero-amount error, not the format one.
+    func testValidateFormEmptyAmountStillReportsPositiveAmountError() async {
+        let vm = SendFormFixture.make()
+        vm.toAddress = "addr"
+        vm.amount = ""
+
+        let isValid = await vm.validateForm()
+
+        XCTAssertFalse(isValid)
+        XCTAssertEqual(vm.errorMessage, "positiveAmountError")
+    }
+
+    /// The Continue hand-off refuses to build a transaction Verify would render
+    /// as `1e5` while 100000 got signed.
+    func testMakeTransactionRejectsScientificNotationAmount() {
+        let vm = SendFormFixture.make()
+        vm.toAddress = "addr"
+        vm.amount = "1e5"
+
+        XCTAssertThrowsError(try vm.makeTransaction())
+    }
+
     func testValidateAddressFormatRejectsEmpty() {
         let vm = SendFormFixture.make()
         vm.toAddress = ""

--- a/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelValidationTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelValidationTests.swift
@@ -228,9 +228,7 @@ final class SendDetailsViewModelValidationTests: XCTestCase {
         XCTAssertFalse(vm.showAmountAlert)
     }
 
-    /// `1e5` is non-zero once expanded, so the non-zero rule waves it through —
-    /// the format rule is what stops it, and it has to run before the address is
-    /// resolved so the failure is about the amount, not the recipient.
+    /// `1e5` is non-zero once expanded, so only the format rule stops it.
     func testValidateFormRejectsScientificNotationAmount() async {
         let vm = SendFormFixture.make()
         vm.toAddress = "addr"
@@ -243,7 +241,6 @@ final class SendDetailsViewModelValidationTests: XCTestCase {
         XCTAssertTrue(vm.showAmountAlert)
     }
 
-    /// An empty amount keeps reporting the zero-amount error, not the format one.
     func testValidateFormEmptyAmountStillReportsPositiveAmountError() async {
         let vm = SendFormFixture.make()
         vm.toAddress = "addr"
@@ -255,8 +252,6 @@ final class SendDetailsViewModelValidationTests: XCTestCase {
         XCTAssertEqual(vm.errorMessage, "positiveAmountError")
     }
 
-    /// The Continue hand-off refuses to build a transaction Verify would render
-    /// as `1e5` while 100000 got signed.
     func testMakeTransactionRejectsScientificNotationAmount() {
         let vm = SendFormFixture.make()
         vm.toAddress = "addr"


### PR DESCRIPTION
Closes #5339

> **Flagged for human review.** This touches the amount that reaches a signing path. **On-device acceptance was not performed** — the acceptance test is opening a `vultisig://send?...&amount=0.005` deeplink on a device set to a comma-decimal locale (de/es/hr/it/pt) and confirming the form stages `0,005` and not `5`. Nobody has run that.

## The headline defect is not the one the issue was filed about

**A canonical payment deeplink overstates the amount by 1000× in five of the eight shipping locales, and this is pre-existing on `main` — it is not introduced by this branch.**

`String.parseInput()` is locale-aware, and the boundary handed it a machine-defined amount. A deeplink or payment-URI amount is dot-decimal by specification, so under a comma-decimal locale `NumberFormatter` reads the `.` in `0.005` as a *grouping* separator:

| locale | `amount=0.005` parses as |
|---|---|
| `pt_BR`, `de_DE`, `es_ES`, `it_IT`, `hr_HR` | **5** |
| `en_US`, `fr_FR`, `ko_KR`, `zh_Hans_CN` | 0.005 |

Five of the eight locales this app ships. `1.234` becomes `1234` the same way. A reviewer should read this as a latent defect that predates the branch and is fixed here, not as a regression introduced by it.

The scientific-notation case the issue was filed about is the **lesser** defect: `NumberFormatter(numberStyle: .decimal)` also accepts `1e5` → 100000, `2.5e3` → 2500, `1e-3` → 0.001 (`0x1F` was already rejected).

## What Verify actually shows

The issue asked for this to be settled before writing the fix, since an older sweep's claim had not been re-verified.

`SendVerifyScreen` passes `tx.amount` into `SendCryptoVerifySummary`, which hands it to `CoinAmountFiatLabel`, which is a plain `Text(amount)` — no formatting hop anywhere on the path. So Verify renders the raw string `1e5` while the signed value is 100000.

The nuance, which the older claim missed: the fiat sub-line underneath (`SendCryptoVerifyViewModel.amountFiat`) derives from `transaction.amountDecimal`, so it *does* reflect the expanded value. The mismatch is real on the amount row but **not total** — the fiat line betrays it.

## Two unguarded external boundaries, not one

1. **Deeplink** — `DeeplinkLogic.processSendDeeplink` took the `amount` query item verbatim (`removingPercentEncoding` only) and published it as `sendAmount`; `HomeScreen` prefills the send form with it.
2. **Scanned QR / payment URI** — `Utils.parseCryptoURI` reads `?amount=` out of a `bitcoin:`/`ton://` URI via `AddressResult.fromURI`, and the send form's address handler assigns it straight into the amount field. This one was not in the issue. It is live on **iOS as well as macOS**: the type sits outside the `#if os(macOS)` guard, and both the iOS camera scan and QR-from-image paths build through it.

## A correction worth stating plainly

The first pass hardened `StyledFloatingPointField`. That component has **zero call sites** — it is dead code. The live gate on function-call and DeFi amount fields is `AmountBalanceValidator`, whose bare `NumberFormatter` still accepted `1e5`, across ~19 forms (bond, unbond, stake/unstake, Cosmos delegate/undelegate/redelegate, Kamino deposit/withdraw, yield deposit/withdraw, TRON freeze, Solana delegate, secured withdraw, mint, redeem, withdraw-rewards, TON stake). Its balance ceiling is not a backstop for an inflated amount — a large enough balance clears it. Now fixed.

## The fix

- **`String.isValidDecimal(locale:)`** requires the character set `isDecimalInput()` allows before `parseInput` rules on the value. Reusing that test on a signing gate made its ASCII-only digit assumption load-bearing, so it now tests for a **Unicode decimal digit (Nd)** — `NumberFormatter` renders in the locale's numbering system (`ar_EG` formats 1234.5 as `١٢٣٤٫٥`), and an amount the app formatted for the user has to validate again or a Max preset would block sending outright. Nd is deliberately narrower than `isNumber`, which also admits `²`, `½`, `Ⅷ`, `②`.
- **`String.externalAmount(locale:)`** reads a boundary amount with fixed ASCII semantics — BIP-321's grammar, `*digit [ "." *digit ]` — then re-renders it with the device's decimal separator, because the form and `toDecimal()` parse with `Locale.current` and passing the raw string through would only move the misparse one step later.
  - `1.` and `.5` are **accepted**: the grammar admits a bare separator on either side and `parseInput` already reads both (`1.` → 1, `.5` → 0.5), so rejecting them would drop a spec-legal QR amount. `""` and `"."` stay rejected — no digit, no amount.
  - A comma-bearing amount is **rejected rather than guessed at**, on the authority of the same spec text: *"All amounts MUST contain no commas and use a period (.) as the separating character."*
- **`validateAmountFormat()`** joins the composed `validateForm()` pipeline as the backstop, ordered *after* the non-zero rule so an empty field still reports `positiveAmountError` (`1e5` is non-zero once expanded, which is exactly why the non-zero rule waves it through). It reuses the existing `decimalAmountError` key, so **no locale files are touched**.

`parseInput`'s locale-fallback behaviour is unchanged: `pt_BR` `"1.234,56"` still parses to 1234.56.

## Verification

`make test` on a dedicated `en_US` simulator: `** TEST SUCCEEDED **`, `Executed 7105 tests, with 11 tests skipped and 0 failures (0 unexpected)`. Baseline `main` is 7078 and this branch adds 27 test functions counted from the diff — 7078 + 27 = 7105, so the suite is provably running the new tests. Disk was flat at ~38Gi throughout, so the result is not a stale-products artifact.

Reviewed commit-by-commit by `codex exec` (read-only) across four rounds; six findings, all fixed or resolved with a recorded reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqdXT9XtXkN4XMwjXyqjND


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved amount validation to reject scientific notation, hexadecimal-like values, malformed, negative, and unrepresentable amounts.
  * Added support for locale-specific separators and Unicode decimal digits.
  * Standardized amount handling for deeplinks and scanned payment requests while preserving associated addresses and memos.
  * Added inline validation errors for invalid send amounts.

* **Tests**
  * Expanded coverage for locale formatting, external amounts, deeplinks, scanned URIs, Unicode digits, and send form validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->