### PR TITLE
fix(swap): keep a manually picked swap route across quote refreshes

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1584,6 +1584,8 @@
 "swapReferralDiscount" = "Empfehlung: %@";
 "swapRouteEta" = "~%lds";
 "swapRouteNotAvailable" = "Tauschroute nicht verfügbar";
+"swapRouteResetToAuto" = "Route auf Auto zurückgesetzt";
+"swapRouteUnavailableResetToAuto" = "Route nicht verfügbar – auf Auto zurückgesetzt";
 "swaps" = "Swaps";
 "swapSecuredAssetBadge" = "Secured";
 "swapSecuredAssetInvalidDestination" = "Ziel des Secured-Asset-Swaps ist keine gültige %1$@-Adresse (%2$@).";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1584,6 +1584,8 @@
 "swapReferralDiscount" = "Referral: %@";
 "swapRouteEta" = "~%lds";
 "swapRouteNotAvailable" = "Swap route not available";
+"swapRouteResetToAuto" = "Route reset to Auto";
+"swapRouteUnavailableResetToAuto" = "Route unavailable — reset to Auto";
 "swaps" = "Swaps";
 "swapSecuredAssetBadge" = "Secured";
 "swapSecuredAssetInvalidDestination" = "Secured-asset swap destination is not a valid %1$@ address (%2$@).";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1584,6 +1584,8 @@
 "swapReferralDiscount" = "Referido: %@";
 "swapRouteEta" = "~%lds";
 "swapRouteNotAvailable" = "Ruta de intercambio no disponible";
+"swapRouteResetToAuto" = "Ruta restablecida a Auto";
+"swapRouteUnavailableResetToAuto" = "Ruta no disponible: restablecida a Auto";
 "swaps" = "Intercambios";
 "swapSecuredAssetBadge" = "Secured";
 "swapSecuredAssetInvalidDestination" = "El destino del swap de activo asegurado no es una dirección %1$@ válida (%2$@).";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1584,6 +1584,8 @@
 "swapReferralDiscount" = "Preporuka: %@";
 "swapRouteEta" = "~%lds";
 "swapRouteNotAvailable" = "Ruta zamjene nije dostupna";
+"swapRouteResetToAuto" = "Ruta vraćena na Auto";
+"swapRouteUnavailableResetToAuto" = "Ruta nije dostupna – vraćena na Auto";
 "swaps" = "Zamjene";
 "swapSecuredAssetBadge" = "Secured";
 "swapSecuredAssetInvalidDestination" = "Odredište zamjene osiguranog sredstva nije valjana %1$@ adresa (%2$@).";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1584,6 +1584,8 @@
 "swapReferralDiscount" = "Referral: %@";
 "swapRouteEta" = "~%lds";
 "swapRouteNotAvailable" = "Percorso di scambio non disponibile";
+"swapRouteResetToAuto" = "Percorso reimpostato su Auto";
+"swapRouteUnavailableResetToAuto" = "Percorso non disponibile – reimpostato su Auto";
 "swaps" = "Scambi";
 "swapSecuredAssetBadge" = "Garantito";
 "swapSecuredAssetInvalidDestination" = "La destinazione dello swap dell'asset protetto non è un indirizzo %1$@ valido (%2$@).";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1584,6 +1584,8 @@
 "swapReferralDiscount" = "추천: %@";
 "swapRouteEta" = "~%ld초";
 "swapRouteNotAvailable" = "스왑 경로를 사용할 수 없습니다";
+"swapRouteResetToAuto" = "경로가 자동으로 재설정되었습니다";
+"swapRouteUnavailableResetToAuto" = "경로를 사용할 수 없어 자동으로 재설정되었습니다";
 "swaps" = "스왑";
 "swapSecuredAssetBadge" = "보안";
 "swapSecuredAssetInvalidDestination" = "보안 자산 스왑 대상이 유효한 %1$@ 주소가 아닙니다 (%2$@).";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1584,6 +1584,8 @@
 "swapReferralDiscount" = "Indicação: %@";
 "swapRouteEta" = "~%lds";
 "swapRouteNotAvailable" = "Rota de troca não disponível";
+"swapRouteResetToAuto" = "Rota redefinida para Auto";
+"swapRouteUnavailableResetToAuto" = "Rota indisponível — redefinida para Auto";
 "swaps" = "Trocas";
 "swapSecuredAssetBadge" = "Secured";
 "swapSecuredAssetInvalidDestination" = "O destino do swap de ativo protegido não é um endereço %1$@ válido (%2$@).";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1584,6 +1584,8 @@
 "swapReferralDiscount" = "推荐：%@";
 "swapRouteEta" = "~%ld秒";
 "swapRouteNotAvailable" = "交换路由不可用";
+"swapRouteResetToAuto" = "路线已重置为自动";
+"swapRouteUnavailableResetToAuto" = "路线不可用 — 已重置为自动";
 "swaps" = "兑换";
 "swapSecuredAssetBadge" = "担保";
 "swapSecuredAssetInvalidDestination" = "受保护资产兑换的目标地址不是有效的 %1$@ 地址（%2$@）。";

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
@@ -113,6 +113,16 @@ struct SwapTransaction: Hashable {
     /// on the verify screen before signing.
     let advancedSettings: SwapAdvancedSettings
 
+    /// The route the user picked by hand, `nil` when the swap is on Auto.
+    /// Deliberately its own field rather than part of `advancedSettings`, which
+    /// is the form's re-fetch trigger — a route pick must never re-quote.
+    ///
+    /// Carried past the hand-off so the verify screen's 60s refresh can re-resolve
+    /// the pick against the fresh candidate set instead of installing the auto
+    /// winner and swapping the route out from under an order the user has already
+    /// confirmed. `var` only so the memberwise init defaults it.
+    var selectedRouteIdentity: SwapRouteIdentity?
+
     /// Final destination for the swapped funds: the user-set external recipient
     /// when present, otherwise the user's own address on the destination chain
     /// (today's behavior). Surfaced on the verify screen.
@@ -174,7 +184,11 @@ extension SwapTransaction {
             referralDiscountBps: referralDiscountBps ?? self.referralDiscountBps,
             networkFeeEstimate: networkFeeEstimate,
             feeCoin: feeCoin,
-            advancedSettings: advancedSettings
+            advancedSettings: advancedSettings,
+            // A re-quote never changes which route the user chose — only which
+            // quote object represents it. Clearing the pick is the caller's job,
+            // done before this call when the route is no longer offered.
+            selectedRouteIdentity: selectedRouteIdentity
         )
     }
 }

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
@@ -113,14 +113,9 @@ struct SwapTransaction: Hashable {
     /// on the verify screen before signing.
     let advancedSettings: SwapAdvancedSettings
 
-    /// The route the user picked by hand, `nil` when the swap is on Auto.
-    /// Deliberately its own field rather than part of `advancedSettings`, which
-    /// is the form's re-fetch trigger — a route pick must never re-quote.
-    ///
-    /// Carried past the hand-off so the verify screen's 60s refresh can re-resolve
-    /// the pick against the fresh candidate set instead of installing the auto
-    /// winner and swapping the route out from under an order the user has already
-    /// confirmed. `var` only so the memberwise init defaults it.
+    /// The route the user picked by hand, `nil` on Auto. Deliberately NOT part of
+    /// `advancedSettings`, which is the form's re-fetch trigger — folding it in
+    /// would make picking a route re-quote.
     var selectedRouteIdentity: SwapRouteIdentity?
 
     /// Final destination for the swapped funds: the user-set external recipient
@@ -185,9 +180,8 @@ extension SwapTransaction {
             networkFeeEstimate: networkFeeEstimate,
             feeCoin: feeCoin,
             advancedSettings: advancedSettings,
-            // A re-quote never changes which route the user chose — only which
-            // quote object represents it. Clearing the pick is the caller's job,
-            // done before this call when the route is no longer offered.
+            // Must be carried: `with` rebuilds field by field, so dropping it here
+            // silently un-pins the route on the next refresh.
             selectedRouteIdentity: selectedRouteIdentity
         )
     }

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
@@ -116,7 +116,7 @@ struct SwapTransaction: Hashable {
     /// The route the user picked by hand, `nil` on Auto. Deliberately NOT part of
     /// `advancedSettings`, which is the form's re-fetch trigger — folding it in
     /// would make picking a route re-quote.
-    var selectedRouteIdentity: SwapRouteIdentity?
+    var selectedProvider: SwapProvider?
 
     /// Final destination for the swapped funds: the user-set external recipient
     /// when present, otherwise the user's own address on the destination chain
@@ -182,7 +182,7 @@ extension SwapTransaction {
             advancedSettings: advancedSettings,
             // Must be carried: `with` rebuilds field by field, so dropping it here
             // silently un-pins the route on the next refresh.
-            selectedRouteIdentity: selectedRouteIdentity
+            selectedProvider: selectedProvider
         )
     }
 }

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -26,7 +26,11 @@ final class SwapDetailsViewModel {
     // pair OR amount change clears it so the "to" field falls back to the
     // instant indicative estimate and the summary shows its loading skeleton.
     @ObservationIgnored private var quotedPair: SwapPairIdentity?
-    @ObservationIgnored private var quotedAmount: String?
+    /// The PARSED amount the held quote was fetched for — the same value that
+    /// went to the provider. Comparing the parsed amount rather than the raw text
+    /// keeps `1` → `1.` → `1.0` a silent refresh instead of a new swap, so it
+    /// neither blanks the summary nor drops a route pick over a re-typed zero.
+    @ObservationIgnored private var quotedAmount: Decimal?
 
     // MARK: - Form fields (mutable while the user is editing)
 
@@ -65,7 +69,8 @@ final class SwapDetailsViewModel {
     // verify, sign — reads the computed `quote`, so a manual pick flows through
     // unchanged. A refresh re-resolves the pick against the fresh candidate
     // set by `routeIdentity`, so it survives while that route is still on offer
-    // and always points at the current numbers.
+    // and always points at the current numbers. `makeTransaction` hands the
+    // identity on, so the verify screen's own refresh keeps the pick too.
 
     /// Full ranked candidate set (best→worst by net output). Drives the
     /// provider-selection sheet. Empty until the first quote of a pair lands.
@@ -455,7 +460,8 @@ final class SwapDetailsViewModel {
             vultDiscountBps: vultDiscountBps,
             referralDiscountBps: referralDiscountBps,
             feeCoin: feeCoin,
-            advancedSettings: resolvedAdvancedSettings
+            advancedSettings: resolvedAdvancedSettings,
+            selectedRouteIdentity: selectedQuote?.routeIdentity
         )
     }
 
@@ -753,7 +759,7 @@ private extension SwapDetailsViewModel {
         // "to" field falls back to the instant indicative estimate and the
         // summary shows its loading skeleton (`showsQuoteSkeleton` =
         // isLoadingQuotes && quote == nil) until the fresh quote lands.
-        let isSilentRefresh = quotedPair == currentPair && quotedAmount == fromAmount
+        let isSilentRefresh = quotedPair == currentPair && quotedAmount == fromAmount.toDecimal()
         if !isSilentRefresh {
             clearQuoteState()
             quotedPair = nil
@@ -809,6 +815,10 @@ private extension SwapDetailsViewModel {
 
         guard !fromAmount.isEmpty else { return }
 
+        // Parse once: the value that goes to the provider is the same value that
+        // stamps quote ownership, so the two can never disagree.
+        let requestedAmount = fromAmount.toDecimal()
+
         // Same-underlying secured selection: there's no meaningful pool swap, so
         // skip the network quote and present a synthetic ~1:1 "Mint (SECURE+)"
         // quote. Confirm builds the real SECURE+ deposit payload.
@@ -816,10 +826,10 @@ private extension SwapDetailsViewModel {
             // The candidate set collapses to the one synthetic mint quote, so
             // any picked route really is gone.
             dropRouteSelection(.routeUnavailable)
-            bestQuote = SwapCryptoLogic.securedMintQuote(fromAmount: fromAmount.toDecimal(), toCoin: toCoin)
+            bestQuote = SwapCryptoLogic.securedMintQuote(fromAmount: requestedAmount, toCoin: toCoin)
             allQuotes = [bestQuote].compactMap { $0 }
             quotedPair = currentPair
-            quotedAmount = fromAmount
+            quotedAmount = requestedAmount
             vultDiscountBps = 0
             referralDiscountBps = 0
             return
@@ -827,7 +837,7 @@ private extension SwapDetailsViewModel {
 
         do {
             let result = try await interactor.fetchQuote(
-                amount: fromAmount.toDecimal(),
+                amount: requestedAmount,
                 fromCoin: fromCoin,
                 toCoin: toCoin,
                 vault: vault,
@@ -859,7 +869,7 @@ private extension SwapDetailsViewModel {
                 bestQuote = result.quote
                 allQuotes = result.allQuotes
                 quotedPair = currentPair
-                quotedAmount = fromAmount
+                quotedAmount = requestedAmount
                 vultDiscountBps = result.vultDiscountBps
                 referralDiscountBps = result.referralDiscountBps
             }

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -65,7 +65,7 @@ final class SwapDetailsViewModel {
     // `bestQuote` is the auto-selected winner; `selectedQuote` is a manual
     // override (provider selection). The rest of the screen — fees, validation,
     // verify, sign — reads the computed `quote`, so a manual pick flows through
-    // unchanged. A refresh re-resolves the pick by `routeIdentity`, and
+    // unchanged. A refresh re-resolves the pick by provider, and
     // `makeTransaction` hands that identity on so verify's refresh keeps it too.
 
     /// Full ranked candidate set (best→worst by net output). Drives the
@@ -448,7 +448,7 @@ final class SwapDetailsViewModel {
             referralDiscountBps: referralDiscountBps,
             feeCoin: feeCoin,
             advancedSettings: resolvedAdvancedSettings,
-            selectedRouteIdentity: selectedQuote?.routeIdentity
+            selectedProvider: selectedQuote?.provider(fromChain: fromCoin.chain)
         )
     }
 
@@ -836,8 +836,8 @@ private extension SwapDetailsViewModel {
             if let result {
                 // Re-point at the object out of `result.allQuotes`, never the one
                 // the user tapped: that is what keeps signing on current numbers.
-                if let picked = selectedQuote?.routeIdentity {
-                    if let refreshed = result.allQuotes.first(where: { $0.routeIdentity == picked }) {
+                if let picked = selectedQuote?.provider(fromChain: fromCoin.chain) {
+                    if let refreshed = result.allQuotes.first(where: { $0.provider(fromChain: fromCoin.chain) == picked }) {
                         selectedQuote = refreshed
                     } else {
                         dropRouteSelection(.routeUnavailable)

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -26,10 +26,8 @@ final class SwapDetailsViewModel {
     // pair OR amount change clears it so the "to" field falls back to the
     // instant indicative estimate and the summary shows its loading skeleton.
     @ObservationIgnored private var quotedPair: SwapPairIdentity?
-    /// The PARSED amount the held quote was fetched for — the same value that
-    /// went to the provider. Comparing the parsed amount rather than the raw text
-    /// keeps `1` → `1.` → `1.0` a silent refresh instead of a new swap, so it
-    /// neither blanks the summary nor drops a route pick over a re-typed zero.
+    /// The PARSED amount the held quote was fetched for — the same value sent to
+    /// the provider, so re-typing an equivalent amount is not a new swap.
     @ObservationIgnored private var quotedAmount: Decimal?
 
     // MARK: - Form fields (mutable while the user is editing)
@@ -67,30 +65,25 @@ final class SwapDetailsViewModel {
     // `bestQuote` is the auto-selected winner; `selectedQuote` is a manual
     // override (provider selection). The rest of the screen — fees, validation,
     // verify, sign — reads the computed `quote`, so a manual pick flows through
-    // unchanged. A refresh re-resolves the pick against the fresh candidate
-    // set by `routeIdentity`, so it survives while that route is still on offer
-    // and always points at the current numbers. `makeTransaction` hands the
-    // identity on, so the verify screen's own refresh keeps the pick too.
+    // unchanged. A refresh re-resolves the pick by `routeIdentity`, and
+    // `makeTransaction` hands that identity on so verify's refresh keeps it too.
 
     /// Full ranked candidate set (best→worst by net output). Drives the
     /// provider-selection sheet. Empty until the first quote of a pair lands.
     var allQuotes: [SwapQuote] = []
     /// Auto-selected winner for the current pair/amount.
     var bestQuote: SwapQuote?
-    /// Manual provider override. `nil` means "use Auto". Survives a refresh of
-    /// the same pair/amount for as long as the picked route is still a
-    /// candidate; every path that drops it goes through `dropRouteSelection`.
+    /// Manual provider override. `nil` means "use Auto". Every path that drops it
+    /// goes through `dropRouteSelection`, so it can never vanish silently.
     var selectedQuote: SwapQuote?
 
-    /// One-shot notice that a manual route pick was dropped, rendered by the
-    /// screen as a banner and cleared by it. `nil` when there's nothing to say.
+    /// Set when a route pick was dropped; the screen renders and clears it.
     var routeSelectionNotice: String?
 
     /// The active quote the whole flow reads. A manual pick wins; otherwise the
-    /// auto-selected best. Writing it replaces the slot wholesale — that clears
-    /// the manual override without a notice, since it isn't a pick being
-    /// invalidated under the user (nothing in the app writes it; the reset paths
-    /// call `clearQuoteState` and tests seed state through it).
+    /// auto-selected best. Writing it replaces the slot wholesale and clears the
+    /// override without a notice — no production path writes it; use
+    /// `clearQuoteState`.
     var quote: SwapQuote? {
         get { selectedQuote ?? bestQuote }
         set {
@@ -214,13 +207,8 @@ final class SwapDetailsViewModel {
         selectedQuote = quote
     }
 
-    /// Why a manual route pick had to be dropped. Each case carries the message
-    /// the screen shows, so a pick can never disappear without the user knowing.
     enum RouteSelectionDropReason {
-        /// The picked route is no longer among the candidates for this swap.
         case routeUnavailable
-        /// The swap itself changed (pair or amount), so the whole candidate set
-        /// is being refetched and nothing carries over.
         case swapChanged
 
         var message: String {
@@ -233,9 +221,8 @@ final class SwapDetailsViewModel {
         }
     }
 
-    /// Drop the manual route pick and say why. No-op without a pick, so an
-    /// invalidation that repeats — `fetchQuotes` runs on every keystroke of an
-    /// amount edit — still surfaces at most one notice per pick.
+    /// No-op without a pick, so a repeating invalidation (`fetchQuotes` runs on
+    /// every keystroke) still surfaces at most one notice per pick.
     func dropRouteSelection(_ reason: RouteSelectionDropReason) {
         guard selectedQuote != nil else { return }
         selectedQuote = nil
@@ -815,16 +802,14 @@ private extension SwapDetailsViewModel {
 
         guard !fromAmount.isEmpty else { return }
 
-        // Parse once: the value that goes to the provider is the same value that
-        // stamps quote ownership, so the two can never disagree.
+        // Parse once so the requested amount and the ownership stamp can't disagree.
         let requestedAmount = fromAmount.toDecimal()
 
         // Same-underlying secured selection: there's no meaningful pool swap, so
         // skip the network quote and present a synthetic ~1:1 "Mint (SECURE+)"
         // quote. Confirm builds the real SECURE+ deposit payload.
         if isSecuredMint {
-            // The candidate set collapses to the one synthetic mint quote, so
-            // any picked route really is gone.
+            // Candidate set collapses to the one synthetic mint quote.
             dropRouteSelection(.routeUnavailable)
             bestQuote = SwapCryptoLogic.securedMintQuote(fromAmount: requestedAmount, toCoin: toCoin)
             allQuotes = [bestQuote].compactMap { $0 }
@@ -849,16 +834,8 @@ private extension SwapDetailsViewModel {
             // quote over the state the new fetch is about to populate.
             guard !Task.isCancelled else { return }
             if let result {
-                // Re-attach a manual pick to the fresh candidate set by route
-                // identity. `SwapQuote` is Hashable by payload, so the refreshed
-                // quote for the same route is a different value — matching on the
-                // quote itself could never survive a refresh. Re-pointing at the
-                // object out of `result.allQuotes` is also what keeps signing on
-                // current numbers rather than the quote the user tapped.
-                //
-                // Only genuine same-pair/same-amount refreshes reach here with a
-                // pick: `fetchQuotes` already dropped it for any pair or amount
-                // change before this fetch started.
+                // Re-point at the object out of `result.allQuotes`, never the one
+                // the user tapped: that is what keeps signing on current numbers.
                 if let picked = selectedQuote?.routeIdentity {
                     if let refreshed = result.allQuotes.first(where: { $0.routeIdentity == picked }) {
                         selectedQuote = refreshed

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -63,20 +63,29 @@ final class SwapDetailsViewModel {
     // `bestQuote` is the auto-selected winner; `selectedQuote` is a manual
     // override (provider selection). The rest of the screen — fees, validation,
     // verify, sign — reads the computed `quote`, so a manual pick flows through
-    // unchanged. A refresh resets `selectedQuote` so it re-defaults to Best.
+    // unchanged. A refresh re-resolves the pick against the fresh candidate
+    // set by `routeIdentity`, so it survives while that route is still on offer
+    // and always points at the current numbers.
 
     /// Full ranked candidate set (best→worst by net output). Drives the
     /// provider-selection sheet. Empty until the first quote of a pair lands.
     var allQuotes: [SwapQuote] = []
     /// Auto-selected winner for the current pair/amount.
     var bestQuote: SwapQuote?
-    /// Manual provider override. `nil` means "use Best". Reset on every refresh.
+    /// Manual provider override. `nil` means "use Auto". Survives a refresh of
+    /// the same pair/amount for as long as the picked route is still a
+    /// candidate; every path that drops it goes through `dropRouteSelection`.
     var selectedQuote: SwapQuote?
 
+    /// One-shot notice that a manual route pick was dropped, rendered by the
+    /// screen as a banner and cleared by it. `nil` when there's nothing to say.
+    var routeSelectionNotice: String?
+
     /// The active quote the whole flow reads. A manual pick wins; otherwise the
-    /// auto-selected best. Writing it (e.g. the reset paths, tests) clears the
-    /// manual override and assigns the best slot so existing call sites behave
-    /// exactly as before.
+    /// auto-selected best. Writing it replaces the slot wholesale — that clears
+    /// the manual override without a notice, since it isn't a pick being
+    /// invalidated under the user (nothing in the app writes it; the reset paths
+    /// call `clearQuoteState` and tests seed state through it).
     var quote: SwapQuote? {
         get { selectedQuote ?? bestQuote }
         set {
@@ -198,6 +207,34 @@ final class SwapDetailsViewModel {
     /// Apply a manual provider pick.
     func selectProvider(_ quote: SwapQuote) {
         selectedQuote = quote
+    }
+
+    /// Why a manual route pick had to be dropped. Each case carries the message
+    /// the screen shows, so a pick can never disappear without the user knowing.
+    enum RouteSelectionDropReason {
+        /// The picked route is no longer among the candidates for this swap.
+        case routeUnavailable
+        /// The swap itself changed (pair or amount), so the whole candidate set
+        /// is being refetched and nothing carries over.
+        case swapChanged
+
+        var message: String {
+            switch self {
+            case .routeUnavailable:
+                return "swapRouteUnavailableResetToAuto".localized
+            case .swapChanged:
+                return "swapRouteResetToAuto".localized
+            }
+        }
+    }
+
+    /// Drop the manual route pick and say why. No-op without a pick, so an
+    /// invalidation that repeats — `fetchQuotes` runs on every keystroke of an
+    /// amount edit — still surfaces at most one notice per pick.
+    func dropRouteSelection(_ reason: RouteSelectionDropReason) {
+        guard selectedQuote != nil else { return }
+        selectedQuote = nil
+        routeSelectionNotice = reason.message
     }
 
     /// Quotes for the picker sheet, with the active (selected) quote pinned to
@@ -684,7 +721,7 @@ private extension SwapDetailsViewModel {
     /// set. Keeps the three in lock-step so a stale provider list can't outlive
     /// the quote it belonged to.
     func clearQuoteState() {
-        selectedQuote = nil
+        dropRouteSelection(.swapChanged)
         bestQuote = nil
         allQuotes = []
     }
@@ -776,7 +813,9 @@ private extension SwapDetailsViewModel {
         // skip the network quote and present a synthetic ~1:1 "Mint (SECURE+)"
         // quote. Confirm builds the real SECURE+ deposit payload.
         if isSecuredMint {
-            selectedQuote = nil
+            // The candidate set collapses to the one synthetic mint quote, so
+            // any picked route really is gone.
+            dropRouteSelection(.routeUnavailable)
             bestQuote = SwapCryptoLogic.securedMintQuote(fromAmount: fromAmount.toDecimal(), toCoin: toCoin)
             allQuotes = [bestQuote].compactMap { $0 }
             quotedPair = currentPair
@@ -800,10 +839,23 @@ private extension SwapDetailsViewModel {
             // quote over the state the new fetch is about to populate.
             guard !Task.isCancelled else { return }
             if let result {
-                // Every refresh re-defaults to Best: drop any manual override so
-                // the active `quote` tracks the fresh winner ("until next refresh"
-                // persistence). `allQuotes` repopulates from the ranked set.
-                selectedQuote = nil
+                // Re-attach a manual pick to the fresh candidate set by route
+                // identity. `SwapQuote` is Hashable by payload, so the refreshed
+                // quote for the same route is a different value — matching on the
+                // quote itself could never survive a refresh. Re-pointing at the
+                // object out of `result.allQuotes` is also what keeps signing on
+                // current numbers rather than the quote the user tapped.
+                //
+                // Only genuine same-pair/same-amount refreshes reach here with a
+                // pick: `fetchQuotes` already dropped it for any pair or amount
+                // change before this fetch started.
+                if let picked = selectedQuote?.routeIdentity {
+                    if let refreshed = result.allQuotes.first(where: { $0.routeIdentity == picked }) {
+                        selectedQuote = refreshed
+                    } else {
+                        dropRouteSelection(.routeUnavailable)
+                    }
+                }
                 bestQuote = result.quote
                 allQuotes = result.allQuotes
                 quotedPair = currentPair

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapVerifyViewModel.swift
@@ -79,6 +79,7 @@ final class SwapVerifyViewModel {
     }
 
     func updateTimer(vault: Vault) async {
+        guard !transaction.isLimit, !isLoadingFees else { return }
         timer -= 1
         if timer < 1 {
             await refreshData(vault: vault)
@@ -92,7 +93,7 @@ final class SwapVerifyViewModel {
         // `quote == nil` limit invariant (the signed artifact is the pre-built
         // limit memo; a refreshed quote would only render misleading
         // provider/fee rows). Covers the 60s ticker and the retry path.
-        guard !transaction.isLimit else { return }
+        guard !transaction.isLimit, !isLoadingFees else { return }
 
         isLoadingFees = true
         defer { isLoadingFees = false }

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapVerifyViewModel.swift
@@ -117,11 +117,11 @@ final class SwapVerifyViewModel {
                     // Installing `result.quote` unconditionally would hand the user
                     // a route they never chose, immediately before signing.
                     var refreshedQuote = result.quote
-                    if let picked = updated.selectedRouteIdentity {
-                        if let stillOffered = result.allQuotes.first(where: { $0.routeIdentity == picked }) {
+                    if let picked = updated.selectedProvider {
+                        if let stillOffered = result.allQuotes.first(where: { $0.provider(fromChain: updated.fromCoin.chain) == picked }) {
                             refreshedQuote = stillOffered
                         } else {
-                            updated.selectedRouteIdentity = nil
+                            updated.selectedProvider = nil
                             routeWasSubstituted = true
                         }
                     }

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapVerifyViewModel.swift
@@ -31,8 +31,7 @@ final class SwapVerifyViewModel {
     var securityScannerState: SecurityScannerState = .idle
 
     var error: Error?
-    /// One-shot notice that the refresh had to substitute the user's picked route,
-    /// rendered by the screen as a banner and cleared by it.
+    /// Set when the refresh substituted the picked route; the screen clears it.
     var routeSelectionNotice: String?
     var isLoading = false
     var isLoadingFees = false
@@ -100,9 +99,7 @@ final class SwapVerifyViewModel {
 
         do {
             var updated = transaction
-            // Set when the refresh had to fall back to the auto winner because the
-            // route the user picked is no longer offered. Applied to the UI only
-            // once the refreshed transaction actually commits below.
+            // Applied to the UI only once the refreshed transaction commits below.
             var routeWasSubstituted = false
             // Same-underlying secured mint has no pool quote to refresh — keep the
             // synthetic ~1:1 quote and refresh only the L1 deposit gas below.
@@ -117,10 +114,8 @@ final class SwapVerifyViewModel {
                     recipientAddress: transaction.advancedSettings.externalRecipient
                 )
                 if let result {
-                    // A manual route pick must survive this refresh too. Installing
-                    // `result.quote` unconditionally would hand the user a route
-                    // they never chose at the last moment before signing — the same
-                    // defect the details screen used to have, one screen later.
+                    // Installing `result.quote` unconditionally would hand the user
+                    // a route they never chose, immediately before signing.
                     var refreshedQuote = result.quote
                     if let picked = updated.selectedRouteIdentity {
                         if let stillOffered = result.allQuotes.first(where: { $0.routeIdentity == picked }) {
@@ -182,9 +177,7 @@ final class SwapVerifyViewModel {
             transaction = updated
             error = nil
             if routeWasSubstituted {
-                // The confirmations were given for a route that is no longer on
-                // offer, so they no longer mean anything — make the user re-read
-                // the summary and re-confirm against the substitute.
+                // The confirmations were given for a route that is now gone.
                 isAmountCorrect = false
                 isFeeCorrect = false
                 isApproveCorrect = false

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapVerifyViewModel.swift
@@ -31,6 +31,9 @@ final class SwapVerifyViewModel {
     var securityScannerState: SecurityScannerState = .idle
 
     var error: Error?
+    /// One-shot notice that the refresh had to substitute the user's picked route,
+    /// rendered by the screen as a banner and cleared by it.
+    var routeSelectionNotice: String?
     var isLoading = false
     var isLoadingFees = false
     var isLoadingTransaction = false
@@ -97,6 +100,10 @@ final class SwapVerifyViewModel {
 
         do {
             var updated = transaction
+            // Set when the refresh had to fall back to the auto winner because the
+            // route the user picked is no longer offered. Applied to the UI only
+            // once the refreshed transaction actually commits below.
+            var routeWasSubstituted = false
             // Same-underlying secured mint has no pool quote to refresh — keep the
             // synthetic ~1:1 quote and refresh only the L1 deposit gas below.
             if transaction.mode == .standard {
@@ -110,8 +117,21 @@ final class SwapVerifyViewModel {
                     recipientAddress: transaction.advancedSettings.externalRecipient
                 )
                 if let result {
+                    // A manual route pick must survive this refresh too. Installing
+                    // `result.quote` unconditionally would hand the user a route
+                    // they never chose at the last moment before signing — the same
+                    // defect the details screen used to have, one screen later.
+                    var refreshedQuote = result.quote
+                    if let picked = updated.selectedRouteIdentity {
+                        if let stillOffered = result.allQuotes.first(where: { $0.routeIdentity == picked }) {
+                            refreshedQuote = stillOffered
+                        } else {
+                            updated.selectedRouteIdentity = nil
+                            routeWasSubstituted = true
+                        }
+                    }
                     updated = updated.with(
-                        quote: result.quote,
+                        quote: refreshedQuote,
                         vultDiscountBps: result.vultDiscountBps,
                         referralDiscountBps: result.referralDiscountBps
                     )
@@ -161,6 +181,15 @@ final class SwapVerifyViewModel {
             }
             transaction = updated
             error = nil
+            if routeWasSubstituted {
+                // The confirmations were given for a route that is no longer on
+                // offer, so they no longer mean anything — make the user re-read
+                // the summary and re-confirm against the substitute.
+                isAmountCorrect = false
+                isFeeCorrect = false
+                isApproveCorrect = false
+                routeSelectionNotice = "swapRouteUnavailableResetToAuto".localized
+            }
         } catch {
             guard (error as? URLError)?.code != .cancelled else { return }
             logger.warning("Refresh quote error: \(error.localizedDescription)")

--- a/VultisigApp/VultisigApp/Features/Swap/Views/AdvancedSwapSheet.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/AdvancedSwapSheet.swift
@@ -211,7 +211,8 @@ struct AdvancedSwapSheet: View {
     }
 
     /// "Auto" until the user manually overrides the route; then the picked
-    /// provider's name. A refresh clears the override, so this reverts to "Auto".
+    /// provider's name. The pick survives a refresh, so this keeps naming the
+    /// provider until the route stops being offered or the swap itself changes.
     private var selectRouteValue: String {
         guard let selected = vm.selectedQuote?.displayName else { return "auto".localized }
         return selected

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
@@ -168,6 +168,9 @@ struct SwapDetailsScreen: View {
         .onChange(of: detailsViewModel.fromAmount) { _, _ in
             detailsViewModel.error = nil
         }
+        // A manual route pick that had to be dropped says so here rather than
+        // reverting to Auto in silence.
+        .withBanner(text: $vm.routeSelectionNotice, style: .error)
         .ignoresSafeArea(.keyboard)
     }
 

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
@@ -179,6 +179,10 @@ struct SwapDetailsScreen: View {
     /// the limit form reads as an error about the order being placed. Withheld,
     /// not dropped — switching back to Market flips the binding and the notice
     /// lands on the form it is about.
+    ///
+    /// This gates when a banner STARTS. One already on screen when the user
+    /// switches tabs still finishes its own ~1.5s dismissal, because the shared
+    /// banner modifier tracks visibility itself and ignores the text going nil.
     private var routeSelectionNotice: Binding<String?> {
         Binding(
             get: { selectedSwapMode == .market ? detailsViewModel.routeSelectionNotice : nil },

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
@@ -168,21 +168,14 @@ struct SwapDetailsScreen: View {
         .onChange(of: detailsViewModel.fromAmount) { _, _ in
             detailsViewModel.error = nil
         }
-        // A manual route pick that had to be dropped says so here rather than
-        // reverting to Auto in silence.
         .withBanner(text: routeSelectionNotice, style: .error)
         .ignoresSafeArea(.keyboard)
     }
 
-    /// The market form's route notice, withheld while the Limit tab is showing:
-    /// the market quote keeps refreshing behind it, and a market-route banner over
-    /// the limit form reads as an error about the order being placed. Withheld,
-    /// not dropped — switching back to Market flips the binding and the notice
-    /// lands on the form it is about.
-    ///
-    /// This gates when a banner STARTS. One already on screen when the user
-    /// switches tabs still finishes its own ~1.5s dismissal, because the shared
-    /// banner modifier tracks visibility itself and ignores the text going nil.
+    /// Withheld while the Limit tab shows — the market quote keeps refreshing
+    /// behind it, so its banner would land on the limit form. Withheld, not
+    /// dropped: returning to Market delivers it. Gates only when a banner STARTS;
+    /// one already visible finishes its own dismissal (the modifier owns that).
     private var routeSelectionNotice: Binding<String?> {
         Binding(
             get: { selectedSwapMode == .market ? detailsViewModel.routeSelectionNotice : nil },

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
@@ -170,8 +170,20 @@ struct SwapDetailsScreen: View {
         }
         // A manual route pick that had to be dropped says so here rather than
         // reverting to Auto in silence.
-        .withBanner(text: $vm.routeSelectionNotice, style: .error)
+        .withBanner(text: routeSelectionNotice, style: .error)
         .ignoresSafeArea(.keyboard)
+    }
+
+    /// The market form's route notice, withheld while the Limit tab is showing:
+    /// the market quote keeps refreshing behind it, and a market-route banner over
+    /// the limit form reads as an error about the order being placed. Withheld,
+    /// not dropped — switching back to Market flips the binding and the notice
+    /// lands on the form it is about.
+    private var routeSelectionNotice: Binding<String?> {
+        Binding(
+            get: { selectedSwapMode == .market ? detailsViewModel.routeSelectionNotice : nil },
+            set: { detailsViewModel.routeSelectionNotice = $0 }
+        )
     }
 
     var swapContent: some View {

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
@@ -44,6 +44,9 @@ struct SwapVerifyScreen: View {
             }
         }
         .withBanner(text: $retryBannerText, style: .error)
+        // The refresh substituted a route the user had picked — say so instead of
+        // silently signing a different provider.
+        .withBanner(text: $vm.routeSelectionNotice, style: .error)
         // Surface build-side failures so the user doesn't see "nothing
         // happens" after entering the FastVault password. `buildSwapKeysignPayload`
         // catches errors into `verifyViewModel.error`; without this binding

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
@@ -44,8 +44,6 @@ struct SwapVerifyScreen: View {
             }
         }
         .withBanner(text: $retryBannerText, style: .error)
-        // The refresh substituted a route the user had picked — say so instead of
-        // silently signing a different provider.
         .withBanner(text: $vm.routeSelectionNotice, style: .error)
         // Surface build-side failures so the user doesn't see "nothing
         // happens" after entering the FastVault password. `buildSwapKeysignPayload`

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
@@ -37,6 +37,7 @@ struct SwapVerifyScreen: View {
                     .disabled(!verifyViewModel.isValidForm(shouldApprove: currentTransaction.isApproveRequired) || verifyViewModel.isLoadingFees || signButtonDisabled)
             }
         }
+        .withLoading(isLoading: $vm.isLoadingFees)
         .screenTitle("swapOverview".localized)
         .screenToolbar {
             CustomToolbarItem(placement: .trailing, hideSharedBackground: true) {
@@ -138,7 +139,6 @@ struct SwapVerifyScreen: View {
                         cryptoAmount: currentTransaction.swapGasString,
                         fiatAmount: currentTransaction.approveFeeString
                     )
-                    .blur(radius: verifyViewModel.isLoadingFees ? 1 : 0)
                 }
 
                 // Gross list-rate Vultisig fee. Applied savings are itemized in
@@ -146,7 +146,6 @@ struct SwapVerifyScreen: View {
                 if currentTransaction.showAffiliateFeeRow {
                     separator
                     affiliateFeeRow
-                        .blur(radius: verifyViewModel.isLoadingFees ? 1 : 0)
                 }
 
                 // Protocol Fee (native THOR/Maya outbound).
@@ -156,7 +155,6 @@ struct SwapVerifyScreen: View {
                         for: "swap.protocol_fee",
                         with: currentTransaction.outboundFeeString
                     )
-                    .blur(radius: verifyViewModel.isLoadingFees ? 1 : 0)
                 }
 
                 if currentTransaction.hasAppliedDiscounts {
@@ -177,7 +175,6 @@ struct SwapVerifyScreen: View {
                         for: "totalFee",
                         with: currentTransaction.totalFeeString
                     )
-                    .blur(radius: verifyViewModel.isLoadingFees ? 1 : 0)
                 }
 
                 if currentTransaction.advancedSettings.slippage != .auto {
@@ -418,7 +415,7 @@ struct SwapVerifyScreen: View {
     var refreshCounter: some View {
         // Limit orders execute at a fixed target price, so there is no live quote
         // to refresh — hide the countdown on the limit verify screen.
-        if !currentTransaction.isLimit {
+        if !currentTransaction.isLimit && !verifyViewModel.isLoadingFees {
             SwapRefreshQuoteCounter(timer: verifyViewModel.timer)
         }
     }

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
@@ -58,17 +58,10 @@ enum SwapQuote: Hashable {
         }
     }
 
-    /// Identity of the route this quote represents, free of the quote payload
-    /// (amounts, fees, calldata) that changes on every fetch. Two quotes from
-    /// consecutive fetches share it exactly when they are the same row in the
-    /// route picker, which is what lets a manual route pick re-attach to the
-    /// fresh quote instead of being dropped.
-    ///
-    /// Network variants stay distinct — they are separate `SwapProvider`s with
-    /// separate `displayName`s, so they are separate rows. The SwapKit
-    /// sub-provider is deliberately excluded: SwapKit is one provider and one
-    /// row whichever protocol it routes through underneath, and that underlying
-    /// choice can legitimately flip between fetches.
+    /// Payload-free identity of this quote's route — stable across fetches, one
+    /// case per row of the picker. The SwapKit sub-provider is excluded on
+    /// purpose: SwapKit is one row whichever protocol it routes through, and that
+    /// choice can flip between fetches, so keying on it would drop a live pick.
     var routeIdentity: SwapRouteIdentity {
         switch self {
         case .thorchain:
@@ -331,8 +324,7 @@ enum SwapQuote: Hashable {
     }
 }
 
-/// Payload-free identity of a swap route, one case per row of the
-/// route-selection sheet. See `SwapQuote.routeIdentity`.
+/// See `SwapQuote.routeIdentity`.
 enum SwapRouteIdentity: Hashable {
     case thorchain
     case thorchainChainnet

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
@@ -58,11 +58,11 @@ enum SwapQuote: Hashable {
         }
     }
 
-    /// Payload-free identity of this quote's route — stable across fetches, one
+    /// Provider for this quote on the source chain — stable across fetches, one
     /// case per row of the picker. The SwapKit sub-provider is excluded on
     /// purpose: SwapKit is one row whichever protocol it routes through, and that
     /// choice can flip between fetches, so keying on it would drop a live pick.
-    var routeIdentity: SwapRouteIdentity {
+    func provider(fromChain: Chain) -> SwapProvider {
         switch self {
         case .thorchain:
             return .thorchain
@@ -73,9 +73,9 @@ enum SwapQuote: Hashable {
         case .mayachain:
             return .mayachain
         case .oneinch:
-            return .oneInch
+            return .oneinch(fromChain)
         case .kyberswap:
-            return .kyberSwap
+            return .kyberswap(fromChain)
         case .lifi:
             return .lifi
         case .swapkit:
@@ -322,17 +322,4 @@ enum SwapQuote: Hashable {
             hasher.combine(feeOnInput)
         }
     }
-}
-
-/// See `SwapQuote.routeIdentity`.
-enum SwapRouteIdentity: Hashable {
-    case thorchain
-    case thorchainChainnet
-    case thorchainStagenet
-    case mayachain
-    case oneInch
-    case kyberSwap
-    case lifi
-    case swapkit
-    case jupiter
 }

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
@@ -58,6 +58,40 @@ enum SwapQuote: Hashable {
         }
     }
 
+    /// Identity of the route this quote represents, free of the quote payload
+    /// (amounts, fees, calldata) that changes on every fetch. Two quotes from
+    /// consecutive fetches share it exactly when they are the same row in the
+    /// route picker, which is what lets a manual route pick re-attach to the
+    /// fresh quote instead of being dropped.
+    ///
+    /// Network variants stay distinct — they are separate `SwapProvider`s with
+    /// separate `displayName`s, so they are separate rows. The SwapKit
+    /// sub-provider is deliberately excluded: SwapKit is one provider and one
+    /// row whichever protocol it routes through underneath, and that underlying
+    /// choice can legitimately flip between fetches.
+    var routeIdentity: SwapRouteIdentity {
+        switch self {
+        case .thorchain:
+            return .thorchain
+        case .thorchainChainnet:
+            return .thorchainChainnet
+        case .thorchainStagenet:
+            return .thorchainStagenet
+        case .mayachain:
+            return .mayachain
+        case .oneinch:
+            return .oneInch
+        case .kyberswap:
+            return .kyberSwap
+        case .lifi:
+            return .lifi
+        case .swapkit:
+            return .swapkit
+        case .jupiter:
+            return .jupiter
+        }
+    }
+
     /// Payload-free provider identity — the single source of truth for this
     /// quote's brand logo and display name. Network variants collapse to their
     /// base kind; `displayName` re-adds the `-Chainnet`/`-Stagenet` suffix.
@@ -295,4 +329,18 @@ enum SwapQuote: Hashable {
             hasher.combine(feeOnInput)
         }
     }
+}
+
+/// Payload-free identity of a swap route, one case per row of the
+/// route-selection sheet. See `SwapQuote.routeIdentity`.
+enum SwapRouteIdentity: Hashable {
+    case thorchain
+    case thorchainChainnet
+    case thorchainStagenet
+    case mayachain
+    case oneInch
+    case kyberSwap
+    case lifi
+    case swapkit
+    case jupiter
 }

--- a/VultisigApp/VultisigAppTests/Swap/SwapProviderSelectionTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapProviderSelectionTests.swift
@@ -8,10 +8,8 @@
 //      when no provider-preference band applies.
 //   2. VM selection — `selectedQuote` drives the computed `quote` and a non-best
 //      pick reaches the active quote (and therefore the verify/sign summary).
-//   3. Pick persistence — a refresh re-resolves the pick by `routeIdentity`, so
-//      it survives while its route is still a candidate and re-points at the
-//      fresh quote; it is dropped, with a notice, when the route leaves the
-//      candidate set or the swap itself changes.
+//   3. Pick persistence — a pick survives a refresh and re-points at the fresh
+//      quote; it is dropped, with a notice, when it stops being valid.
 //   4. Availability — provider selection depends solely on `allQuotes.count > 1`
 //      (the advanced-settings entry point is already silver-gated, so there is
 //      no second tier gate on the row itself).
@@ -128,7 +126,6 @@ final class SwapProviderSelectionTests: XCTestCase {
         vm.selectProvider(alt)
         XCTAssertEqual(vm.quote, alt)
 
-        // A silent same-pair/same-amount refresh — the 60s auto-refresh.
         await landQuotes(on: vm)
 
         XCTAssertEqual(interactor.fetchCount, 2, "The refresh this test is about must actually have landed")
@@ -154,8 +151,8 @@ final class SwapProviderSelectionTests: XCTestCase {
         vm.fromAmount = "1"
         await landQuotes(on: vm)
 
-        // Pick out of the set the VM actually landed, so the test can't pass by
-        // selecting a value the first fetch never returned.
+        // Pick from the landed set, so the test can't select a value the first
+        // fetch never returned.
         XCTAssertEqual(interactor.fetchCount, 1, "The first landing must be script entry 0")
         guard let landed = vm.allQuotes.first(where: { $0.routeIdentity == .oneInch }) else {
             return XCTFail("The first landing must offer the 1inch route")
@@ -203,11 +200,9 @@ final class SwapProviderSelectionTests: XCTestCase {
         await landQuotes(on: vm)
         vm.selectProvider(alt)
 
-        // "1" and "1<sep>0" are the same number to the provider, so this is a
-        // refresh of the same swap rather than a new one. Built from the running
-        // locale's separator: `toDecimal` parses with `Locale.current` first, so a
-        // hard-coded "1.0" reads as ten under a comma-decimal locale and would
-        // fail this test against correct production behaviour.
+        // Built from the running locale's separator: `toDecimal` parses with
+        // `Locale.current` first, so a hard-coded "1.0" is TEN in five of the eight
+        // shipping locales and would fail against correct production behaviour.
         let separator = Locale.current.decimalSeparator ?? "."
         let equivalentAmount = "1\(separator)0"
         XCTAssertEqual(
@@ -259,8 +254,7 @@ final class SwapProviderSelectionTests: XCTestCase {
         await landQuotes(on: vm)
         vm.selectProvider(stale)
 
-        // Changing a quote-affecting setting re-fetches at the SAME pair/amount,
-        // so it is a refresh: a new slippage does not invalidate a route choice.
+        // Re-fetches at the SAME pair/amount, so it is a refresh, not a new swap.
         vm.snapshotAdvancedSettings()
         vm.advancedSettings.gasLimit = 100_000
         vm.advancedSettingsSheetDidClose(vault: makeVault())
@@ -272,8 +266,7 @@ final class SwapProviderSelectionTests: XCTestCase {
     }
 
     func testAdvancedSettingsRefetchDropsSelectionWhenRoutePruned() async {
-        // An external recipient prunes the aggregator routes that can't honour it,
-        // so a picked 1inch route legitimately disappears on the re-fetch.
+        // An external recipient prunes aggregator routes that can't honour it.
         let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
         let alt = SwapQuote.oneinch(makeEVMQuote(dstAmount: "100000000"), fee: nil)
         let (vm, interactor) = makeVM(script: [
@@ -298,9 +291,9 @@ final class SwapProviderSelectionTests: XCTestCase {
     }
 
     func testSecuredMintRefreshDropsSelectionWithNotice() async {
-        // Defensive branch: a pair change to a secured mint already clears the pick
-        // in `fetchQuotes`, so production can't reach here holding one. Pinned so
-        // the branch stays a NOTIFIED drop rather than reverting to a silent nil.
+        // Defensive branch — `fetchQuotes` clears the pick on the pair change that
+        // gets here, so production can't hold one. Pinned so it stays a NOTIFIED
+        // drop rather than reverting to a silent nil.
         let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
         let vm = makeVM(best: best, allQuotes: [best])
         vm.fromCoin = makeCoin(.bitcoin, ticker: "BTC", balance: "100000000")
@@ -391,9 +384,7 @@ final class SwapProviderSelectionTests: XCTestCase {
     }
 
     func testRouteIdentityIgnoresSwapKitSubProvider() {
-        // SwapKit is one row whichever protocol it routes through underneath, and
-        // that underlying choice can legitimately change between fetches — keying
-        // on it would drop a pick the user can still see on screen.
+        // Keying on the sub-provider would drop a pick still visible on screen.
         let viaChainflip = SwapQuote.swapkit(
             makeSwapKitResponse(providers: ["Chainflip"]), fee: nil, subProvider: "Chainflip"
         )
@@ -433,10 +424,8 @@ final class SwapProviderSelectionTests: XCTestCase {
         makeVM(script: [makeResult(best: best, allQuotes: allQuotes)]).vm
     }
 
-    /// A VM whose interactor hands out `script` one entry per fetch, so a test can
-    /// make a refresh return something different from the first landing. The
-    /// interactor comes back too: the script repeats its last entry once exhausted,
-    /// so a test that depends on WHICH entry landed must pin `fetchCount`.
+    /// One scripted result per fetch. The script repeats its last entry once
+    /// exhausted, so a test depending on WHICH entry landed must pin `fetchCount`.
     private func makeVM(script: [SwapQuoteResult]) -> (vm: SwapDetailsViewModel, interactor: ProviderSelectionMockInteractor) {
         let interactor = ProviderSelectionMockInteractor(script: script)
         return (SwapDetailsViewModel(interactor: interactor), interactor)
@@ -503,9 +492,7 @@ final class SwapProviderSelectionTests: XCTestCase {
         )
     }
 
-    /// THORChain secured BTC: not native, `contractAddress` "btc-btc", so
-    /// `isSameUnderlyingSecuredMint` resolves its underlying to "BTC.BTC" and
-    /// matches a native BTC source.
+    /// Underlying resolves to "BTC.BTC", matching a native BTC source.
     private func makeSecuredBTCCoin() -> Coin {
         let meta = CoinMeta(
             chain: .thorChain,
@@ -519,8 +506,7 @@ final class SwapProviderSelectionTests: XCTestCase {
         return Coin(asset: meta, address: "test-address-secured-BTC", hexPublicKey: "")
     }
 
-    /// SwapKit responses are `Decodable`-only (custom `init(from:)`, no memberwise
-    /// init), so the fixture is built from a minimal EVM-txType JSON payload.
+    /// `Decodable`-only (custom `init(from:)`), so build it from JSON.
     private func makeSwapKitResponse(providers: [String] = ["Chainflip"]) -> SwapKitSwapResponse {
         let providerList = providers.map { "\"\($0)\"" }.joined(separator: ", ")
         let json = """
@@ -580,16 +566,13 @@ private extension SwapDetailsViewModel {
 
 // swiftlint:disable async_without_await unused_parameter
 
-/// Hands out a scripted result per fetch so the VM's quote-landing path can be
-/// driven without the network, including a refresh that returns a different
-/// candidate set from the first landing. The last entry repeats once the script
-/// is exhausted, so a steady-state test can pass a single one.
+/// Drives the VM's quote-landing path without the network. The last entry repeats
+/// once the script is exhausted, so a steady-state test can pass a single one.
 @MainActor
 private final class ProviderSelectionMockInteractor: SwapInteractor {
     private let script: [SwapQuoteResult]
-    /// Lets a test prove the landings it expected actually happened — without it,
-    /// an extra fetch could consume the script early and the repeat-last behaviour
-    /// would hide the desync behind a passing assertion.
+    /// Pin this: an extra fetch consuming the script early would otherwise hide
+    /// the desync behind a passing assertion.
     private(set) var fetchCount = 0
 
     init(script: [SwapQuoteResult]) {

--- a/VultisigApp/VultisigAppTests/Swap/SwapProviderSelectionTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapProviderSelectionTests.swift
@@ -121,7 +121,8 @@ final class SwapProviderSelectionTests: XCTestCase {
     func testRefreshPreservesManualRouteSelection() async {
         let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
         let alt = SwapQuote.oneinch(makeEVMQuote(dstAmount: "100000000"), fee: nil)
-        let vm = makeVM(best: best, allQuotes: [best, alt])
+        let candidates = makeResult(best: best, allQuotes: [best, alt])
+        let (vm, interactor) = makeVM(script: [candidates, candidates])
         await landQuotes(on: vm)
 
         vm.selectProvider(alt)
@@ -130,6 +131,7 @@ final class SwapProviderSelectionTests: XCTestCase {
         // A silent same-pair/same-amount refresh — the 60s auto-refresh.
         await landQuotes(on: vm)
 
+        XCTAssertEqual(interactor.fetchCount, 2, "The refresh this test is about must actually have landed")
         XCTAssertEqual(vm.selectedQuote, alt, "A refresh must not drop a still-valid manual pick")
         XCTAssertEqual(vm.quote, alt, "The active quote stays on the picked route")
         XCTAssertNil(vm.routeSelectionNotice, "Nothing was dropped, so there is nothing to tell the user")
@@ -143,7 +145,7 @@ final class SwapProviderSelectionTests: XCTestCase {
         XCTAssertNotEqual(stale, fresh, "Fixture must differ by payload for this test to mean anything")
         XCTAssertEqual(stale.routeIdentity, fresh.routeIdentity, "…while still being the same route")
 
-        let vm = makeVM(script: [
+        let (vm, interactor) = makeVM(script: [
             makeResult(best: best, allQuotes: [best, stale]),
             makeResult(best: best, allQuotes: [best, fresh])
         ])
@@ -152,9 +154,18 @@ final class SwapProviderSelectionTests: XCTestCase {
         vm.fromAmount = "1"
         await landQuotes(on: vm)
 
-        vm.selectProvider(stale)
+        // Pick out of the set the VM actually landed, so the test can't pass by
+        // selecting a value the first fetch never returned.
+        XCTAssertEqual(interactor.fetchCount, 1, "The first landing must be script entry 0")
+        guard let landed = vm.allQuotes.first(where: { $0.routeIdentity == .oneInch }) else {
+            return XCTFail("The first landing must offer the 1inch route")
+        }
+        XCTAssertEqual(landed, stale, "…and it must be the stale payload, not the refreshed one")
+        vm.selectProvider(landed)
+
         await landQuotes(on: vm)
 
+        XCTAssertEqual(interactor.fetchCount, 2, "The refresh must be script entry 1")
         XCTAssertEqual(vm.selectedQuote, fresh, "The pick must re-point at the refreshed quote")
         XCTAssertEqual(
             vm.makeTransaction()?.quote,
@@ -166,7 +177,7 @@ final class SwapProviderSelectionTests: XCTestCase {
     func testRefreshDropsSelectionWhenRouteLeavesCandidateSet() async {
         let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
         let alt = SwapQuote.oneinch(makeEVMQuote(dstAmount: "100000000"), fee: nil)
-        let vm = makeVM(script: [
+        let (vm, interactor) = makeVM(script: [
             makeResult(best: best, allQuotes: [best, alt]),
             makeResult(best: best, allQuotes: [best])
         ])
@@ -175,6 +186,7 @@ final class SwapProviderSelectionTests: XCTestCase {
         vm.selectProvider(alt)
         await landQuotes(on: vm)
 
+        XCTAssertEqual(interactor.fetchCount, 2, "The refresh must be the entry that drops 1inch")
         XCTAssertNil(vm.selectedQuote, "A route that is no longer offered can't stay picked")
         XCTAssertEqual(vm.quote, best, "The active quote falls back to the auto-selected winner")
         XCTAssertEqual(
@@ -182,6 +194,118 @@ final class SwapProviderSelectionTests: XCTestCase {
             "swapRouteUnavailableResetToAuto".localized,
             "Dropping the pick must be surfaced, not silent"
         )
+    }
+
+    func testRetypingAnEquivalentAmountKeepsTheSelection() async {
+        let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
+        let alt = SwapQuote.oneinch(makeEVMQuote(dstAmount: "100000000"), fee: nil)
+        let vm = makeVM(best: best, allQuotes: [best, alt])
+        await landQuotes(on: vm)
+        vm.selectProvider(alt)
+
+        // "1" -> "1.0" is the same number to the provider, so it is a refresh of
+        // the same swap, not a new one.
+        vm.fromAmount = "1.0"
+        vm.updateFromAmount(vault: makeVault(), immediate: true)
+
+        XCTAssertEqual(vm.selectedQuote, alt, "An equivalent amount must not drop the pick")
+        XCTAssertNil(vm.routeSelectionNotice, "…and must not claim the swap changed")
+
+        await vm.waitForQuoteTask()
+        XCTAssertEqual(vm.selectedQuote, alt, "The refresh re-attaches the pick as usual")
+    }
+
+    func testMakeTransactionCarriesTheManualRouteIdentity() async {
+        let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
+        let alt = SwapQuote.oneinch(makeEVMQuote(dstAmount: "100000000"), fee: BigInt(1_000))
+        let vm = makeVM(best: best, allQuotes: [best, alt])
+        vm.fromCoin = makeCoin(.ethereum, ticker: "ETH", balance: "5000000000000000000")
+        vm.toCoin = makeCoin(.bitcoin, ticker: "BTC")
+        vm.fromAmount = "1"
+        await landQuotes(on: vm)
+
+        XCTAssertNil(
+            vm.makeTransaction()?.selectedRouteIdentity,
+            "On Auto the transaction pins no route, so verify stays free to follow the winner"
+        )
+
+        vm.selectProvider(alt)
+
+        XCTAssertEqual(
+            vm.makeTransaction()?.selectedRouteIdentity,
+            .oneInch,
+            "A manual pick must reach verify, which re-resolves it on its own refresh"
+        )
+    }
+
+    func testAdvancedSettingsRefetchPreservesAndRepointsSelection() async {
+        let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
+        let stale = SwapQuote.oneinch(makeEVMQuote(dstAmount: "100000000"), fee: nil)
+        let fresh = SwapQuote.oneinch(makeEVMQuote(dstAmount: "111111111"), fee: nil)
+        let (vm, interactor) = makeVM(script: [
+            makeResult(best: best, allQuotes: [best, stale]),
+            makeResult(best: best, allQuotes: [best, fresh])
+        ])
+        await landQuotes(on: vm)
+        vm.selectProvider(stale)
+
+        // Changing a quote-affecting setting re-fetches at the SAME pair/amount,
+        // so it is a refresh: a new slippage does not invalidate a route choice.
+        vm.snapshotAdvancedSettings()
+        vm.advancedSettings.gasLimit = 100_000
+        vm.advancedSettingsSheetDidClose(vault: makeVault())
+        await vm.waitForQuoteTask()
+
+        XCTAssertEqual(interactor.fetchCount, 2, "The settings change must have re-fetched")
+        XCTAssertEqual(vm.selectedQuote, fresh, "The pick survives the re-fetch, re-pointed at the fresh quote")
+        XCTAssertNil(vm.routeSelectionNotice)
+    }
+
+    func testAdvancedSettingsRefetchDropsSelectionWhenRoutePruned() async {
+        // An external recipient prunes the aggregator routes that can't honour it,
+        // so a picked 1inch route legitimately disappears on the re-fetch.
+        let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
+        let alt = SwapQuote.oneinch(makeEVMQuote(dstAmount: "100000000"), fee: nil)
+        let (vm, interactor) = makeVM(script: [
+            makeResult(best: best, allQuotes: [best, alt]),
+            makeResult(best: best, allQuotes: [best])
+        ])
+        await landQuotes(on: vm)
+        vm.selectProvider(alt)
+
+        vm.snapshotAdvancedSettings()
+        vm.advancedSettings.externalRecipient = "thor1recipient"
+        vm.advancedSettingsSheetDidClose(vault: makeVault())
+        await vm.waitForQuoteTask()
+
+        XCTAssertEqual(interactor.fetchCount, 2)
+        XCTAssertNil(vm.selectedQuote, "A pruned route can't stay picked")
+        XCTAssertEqual(
+            vm.routeSelectionNotice,
+            "swapRouteUnavailableResetToAuto".localized,
+            "The user must be told the recipient cost them their route"
+        )
+    }
+
+    func testSecuredMintRefreshDropsSelectionWithNotice() async {
+        // Defensive branch: a pair change to a secured mint already clears the pick
+        // in `fetchQuotes`, so production can't reach here holding one. Pinned so
+        // the branch stays a NOTIFIED drop rather than reverting to a silent nil.
+        let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
+        let vm = makeVM(best: best, allQuotes: [best])
+        vm.fromCoin = makeCoin(.bitcoin, ticker: "BTC", balance: "100000000")
+        vm.toCoin = makeSecuredBTCCoin()
+        vm.fromAmount = "1"
+        vm.updateFromAmount(vault: makeVault(), immediate: true)
+        await vm.waitForQuoteTask()
+        XCTAssertTrue(vm.isSecuredMint, "Fixture must actually be a same-underlying secured mint")
+
+        vm.selectedQuote = SwapQuote.oneinch(makeEVMQuote(dstAmount: "1"), fee: nil)
+        vm.updateFromAmount(vault: makeVault(), immediate: true)
+        await vm.waitForQuoteTask()
+
+        XCTAssertNil(vm.selectedQuote, "The synthetic mint quote is the only candidate")
+        XCTAssertEqual(vm.routeSelectionNotice, "swapRouteUnavailableResetToAuto".localized)
     }
 
     func testAmountChangeDropsSelectionWithNotice() async {
@@ -296,13 +420,16 @@ final class SwapProviderSelectionTests: XCTestCase {
         best: SwapQuote,
         allQuotes: [SwapQuote]
     ) -> SwapDetailsViewModel {
-        makeVM(script: [makeResult(best: best, allQuotes: allQuotes)])
+        makeVM(script: [makeResult(best: best, allQuotes: allQuotes)]).vm
     }
 
-    /// A VM whose interactor hands out `script` one entry per fetch, so a test
-    /// can make a refresh return something different from the first landing.
-    private func makeVM(script: [SwapQuoteResult]) -> SwapDetailsViewModel {
-        SwapDetailsViewModel(interactor: ProviderSelectionMockInteractor(script: script))
+    /// A VM whose interactor hands out `script` one entry per fetch, so a test can
+    /// make a refresh return something different from the first landing. The
+    /// interactor comes back too: the script repeats its last entry once exhausted,
+    /// so a test that depends on WHICH entry landed must pin `fetchCount`.
+    private func makeVM(script: [SwapQuoteResult]) -> (vm: SwapDetailsViewModel, interactor: ProviderSelectionMockInteractor) {
+        let interactor = ProviderSelectionMockInteractor(script: script)
+        return (SwapDetailsViewModel(interactor: interactor), interactor)
     }
 
     private func makeResult(best: SwapQuote, allQuotes: [SwapQuote]) -> SwapQuoteResult {
@@ -364,6 +491,22 @@ final class SwapProviderSelectionTests: XCTestCase {
             router: nil,
             maxStreamingQuantity: nil
         )
+    }
+
+    /// THORChain secured BTC: not native, `contractAddress` "btc-btc", so
+    /// `isSameUnderlyingSecuredMint` resolves its underlying to "BTC.BTC" and
+    /// matches a native BTC source.
+    private func makeSecuredBTCCoin() -> Coin {
+        let meta = CoinMeta(
+            chain: .thorChain,
+            ticker: "BTC",
+            logo: "logo",
+            decimals: 8,
+            priceProviderId: "bitcoin",
+            contractAddress: "btc-btc",
+            isNativeToken: false
+        )
+        return Coin(asset: meta, address: "test-address-secured-BTC", hexPublicKey: "")
     }
 
     /// SwapKit responses are `Decodable`-only (custom `init(from:)`, no memberwise
@@ -434,7 +577,10 @@ private extension SwapDetailsViewModel {
 @MainActor
 private final class ProviderSelectionMockInteractor: SwapInteractor {
     private let script: [SwapQuoteResult]
-    private var fetchCount = 0
+    /// Lets a test prove the landings it expected actually happened — without it,
+    /// an extra fetch could consume the script early and the repeat-last behaviour
+    /// would hide the desync behind a passing assertion.
+    private(set) var fetchCount = 0
 
     init(script: [SwapQuoteResult]) {
         precondition(!script.isEmpty, "The script needs at least one result")

--- a/VultisigApp/VultisigAppTests/Swap/SwapProviderSelectionTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapProviderSelectionTests.swift
@@ -203,9 +203,19 @@ final class SwapProviderSelectionTests: XCTestCase {
         await landQuotes(on: vm)
         vm.selectProvider(alt)
 
-        // "1" -> "1.0" is the same number to the provider, so it is a refresh of
-        // the same swap, not a new one.
-        vm.fromAmount = "1.0"
+        // "1" and "1<sep>0" are the same number to the provider, so this is a
+        // refresh of the same swap rather than a new one. Built from the running
+        // locale's separator: `toDecimal` parses with `Locale.current` first, so a
+        // hard-coded "1.0" reads as ten under a comma-decimal locale and would
+        // fail this test against correct production behaviour.
+        let separator = Locale.current.decimalSeparator ?? "."
+        let equivalentAmount = "1\(separator)0"
+        XCTAssertEqual(
+            equivalentAmount.toDecimal(),
+            "1".toDecimal(),
+            "Fixture must be numerically equivalent for this test to mean anything"
+        )
+        vm.fromAmount = equivalentAmount
         vm.updateFromAmount(vault: makeVault(), immediate: true)
 
         XCTAssertEqual(vm.selectedQuote, alt, "An equivalent amount must not drop the pick")

--- a/VultisigApp/VultisigAppTests/Swap/SwapProviderSelectionTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapProviderSelectionTests.swift
@@ -140,7 +140,7 @@ final class SwapProviderSelectionTests: XCTestCase {
         let stale = SwapQuote.oneinch(makeEVMQuote(dstAmount: "100000000"), fee: BigInt(1_000))
         let fresh = SwapQuote.oneinch(makeEVMQuote(dstAmount: "123456789"), fee: BigInt(1_000))
         XCTAssertNotEqual(stale, fresh, "Fixture must differ by payload for this test to mean anything")
-        XCTAssertEqual(stale.routeIdentity, fresh.routeIdentity, "…while still being the same route")
+        XCTAssertEqual(stale.provider(fromChain: .ethereum), fresh.provider(fromChain: .ethereum), "…while still being the same route")
 
         let (vm, interactor) = makeVM(script: [
             makeResult(best: best, allQuotes: [best, stale]),
@@ -154,7 +154,7 @@ final class SwapProviderSelectionTests: XCTestCase {
         // Pick from the landed set, so the test can't select a value the first
         // fetch never returned.
         XCTAssertEqual(interactor.fetchCount, 1, "The first landing must be script entry 0")
-        guard let landed = vm.allQuotes.first(where: { $0.routeIdentity == .oneInch }) else {
+        guard let landed = vm.allQuotes.first(where: { $0.provider(fromChain: .ethereum) == .oneinch(.ethereum) }) else {
             return XCTFail("The first landing must offer the 1inch route")
         }
         XCTAssertEqual(landed, stale, "…and it must be the stale payload, not the refreshed one")
@@ -220,25 +220,25 @@ final class SwapProviderSelectionTests: XCTestCase {
         XCTAssertEqual(vm.selectedQuote, alt, "The refresh re-attaches the pick as usual")
     }
 
-    func testMakeTransactionCarriesTheManualRouteIdentity() async {
+    func testMakeTransactionCarriesTheSelectedProvider() async {
         let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
         let alt = SwapQuote.oneinch(makeEVMQuote(dstAmount: "100000000"), fee: BigInt(1_000))
         let vm = makeVM(best: best, allQuotes: [best, alt])
-        vm.fromCoin = makeCoin(.ethereum, ticker: "ETH", balance: "5000000000000000000")
+        vm.fromCoin = makeCoin(.arbitrum, ticker: "ETH", balance: "5000000000000000000")
         vm.toCoin = makeCoin(.bitcoin, ticker: "BTC")
         vm.fromAmount = "1"
         await landQuotes(on: vm)
 
         XCTAssertNil(
-            vm.makeTransaction()?.selectedRouteIdentity,
+            vm.makeTransaction()?.selectedProvider,
             "On Auto the transaction pins no route, so verify stays free to follow the winner"
         )
 
         vm.selectProvider(alt)
 
         XCTAssertEqual(
-            vm.makeTransaction()?.selectedRouteIdentity,
-            .oneInch,
+            vm.makeTransaction()?.selectedProvider,
+            .oneinch(.arbitrum),
             "A manual pick must reach verify, which re-resolves it on its own refresh"
         )
     }
@@ -348,17 +348,17 @@ final class SwapProviderSelectionTests: XCTestCase {
         XCTAssertNotEqual("swapRouteUnavailableResetToAuto".localized, "swapRouteUnavailableResetToAuto")
     }
 
-    // MARK: - Route identity
+    // MARK: - Provider matching
 
-    func testRouteIdentityIsStableAcrossPayloadChanges() {
+    func testProviderIsStableAcrossPayloadChanges() {
         let stale = SwapQuote.lifi(makeEVMQuote(dstAmount: "100000000"), fee: BigInt(1), integratorFee: 0.001)
         let fresh = SwapQuote.lifi(makeEVMQuote(dstAmount: "999999999"), fee: BigInt(2), integratorFee: 0.002)
 
         XCTAssertNotEqual(stale, fresh, "Quotes compare by payload, so these are different values")
-        XCTAssertEqual(stale.routeIdentity, fresh.routeIdentity, "…but the same route")
+        XCTAssertEqual(stale.provider(fromChain: .ethereum), fresh.provider(fromChain: .ethereum), "…but the same route")
     }
 
-    func testRouteIdentityIsDistinctPerPickerRow() {
+    func testProviderIsDistinctPerPickerRow() {
         let quotes: [SwapQuote] = [
             .thorchain(makeThorQuote(expectedAmountOut: "1")),
             .thorchainChainnet(makeThorQuote(expectedAmountOut: "1")),
@@ -372,7 +372,7 @@ final class SwapProviderSelectionTests: XCTestCase {
         ]
 
         XCTAssertEqual(
-            Set(quotes.map(\.routeIdentity)).count,
+            Set(quotes.map { $0.provider(fromChain: .ethereum) }).count,
             quotes.count,
             "Every route the picker can show must be separately identifiable"
         )
@@ -383,7 +383,18 @@ final class SwapProviderSelectionTests: XCTestCase {
         )
     }
 
-    func testRouteIdentityIgnoresSwapKitSubProvider() {
+    func testAggregatorProviderUsesSourceChain() {
+        let quote = makeEVMQuote(dstAmount: "1")
+        let oneInch = SwapQuote.oneinch(quote, fee: nil)
+        let kyberSwap = SwapQuote.kyberswap(quote, fee: nil)
+
+        XCTAssertEqual(oneInch.provider(fromChain: .ethereum), .oneinch(.ethereum))
+        XCTAssertEqual(oneInch.provider(fromChain: .arbitrum), .oneinch(.arbitrum))
+        XCTAssertEqual(kyberSwap.provider(fromChain: .ethereum), .kyberswap(.ethereum))
+        XCTAssertEqual(kyberSwap.provider(fromChain: .arbitrum), .kyberswap(.arbitrum))
+    }
+
+    func testProviderIgnoresSwapKitSubProvider() {
         // Keying on the sub-provider would drop a pick still visible on screen.
         let viaChainflip = SwapQuote.swapkit(
             makeSwapKitResponse(providers: ["Chainflip"]), fee: nil, subProvider: "Chainflip"
@@ -392,7 +403,7 @@ final class SwapProviderSelectionTests: XCTestCase {
             makeSwapKitResponse(providers: ["NEAR"]), fee: nil, subProvider: "NEAR"
         )
 
-        XCTAssertEqual(viaChainflip.routeIdentity, viaNear.routeIdentity)
+        XCTAssertEqual(viaChainflip.provider(fromChain: .ethereum), viaNear.provider(fromChain: .ethereum))
     }
 
     // MARK: - Item 4: availability depends only on the quote count

--- a/VultisigApp/VultisigAppTests/Swap/SwapProviderSelectionTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapProviderSelectionTests.swift
@@ -6,10 +6,13 @@
 //   1. Ranking — `SwapService.rankedQuotes` sorts best→worst by
 //      `expectedNetToAmount`, and `selectBestQuote`'s winner is the rate-top
 //      when no provider-preference band applies.
-//   2. VM selection — `selectedQuote` drives the computed `quote`, a non-best
-//      pick reaches the active quote (and therefore the verify/sign summary),
-//      and every refresh resets the override back to Best.
-//   3. Availability — provider selection depends solely on `allQuotes.count > 1`
+//   2. VM selection — `selectedQuote` drives the computed `quote` and a non-best
+//      pick reaches the active quote (and therefore the verify/sign summary).
+//   3. Pick persistence — a refresh re-resolves the pick by `routeIdentity`, so
+//      it survives while its route is still a candidate and re-points at the
+//      fresh quote; it is dropped, with a notice, when the route leaves the
+//      candidate set or the swap itself changes.
+//   4. Availability — provider selection depends solely on `allQuotes.count > 1`
 //      (the advanced-settings entry point is already silver-gated, so there is
 //      no second tier gate on the row itself).
 //
@@ -94,21 +97,6 @@ final class SwapProviderSelectionTests: XCTestCase {
         XCTAssertEqual(transaction?.quote, alt, "The non-best pick must carry into the signed transaction")
     }
 
-    func testRefreshResetsSelectionBackToBest() async {
-        let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
-        let alt = SwapQuote.oneinch(makeEVMQuote(dstAmount: "100000000"), fee: nil)
-        let vm = makeVM(best: best, allQuotes: [best, alt])
-        await landQuotes(on: vm)
-
-        vm.selectProvider(alt)
-        XCTAssertEqual(vm.quote, alt)
-
-        // A fresh quote landing (same-pair refresh) must drop the manual override.
-        await landQuotes(on: vm)
-        XCTAssertNil(vm.selectedQuote, "A refresh must reset the manual override")
-        XCTAssertEqual(vm.quote, best, "After a refresh the active quote re-defaults to Best")
-    }
-
     func testEmptyAmountClearsAllQuoteState() async {
         let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
         let alt = SwapQuote.oneinch(makeEVMQuote(dstAmount: "100000000"), fee: nil)
@@ -128,7 +116,161 @@ final class SwapProviderSelectionTests: XCTestCase {
         XCTAssertTrue(vm.allQuotes.isEmpty, "Emptying the amount clears the ranked set")
     }
 
-    // MARK: - Item 3: availability depends only on the quote count
+    // MARK: - Item 3: the pick survives a refresh
+
+    func testRefreshPreservesManualRouteSelection() async {
+        let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
+        let alt = SwapQuote.oneinch(makeEVMQuote(dstAmount: "100000000"), fee: nil)
+        let vm = makeVM(best: best, allQuotes: [best, alt])
+        await landQuotes(on: vm)
+
+        vm.selectProvider(alt)
+        XCTAssertEqual(vm.quote, alt)
+
+        // A silent same-pair/same-amount refresh — the 60s auto-refresh.
+        await landQuotes(on: vm)
+
+        XCTAssertEqual(vm.selectedQuote, alt, "A refresh must not drop a still-valid manual pick")
+        XCTAssertEqual(vm.quote, alt, "The active quote stays on the picked route")
+        XCTAssertNil(vm.routeSelectionNotice, "Nothing was dropped, so there is nothing to tell the user")
+    }
+
+    func testRefreshRepointsSelectionAtFreshQuoteForSameRoute() async {
+        let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
+        // Same route, different payload — what a real refresh returns.
+        let stale = SwapQuote.oneinch(makeEVMQuote(dstAmount: "100000000"), fee: BigInt(1_000))
+        let fresh = SwapQuote.oneinch(makeEVMQuote(dstAmount: "123456789"), fee: BigInt(1_000))
+        XCTAssertNotEqual(stale, fresh, "Fixture must differ by payload for this test to mean anything")
+        XCTAssertEqual(stale.routeIdentity, fresh.routeIdentity, "…while still being the same route")
+
+        let vm = makeVM(script: [
+            makeResult(best: best, allQuotes: [best, stale]),
+            makeResult(best: best, allQuotes: [best, fresh])
+        ])
+        vm.fromCoin = makeCoin(.ethereum, ticker: "ETH", balance: "5000000000000000000")
+        vm.toCoin = makeCoin(.bitcoin, ticker: "BTC")
+        vm.fromAmount = "1"
+        await landQuotes(on: vm)
+
+        vm.selectProvider(stale)
+        await landQuotes(on: vm)
+
+        XCTAssertEqual(vm.selectedQuote, fresh, "The pick must re-point at the refreshed quote")
+        XCTAssertEqual(
+            vm.makeTransaction()?.quote,
+            fresh,
+            "Signing must carry the refreshed quote, never the one the user tapped"
+        )
+    }
+
+    func testRefreshDropsSelectionWhenRouteLeavesCandidateSet() async {
+        let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
+        let alt = SwapQuote.oneinch(makeEVMQuote(dstAmount: "100000000"), fee: nil)
+        let vm = makeVM(script: [
+            makeResult(best: best, allQuotes: [best, alt]),
+            makeResult(best: best, allQuotes: [best])
+        ])
+        await landQuotes(on: vm)
+
+        vm.selectProvider(alt)
+        await landQuotes(on: vm)
+
+        XCTAssertNil(vm.selectedQuote, "A route that is no longer offered can't stay picked")
+        XCTAssertEqual(vm.quote, best, "The active quote falls back to the auto-selected winner")
+        XCTAssertEqual(
+            vm.routeSelectionNotice,
+            "swapRouteUnavailableResetToAuto".localized,
+            "Dropping the pick must be surfaced, not silent"
+        )
+    }
+
+    func testAmountChangeDropsSelectionWithNotice() async {
+        let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
+        let alt = SwapQuote.oneinch(makeEVMQuote(dstAmount: "100000000"), fee: nil)
+        let vm = makeVM(best: best, allQuotes: [best, alt])
+        await landQuotes(on: vm)
+        vm.selectProvider(alt)
+
+        vm.fromAmount = "2"
+        vm.updateFromAmount(vault: makeVault(), immediate: true)
+
+        XCTAssertNil(vm.selectedQuote, "A new amount invalidates the pick")
+        XCTAssertEqual(vm.routeSelectionNotice, "swapRouteResetToAuto".localized)
+
+        await vm.waitForQuoteTask()
+        XCTAssertNil(vm.selectedQuote, "The refetch must not resurrect the dropped pick")
+        XCTAssertEqual(vm.quote, best)
+    }
+
+    func testPairChangeDropsSelectionWithNotice() async {
+        let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
+        let alt = SwapQuote.oneinch(makeEVMQuote(dstAmount: "100000000"), fee: nil)
+        let vm = makeVM(best: best, allQuotes: [best, alt])
+        await landQuotes(on: vm)
+        vm.selectProvider(alt)
+
+        vm.updateToCoin(coin: makeCoin(.ethereum, ticker: "ETH"), vault: makeVault())
+
+        XCTAssertNil(vm.selectedQuote, "A new pair invalidates the pick")
+        XCTAssertEqual(vm.routeSelectionNotice, "swapRouteResetToAuto".localized)
+    }
+
+    func testDropNoticeKeysAreBundled() {
+        // `.localized` echoes a missing key back, so assert both keys resolve.
+        XCTAssertNotEqual("swapRouteResetToAuto".localized, "swapRouteResetToAuto")
+        XCTAssertNotEqual("swapRouteUnavailableResetToAuto".localized, "swapRouteUnavailableResetToAuto")
+    }
+
+    // MARK: - Route identity
+
+    func testRouteIdentityIsStableAcrossPayloadChanges() {
+        let stale = SwapQuote.lifi(makeEVMQuote(dstAmount: "100000000"), fee: BigInt(1), integratorFee: 0.001)
+        let fresh = SwapQuote.lifi(makeEVMQuote(dstAmount: "999999999"), fee: BigInt(2), integratorFee: 0.002)
+
+        XCTAssertNotEqual(stale, fresh, "Quotes compare by payload, so these are different values")
+        XCTAssertEqual(stale.routeIdentity, fresh.routeIdentity, "…but the same route")
+    }
+
+    func testRouteIdentityIsDistinctPerPickerRow() {
+        let quotes: [SwapQuote] = [
+            .thorchain(makeThorQuote(expectedAmountOut: "1")),
+            .thorchainChainnet(makeThorQuote(expectedAmountOut: "1")),
+            .thorchainStagenet(makeThorQuote(expectedAmountOut: "1")),
+            .mayachain(makeThorQuote(expectedAmountOut: "1")),
+            .oneinch(makeEVMQuote(dstAmount: "1"), fee: nil),
+            .kyberswap(makeEVMQuote(dstAmount: "1"), fee: nil),
+            .lifi(makeEVMQuote(dstAmount: "1"), fee: nil, integratorFee: nil),
+            .swapkit(makeSwapKitResponse(), fee: nil, subProvider: "Chainflip"),
+            .jupiter(makeEVMQuote(dstAmount: "1"), fee: nil, platformFee: 0, feeOnInput: false)
+        ]
+
+        XCTAssertEqual(
+            Set(quotes.map(\.routeIdentity)).count,
+            quotes.count,
+            "Every route the picker can show must be separately identifiable"
+        )
+        XCTAssertEqual(
+            Set(quotes.compactMap(\.displayName)).count,
+            quotes.count,
+            "…and the identity must be as fine-grained as the row labels the user sees"
+        )
+    }
+
+    func testRouteIdentityIgnoresSwapKitSubProvider() {
+        // SwapKit is one row whichever protocol it routes through underneath, and
+        // that underlying choice can legitimately change between fetches — keying
+        // on it would drop a pick the user can still see on screen.
+        let viaChainflip = SwapQuote.swapkit(
+            makeSwapKitResponse(providers: ["Chainflip"]), fee: nil, subProvider: "Chainflip"
+        )
+        let viaNear = SwapQuote.swapkit(
+            makeSwapKitResponse(providers: ["NEAR"]), fee: nil, subProvider: "NEAR"
+        )
+
+        XCTAssertEqual(viaChainflip.routeIdentity, viaNear.routeIdentity)
+    }
+
+    // MARK: - Item 4: availability depends only on the quote count
 
     func testCanSelectProviderFalseWithSingleQuote() async {
         let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
@@ -154,11 +296,17 @@ final class SwapProviderSelectionTests: XCTestCase {
         best: SwapQuote,
         allQuotes: [SwapQuote]
     ) -> SwapDetailsViewModel {
-        let interactor = ProviderSelectionMockInteractor(
-            best: best,
-            allQuotes: allQuotes
-        )
-        return SwapDetailsViewModel(interactor: interactor)
+        makeVM(script: [makeResult(best: best, allQuotes: allQuotes)])
+    }
+
+    /// A VM whose interactor hands out `script` one entry per fetch, so a test
+    /// can make a refresh return something different from the first landing.
+    private func makeVM(script: [SwapQuoteResult]) -> SwapDetailsViewModel {
+        SwapDetailsViewModel(interactor: ProviderSelectionMockInteractor(script: script))
+    }
+
+    private func makeResult(best: SwapQuote, allQuotes: [SwapQuote]) -> SwapQuoteResult {
+        SwapQuoteResult(quote: best, allQuotes: allQuotes, vultDiscountBps: 0, referralDiscountBps: 0)
     }
 
     /// Drive a quote fetch to completion so `allQuotes`/`bestQuote` populate via
@@ -218,6 +366,40 @@ final class SwapProviderSelectionTests: XCTestCase {
         )
     }
 
+    /// SwapKit responses are `Decodable`-only (custom `init(from:)`, no memberwise
+    /// init), so the fixture is built from a minimal EVM-txType JSON payload.
+    private func makeSwapKitResponse(providers: [String] = ["Chainflip"]) -> SwapKitSwapResponse {
+        let providerList = providers.map { "\"\($0)\"" }.joined(separator: ", ")
+        let json = """
+        {
+          "swapId": "swap-1",
+          "routeId": "route-1",
+          "providers": [\(providerList)],
+          "sellAsset": "ETH.USDC",
+          "buyAsset": "ETH.ETH",
+          "sellAmount": "10",
+          "expectedBuyAmount": "1",
+          "expectedBuyAmountMaxSlippage": "1",
+          "sourceAddress": "0xfrom",
+          "destinationAddress": "0xto",
+          "targetAddress": "0xtarget",
+          "meta": { "txType": "EVM" },
+          "tx": {
+            "from": "0xfrom",
+            "to": "0xto",
+            "value": "0",
+            "data": "0x",
+            "gas": "200000",
+            "gasPrice": "20000000000"
+          },
+          "fees": []
+        }
+        """
+        // Test fixture: a decode failure here is a test bug, so force-unwrap is acceptable.
+        // swiftlint:disable:next force_try
+        return try! JSONDecoder().decode(SwapKitSwapResponse.self, from: Data(json.utf8))
+    }
+
     private func makeEVMQuote(dstAmount: String) -> EVMQuote {
         EVMQuote(
             dstAmount: dstAmount,
@@ -245,16 +427,18 @@ private extension SwapDetailsViewModel {
 
 // swiftlint:disable async_without_await unused_parameter
 
-/// Returns a fixed best + ranked set so the VM's quote-landing path can be
-/// driven without the network.
+/// Hands out a scripted result per fetch so the VM's quote-landing path can be
+/// driven without the network, including a refresh that returns a different
+/// candidate set from the first landing. The last entry repeats once the script
+/// is exhausted, so a steady-state test can pass a single one.
 @MainActor
 private final class ProviderSelectionMockInteractor: SwapInteractor {
-    private let best: SwapQuote
-    private let allQuotes: [SwapQuote]
+    private let script: [SwapQuoteResult]
+    private var fetchCount = 0
 
-    init(best: SwapQuote, allQuotes: [SwapQuote]) {
-        self.best = best
-        self.allQuotes = allQuotes
+    init(script: [SwapQuoteResult]) {
+        precondition(!script.isEmpty, "The script needs at least one result")
+        self.script = script
     }
 
     func fetchQuote(
@@ -266,7 +450,8 @@ private final class ProviderSelectionMockInteractor: SwapInteractor {
         slippageBps: Int?,
         recipientAddress: String?
     ) async throws -> SwapQuoteResult? {
-        SwapQuoteResult(quote: best, allQuotes: allQuotes, vultDiscountBps: 0, referralDiscountBps: 0)
+        defer { fetchCount += 1 }
+        return script[min(fetchCount, script.count - 1)]
     }
 
     func assertSourceChainNotHalted(transaction: SwapTransaction) async throws {}

--- a/VultisigApp/VultisigAppTests/Swap/SwapVerifyRouteSelectionTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapVerifyRouteSelectionTests.swift
@@ -20,7 +20,7 @@ final class SwapVerifyRouteSelectionTests: XCTestCase {
         XCTAssertNotEqual(stale, fresh, "Fixture must differ by payload")
 
         let vm = makeVM(
-            transaction: makeTransaction(quote: stale, pickedRoute: .oneInch),
+            transaction: makeTransaction(quote: stale, pickedProvider: .oneinch(.arbitrum), fromChain: .arbitrum),
             refreshed: makeResult(best: best, allQuotes: [best, fresh])
         )
         vm.isAmountCorrect = true
@@ -29,7 +29,7 @@ final class SwapVerifyRouteSelectionTests: XCTestCase {
         await vm.refreshData(vault: makeVault())
 
         XCTAssertEqual(vm.transaction.quote, fresh, "The refresh must keep the picked route, on fresh numbers")
-        XCTAssertEqual(vm.transaction.selectedRouteIdentity, .oneInch, "…and keep it pinned for the next refresh")
+        XCTAssertEqual(vm.transaction.selectedProvider, .oneinch(.arbitrum), "…and keep it pinned for the next refresh")
         XCTAssertNil(vm.routeSelectionNotice, "Nothing was substituted, so there is nothing to say")
         XCTAssertTrue(vm.isAmountCorrect, "Confirmations stand when the route did not change")
         XCTAssertTrue(vm.isFeeCorrect)
@@ -40,7 +40,7 @@ final class SwapVerifyRouteSelectionTests: XCTestCase {
         let stale = SwapQuote.oneinch(makeEVMQuote(dstAmount: "100000000"), fee: nil)
 
         let vm = makeVM(
-            transaction: makeTransaction(quote: stale, pickedRoute: .oneInch),
+            transaction: makeTransaction(quote: stale, pickedProvider: .oneinch(.ethereum)),
             refreshed: makeResult(best: best, allQuotes: [best])
         )
         vm.isAmountCorrect = true
@@ -50,7 +50,7 @@ final class SwapVerifyRouteSelectionTests: XCTestCase {
         await vm.refreshData(vault: makeVault())
 
         XCTAssertEqual(vm.transaction.quote, best, "With the picked route gone, the auto winner takes over")
-        XCTAssertNil(vm.transaction.selectedRouteIdentity, "The pin is released so later refreshes follow Auto")
+        XCTAssertNil(vm.transaction.selectedProvider, "The pin is released so later refreshes follow Auto")
         XCTAssertEqual(
             vm.routeSelectionNotice,
             "swapRouteUnavailableResetToAuto".localized,
@@ -67,7 +67,7 @@ final class SwapVerifyRouteSelectionTests: XCTestCase {
 
         // Auto must stay free to change winner between refreshes.
         let vm = makeVM(
-            transaction: makeTransaction(quote: previousBest, pickedRoute: nil),
+            transaction: makeTransaction(quote: previousBest, pickedProvider: nil),
             refreshed: makeResult(best: newBest, allQuotes: [newBest, previousBest])
         )
         vm.isAmountCorrect = true
@@ -75,7 +75,7 @@ final class SwapVerifyRouteSelectionTests: XCTestCase {
         await vm.refreshData(vault: makeVault())
 
         XCTAssertEqual(vm.transaction.quote, newBest, "Auto follows the fresh winner")
-        XCTAssertNil(vm.transaction.selectedRouteIdentity)
+        XCTAssertNil(vm.transaction.selectedProvider)
         XCTAssertNil(vm.routeSelectionNotice, "Auto changing winner is not a substitution")
         XCTAssertTrue(vm.isAmountCorrect, "The Auto path must not disturb the confirmations")
     }
@@ -93,8 +93,12 @@ final class SwapVerifyRouteSelectionTests: XCTestCase {
         SwapQuoteResult(quote: best, allQuotes: allQuotes, vultDiscountBps: 0, referralDiscountBps: 0)
     }
 
-    private func makeTransaction(quote: SwapQuote, pickedRoute: SwapRouteIdentity?) -> SwapTransaction {
-        let eth = makeCoin(.ethereum, ticker: "ETH", balance: "5000000000000000000")
+    private func makeTransaction(
+        quote: SwapQuote,
+        pickedProvider: SwapProvider?,
+        fromChain: Chain = .ethereum
+    ) -> SwapTransaction {
+        let eth = makeCoin(fromChain, ticker: "ETH", balance: "5000000000000000000")
         let btc = makeCoin(.bitcoin, ticker: "BTC")
         return SwapTransaction(
             fromCoin: eth,
@@ -108,7 +112,7 @@ final class SwapVerifyRouteSelectionTests: XCTestCase {
             referralDiscountBps: 0,
             feeCoin: eth,
             advancedSettings: .default,
-            selectedRouteIdentity: pickedRoute
+            selectedProvider: pickedProvider
         )
     }
 

--- a/VultisigApp/VultisigAppTests/Swap/SwapVerifyRouteSelectionTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapVerifyRouteSelectionTests.swift
@@ -2,10 +2,8 @@
 //  SwapVerifyRouteSelectionTests.swift
 //  VultisigAppTests
 //
-//  The verify screen re-quotes every 60s. It must re-resolve a manual route pick
-//  against the fresh candidate set — exactly as the details screen does — instead
-//  of installing the auto winner, which would hand the user a route they never
-//  chose at the last moment before signing.
+//  The verify screen re-quotes every 60s and must re-resolve a manual route pick
+//  against the fresh candidate set rather than installing the auto winner.
 //
 
 import BigInt
@@ -67,7 +65,7 @@ final class SwapVerifyRouteSelectionTests: XCTestCase {
         let previousBest = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
         let newBest = SwapQuote.oneinch(makeEVMQuote(dstAmount: "900000000"), fee: nil)
 
-        // No manual pick: Auto must stay free to change winner between refreshes.
+        // Auto must stay free to change winner between refreshes.
         let vm = makeVM(
             transaction: makeTransaction(quote: previousBest, pickedRoute: nil),
             refreshed: makeResult(best: newBest, allQuotes: [newBest, previousBest])
@@ -168,8 +166,7 @@ final class SwapVerifyRouteSelectionTests: XCTestCase {
 
 // swiftlint:disable async_without_await unused_parameter
 
-/// Returns one fixed refreshed candidate set, so the verify VM's refresh path can
-/// be driven without the network. Everything else is a no-op stub.
+/// One fixed refreshed candidate set; everything else is a no-op stub.
 private struct RouteSelectionStubInteractor: SwapInteractor {
     let refreshed: SwapQuoteResult
 

--- a/VultisigApp/VultisigAppTests/Swap/SwapVerifyRouteSelectionTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapVerifyRouteSelectionTests.swift
@@ -12,6 +12,16 @@ import XCTest
 
 @MainActor
 final class SwapVerifyRouteSelectionTests: XCTestCase {
+    private var storeToken: TestContextToken?
+
+    override func setUpWithError() throws {
+        storeToken = try TestStore.installInMemoryContainer()
+    }
+
+    override func tearDown() {
+        TestStore.restore(storeToken)
+        storeToken = nil
+    }
 
     func testRefreshKeepsThePickedRouteAndRepointsIt() async {
         let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
@@ -78,6 +88,79 @@ final class SwapVerifyRouteSelectionTests: XCTestCase {
         XCTAssertNil(vm.transaction.selectedProvider)
         XCTAssertNil(vm.routeSelectionNotice, "Auto changing winner is not a substitution")
         XCTAssertTrue(vm.isAmountCorrect, "The Auto path must not disturb the confirmations")
+    }
+
+    func testTimerRefreshDoesNotOverlapTimerOrExplicitRefetch() async {
+        let quote = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "100000000"))
+        let gate = RefreshRequestGate()
+        let vm = SwapVerifyViewModel(
+            transaction: makeTransaction(quote: quote, pickedProvider: nil),
+            interactor: RouteSelectionStubInteractor(
+                refreshed: makeResult(best: quote, allQuotes: [quote]),
+                beforeFetch: { try await gate.wait() }
+            )
+        )
+        let vault = makeVault()
+        vm.timer = 1
+        let refresh = Task { await vm.updateTimer(vault: vault) }
+        await fulfillment(of: [gate.started], timeout: 2)
+
+        XCTAssertTrue(vm.isLoadingFees)
+        XCTAssertEqual(vm.timer, 0)
+        await vm.updateTimer(vault: vault)
+        await vm.refreshData(vault: vault)
+        XCTAssertEqual(gate.calls, 1, "Timer ticks and explicit refetches must not overlap the pending request")
+        XCTAssertTrue(vm.isLoadingFees, "A duplicate refresh must not clear the active request's loading state")
+        XCTAssertEqual(vm.timer, 0, "The countdown pauses until the refresh completes")
+
+        gate.finish()
+        await refresh.value
+        XCTAssertFalse(vm.isLoadingFees)
+        XCTAssertEqual(vm.timer, 59)
+    }
+
+    func testRefreshStaysLoadingUntilFeeFetchCompletes() async {
+        let stale = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "100000000"))
+        let fresh = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "200000000"))
+        let gate = RefreshRequestGate()
+        let vm = SwapVerifyViewModel(
+            transaction: makeTransaction(quote: stale, pickedProvider: nil),
+            interactor: RouteSelectionStubInteractor(
+                refreshed: makeResult(best: fresh, allQuotes: [fresh]),
+                beforeFees: { try await gate.wait() }
+            )
+        )
+        let refresh = Task { await vm.refreshData(vault: makeVault()) }
+        await fulfillment(of: [gate.started], timeout: 2)
+
+        XCTAssertTrue(vm.isLoadingFees, "Receiving the quote must not dismiss loading while fees are pending")
+        XCTAssertEqual(vm.transaction.quote, stale)
+        gate.finish()
+        await refresh.value
+        XCTAssertFalse(vm.isLoadingFees)
+        XCTAssertEqual(vm.transaction.quote, fresh)
+    }
+
+    func testFailedRefreshClearsLoadingAndRestartsCountdown() async {
+        let quote = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "100000000"))
+        let gate = RefreshRequestGate()
+        let vm = SwapVerifyViewModel(
+            transaction: makeTransaction(quote: quote, pickedProvider: nil),
+            interactor: RouteSelectionStubInteractor(
+                refreshed: makeResult(best: quote, allQuotes: [quote]),
+                beforeFetch: { try await gate.wait() }
+            )
+        )
+        vm.timer = 1
+        let refresh = Task { await vm.updateTimer(vault: makeVault()) }
+        await fulfillment(of: [gate.started], timeout: 2)
+        XCTAssertTrue(vm.isLoadingFees)
+
+        gate.finish(error: URLError(.timedOut))
+        await refresh.value
+        XCTAssertFalse(vm.isLoadingFees)
+        XCTAssertEqual(vm.timer, 59)
+        XCTAssertEqual(vm.transaction.quote, quote)
     }
 
     // MARK: - Fixtures
@@ -173,6 +256,8 @@ final class SwapVerifyRouteSelectionTests: XCTestCase {
 /// One fixed refreshed candidate set; everything else is a no-op stub.
 private struct RouteSelectionStubInteractor: SwapInteractor {
     let refreshed: SwapQuoteResult
+    var beforeFetch: (() async throws -> Void)? = nil
+    var beforeFees: (() async throws -> Void)? = nil
 
     func fetchQuote(
         amount: Decimal,
@@ -183,7 +268,8 @@ private struct RouteSelectionStubInteractor: SwapInteractor {
         slippageBps: Int?,
         recipientAddress: String?
     ) async throws -> SwapQuoteResult? {
-        refreshed
+        try await beforeFetch?()
+        return refreshed
     }
 
     func fetchChainSpecific(
@@ -192,7 +278,8 @@ private struct RouteSelectionStubInteractor: SwapInteractor {
         fromAmount: Decimal,
         quote: SwapQuote?
     ) async throws -> BlockChainSpecific {
-        .Cosmos(accountNumber: 0, sequence: 0, gas: 0, transactionType: 0, ibcDenomTrace: nil, gasLimit: nil)
+        try await beforeFees?()
+        return .Cosmos(accountNumber: 0, sequence: 0, gas: 0, transactionType: 0, ibcDenomTrace: nil, gasLimit: nil)
     }
 
     func computeThorchainFee(
@@ -216,3 +303,30 @@ private struct RouteSelectionStubInteractor: SwapInteractor {
 }
 
 // swiftlint:enable async_without_await unused_parameter
+
+@MainActor
+private final class RefreshRequestGate {
+    let started = XCTestExpectation(description: "Refresh reached the delayed request")
+    private(set) var calls = 0
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    func wait() async throws {
+        calls += 1
+        // Let accidental overlapping calls finish so the test can assert the
+        // wrong count/loading state without leaving a second task suspended.
+        guard calls == 1 else { return }
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            started.fulfill()
+        }
+    }
+
+    func finish(error: Error? = nil) {
+        if let error {
+            continuation?.resume(throwing: error)
+        } else {
+            continuation?.resume()
+        }
+        continuation = nil
+    }
+}

--- a/VultisigApp/VultisigAppTests/Swap/SwapVerifyRouteSelectionTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapVerifyRouteSelectionTests.swift
@@ -1,0 +1,217 @@
+//
+//  SwapVerifyRouteSelectionTests.swift
+//  VultisigAppTests
+//
+//  The verify screen re-quotes every 60s. It must re-resolve a manual route pick
+//  against the fresh candidate set — exactly as the details screen does — instead
+//  of installing the auto winner, which would hand the user a route they never
+//  chose at the last moment before signing.
+//
+
+import BigInt
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class SwapVerifyRouteSelectionTests: XCTestCase {
+
+    func testRefreshKeepsThePickedRouteAndRepointsIt() async {
+        let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
+        let stale = SwapQuote.oneinch(makeEVMQuote(dstAmount: "100000000"), fee: nil)
+        let fresh = SwapQuote.oneinch(makeEVMQuote(dstAmount: "123456789"), fee: nil)
+        XCTAssertNotEqual(stale, fresh, "Fixture must differ by payload")
+
+        let vm = makeVM(
+            transaction: makeTransaction(quote: stale, pickedRoute: .oneInch),
+            refreshed: makeResult(best: best, allQuotes: [best, fresh])
+        )
+        vm.isAmountCorrect = true
+        vm.isFeeCorrect = true
+
+        await vm.refreshData(vault: makeVault())
+
+        XCTAssertEqual(vm.transaction.quote, fresh, "The refresh must keep the picked route, on fresh numbers")
+        XCTAssertEqual(vm.transaction.selectedRouteIdentity, .oneInch, "…and keep it pinned for the next refresh")
+        XCTAssertNil(vm.routeSelectionNotice, "Nothing was substituted, so there is nothing to say")
+        XCTAssertTrue(vm.isAmountCorrect, "Confirmations stand when the route did not change")
+        XCTAssertTrue(vm.isFeeCorrect)
+    }
+
+    func testRefreshSubstitutesAutoAndResetsConfirmationsWhenRouteGone() async {
+        let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
+        let stale = SwapQuote.oneinch(makeEVMQuote(dstAmount: "100000000"), fee: nil)
+
+        let vm = makeVM(
+            transaction: makeTransaction(quote: stale, pickedRoute: .oneInch),
+            refreshed: makeResult(best: best, allQuotes: [best])
+        )
+        vm.isAmountCorrect = true
+        vm.isFeeCorrect = true
+        vm.isApproveCorrect = true
+
+        await vm.refreshData(vault: makeVault())
+
+        XCTAssertEqual(vm.transaction.quote, best, "With the picked route gone, the auto winner takes over")
+        XCTAssertNil(vm.transaction.selectedRouteIdentity, "The pin is released so later refreshes follow Auto")
+        XCTAssertEqual(
+            vm.routeSelectionNotice,
+            "swapRouteUnavailableResetToAuto".localized,
+            "Swapping the route under a confirmed order must never be silent"
+        )
+        XCTAssertFalse(vm.isAmountCorrect, "Confirmations were given for a route that is gone")
+        XCTAssertFalse(vm.isFeeCorrect)
+        XCTAssertFalse(vm.isApproveCorrect)
+    }
+
+    func testRefreshOnAutoFollowsTheFreshWinner() async {
+        let previousBest = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
+        let newBest = SwapQuote.oneinch(makeEVMQuote(dstAmount: "900000000"), fee: nil)
+
+        // No manual pick: Auto must stay free to change winner between refreshes.
+        let vm = makeVM(
+            transaction: makeTransaction(quote: previousBest, pickedRoute: nil),
+            refreshed: makeResult(best: newBest, allQuotes: [newBest, previousBest])
+        )
+        vm.isAmountCorrect = true
+
+        await vm.refreshData(vault: makeVault())
+
+        XCTAssertEqual(vm.transaction.quote, newBest, "Auto follows the fresh winner")
+        XCTAssertNil(vm.transaction.selectedRouteIdentity)
+        XCTAssertNil(vm.routeSelectionNotice, "Auto changing winner is not a substitution")
+        XCTAssertTrue(vm.isAmountCorrect, "The Auto path must not disturb the confirmations")
+    }
+
+    // MARK: - Fixtures
+
+    private func makeVM(transaction: SwapTransaction, refreshed: SwapQuoteResult) -> SwapVerifyViewModel {
+        SwapVerifyViewModel(
+            transaction: transaction,
+            interactor: RouteSelectionStubInteractor(refreshed: refreshed)
+        )
+    }
+
+    private func makeResult(best: SwapQuote, allQuotes: [SwapQuote]) -> SwapQuoteResult {
+        SwapQuoteResult(quote: best, allQuotes: allQuotes, vultDiscountBps: 0, referralDiscountBps: 0)
+    }
+
+    private func makeTransaction(quote: SwapQuote, pickedRoute: SwapRouteIdentity?) -> SwapTransaction {
+        let eth = makeCoin(.ethereum, ticker: "ETH", balance: "5000000000000000000")
+        let btc = makeCoin(.bitcoin, ticker: "BTC")
+        return SwapTransaction(
+            fromCoin: eth,
+            toCoin: btc,
+            fromAmount: 1,
+            kind: .market(quote),
+            gas: .zero,
+            gasLimit: .zero,
+            thorchainFee: .zero,
+            vultDiscountBps: 0,
+            referralDiscountBps: 0,
+            feeCoin: eth,
+            advancedSettings: .default,
+            selectedRouteIdentity: pickedRoute
+        )
+    }
+
+    private func makeVault() -> Vault {
+        Vault(
+            name: "Test Vault", signers: [], pubKeyECDSA: "e", pubKeyEdDSA: "d",
+            keyshares: [], localPartyID: "iPhone", hexChainCode: "hex",
+            resharePrefix: nil, libType: .DKLS
+        )
+    }
+
+    private func makeCoin(_ chain: Chain, ticker: String, balance: String = "0") -> Coin {
+        let meta = CoinMeta.make(chain: chain, ticker: ticker, decimals: 8, isNativeToken: true)
+        let coin = Coin(asset: meta, address: "test-address-\(ticker)", hexPublicKey: "")
+        coin.rawBalance = balance
+        return coin
+    }
+
+    private func makeThorQuote(expectedAmountOut: String) -> ThorchainSwapQuote {
+        ThorchainSwapQuote(
+            dustThreshold: nil,
+            expectedAmountOut: expectedAmountOut,
+            expiry: 0,
+            fees: Fees(affiliate: "0", asset: "RUNE", outbound: "0", total: "0", liquidity: nil, slippageBps: nil, totalBps: nil),
+            inboundAddress: nil,
+            inboundConfirmationBlocks: nil,
+            inboundConfirmationSeconds: nil,
+            memo: "memo",
+            notes: "",
+            outboundDelayBlocks: 0,
+            outboundDelaySeconds: 0,
+            recommendedMinAmountIn: "0",
+            slippageBps: nil,
+            totalSwapSeconds: nil,
+            warning: "",
+            router: nil,
+            maxStreamingQuantity: nil
+        )
+    }
+
+    private func makeEVMQuote(dstAmount: String) -> EVMQuote {
+        EVMQuote(
+            dstAmount: dstAmount,
+            tx: EVMQuote.Transaction(
+                from: "0xfrom",
+                to: "0xto",
+                data: "0x",
+                value: "0",
+                gasPrice: "0",
+                gas: 0
+            )
+        )
+    }
+}
+
+// swiftlint:disable async_without_await unused_parameter
+
+/// Returns one fixed refreshed candidate set, so the verify VM's refresh path can
+/// be driven without the network. Everything else is a no-op stub.
+private struct RouteSelectionStubInteractor: SwapInteractor {
+    let refreshed: SwapQuoteResult
+
+    func fetchQuote(
+        amount: Decimal,
+        fromCoin: Coin,
+        toCoin: Coin,
+        vault: Vault,
+        referredCode: String,
+        slippageBps: Int?,
+        recipientAddress: String?
+    ) async throws -> SwapQuoteResult? {
+        refreshed
+    }
+
+    func fetchChainSpecific(
+        fromCoin: Coin,
+        toCoin: Coin,
+        fromAmount: Decimal,
+        quote: SwapQuote?
+    ) async throws -> BlockChainSpecific {
+        .Cosmos(accountNumber: 0, sequence: 0, gas: 0, transactionType: 0, ibcDenomTrace: nil, gasLimit: nil)
+    }
+
+    func computeThorchainFee(
+        chainSpecific: BlockChainSpecific,
+        fromCoin: Coin,
+        fromAmount: Decimal,
+        vault: Vault
+    ) async throws -> BigInt {
+        .zero
+    }
+
+    func assertSourceChainNotHalted(transaction: SwapTransaction) async throws {}
+
+    func buildSwapKeysignPayload(transaction: SwapTransaction, vault: Vault) async throws -> KeysignPayload {
+        throw CancellationError()
+    }
+
+    func updateBalance(for coin: Coin) async {}
+
+    func warmDiscountTier(for vault: Vault) async {}
+}
+
+// swiftlint:enable async_without_await unused_parameter


### PR DESCRIPTION
## Problem

A manually picked swap route did not stick. A user who opened Advanced Swap → Select route and chose a non-default provider had that choice silently discarded on the next quote refresh — within 60 seconds, often sooner — and could then sign a route they never chose.

## Root cause

`SwapQuote` is `Hashable` **by its full payload**, so the quote a refresh returns for a given provider is never `==` the one it returned a moment earlier. The pick was stored as `selectedQuote: SwapQuote?`, which therefore could never have survived a fetch. The unconditional reset on every landing — documented as intentional (*"Every refresh re-defaults to Best"*) — was papering over an identity problem, not expressing a policy.

Fixing only the details screen turned out not to be enough. `SwapTransaction` carried the chosen quote but not the fact that it *was* chosen, so the verify screen's own 60s re-quote installed the fresh auto winner over it — the same silent substitution, one screen later and immediately before signing, with the confirmation checkboxes still ticked. That is worse than losing the pick early: the user has already read and confirmed a summary for a specific route.

## Fix

- **`SwapQuote.routeIdentity`** — a payload-free identity, one case per row of the route picker. THORChain network variants stay distinct (separate `SwapProvider`s, separate display names); the SwapKit `subProvider` is deliberately excluded, since SwapKit is one row whichever protocol it routes through and that choice can legitimately flip between fetches.
- **Details screen** — `updateQuotes` re-resolves the pick against the fresh candidate set by identity and re-points it at the quote object out of `result.allQuotes`, so signing uses current numbers and never the quote the user tapped.
- **Verify screen** — `SwapTransaction` carries an optional `selectedRouteIdentity` (its own field, **not** part of `advancedSettings`, which is the form's re-fetch trigger — a route pick must never re-quote). `refreshData` re-resolves it the same way. Auto, with nothing pinned, still follows a changed winner. When the picked route is genuinely gone the refresh falls back to Auto, raises the banner, and clears the three confirmations — they were given for a route that no longer exists.
- **Notices** — every production path that drops a pick goes through one `dropRouteSelection(_:)`, so a selection can never disappear silently. Two messages, since the causes differ (route withdrawn vs. the swap itself changed), in all 8 shipping locales.
- **Equivalent amounts** — quote ownership stamped the raw amount *text* and compared it byte-for-byte, so editing `1` to `1.` or `1.0` counted as a new swap. It now stamps the parsed `Decimal`, parsed once and reused for both the provider request and the stamp so the two cannot disagree.

### Reset-site audit

Three of the four sites were genuinely invalidating and stay: the `quote` setter (a wholesale write of the slot; nothing in the app writes it), `clearQuoteState` (any pair or amount change, which already runs before the fetch), and the secured-mint branch (the candidate set collapses to one synthetic quote). Only the refresh reset was the bug.

### One trap worth knowing about

`SwapTransaction.with(...)` rebuilds the struct field by field. Omitting `selectedRouteIdentity` there would have silently un-pinned the route on the very first verify refresh — the fix would have read as correct while doing nothing. It is carried explicitly, and `testRefreshKeepsThePickedRouteAndRepointsIt` fails if either `with(...)` call drops it.

## Tests

**+16 net** (`SwapProviderSelectionTests` 9 → 22, new `SwapVerifyRouteSelectionTests` ×3). `testRefreshResetsSelectionBackToBest` asserted the old behaviour and is replaced — an intentional behaviour change, not a regression.

Covers: the pick survives a refresh and re-points at the refreshed quote (and that is what reaches `makeTransaction()`); it clears with a notice when the route leaves the candidate set, on pair change, on amount change, and when an external recipient prunes it; the advanced-settings re-fetch preserves it; a re-typed equivalent amount keeps it; `makeTransaction` pins the identity only when the user picked one; the verify refresh keeps and re-points a pick, substitutes Auto with cleared confirmations when the route is gone, and leaves the Auto path free to follow a new winner.

The equivalent-amount fixture is built from `Locale.current.decimalSeparator`, not a hard-coded `"1.0"` — a dot is the *grouping* separator in five of the eight shipping locales, where `"1.0"` parses as ten.

## Verification

Full gate on an `en_US`-pinned simulator at `d603fffd3`:

```
** TEST SUCCEEDED **
Executed 7094 tests, with 11 tests skipped and 0 failures (0 unexpected)
```

7094 = the 7078 baseline + the 16 added tests, and corroborated per case (22 + 3 passing names matching the `func test` counts) so nothing was silently dropped from the generated project. Disk 34 Gi free before and after, so not a stale-products run. SwiftLint clean on every touched file. Locale entry counts equal across all 8 files (1921 → 1923).

**On-device acceptance was not performed** — the two acceptance criteria that need a real device (selecting a non-default route and waiting through two refresh cycles; confirming the signed swap uses the selected provider's current quote) are covered by unit tests only.

## Known, out of scope, tracked separately

Both were surfaced by review of this branch, both are pre-existing, and neither is introduced or widened here.

- **A failed refresh leaves the previously-fetched quote on screen and signable** — #5354. `main`'s `catch` block in `updateQuotes` is byte-identical and also kept `bestQuote`.
- **The verify screen's refresh can race signing** — #5355. The timer commits a refreshed `transaction` while signing reads `transaction` independently, and the navigation context re-reads it after the payload is built, so the recorded transaction can differ from the payload signed. Every element predates this branch (`main`: `transaction = updated` at `:162`, `buildSwapKeysignPayload(transaction: transaction)` at `:264`, `currentTransaction` at `SwapVerifyScreen:29`); the only change here to that screen is a 3-line banner modifier. Note the confirmation reset added here lands *after* the commit, so it does not mitigate this race — it is not broader protection than it looks.
- **A route banner already on screen finishes its ~1.5s dismissal after switching to the Limit tab.** The binding gates when a notice *starts*; the shared `BannerViewModifier` owns its own visibility and ignores the text going nil. Closing it means changing a modifier six other screens use.

## Review notes

Touches a signing path: the quote a pick resolves to is what gets signed. The re-attach only ever takes an object out of the freshly-returned `result.allQuotes`, never a carried-over one. Wants a human read and on-device acceptance.

Closes #5345

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqdXT9XtXkN4XMwjXyqjND


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Manual swap-route selections persist through quote refreshes while available.
  - Unavailable routes automatically fall back to the refreshed default, with localized notices in Market swaps.
  - Route selections remain consistent when transactions are rebuilt.
  - Fee loading now uses a dedicated overlay, with refresh countdowns hidden during loading.

- **Localization**
  - Added route-reset notices in English, German, Spanish, Croatian, Italian, Korean, Portuguese, and Simplified Chinese.

- **Tests**
  - Added coverage for route persistence, fallback behavior, refresh concurrency, and loading states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->