### PR TITLE
fix(swap): bump the commondata pin and carry price impact, the SwapKit fee and the route tag to the co-signer

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vultisig/commondata",
       "state" : {
-        "revision" : "63a65c37c50f6a944f6791d36eb905810af82760"
+        "revision" : "08e17eb63cc634fa81b65306a294ef1455ec4c38"
       }
     },
     {

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
@@ -228,22 +228,19 @@ private func writeNativeSwapFee(_ fee: String?, to proto: inout VSTHORChainSwapP
     proto.fee = fee
 }
 
-/// `router_address` is an `optional string`, so assigning `""` marks it
-/// present-but-empty rather than leaving it off the wire: a relayed payload that
-/// carried no router came back two bytes longer than the one its sender built.
-/// Readers already normalize empty to absent (`nilIfEmpty` on the way in), so
-/// nothing reads differently — but byte-stability across a mixed-version
-/// committee is worth more than the assignment's brevity.
+/// `router_address` has EXPLICIT presence (`optional string`), so assigning `""`
+/// marks it present rather than eliding it as a default. Do not "simplify" this
+/// back to `?? .empty`: a payload carrying no router would then re-serialize
+/// larger than the bytes its sender built, and those bytes are the relay's
+/// content hash.
 private func writeNativeSwapRouterAddress(_ routerAddress: String?, to proto: inout VSTHORChainSwapPayload) {
     guard let routerAddress = routerAddress?.nilIfEmpty else { return }
     proto.routerAddress = routerAddress
 }
 
-/// Explicit presence for the carried price impact. `slippage_bps` is an
-/// `optional uint32`, so absent means "sender predates the field, impact
-/// unknown" and the receiver hides the row, while a present `0` is a real claim
-/// of a zero-impact route. Only a nil leaves the field untouched -- writing a
-/// stand-in would turn "unknown" into a definite statement.
+/// `slippage_bps` has explicit presence: absent means "sender predates the
+/// field" and the row is hidden, a present `0` claims a zero-impact route. Never
+/// write a stand-in, or "unknown" becomes a statement.
 private func writeNativeSwapSlippageBps(_ slippageBps: UInt32?, to proto: inout VSTHORChainSwapPayload) {
     guard let slippageBps else { return }
     proto.slippageBps = slippageBps
@@ -287,9 +284,8 @@ extension SwapPayload {
                 slippageBps: value.hasSlippageBps ? value.slippageBps : nil
             ))
         case .oneinchSwapPayload(let value):
-            // `has*` guards distinguish "legacy sender, context unknown"
-            // (field absent → nil) from a populated value. Empty strings are
-            // normalized to nil so consumers have a single "unknown" shape.
+            // `has*` distinguishes "legacy sender, unknown" from a populated
+            // value; empty normalizes to nil so consumers see one unknown shape.
             let swapFeeTokenId = value.quote.tx.hasSwapFeeTokenID ? value.quote.tx.swapFeeTokenID.nilIfEmpty : nil
             self = .generic(GenericSwapPayload(
                 fromCoin: try ProtoCoinResolver.resolve(coin: value.fromCoin),
@@ -349,8 +345,6 @@ extension SwapPayload {
                 memo: value.hasMemo ? value.memo : nil,
                 subProvider: value.subProvider,
                 swapID: value.swapID,
-                // Same `has*` discipline as the 1inch fee context above: an
-                // absent field means "legacy sender, unknown", not zero.
                 swapFee: value.swapFee.nilIfEmpty,
                 swapFeeChain: value.hasSwapFeeChain ? value.swapFeeChain.nilIfEmpty : nil,
                 swapFeeTokenId: value.hasSwapFeeTokenID ? value.swapFeeTokenID.nilIfEmpty : nil,
@@ -430,8 +424,6 @@ extension SwapPayload {
                     }
                 }
                 $0.provider = payload.provider.rawValue
-                // Same discipline as the fee context above: never set from a
-                // nil, so a legacy payload decoded here re-encodes byte-stable.
                 if let subProvider = payload.subProvider?.nilIfEmpty {
                     $0.subProvider = subProvider
                 }
@@ -456,8 +448,7 @@ extension SwapPayload {
                 if let swapFee = payload.swapFee?.nilIfEmpty, swapFee != "0" {
                     $0.swapFee = swapFee
                     // Never set from nils: a present-but-empty chain or token id
-                    // breaks a receiver's coin lookup, and re-encoding a legacy
-                    // payload has to stay byte-stable.
+                    // breaks a receiver's coin lookup.
                     if let swapFeeChain = payload.swapFeeChain?.nilIfEmpty {
                         $0.swapFeeChain = swapFeeChain
                     }

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
@@ -445,7 +445,9 @@ extension SwapPayload {
                 }
                 $0.subProvider = payload.subProvider
                 $0.swapID = payload.swapID
-                if let swapFee = payload.swapFee?.nilIfEmpty, swapFee != "0" {
+                // No `!= "0"` guard: a stated zero is a claim the sender made and
+                // must survive a relay, the same way the native `fee` does.
+                if let swapFee = payload.swapFee?.nilIfEmpty {
                     $0.swapFee = swapFee
                     // Never set from nils: a present-but-empty chain or token id
                     // breaks a receiver's coin lookup.

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
@@ -228,6 +228,16 @@ private func writeNativeSwapFee(_ fee: String?, to proto: inout VSTHORChainSwapP
     proto.fee = fee
 }
 
+/// Explicit presence for the carried price impact. `slippage_bps` is an
+/// `optional uint32`, so absent means "sender predates the field, impact
+/// unknown" and the receiver hides the row, while a present `0` is a real claim
+/// of a zero-impact route. Only a nil leaves the field untouched -- writing a
+/// stand-in would turn "unknown" into a definite statement.
+private func writeNativeSwapSlippageBps(_ slippageBps: UInt32?, to proto: inout VSTHORChainSwapPayload) {
+    guard let slippageBps else { return }
+    proto.slippageBps = slippageBps
+}
+
 extension SwapPayload {
     init(proto: VSKeysignPayload.OneOf_SwapPayload) throws {
         switch proto {
@@ -245,7 +255,8 @@ extension SwapPayload {
                 streamingQuantity: value.streamingQuantity,
                 expirationTime: value.expirationTime,
                 isAffiliate: value.isAffiliate,
-                fee: value.fee.nilIfEmpty
+                fee: value.fee.nilIfEmpty,
+                slippageBps: value.hasSlippageBps ? value.slippageBps : nil
             ))
         case .mayachainSwapPayload(let value):
             self = .mayachain(THORChainSwapPayload(
@@ -261,7 +272,8 @@ extension SwapPayload {
                 streamingQuantity: value.streamingQuantity,
                 expirationTime: value.expirationTime,
                 isAffiliate: value.isAffiliate,
-                fee: value.fee.nilIfEmpty
+                fee: value.fee.nilIfEmpty,
+                slippageBps: value.hasSlippageBps ? value.slippageBps : nil
             ))
         case .oneinchSwapPayload(let value):
             // `has*` guards distinguish "legacy sender, context unknown"
@@ -289,7 +301,8 @@ extension SwapPayload {
                 provider: SwapProviderId.from(rawValue: value.provider),
                 swapFeeChain: value.quote.tx.hasSwapFeeChain ? value.quote.tx.swapFeeChain.nilIfEmpty : nil,
                 swapFeeTokenId: swapFeeTokenId,
-                swapFeeDecimals: value.quote.tx.hasSwapFeeDecimals ? Int(value.quote.tx.swapFeeDecimals) : nil
+                swapFeeDecimals: value.quote.tx.hasSwapFeeDecimals ? Int(value.quote.tx.swapFeeDecimals) : nil,
+                subProvider: value.subProvider.nilIfEmpty
             ))
         case .kyberswapSwapPayload(let value):
             self = .generic(GenericSwapPayload(
@@ -324,7 +337,13 @@ extension SwapPayload {
                 inboundAddress: value.hasInboundAddress ? value.inboundAddress : nil,
                 memo: value.hasMemo ? value.memo : nil,
                 subProvider: value.subProvider,
-                swapID: value.swapID
+                swapID: value.swapID,
+                // Same `has*` discipline as the 1inch fee context above: an
+                // absent field means "legacy sender, unknown", not zero.
+                swapFee: value.swapFee.nilIfEmpty,
+                swapFeeChain: value.hasSwapFeeChain ? value.swapFeeChain.nilIfEmpty : nil,
+                swapFeeTokenId: value.hasSwapFeeTokenID ? value.swapFeeTokenID.nilIfEmpty : nil,
+                swapFeeDecimals: value.hasSwapFeeDecimals ? Int(value.swapFeeDecimals) : nil
             ))
         }
     }
@@ -346,6 +365,7 @@ extension SwapPayload {
                 $0.expirationTime = payload.expirationTime
                 $0.isAffiliate = payload.isAffiliate
                 writeNativeSwapFee(payload.fee, to: &$0)
+                writeNativeSwapSlippageBps(payload.slippageBps, to: &$0)
             })
         case .mayachain(let payload):
             return .mayachainSwapPayload(.with {
@@ -362,6 +382,7 @@ extension SwapPayload {
                 $0.expirationTime = payload.expirationTime
                 $0.isAffiliate = payload.isAffiliate
                 writeNativeSwapFee(payload.fee, to: &$0)
+                writeNativeSwapSlippageBps(payload.slippageBps, to: &$0)
             })
         case .generic(let payload):
             return .oneinchSwapPayload(.with {
@@ -398,6 +419,11 @@ extension SwapPayload {
                     }
                 }
                 $0.provider = payload.provider.rawValue
+                // Same discipline as the fee context above: never set from a
+                // nil, so a legacy payload decoded here re-encodes byte-stable.
+                if let subProvider = payload.subProvider?.nilIfEmpty {
+                    $0.subProvider = subProvider
+                }
             })
         case .swapkit(let payload):
             return .swapkitSwapPayload(.with {
@@ -416,6 +442,21 @@ extension SwapPayload {
                 }
                 $0.subProvider = payload.subProvider
                 $0.swapID = payload.swapID
+                if let swapFee = payload.swapFee?.nilIfEmpty, swapFee != "0" {
+                    $0.swapFee = swapFee
+                    // Never set from nils: a present-but-empty chain or token id
+                    // breaks a receiver's coin lookup, and re-encoding a legacy
+                    // payload has to stay byte-stable.
+                    if let swapFeeChain = payload.swapFeeChain?.nilIfEmpty {
+                        $0.swapFeeChain = swapFeeChain
+                    }
+                    if let swapFeeTokenId = payload.swapFeeTokenId?.nilIfEmpty {
+                        $0.swapFeeTokenID = swapFeeTokenId
+                    }
+                    if let swapFeeDecimals = payload.swapFeeDecimals {
+                        $0.swapFeeDecimals = Int32(swapFeeDecimals)
+                    }
+                }
             })
         }
     }

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
@@ -228,6 +228,17 @@ private func writeNativeSwapFee(_ fee: String?, to proto: inout VSTHORChainSwapP
     proto.fee = fee
 }
 
+/// `router_address` is an `optional string`, so assigning `""` marks it
+/// present-but-empty rather than leaving it off the wire: a relayed payload that
+/// carried no router came back two bytes longer than the one its sender built.
+/// Readers already normalize empty to absent (`nilIfEmpty` on the way in), so
+/// nothing reads differently — but byte-stability across a mixed-version
+/// committee is worth more than the assignment's brevity.
+private func writeNativeSwapRouterAddress(_ routerAddress: String?, to proto: inout VSTHORChainSwapPayload) {
+    guard let routerAddress = routerAddress?.nilIfEmpty else { return }
+    proto.routerAddress = routerAddress
+}
+
 /// Explicit presence for the carried price impact. `slippage_bps` is an
 /// `optional uint32`, so absent means "sender predates the field, impact
 /// unknown" and the receiver hides the row, while a present `0` is a real claim
@@ -356,7 +367,7 @@ extension SwapPayload {
                 $0.fromCoin = ProtoCoinResolver.proto(from: payload.fromCoin)
                 $0.toCoin = ProtoCoinResolver.proto(from: payload.toCoin)
                 $0.vaultAddress = payload.vaultAddress
-                $0.routerAddress = payload.routerAddress ?? .empty
+                writeNativeSwapRouterAddress(payload.routerAddress, to: &$0)
                 $0.fromAmount = String(payload.fromAmount)
                 $0.toAmountDecimal = payload.toAmountDecimal.description
                 $0.toAmountLimit = payload.toAmountLimit
@@ -373,7 +384,7 @@ extension SwapPayload {
                 $0.fromCoin = ProtoCoinResolver.proto(from: payload.fromCoin)
                 $0.toCoin = ProtoCoinResolver.proto(from: payload.toCoin)
                 $0.vaultAddress = payload.vaultAddress
-                $0.routerAddress = payload.routerAddress ?? .empty
+                writeNativeSwapRouterAddress(payload.routerAddress, to: &$0)
                 $0.fromAmount = String(payload.fromAmount)
                 $0.toAmountDecimal = payload.toAmountDecimal.description
                 $0.toAmountLimit = payload.toAmountLimit

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/GenericSwapPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/GenericSwapPayload.swift
@@ -25,10 +25,7 @@ struct GenericSwapPayload: Codable, Hashable {
     var swapFeeTokenId: String? = nil
     var swapFeeDecimals: Int? = nil
 
-    /// Route tag under the aggregator named by `provider` — "NEAR", "CHAINFLIP",
-    /// "GARDEN". SwapKit's EVM and Solana routes ride this payload shape, and
-    /// without the tag a co-signer names the aggregator while the initiator that
-    /// holds the quote names the route too. nil for aggregators that route
-    /// directly and for senders that predate the field.
+    /// Route tag under `provider` — "NEAR", "CHAINFLIP", "GARDEN". nil for
+    /// aggregators that route directly and for senders predating the field.
     var subProvider: String? = nil
 }

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/GenericSwapPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/GenericSwapPayload.swift
@@ -24,4 +24,11 @@ struct GenericSwapPayload: Codable, Hashable {
     var swapFeeChain: String? = nil
     var swapFeeTokenId: String? = nil
     var swapFeeDecimals: Int? = nil
+
+    /// Route tag under the aggregator named by `provider` — "NEAR", "CHAINFLIP",
+    /// "GARDEN". SwapKit's EVM and Solana routes ride this payload shape, and
+    /// without the tag a co-signer names the aggregator while the initiator that
+    /// holds the quote names the route too. nil for aggregators that route
+    /// directly and for senders that predate the field.
+    var subProvider: String? = nil
 }

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/SwapKitSwapPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/SwapKitSwapPayload.swift
@@ -59,26 +59,19 @@ struct SwapKitSwapPayload: Codable, Hashable {
     /// accepted by `POST /track` — track by broadcast hash + chain id.
     let swapID: String
 
-    /// Provider fee for this swap, raw in the base units of the coin the three
-    /// fields below identify. A co-signer holds no quote, so a fee that does not
-    /// travel here is one it can neither recover nor show.
+    /// Provider fee, raw in the base units of the coin the three fields below
+    /// identify. Display only.
     ///
-    /// Read from the wire but not yet written by this app: iOS treats SwapKit's
-    /// affiliate charge as embedded in the quoted rate (`SwapCryptoLogic`'s
-    /// `affiliateFeeFiat` returns zero for SwapKit and the form shows an
-    /// "included in rate" note instead of an amount), so there is no itemized
-    /// initiator figure to carry. Populating one here would give the joiner a fee
-    /// row and a total that the initiator's own verify screen does not show —
-    /// the disagreement these fields exist to remove. A sender that does itemize
-    /// it (Windows, Android, the SDK) reaches an iOS joiner through these fields.
-    ///
-    /// Display only: no signer reads any of them.
+    /// Read but deliberately NOT written here: iOS treats SwapKit's affiliate
+    /// charge as embedded in the quoted rate and itemizes no figure for it on the
+    /// initiator, so populating this would show the joiner a fee its own
+    /// initiator does not. Senders that do itemize it reach an iOS joiner
+    /// through these fields.
     var swapFee: String? = nil
 
-    /// Coin context for `swapFee`. The amount alone is ambiguous — providers
-    /// charge in the source gas coin, the sell asset or the destination token —
-    /// and a 6-decimal fee read as an 18-decimal one is wrong by 10^12. All nil
-    /// means "unknown"; the consumer renders no row rather than guessing a coin.
+    /// Coin context for `swapFee` — the amount alone is ambiguous, and a
+    /// 6-decimal fee read as an 18-decimal one is wrong by 10^12. All nil means
+    /// unknown; consumers render no row rather than guess a coin.
     var swapFeeChain: String? = nil
     var swapFeeTokenId: String? = nil
     var swapFeeDecimals: Int? = nil

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/SwapKitSwapPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/SwapKitSwapPayload.swift
@@ -58,4 +58,28 @@ struct SwapKitSwapPayload: Codable, Hashable {
     /// SwapKit swap identifier. Persisted for tracking + analytics. NOT
     /// accepted by `POST /track` — track by broadcast hash + chain id.
     let swapID: String
+
+    /// Provider fee for this swap, raw in the base units of the coin the three
+    /// fields below identify. A co-signer holds no quote, so a fee that does not
+    /// travel here is one it can neither recover nor show.
+    ///
+    /// Read from the wire but not yet written by this app: iOS treats SwapKit's
+    /// affiliate charge as embedded in the quoted rate (`SwapCryptoLogic`'s
+    /// `affiliateFeeFiat` returns zero for SwapKit and the form shows an
+    /// "included in rate" note instead of an amount), so there is no itemized
+    /// initiator figure to carry. Populating one here would give the joiner a fee
+    /// row and a total that the initiator's own verify screen does not show —
+    /// the disagreement these fields exist to remove. A sender that does itemize
+    /// it (Windows, Android, the SDK) reaches an iOS joiner through these fields.
+    ///
+    /// Display only: no signer reads any of them.
+    var swapFee: String? = nil
+
+    /// Coin context for `swapFee`. The amount alone is ambiguous — providers
+    /// charge in the source gas coin, the sell asset or the destination token —
+    /// and a 6-decimal fee read as an 18-decimal one is wrong by 10^12. All nil
+    /// means "unknown"; the consumer renders no row rather than guessing a coin.
+    var swapFeeChain: String? = nil
+    var swapFeeTokenId: String? = nil
+    var swapFeeDecimals: Int? = nil
 }

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/SwapPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/SwapPayload.swift
@@ -89,6 +89,36 @@ enum SwapPayload: Codable, Hashable { // TODO: Merge with SwapQuote
         }
     }
 
+    /// Price impact of the route as a fraction (`0.0125` == 1.25%), mirroring
+    /// `SwapQuote.priceImpact` for the co-signer, which holds only the serialized
+    /// payload. Native routes carry the quote's basis points on the wire; the
+    /// aggregator routes put none there. `nil` also for a sender that pre-dates
+    /// the field — consumers hide the row rather than claim a zero-impact route,
+    /// which a carried `0` would legitimately mean.
+    /// "SwapKit (NEAR)" when a route tag travelled with the payload, the bare
+    /// aggregator name when it did not. A tag naming the aggregator itself is
+    /// dropped rather than repeated: SwapKit's `providers` is empty for some
+    /// routes and its own name is the fallback, which would otherwise read
+    /// "SwapKit (SwapKit)".
+    private static func appendingRoute(_ provider: String, subProvider: String?) -> String {
+        guard let subProvider = subProvider?.nilIfEmpty,
+              subProvider.caseInsensitiveCompare(provider) != .orderedSame else {
+            return provider
+        }
+        return "\(provider) (\(subProvider))"
+    }
+
+    var priceImpact: Decimal? {
+        switch self {
+        case .thorchain(let payload), .thorchainChainnet(let payload),
+             .thorchainStagenet(let payload), .mayachain(let payload):
+            guard let slippageBps = payload.slippageBps else { return nil }
+            return Decimal(slippageBps) / 10000
+        case .generic, .swapkit:
+            return nil
+        }
+    }
+
     var isDeposit: Bool {
         switch self {
         case .mayachain(let payload):
@@ -98,6 +128,9 @@ enum SwapPayload: Codable, Hashable { // TODO: Merge with SwapQuote
         }
     }
 
+    /// Persisted / explorer-facing provider identity. Transaction History stores
+    /// this string and `ExplorerLinkBuilder` aliases it back to a tracker, so the
+    /// route tag lives on `providerDisplayName` instead of here.
     var providerName: String {
         switch self {
         case .thorchain:
@@ -113,7 +146,21 @@ enum SwapPayload: Codable, Hashable { // TODO: Merge with SwapQuote
         case .swapkit(let payload):
             // Sub-provider tag preserves the verify-screen "via Chainflip" /
             // "via NEAR Intents" / "via Garden" affordance.
-            return payload.subProvider.isEmpty ? "SwapKit" : "SwapKit (\(payload.subProvider))"
+            return Self.appendingRoute("SwapKit", subProvider: payload.subProvider)
         }
+    }
+
+    /// Verify-screen name: the aggregator plus the route it actually took, when
+    /// a route tag travelled with the payload. SwapKit's EVM and Solana routes
+    /// ride `.generic`, so this is what lets a co-signer name them the way every
+    /// other SwapKit route is already named.
+    ///
+    /// Kept separate from `providerName` deliberately. That string is persisted
+    /// to Transaction History and aliased back to a tracker URL by
+    /// `ExplorerLinkBuilder`, whose lookup is exact — folding a route tag into it
+    /// would drop the aggregator's own tracker for every affected row.
+    var providerDisplayName: String {
+        guard case let .generic(payload) = self else { return providerName }
+        return Self.appendingRoute(payload.provider.name, subProvider: payload.subProvider)
     }
 }

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/SwapPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/SwapPayload.swift
@@ -129,8 +129,11 @@ enum SwapPayload: Codable, Hashable { // TODO: Merge with SwapQuote
     }
 
     /// Persisted / explorer-facing provider identity. Transaction History stores
-    /// this string and `ExplorerLinkBuilder` aliases it back to a tracker, so the
-    /// route tag lives on `providerDisplayName` instead of here.
+    /// this string and `ExplorerLinkBuilder` resolves it back to a tracker URL
+    /// through an exact alias lookup, so the route tag lives on
+    /// `providerDisplayName` instead of here: `"SwapKit (CHAINFLIP)"` normalizes
+    /// to `swapkitchainflip`, which is in no alias table, and the row silently
+    /// falls back to the chain explorer instead of the aggregator's tracker.
     var providerName: String {
         switch self {
         case .thorchain:
@@ -143,10 +146,8 @@ enum SwapPayload: Codable, Hashable { // TODO: Merge with SwapQuote
             return "Maya Protocol"
         case .generic(let payload):
             return payload.provider.name
-        case .swapkit(let payload):
-            // Sub-provider tag preserves the verify-screen "via Chainflip" /
-            // "via NEAR Intents" / "via Garden" affordance.
-            return Self.appendingRoute("SwapKit", subProvider: payload.subProvider)
+        case .swapkit:
+            return "SwapKit"
         }
     }
 
@@ -160,7 +161,15 @@ enum SwapPayload: Codable, Hashable { // TODO: Merge with SwapQuote
     /// `ExplorerLinkBuilder`, whose lookup is exact — folding a route tag into it
     /// would drop the aggregator's own tracker for every affected row.
     var providerDisplayName: String {
-        guard case let .generic(payload) = self else { return providerName }
-        return Self.appendingRoute(payload.provider.name, subProvider: payload.subProvider)
+        switch self {
+        case .generic(let payload):
+            return Self.appendingRoute(payload.provider.name, subProvider: payload.subProvider)
+        case .swapkit(let payload):
+            // Preserves the verify-screen "via Chainflip" / "via NEAR Intents" /
+            // "via Garden" affordance this shape has always had.
+            return Self.appendingRoute("SwapKit", subProvider: payload.subProvider)
+        case .thorchain, .thorchainChainnet, .thorchainStagenet, .mayachain:
+            return providerName
+        }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/SwapPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/SwapPayload.swift
@@ -151,24 +151,25 @@ enum SwapPayload: Codable, Hashable { // TODO: Merge with SwapQuote
         }
     }
 
-    /// Verify-screen name: the aggregator plus the route it actually took, when
-    /// a route tag travelled with the payload. SwapKit's EVM and Solana routes
-    /// ride `.generic`, so this is what lets a co-signer name them the way every
-    /// other SwapKit route is already named.
+    /// Verify-screen name, kept separate from `providerName` because that string
+    /// is persisted to Transaction History and aliased back to a tracker URL by
+    /// an exact lookup — a route tag folded into it drops the aggregator's own
+    /// tracker for every affected row.
     ///
-    /// Kept separate from `providerName` deliberately. That string is persisted
-    /// to Transaction History and aliased back to a tracker URL by
-    /// `ExplorerLinkBuilder`, whose lookup is exact — folding a route tag into it
-    /// would drop the aggregator's own tracker for every affected row.
+    /// `.generic` deliberately does NOT render the route tag it now carries, even
+    /// though the tag is on the wire. This device's own swap verify screen names
+    /// the clean brand (`SwapQuote.displayName`), and a joiner that appended the
+    /// route would describe the same swap differently from the device that
+    /// initiated it. Whether iOS should show sub-provider tags is a decision for
+    /// both screens together, not one that arrives on the joiner as a side
+    /// effect; the tag travels so the clients that do render it can.
     var providerDisplayName: String {
         switch self {
-        case .generic(let payload):
-            return Self.appendingRoute(payload.provider.name, subProvider: payload.subProvider)
         case .swapkit(let payload):
-            // Preserves the verify-screen "via Chainflip" / "via NEAR Intents" /
-            // "via Garden" affordance this shape has always had.
+            // Long-standing behaviour for the transfer routes: preserves the
+            // "via Chainflip" / "via NEAR Intents" / "via Garden" affordance.
             return Self.appendingRoute("SwapKit", subProvider: payload.subProvider)
-        case .thorchain, .thorchainChainnet, .thorchainStagenet, .mayachain:
+        case .generic, .thorchain, .thorchainChainnet, .thorchainStagenet, .mayachain:
             return providerName
         }
     }

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/SwapPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/SwapPayload.swift
@@ -89,17 +89,12 @@ enum SwapPayload: Codable, Hashable { // TODO: Merge with SwapQuote
         }
     }
 
-    /// Price impact of the route as a fraction (`0.0125` == 1.25%), mirroring
-    /// `SwapQuote.priceImpact` for the co-signer, which holds only the serialized
-    /// payload. Native routes carry the quote's basis points on the wire; the
-    /// aggregator routes put none there. `nil` also for a sender that pre-dates
-    /// the field — consumers hide the row rather than claim a zero-impact route,
-    /// which a carried `0` would legitimately mean.
-    /// "SwapKit (NEAR)" when a route tag travelled with the payload, the bare
-    /// aggregator name when it did not. A tag naming the aggregator itself is
-    /// dropped rather than repeated: SwapKit's `providers` is empty for some
-    /// routes and its own name is the fallback, which would otherwise read
-    /// "SwapKit (SwapKit)".
+    /// Route price impact as a fraction (`0.0125` == 1.25%). `nil` where no
+    /// impact travelled; consumers hide the row rather than render a zero, which
+    /// a carried `0` would legitimately mean.
+    /// A tag naming the aggregator itself is dropped rather than repeated:
+    /// SwapKit's `providers` can be empty and its own name is the fallback,
+    /// which would otherwise read "SwapKit (SwapKit)".
     private static func appendingRoute(_ provider: String, subProvider: String?) -> String {
         guard let subProvider = subProvider?.nilIfEmpty,
               subProvider.caseInsensitiveCompare(provider) != .orderedSame else {
@@ -128,12 +123,11 @@ enum SwapPayload: Codable, Hashable { // TODO: Merge with SwapQuote
         }
     }
 
-    /// Persisted / explorer-facing provider identity. Transaction History stores
-    /// this string and `ExplorerLinkBuilder` resolves it back to a tracker URL
-    /// through an exact alias lookup, so the route tag lives on
-    /// `providerDisplayName` instead of here: `"SwapKit (CHAINFLIP)"` normalizes
-    /// to `swapkitchainflip`, which is in no alias table, and the row silently
-    /// falls back to the chain explorer instead of the aggregator's tracker.
+    /// Persisted identity. Transaction History stores this string and
+    /// `ExplorerLinkBuilder` resolves it to a tracker through an EXACT alias
+    /// lookup, so a route tag must not be folded in here: "SwapKit (CHAINFLIP)"
+    /// normalizes to `swapkitchainflip`, matches no alias, and the row silently
+    /// loses its tracker. The tag lives on `providerDisplayName`.
     var providerName: String {
         switch self {
         case .thorchain:
@@ -151,23 +145,14 @@ enum SwapPayload: Codable, Hashable { // TODO: Merge with SwapQuote
         }
     }
 
-    /// Verify-screen name, kept separate from `providerName` because that string
-    /// is persisted to Transaction History and aliased back to a tracker URL by
-    /// an exact lookup — a route tag folded into it drops the aggregator's own
-    /// tracker for every affected row.
-    ///
-    /// `.generic` deliberately does NOT render the route tag it now carries, even
-    /// though the tag is on the wire. This device's own swap verify screen names
-    /// the clean brand (`SwapQuote.displayName`), and a joiner that appended the
-    /// route would describe the same swap differently from the device that
-    /// initiated it. Whether iOS should show sub-provider tags is a decision for
-    /// both screens together, not one that arrives on the joiner as a side
-    /// effect; the tag travels so the clients that do render it can.
+    /// Verify-screen name. `.generic` deliberately does NOT render the route tag
+    /// it carries: this device's initiator screen names the clean brand
+    /// (`SwapQuote.displayName`), so rendering it here alone would describe one
+    /// swap two ways. The tag travels for the clients that do render it.
     var providerDisplayName: String {
         switch self {
         case .swapkit(let payload):
-            // Long-standing behaviour for the transfer routes: preserves the
-            // "via Chainflip" / "via NEAR Intents" / "via Garden" affordance.
+            // Long-standing "via Chainflip" affordance for the transfer routes.
             return Self.appendingRoute("SwapKit", subProvider: payload.subProvider)
         case .generic, .thorchain, .thorchainChainnet, .thorchainStagenet, .mayachain:
             return providerName

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/THORChainSwapPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/THORChainSwapPayload.swift
@@ -52,6 +52,14 @@ struct THORChainSwapPayload: Codable, Hashable {
     /// `$0.00`; `nil` is a sender that stated nothing and renders no row.
     /// Display only.
     var fee: String? = nil
+    /// Price impact of the route in basis points, as the quote reported it —
+    /// carried rather than recomputed because a co-signer fetching its own quote
+    /// would price a pool that has moved since the initiator quoted it, making
+    /// this the one term on the two verify screens where honest devices disagree.
+    /// `nil` from a quote that reports none or a sender that pre-dates the field,
+    /// and the row is hidden; a carried `0` is a real claim of a zero-impact
+    /// route and renders as one. Display only: no signer reads it.
+    var slippageBps: UInt32? = nil
 
     var toAddress: String {
         return toCoin.address

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/THORChainSwapPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/THORChainSwapPayload.swift
@@ -52,13 +52,9 @@ struct THORChainSwapPayload: Codable, Hashable {
     /// `$0.00`; `nil` is a sender that stated nothing and renders no row.
     /// Display only.
     var fee: String? = nil
-    /// Price impact of the route in basis points, as the quote reported it —
-    /// carried rather than recomputed because a co-signer fetching its own quote
-    /// would price a pool that has moved since the initiator quoted it, making
-    /// this the one term on the two verify screens where honest devices disagree.
-    /// `nil` from a quote that reports none or a sender that pre-dates the field,
-    /// and the row is hidden; a carried `0` is a real claim of a zero-impact
-    /// route and renders as one. Display only: no signer reads it.
+    /// Route price impact in basis points, carried rather than recomputed: a
+    /// co-signer's own quote would price a pool that has since moved. `nil` hides
+    /// the row; a carried `0` claims a zero-impact route. Display only.
     var slippageBps: UInt32? = nil
 
     var toAddress: String {

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignSwapFeeViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignSwapFeeViewModel.swift
@@ -80,11 +80,8 @@ struct JoinKeysignSwapFeeViewModel {
         )
     }
 
-    /// SwapKit's transfer routes (PSBT / TON / TRON / SUI / Cardano / XRP) carry
-    /// the provider fee in a group of their own on the wire, in the same shape
-    /// the EVM routes carry it: raw amount plus the chain, token id and decimals
-    /// that say what coin it is denominated in. Same resolution, same refusal to
-    /// guess.
+    /// SwapKit's transfer routes carry the fee in a group of their own, in the
+    /// same shape the EVM routes use.
     private func resolveSwapKitSwapFee(payload: SwapKitSwapPayload, vault: Vault?) -> ResolvedSwapFee? {
         resolveContextualSwapFee(
             rawFee: payload.swapFee,
@@ -97,9 +94,8 @@ struct JoinKeysignSwapFeeViewModel {
         )
     }
 
-    /// Shared resolution for the aggregator payloads, which all denominate their
-    /// fee in a coin that has to be named on the wire because it is neither side
-    /// of the swap by construction.
+    /// Shared by the aggregator payloads: the fee coin is not either side of the
+    /// swap by construction, so it has to be named on the wire.
     private func resolveContextualSwapFee(
         rawFee: String?,
         chainName: String?,

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignSwapFeeViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignSwapFeeViewModel.swift
@@ -47,8 +47,9 @@ struct JoinKeysignSwapFeeViewModel {
             return resolveNativeSwapFee(payload: payload)
         case let .generic(payload):
             return resolveGenericSwapFee(payload: payload, vault: vault)
-        case .swapkit, .none:
-            // SwapKit keeps its fee in a wire group this payload shape lacks.
+        case let .swapkit(payload):
+            return resolveSwapKitSwapFee(payload: payload, vault: vault)
+        case .none:
             return nil
         }
     }
@@ -68,22 +69,62 @@ struct JoinKeysignSwapFeeViewModel {
     }
 
     private func resolveGenericSwapFee(payload: GenericSwapPayload, vault: Vault?) -> ResolvedSwapFee? {
-        guard let fee = BigInt(payload.quote.tx.swapFee), fee > 0 else { return nil }
+        resolveContextualSwapFee(
+            rawFee: payload.quote.tx.swapFee,
+            chainName: payload.swapFeeChain,
+            tokenId: payload.swapFeeTokenId,
+            wireDecimals: payload.swapFeeDecimals,
+            fromCoin: payload.fromCoin,
+            toCoin: payload.toCoin,
+            vault: vault
+        )
+    }
+
+    /// SwapKit's transfer routes (PSBT / TON / TRON / SUI / Cardano / XRP) carry
+    /// the provider fee in a group of their own on the wire, in the same shape
+    /// the EVM routes carry it: raw amount plus the chain, token id and decimals
+    /// that say what coin it is denominated in. Same resolution, same refusal to
+    /// guess.
+    private func resolveSwapKitSwapFee(payload: SwapKitSwapPayload, vault: Vault?) -> ResolvedSwapFee? {
+        resolveContextualSwapFee(
+            rawFee: payload.swapFee,
+            chainName: payload.swapFeeChain,
+            tokenId: payload.swapFeeTokenId,
+            wireDecimals: payload.swapFeeDecimals,
+            fromCoin: payload.fromCoin,
+            toCoin: payload.toCoin,
+            vault: vault
+        )
+    }
+
+    /// Shared resolution for the aggregator payloads, which all denominate their
+    /// fee in a coin that has to be named on the wire because it is neither side
+    /// of the swap by construction.
+    private func resolveContextualSwapFee(
+        rawFee: String?,
+        chainName: String?,
+        tokenId: String?,
+        wireDecimals: Int?,
+        fromCoin: Coin,
+        toCoin: Coin,
+        vault: Vault?
+    ) -> ResolvedSwapFee? {
+        guard let rawFee, let fee = BigInt(rawFee), fee > 0 else { return nil }
 
         // Pre-context senders omit chain/decimals — render no row rather
         // than guessing a coin (a 6-decimal destination-token fee read as an
         // 18-decimal native amount is wrong by ~10^12).
         guard
-            let chainName = payload.swapFeeChain,
+            let chainName,
             let chain = Chain(name: chainName),
-            let wireDecimals = payload.swapFeeDecimals
+            let wireDecimals
         else { return nil }
 
         guard let coin = resolveDisplayCoin(
             chain: chain,
-            tokenId: payload.swapFeeTokenId,
-            fromCoin: payload.fromCoin,
-            toCoin: payload.toCoin,
+            tokenId: tokenId,
+            fromCoin: fromCoin,
+            toCoin: toCoin,
             vault: vault
         ) else { return nil }
 

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignSwapFeeViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignSwapFeeViewModel.swift
@@ -14,6 +14,10 @@ import BigInt
 /// beats a fiat value that's wrong by orders of magnitude.
 struct JoinKeysignSwapFeeViewModel {
 
+    /// Matches `TokenMetadataResolver` and `CosmosTokenMetadataResolver`: the
+    /// bound this app already applies to decimals it did not choose itself.
+    private static let supportedWireDecimals = 0...36
+
     struct ResolvedSwapFee {
         /// Fee in human units. Scaled by the wire decimals (not the resolved
         /// coin's) — the sender serialized the raw amount in those units.
@@ -119,10 +123,17 @@ struct JoinKeysignSwapFeeViewModel {
         // Pre-context senders omit chain/decimals — render no row rather
         // than guessing a coin (a 6-decimal destination-token fee read as an
         // 18-decimal native amount is wrong by ~10^12).
+        //
+        // `wireDecimals` is an unvalidated `int32` off the wire, and it lands in
+        // `pow(10, wireDecimals)`: a negative exponent inverts the scale (-9 shows
+        // a fee 10^9x too large) and one past `Decimal`'s range yields `.nan`,
+        // which formats as the literal string "NaN" on the confirm screen. Bound
+        // it the way the token-metadata resolvers bound untrusted decimals.
         guard
             let chainName,
             let chain = Chain(name: chainName),
-            let wireDecimals
+            let wireDecimals,
+            Self.supportedWireDecimals.contains(wireDecimals)
         else { return nil }
 
         guard let coin = resolveDisplayCoin(

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignSwapFeeViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignSwapFeeViewModel.swift
@@ -71,6 +71,9 @@ struct JoinKeysignSwapFeeViewModel {
     private func resolveGenericSwapFee(payload: GenericSwapPayload, vault: Vault?) -> ResolvedSwapFee? {
         resolveContextualSwapFee(
             rawFee: payload.quote.tx.swapFee,
+            // `EVMQuote.Transaction.swapFee` defaults to "0" when a quote omits
+            // the key, so a zero here cannot be told from "never quoted".
+            statedZeroIsMeaningful: false,
             chainName: payload.swapFeeChain,
             tokenId: payload.swapFeeTokenId,
             wireDecimals: payload.swapFeeDecimals,
@@ -85,6 +88,10 @@ struct JoinKeysignSwapFeeViewModel {
     private func resolveSwapKitSwapFee(payload: SwapKitSwapPayload, vault: Vault?) -> ResolvedSwapFee? {
         resolveContextualSwapFee(
             rawFee: payload.swapFee,
+            // Optional on this payload, so nil is "absent" and "0" is a sender
+            // stating the route charges nothing — render it, matching a
+            // cross-client initiator that shows $0.00.
+            statedZeroIsMeaningful: true,
             chainName: payload.swapFeeChain,
             tokenId: payload.swapFeeTokenId,
             wireDecimals: payload.swapFeeDecimals,
@@ -98,6 +105,7 @@ struct JoinKeysignSwapFeeViewModel {
     /// swap by construction, so it has to be named on the wire.
     private func resolveContextualSwapFee(
         rawFee: String?,
+        statedZeroIsMeaningful: Bool,
         chainName: String?,
         tokenId: String?,
         wireDecimals: Int?,
@@ -105,7 +113,8 @@ struct JoinKeysignSwapFeeViewModel {
         toCoin: Coin,
         vault: Vault?
     ) -> ResolvedSwapFee? {
-        guard let rawFee, let fee = BigInt(rawFee), fee > 0 else { return nil }
+        guard let rawFee, let fee = BigInt(rawFee), fee >= 0 else { return nil }
+        guard fee > 0 || statedZeroIsMeaningful else { return nil }
 
         // Pre-context senders omit chain/decimals — render no row rather
         // than guessing a coin (a 6-decimal destination-token fee read as an

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
@@ -734,8 +734,6 @@ class JoinKeysignViewModel: ObservableObject {
         resolvedHero ?? heroContent
     }
 
-    /// Provider row on the swap confirm screen — the aggregator plus the route
-    /// it took, where the payload names one.
     var providerDisplayName: String {
         keysignPayload?.swapPayload?.providerDisplayName ?? .empty
     }
@@ -790,11 +788,8 @@ class JoinKeysignViewModel: ObservableObject {
         return SwapCryptoLogic.minPayoutCaption(amount: amount, ticker: swapPayload.toCoin.ticker)
     }
 
-    /// Price-impact label for the swap confirm screen, formatted by the same
-    /// helper the initiator's verify screen uses so the two cannot word it
-    /// differently. Empty when the payload carries no impact — a joiner must not
-    /// re-derive one from its own quote, because it would price a pool that has
-    /// moved since the initiator was quoted.
+    /// Empty when the payload carries no impact. A joiner must not re-derive one
+    /// from its own quote: that prices a pool that has moved since.
     var priceImpactString: String {
         SwapCryptoLogic.priceImpactString(impact: keysignPayload?.swapPayload?.priceImpact)
     }

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
@@ -734,8 +734,10 @@ class JoinKeysignViewModel: ObservableObject {
         resolvedHero ?? heroContent
     }
 
-    var providerName: String {
-        keysignPayload?.swapPayload?.providerName ?? .empty
+    /// Provider row on the swap confirm screen — the aggregator plus the route
+    /// it took, where the payload names one.
+    var providerDisplayName: String {
+        keysignPayload?.swapPayload?.providerDisplayName ?? .empty
     }
 
     /// dApp identity (name / url / icon) attached to the keysign request, if
@@ -786,6 +788,19 @@ class JoinKeysignViewModel: ObservableObject {
         }
         let amount = Decimal(limit) / swapPayload.toCoin.thorswapMultiplier
         return SwapCryptoLogic.minPayoutCaption(amount: amount, ticker: swapPayload.toCoin.ticker)
+    }
+
+    /// Price-impact label for the swap confirm screen, formatted by the same
+    /// helper the initiator's verify screen uses so the two cannot word it
+    /// differently. Empty when the payload carries no impact — a joiner must not
+    /// re-derive one from its own quote, because it would price a pool that has
+    /// moved since the initiator was quoted.
+    var priceImpactString: String {
+        SwapCryptoLogic.priceImpactString(impact: keysignPayload?.swapPayload?.priceImpact)
+    }
+
+    var priceImpactColor: Color {
+        SwapCryptoLogic.priceImpactColor(impact: keysignPayload?.swapPayload?.priceImpact)
     }
 
     func getCalculatedNetworkFee() -> (feeCrypto: String, feeFiat: String) {

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignSwapConfirmView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignSwapConfirmView.swift
@@ -54,9 +54,6 @@ struct KeysignSwapConfirmView: View {
             separator
             getNetworkFeeCell()
 
-            // Only when the initiator carried the quote's impact. Re-deriving it
-            // here would price a pool that has moved since, so no row beats a
-            // number this device made up.
             if !viewModel.priceImpactString.isEmpty {
                 separator
                 priceImpactRow

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignSwapConfirmView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignSwapConfirmView.swift
@@ -42,7 +42,7 @@ struct KeysignSwapConfirmView: View {
             separator
             getValueCell(
                 for: "provider",
-                with: viewModel.providerName,
+                with: viewModel.providerDisplayName,
                 showIcon: true
             )
 
@@ -53,6 +53,14 @@ struct KeysignSwapConfirmView: View {
 
             separator
             getNetworkFeeCell()
+
+            // Only when the initiator carried the quote's impact. Re-deriving it
+            // here would price a pool that has moved since, so no row beats a
+            // number this device made up.
+            if !viewModel.priceImpactString.isEmpty {
+                separator
+                priceImpactRow
+            }
 
             if let totalFee = viewModel.getSwapTotalFee() {
                 separator
@@ -169,6 +177,20 @@ struct KeysignSwapConfirmView: View {
                     .foregroundStyle(Theme.colors.textTertiary)
             }
 
+        }
+        .font(Theme.fonts.bodySMedium)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var priceImpactRow: some View {
+        HStack(spacing: 4) {
+            Text(NSLocalizedString("swap.price_impact", comment: "Price Impact"))
+                .foregroundStyle(Theme.colors.textTertiary)
+
+            Spacer()
+
+            Text(viewModel.priceImpactString)
+                .foregroundStyle(viewModel.priceImpactColor)
         }
         .font(Theme.fonts.bodySMedium)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
@@ -199,8 +199,24 @@ extension SwapCryptoLogic {
             streamingQuantity: memoTerms.streamingQuantity,
             expirationTime: UInt64(expirationTime.timeIntervalSince1970),
             isAffiliate: SwapCryptoLogic.isAffiliate,
-            fee: nativeSwapPayloadFee(quote: quote)
+            fee: nativeSwapPayloadFee(quote: quote),
+            slippageBps: nativeSwapPayloadSlippageBps(quote: quote)
         )
+    }
+
+    /// The quote's reported price impact, in basis points, to carry on the
+    /// keysign payload so a co-signer shows the impact the initiator was quoted
+    /// instead of re-deriving one from a pool that has since moved.
+    ///
+    /// `nil` when the node reports none — the receiver hides the row rather than
+    /// claiming a zero-impact route. A reported `0` is carried as `0`: the field
+    /// has explicit presence on the wire, so the receiver can tell the two apart,
+    /// and the initiator renders that case as `+0.00%` too. Negative values are
+    /// dropped rather than wrapped: `slippage_bps` is a `uint32`, and a negative
+    /// would land on the peer as a ~4-billion-bps impact.
+    static func nativeSwapPayloadSlippageBps(quote: ThorchainSwapQuote) -> UInt32? {
+        guard let bps = quote.fees.slippageBps else { return nil }
+        return UInt32(exactly: bps)
     }
 
     /// Sums exactly the two components the verify screens itemize, so a co-signer
@@ -397,13 +413,13 @@ extension SwapCryptoLogic {
                     swapResponse: swapResponse,
                     fallback: approvePayload
                 )
-                let payload = GenericSwapPayload(
+                let payload = buildSwapKitGenericPayload(
                     fromCoin: fromCoin,
                     toCoin: toCoin,
-                    fromAmount: amountInCoin,
+                    fromAmountInCoin: amountInCoin,
                     toAmountDecimal: toDecimal,
                     quote: evmQuote,
-                    provider: .swapkit
+                    swapResponse: swapResponse
                 )
                 return try await keysignFactory.buildTransfer(
                     coin: fromCoin,
@@ -720,6 +736,34 @@ extension SwapCryptoLogic {
                 vault: vault
             )
         }
+    }
+
+    /// Build the `GenericSwapPayload` for SwapKit's EVM and Solana routes, whose
+    /// wire shape matches `OneInchSwapPayload` 1:1 and so ride the shared
+    /// aggregator payload rather than `SwapPayload.swapkit`.
+    ///
+    /// Carries the route tag (`route.providers[0]`) that the non-EVM SwapKit
+    /// payload already carries. Without it a co-signer on an EVM route names the
+    /// aggregator alone while every other SwapKit route names the route it
+    /// actually took — the same swap described two ways depending on its source
+    /// chain.
+    static func buildSwapKitGenericPayload(
+        fromCoin: Coin,
+        toCoin: Coin,
+        fromAmountInCoin: BigInt,
+        toAmountDecimal: Decimal,
+        quote: EVMQuote,
+        swapResponse: SwapKitSwapResponse
+    ) -> GenericSwapPayload {
+        return GenericSwapPayload(
+            fromCoin: fromCoin,
+            toCoin: toCoin,
+            fromAmount: fromAmountInCoin,
+            toAmountDecimal: toAmountDecimal,
+            quote: quote,
+            provider: .swapkit,
+            subProvider: swapResponse.subProvider
+        )
     }
 
     /// Build a `SwapKitSwapPayload` for the BTC PSBT path: base64-decode the

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
@@ -208,6 +208,14 @@ extension SwapCryptoLogic {
     /// keysign payload so a co-signer shows the impact the initiator was quoted
     /// instead of re-deriving one from a pool that has since moved.
     ///
+    /// Read from the quote's TOP-LEVEL `slippage_bps`, which is the field
+    /// `SwapQuote.priceImpact` renders on this device's own verify screen —
+    /// deliberately not `fees.slippage_bps`, which the node reports separately
+    /// and which can differ (THORChain's own streaming example quotes 41 against
+    /// a nested 9). Carrying the other one would hand the co-signer a different
+    /// number from the one the initiator is looking at, which is the single
+    /// failure this field exists to prevent.
+    ///
     /// `nil` when the node reports none — the receiver hides the row rather than
     /// claiming a zero-impact route. A reported `0` is carried as `0`: the field
     /// has explicit presence on the wire, so the receiver can tell the two apart,
@@ -215,7 +223,7 @@ extension SwapCryptoLogic {
     /// dropped rather than wrapped: `slippage_bps` is a `uint32`, and a negative
     /// would land on the peer as a ~4-billion-bps impact.
     static func nativeSwapPayloadSlippageBps(quote: ThorchainSwapQuote) -> UInt32? {
-        guard let bps = quote.fees.slippageBps else { return nil }
+        guard let bps = quote.slippageBps else { return nil }
         return UInt32(exactly: bps)
     }
 

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
@@ -204,24 +204,17 @@ extension SwapCryptoLogic {
         )
     }
 
-    /// The quote's reported price impact, in basis points, to carry on the
-    /// keysign payload so a co-signer shows the impact the initiator was quoted
-    /// instead of re-deriving one from a pool that has since moved.
+    /// Price impact in basis points, carried so a co-signer shows what the
+    /// initiator was quoted rather than re-deriving it from a pool that has moved.
     ///
-    /// Read from the quote's TOP-LEVEL `slippage_bps`, which is the field
-    /// `SwapQuote.priceImpact` renders on this device's own verify screen —
-    /// deliberately not `fees.slippage_bps`, which the node reports separately
-    /// and which can differ (THORChain's own streaming example quotes 41 against
-    /// a nested 9). Carrying the other one would hand the co-signer a different
-    /// number from the one the initiator is looking at, which is the single
-    /// failure this field exists to prevent.
+    /// Reads the quote's TOP-LEVEL `slippage_bps` — the field
+    /// `SwapQuote.priceImpact` renders here — and deliberately NOT
+    /// `fees.slippage_bps`, which the node reports separately and which can
+    /// differ (THORChain's streaming example: 41 against a nested 9). Switching
+    /// them hands the co-signer a different number from the initiator's.
     ///
-    /// `nil` when the node reports none — the receiver hides the row rather than
-    /// claiming a zero-impact route. A reported `0` is carried as `0`: the field
-    /// has explicit presence on the wire, so the receiver can tell the two apart,
-    /// and the initiator renders that case as `+0.00%` too. Negative values are
-    /// dropped rather than wrapped: `slippage_bps` is a `uint32`, and a negative
-    /// would land on the peer as a ~4-billion-bps impact.
+    /// A reported `0` is carried as `0`; out-of-range is dropped rather than
+    /// wrapped, since `uint32` would land a negative as ~4 billion bps.
     static func nativeSwapPayloadSlippageBps(quote: ThorchainSwapQuote) -> UInt32? {
         guard let bps = quote.slippageBps else { return nil }
         return UInt32(exactly: bps)
@@ -746,15 +739,9 @@ extension SwapCryptoLogic {
         }
     }
 
-    /// Build the `GenericSwapPayload` for SwapKit's EVM and Solana routes, whose
-    /// wire shape matches `OneInchSwapPayload` 1:1 and so ride the shared
-    /// aggregator payload rather than `SwapPayload.swapkit`.
-    ///
-    /// Carries the route tag (`route.providers[0]`) that the non-EVM SwapKit
-    /// payload already carries. Without it a co-signer on an EVM route names the
-    /// aggregator alone while every other SwapKit route names the route it
-    /// actually took — the same swap described two ways depending on its source
-    /// chain.
+    /// SwapKit's EVM and Solana routes: their wire shape matches
+    /// `OneInchSwapPayload` 1:1, so they ride the shared aggregator payload and
+    /// carry the same route tag the non-EVM SwapKit payload does.
     static func buildSwapKitGenericPayload(
         fromCoin: Coin,
         toCoin: Coin,

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -806,10 +806,8 @@ enum SwapCryptoLogic {
         priceImpactString(impact: quote?.priceImpact)
     }
 
-    /// Price-impact label for a fractional impact (0.0125 == 1.25%), whatever its
-    /// source: the initiator passes its live quote's, the co-signer passes the
-    /// `slippage_bps` carried on the keysign payload. Both go through this one
-    /// formatter so the two verify screens cannot drift in wording, precision or
+    /// Shared by the initiator (live quote) and the co-signer (carried
+    /// `slippage_bps`) so the two verify screens cannot drift in wording or
     /// quality band. `.empty` for an unknown impact — callers hide the row.
     static func priceImpactString(impact: Decimal?) -> String {
         guard let impact else { return .empty }

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -803,7 +803,16 @@ enum SwapCryptoLogic {
     // MARK: - Price impact
 
     static func priceImpactString(quote: SwapQuote?) -> String {
-        guard let impact = quote?.priceImpact else { return .empty }
+        priceImpactString(impact: quote?.priceImpact)
+    }
+
+    /// Price-impact label for a fractional impact (0.0125 == 1.25%), whatever its
+    /// source: the initiator passes its live quote's, the co-signer passes the
+    /// `slippage_bps` carried on the keysign payload. Both go through this one
+    /// formatter so the two verify screens cannot drift in wording, precision or
+    /// quality band. `.empty` for an unknown impact — callers hide the row.
+    static func priceImpactString(impact: Decimal?) -> String {
+        guard let impact else { return .empty }
         // THORChain returns positive slippage bps; we negate for consistent display.
         let displayImpact = -impact
         let formatter = NumberFormatter()
@@ -826,7 +835,12 @@ enum SwapCryptoLogic {
     }
 
     static func priceImpactColor(quote: SwapQuote?) -> Color {
-        guard let impact = quote?.priceImpact else { return Theme.colors.textSecondary }
+        priceImpactColor(impact: quote?.priceImpact)
+    }
+
+    /// Colour bands for `priceImpactString(impact:)`, shared for the same reason.
+    static func priceImpactColor(impact: Decimal?) -> Color {
+        guard let impact else { return Theme.colors.textSecondary }
         let displayImpact = -impact
 
         if displayImpact > -0.01 {

--- a/VultisigApp/VultisigAppTests/Keysign/NativeSwapPriceImpactProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/NativeSwapPriceImpactProtoMappingTests.swift
@@ -140,6 +140,49 @@ final class NativeSwapPriceImpactProtoMappingTests: XCTestCase {
         )
     }
 
+    /// A router that IS present must still travel — the presence fix must not
+    /// turn into "never write the field".
+    func testAPresentRouterAddressStillTravels() throws {
+        var payload = makeNativePayload(slippageBps: nil)
+        payload = THORChainSwapPayload(
+            fromAddress: payload.fromAddress,
+            fromCoin: payload.fromCoin,
+            toCoin: payload.toCoin,
+            vaultAddress: payload.vaultAddress,
+            routerAddress: "0xrouter",
+            fromAmount: payload.fromAmount,
+            toAmountDecimal: payload.toAmountDecimal,
+            toAmountLimit: payload.toAmountLimit,
+            streamingInterval: payload.streamingInterval,
+            streamingQuantity: payload.streamingQuantity,
+            expirationTime: payload.expirationTime,
+            isAffiliate: payload.isAffiliate
+        )
+        guard case let .thorchainSwapPayload(proto) = SwapPayload.thorchain(payload).mapToProtobuff() else {
+            XCTFail("Expected .thorchainSwapPayload"); return
+        }
+        XCTAssertTrue(proto.hasRouterAddress)
+        XCTAssertEqual(proto.routerAddress, "0xrouter")
+
+        guard case let .thorchain(decoded) = try SwapPayload(proto: .thorchainSwapPayload(proto)) else {
+            XCTFail("Expected .thorchain"); return
+        }
+        XCTAssertEqual(decoded.routerAddress, "0xrouter")
+    }
+
+    /// The reason the legacy round-trip was two bytes long: `router_address` is
+    /// an `optional string`, so writing `""` for "no router" marks it present.
+    func testAnAbsentRouterAddressStaysOffTheWire() {
+        guard case let .thorchainSwapPayload(proto) =
+                SwapPayload.thorchain(makeNativePayload(slippageBps: nil)).mapToProtobuff() else {
+            XCTFail("Expected .thorchainSwapPayload"); return
+        }
+        XCTAssertFalse(
+            proto.hasRouterAddress,
+            "An absent router must not be written as a present empty string"
+        )
+    }
+
     // MARK: - What the builder puts on the wire
 
     func testBuilderCarriesTheQuotesSlippageBps() {

--- a/VultisigApp/VultisigAppTests/Keysign/NativeSwapPriceImpactProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/NativeSwapPriceImpactProtoMappingTests.swift
@@ -128,6 +128,12 @@ final class NativeSwapPriceImpactProtoMappingTests: XCTestCase {
             reEncoded.hasSlippageBps,
             "Relaying a legacy payload must not invent an impact its sender never stated"
         )
+        // Message equality first: it names the offending field on failure, where
+        // a raw byte comparison only reports that two blobs differ.
+        XCTAssertEqual(
+            reEncoded, try VSTHORChainSwapPayload(serializedBytes: originalBytes),
+            "Re-encoding must not add, drop or rewrite any field"
+        )
         XCTAssertEqual(
             try reEncoded.serializedData(), originalBytes,
             "A relayed legacy payload must re-serialize to the sender's exact bytes"

--- a/VultisigApp/VultisigAppTests/Keysign/NativeSwapPriceImpactProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/NativeSwapPriceImpactProtoMappingTests.swift
@@ -112,9 +112,14 @@ final class NativeSwapPriceImpactProtoMappingTests: XCTestCase {
         )
     }
 
-    func testReEncodingALegacyPayloadLeavesSlippageUnset() throws {
+    /// Byte-for-byte, not just "the field is unset". Mixed-version MPC committees
+    /// depend on a relayed legacy payload re-serializing to the identical bytes;
+    /// an assertion that only checks presence would survive a change that shifted
+    /// any other field on the wire.
+    func testReEncodingALegacyPayloadIsByteIdentical() throws {
+        let originalBytes = try makeLegacyProto().serializedData()
         let decoded = try SwapPayload(proto: .thorchainSwapPayload(
-            try VSTHORChainSwapPayload(serializedBytes: try makeLegacyProto().serializedData())
+            try VSTHORChainSwapPayload(serializedBytes: originalBytes)
         ))
         guard case let .thorchainSwapPayload(reEncoded) = decoded.mapToProtobuff() else {
             XCTFail("Expected .thorchainSwapPayload"); return
@@ -122,6 +127,10 @@ final class NativeSwapPriceImpactProtoMappingTests: XCTestCase {
         XCTAssertFalse(
             reEncoded.hasSlippageBps,
             "Relaying a legacy payload must not invent an impact its sender never stated"
+        )
+        XCTAssertEqual(
+            try reEncoded.serializedData(), originalBytes,
+            "A relayed legacy payload must re-serialize to the sender's exact bytes"
         )
     }
 
@@ -133,6 +142,39 @@ final class NativeSwapPriceImpactProtoMappingTests: XCTestCase {
             125
         )
         XCTAssertEqual(builtPayload(slippageBps: 125).slippageBps, 125)
+    }
+
+    /// The quote reports price impact in two places and they can differ. The one
+    /// that has to travel is the one THIS device renders (`SwapQuote.priceImpact`
+    /// reads the top-level field); carrying the nested `fees.slippage_bps` would
+    /// show the co-signer a different number from the initiator, which is the one
+    /// failure this field exists to prevent.
+    func testBuilderCarriesTheTopLevelSlippageNotTheNestedFeeSlippage() {
+        let quote = makeThorQuote(topLevel: 41, nested: 9)
+        XCTAssertEqual(SwapCryptoLogic.nativeSwapPayloadSlippageBps(quote: quote), 41)
+
+        let payload = SwapCryptoLogic.buildThorchainSwapPayload(
+            fromCoin: makeBTC(),
+            toCoin: makeTRX(),
+            fromAmountInCoin: BigInt(100_000),
+            toAmountDecimal: 3000,
+            quote: quote
+        )
+        XCTAssertEqual(payload.slippageBps, 41)
+        XCTAssertEqual(
+            SwapPayload.thorchain(payload).priceImpact,
+            SwapQuote.thorchain(quote).priceImpact,
+            "Co-signer and initiator must read the same source"
+        )
+    }
+
+    /// Presence follows the top-level field alone: a nested value with no
+    /// top-level one is not a substitute.
+    func testNestedFeeSlippageAloneCarriesNothing() {
+        XCTAssertNil(
+            SwapCryptoLogic.nativeSwapPayloadSlippageBps(quote: makeThorQuote(topLevel: nil, nested: 9))
+        )
+        XCTAssertNil(SwapQuote.thorchain(makeThorQuote(topLevel: nil, nested: 9)).priceImpact)
     }
 
     func testBuilderCarriesAQuotedZero() {
@@ -213,17 +255,27 @@ final class NativeSwapPriceImpactProtoMappingTests: XCTestCase {
 
     // MARK: - Signing is untouched
 
-    /// These fields are display-only. The memo is the signed statement of the
-    /// swap for a native route, and it must not move when the impact does.
-    func testCarriedImpactDoesNotChangeTheSignedMemo() {
-        let withImpact = builtPayload(slippageBps: 305)
-        let withoutImpact = builtPayload(slippageBps: nil)
+    /// Display-only, asserted on the bytes rather than on a handful of fields.
+    /// Clearing `slippage_bps` from a payload that carries it must reproduce the
+    /// serialized bytes of a payload that never had it: that proves the field is
+    /// purely additive and that nothing else on the wire — the memo terms, the
+    /// vault address, the amounts a signer consumes — moved with it. A
+    /// field-by-field comparison would pass even if an unlisted field had.
+    func testCarriedImpactIsPurelyAdditiveOnTheWire() throws {
+        guard case var .thorchainSwapPayload(withImpact) =
+                SwapPayload.thorchain(builtPayload(slippageBps: 305)).mapToProtobuff(),
+              case let .thorchainSwapPayload(withoutImpact) =
+                SwapPayload.thorchain(builtPayload(slippageBps: nil)).mapToProtobuff() else {
+            XCTFail("Expected .thorchainSwapPayload"); return
+        }
+        XCTAssertTrue(withImpact.hasSlippageBps, "…or this asserts nothing")
+        XCTAssertNotEqual(try withImpact.serializedData(), try withoutImpact.serializedData())
 
-        XCTAssertEqual(withImpact.toAmountLimit, withoutImpact.toAmountLimit)
-        XCTAssertEqual(withImpact.streamingInterval, withoutImpact.streamingInterval)
-        XCTAssertEqual(withImpact.streamingQuantity, withoutImpact.streamingQuantity)
-        XCTAssertEqual(withImpact.vaultAddress, withoutImpact.vaultAddress)
-        XCTAssertEqual(withImpact.fromAmount, withoutImpact.fromAmount)
+        withImpact.clearSlippageBps()
+        XCTAssertEqual(
+            try withImpact.serializedData(), try withoutImpact.serializedData(),
+            "The impact must be the ONLY difference these bytes carry"
+        )
     }
 
     // MARK: - Fixtures
@@ -341,7 +393,15 @@ final class NativeSwapPriceImpactProtoMappingTests: XCTestCase {
         )
     }
 
+    /// Every fixture deliberately gives the quote's two price-impact sources
+    /// DIFFERENT values. A fixture that set `slippage_bps` and
+    /// `fees.slippage_bps` to the same number passes whichever one the builder
+    /// happens to read — which is exactly how the wrong one shipped once.
     private func makeThorQuote(slippageBps: Int?) -> ThorchainSwapQuote {
+        makeThorQuote(topLevel: slippageBps, nested: slippageBps.map { $0 + 7 })
+    }
+
+    private func makeThorQuote(topLevel: Int?, nested: Int?) -> ThorchainSwapQuote {
         ThorchainSwapQuote(
             dustThreshold: nil,
             expectedAmountOut: "300000000000",
@@ -352,7 +412,7 @@ final class NativeSwapPriceImpactProtoMappingTests: XCTestCase {
                 outbound: "0",
                 total: "0",
                 liquidity: nil,
-                slippageBps: slippageBps,
+                slippageBps: nested,
                 totalBps: nil
             ),
             inboundAddress: "bc1qasgard",
@@ -363,7 +423,7 @@ final class NativeSwapPriceImpactProtoMappingTests: XCTestCase {
             outboundDelayBlocks: 0,
             outboundDelaySeconds: 0,
             recommendedMinAmountIn: "0",
-            slippageBps: slippageBps,
+            slippageBps: topLevel,
             totalSwapSeconds: nil,
             warning: "",
             router: nil,

--- a/VultisigApp/VultisigAppTests/Keysign/NativeSwapPriceImpactProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/NativeSwapPriceImpactProtoMappingTests.swift
@@ -1,0 +1,397 @@
+//
+//  NativeSwapPriceImpactProtoMappingTests.swift
+//  VultisigAppTests
+//
+//  Coverage for the native (THORChain / MayaChain) price impact carried on
+//  `THORChainSwapPayload.slippageBps`. A co-signer holds no quote, and a quote
+//  it fetched for itself would price a pool that has moved since the initiator
+//  was quoted — which would make price impact the one term on the two verify
+//  screens where two honest devices disagree. So it travels on the payload, and
+//  these tests pin what goes on the wire, what an absent field means, and that
+//  the string the joiner renders is the string the initiator renders.
+//
+
+import BigInt
+import SwiftData
+import XCTest
+import VultisigCommonData
+@testable import VultisigApp
+
+@MainActor
+final class NativeSwapPriceImpactProtoMappingTests: XCTestCase {
+
+    private var token: TestContextToken!
+
+    override func setUpWithError() throws {
+        token = try TestStore.installInMemoryContainer()
+    }
+
+    override func tearDown() {
+        TestStore.restore(token)
+        token = nil
+    }
+
+    // MARK: - Proto round-trip
+
+    func testThorchainProtoRoundTripCarriesSlippageBps() throws {
+        let proto = SwapPayload.thorchain(makeNativePayload(slippageBps: 125)).mapToProtobuff()
+        guard case let .thorchainSwapPayload(value) = proto else {
+            XCTFail("Expected .thorchainSwapPayload"); return
+        }
+        XCTAssertTrue(value.hasSlippageBps)
+        XCTAssertEqual(value.slippageBps, 125)
+
+        guard case let .thorchain(decoded) = try SwapPayload(proto: proto) else {
+            XCTFail("Expected .thorchain"); return
+        }
+        XCTAssertEqual(decoded.slippageBps, 125)
+    }
+
+    func testMayachainProtoRoundTripCarriesSlippageBps() throws {
+        let proto = SwapPayload.mayachain(makeNativePayload(slippageBps: 87)).mapToProtobuff()
+        guard case let .mayachainSwapPayload(value) = proto else {
+            XCTFail("Expected .mayachainSwapPayload"); return
+        }
+        XCTAssertTrue(value.hasSlippageBps)
+        XCTAssertEqual(value.slippageBps, 87)
+
+        guard case let .mayachain(decoded) = try SwapPayload(proto: proto) else {
+            XCTFail("Expected .mayachain"); return
+        }
+        XCTAssertEqual(decoded.slippageBps, 87)
+    }
+
+    func testNilSlippageStaysOffTheWire() throws {
+        let proto = SwapPayload.thorchain(makeNativePayload(slippageBps: nil)).mapToProtobuff()
+        guard case let .thorchainSwapPayload(value) = proto else {
+            XCTFail("Expected .thorchainSwapPayload"); return
+        }
+        XCTAssertFalse(
+            value.hasSlippageBps,
+            "An unknown impact must stay absent; a written 0 would claim a zero-impact route"
+        )
+
+        guard case let .thorchain(decoded) = try SwapPayload(proto: proto) else {
+            XCTFail("Expected .thorchain"); return
+        }
+        XCTAssertNil(decoded.slippageBps)
+    }
+
+    /// The whole reason the field is `optional`: unlike the swap fee, a carried
+    /// `0` is a real statement — the node quoted a zero-impact route — and it has
+    /// to survive the wire as such rather than collapse into "unknown".
+    func testZeroSlippageSurvivesTheWireAsAPresentZero() throws {
+        let bytes = try protoBytes(for: makeNativePayload(slippageBps: 0))
+        let reparsed = try VSTHORChainSwapPayload(serializedBytes: bytes)
+        XCTAssertTrue(reparsed.hasSlippageBps, "A quoted zero is a claim, not an absence")
+
+        let decoded = try SwapPayload(proto: .thorchainSwapPayload(reparsed))
+        guard case let .thorchain(payload) = decoded else {
+            XCTFail("Expected .thorchain"); return
+        }
+        XCTAssertEqual(payload.slippageBps, 0)
+        XCTAssertEqual(decoded.priceImpact, 0)
+        XCTAssertFalse(
+            SwapCryptoLogic.priceImpactString(impact: decoded.priceImpact).isEmpty,
+            "A zero-impact route renders a row; only an absent field hides one"
+        )
+    }
+
+    func testLegacyWireBytesDecodeToNoImpactAndNoRow() throws {
+        let reparsed = try VSTHORChainSwapPayload(serializedBytes: try makeLegacyProto().serializedData())
+        let decoded = try SwapPayload(proto: .thorchainSwapPayload(reparsed))
+
+        guard case let .thorchain(payload) = decoded else {
+            XCTFail("Expected .thorchain"); return
+        }
+        XCTAssertNil(payload.slippageBps)
+        XCTAssertNil(decoded.priceImpact)
+        XCTAssertEqual(
+            SwapCryptoLogic.priceImpactString(impact: decoded.priceImpact), .empty,
+            "A sender predating the field says nothing about impact; hide the row"
+        )
+    }
+
+    func testReEncodingALegacyPayloadLeavesSlippageUnset() throws {
+        let decoded = try SwapPayload(proto: .thorchainSwapPayload(
+            try VSTHORChainSwapPayload(serializedBytes: try makeLegacyProto().serializedData())
+        ))
+        guard case let .thorchainSwapPayload(reEncoded) = decoded.mapToProtobuff() else {
+            XCTFail("Expected .thorchainSwapPayload"); return
+        }
+        XCTAssertFalse(
+            reEncoded.hasSlippageBps,
+            "Relaying a legacy payload must not invent an impact its sender never stated"
+        )
+    }
+
+    // MARK: - What the builder puts on the wire
+
+    func testBuilderCarriesTheQuotesSlippageBps() {
+        XCTAssertEqual(
+            SwapCryptoLogic.nativeSwapPayloadSlippageBps(quote: makeThorQuote(slippageBps: 125)),
+            125
+        )
+        XCTAssertEqual(builtPayload(slippageBps: 125).slippageBps, 125)
+    }
+
+    func testBuilderCarriesAQuotedZero() {
+        XCTAssertEqual(SwapCryptoLogic.nativeSwapPayloadSlippageBps(quote: makeThorQuote(slippageBps: 0)), 0)
+        XCTAssertEqual(builtPayload(slippageBps: 0).slippageBps, 0)
+    }
+
+    func testBuilderDropsAnAbsentSlippageBps() {
+        XCTAssertNil(SwapCryptoLogic.nativeSwapPayloadSlippageBps(quote: makeThorQuote(slippageBps: nil)))
+        XCTAssertNil(builtPayload(slippageBps: nil).slippageBps)
+    }
+
+    /// `slippage_bps` is a `uint32`. A negative would wrap into a ~4-billion-bps
+    /// impact on the peer, which is worse than showing no row at all.
+    func testBuilderDropsAnOutOfRangeSlippageBps() {
+        for bps in [-1, -50, Int(UInt32.max) + 1] {
+            XCTAssertNil(
+                SwapCryptoLogic.nativeSwapPayloadSlippageBps(quote: makeThorQuote(slippageBps: bps)),
+                "\(bps) does not fit a uint32 and must not be wrapped onto the wire"
+            )
+        }
+    }
+
+    // MARK: - What the co-signer renders
+
+    /// The point of the change: the joiner's Price Impact row is the initiator's,
+    /// arrived at from the serialized payload alone.
+    func testCoSignerPriceImpactMatchesTheInitiatorsForTheSameQuote() throws {
+        for bps in [0, 1, 99, 125, 305, 4_000] {
+            let quote = makeThorQuote(slippageBps: bps)
+            let initiatorQuote = SwapQuote.thorchain(quote)
+            let payload = builtPayload(slippageBps: bps)
+            // Through the wire, not just the in-memory struct — the device that
+            // renders this row only ever sees the serialized bytes.
+            let decoded = try SwapPayload(proto: .thorchainSwapPayload(
+                try VSTHORChainSwapPayload(serializedBytes: try protoBytes(for: payload))
+            ))
+
+            let viewModel = JoinKeysignViewModel()
+            viewModel.keysignPayload = makeKeysignPayload(swapPayload: decoded)
+
+            XCTAssertEqual(
+                viewModel.priceImpactString,
+                SwapCryptoLogic.priceImpactString(quote: initiatorQuote),
+                "Joiner and initiator must word \(bps) bps identically"
+            )
+            XCTAssertEqual(
+                viewModel.priceImpactColor,
+                SwapCryptoLogic.priceImpactColor(quote: initiatorQuote),
+                "…and land in the same quality band"
+            )
+        }
+    }
+
+    func testCoSignerHidesTheRowForALegacySender() throws {
+        let decoded = try SwapPayload(proto: .thorchainSwapPayload(
+            try VSTHORChainSwapPayload(serializedBytes: try makeLegacyProto().serializedData())
+        ))
+        let viewModel = JoinKeysignViewModel()
+        viewModel.keysignPayload = makeKeysignPayload(swapPayload: decoded)
+
+        XCTAssertEqual(viewModel.priceImpactString, .empty)
+    }
+
+    func testChainnetAndStagenetVariantsSurfaceTheSameImpact() {
+        let payload = makeNativePayload(slippageBps: 125)
+        XCTAssertEqual(SwapPayload.thorchainChainnet(payload).priceImpact, Decimal(string: "0.0125"))
+        XCTAssertEqual(SwapPayload.thorchainStagenet(payload).priceImpact, Decimal(string: "0.0125"))
+        XCTAssertEqual(SwapPayload.mayachain(payload).priceImpact, Decimal(string: "0.0125"))
+    }
+
+    /// Aggregator routes put no impact on the keysign wire. Reporting one would
+    /// mean re-deriving it here, which is exactly what this change refuses to do.
+    func testAggregatorPayloadsCarryNoPriceImpact() {
+        XCTAssertNil(SwapPayload.generic(makeGenericPayload()).priceImpact)
+        XCTAssertNil(SwapPayload.swapkit(makeSwapKitPayload()).priceImpact)
+    }
+
+    // MARK: - Signing is untouched
+
+    /// These fields are display-only. The memo is the signed statement of the
+    /// swap for a native route, and it must not move when the impact does.
+    func testCarriedImpactDoesNotChangeTheSignedMemo() {
+        let withImpact = builtPayload(slippageBps: 305)
+        let withoutImpact = builtPayload(slippageBps: nil)
+
+        XCTAssertEqual(withImpact.toAmountLimit, withoutImpact.toAmountLimit)
+        XCTAssertEqual(withImpact.streamingInterval, withoutImpact.streamingInterval)
+        XCTAssertEqual(withImpact.streamingQuantity, withoutImpact.streamingQuantity)
+        XCTAssertEqual(withImpact.vaultAddress, withoutImpact.vaultAddress)
+        XCTAssertEqual(withImpact.fromAmount, withoutImpact.fromAmount)
+    }
+
+    // MARK: - Fixtures
+
+    private enum FixtureError: Error { case unexpectedProtoCase }
+
+    private func protoBytes(for payload: THORChainSwapPayload) throws -> Data {
+        guard case let .thorchainSwapPayload(value) = SwapPayload.thorchain(payload).mapToProtobuff() else {
+            throw FixtureError.unexpectedProtoCase
+        }
+        return try value.serializedData()
+    }
+
+    private func builtPayload(slippageBps: Int?) -> THORChainSwapPayload {
+        SwapCryptoLogic.buildThorchainSwapPayload(
+            fromCoin: makeBTC(),
+            toCoin: makeTRX(),
+            fromAmountInCoin: BigInt(100_000),
+            toAmountDecimal: 3000,
+            quote: makeThorQuote(slippageBps: slippageBps)
+        )
+    }
+
+    private func makeNativePayload(slippageBps: UInt32?) -> THORChainSwapPayload {
+        THORChainSwapPayload(
+            fromAddress: "bc1qsender",
+            fromCoin: makeBTC(),
+            toCoin: makeTRX(),
+            vaultAddress: "bc1qasgard",
+            routerAddress: nil,
+            fromAmount: BigInt(100_000),
+            toAmountDecimal: 3000,
+            toAmountLimit: "0",
+            streamingInterval: "1",
+            streamingQuantity: "0",
+            expirationTime: 1_757_000_000,
+            isAffiliate: true,
+            fee: nil,
+            slippageBps: slippageBps
+        )
+    }
+
+    /// Fields 1-12 only — the shape a sender that predates both field 13 and
+    /// field 14 puts on the wire.
+    private func makeLegacyProto() -> VSTHORChainSwapPayload {
+        var legacy = VSTHORChainSwapPayload()
+        legacy.fromAddress = "bc1qsender"
+        legacy.fromCoin = ProtoCoinResolver.proto(from: makeBTC())
+        legacy.toCoin = ProtoCoinResolver.proto(from: makeTRX())
+        legacy.vaultAddress = "bc1qasgard"
+        legacy.fromAmount = "100000"
+        legacy.toAmountDecimal = "3000"
+        legacy.toAmountLimit = "0"
+        legacy.streamingInterval = "1"
+        legacy.streamingQuantity = "0"
+        legacy.expirationTime = 1_757_000_000
+        legacy.isAffiliate = true
+        return legacy
+    }
+
+    private func makeGenericPayload() -> GenericSwapPayload {
+        GenericSwapPayload(
+            fromCoin: makeBTC(),
+            toCoin: makeTRX(),
+            fromAmount: BigInt(100_000),
+            toAmountDecimal: 3000,
+            quote: EVMQuote(
+                dstAmount: "3000",
+                tx: EVMQuote.Transaction(
+                    from: "0xfrom", to: "0xto", data: "0x", value: "0",
+                    gasPrice: "0", gas: 0, swapFee: "0", swapFeeTokenContract: ""
+                )
+            ),
+            provider: .oneInch
+        )
+    }
+
+    private func makeSwapKitPayload() -> SwapKitSwapPayload {
+        SwapKitSwapPayload(
+            fromCoin: makeBTC(),
+            toCoin: makeTRX(),
+            fromAmount: BigInt(100_000),
+            toAmountDecimal: 3000,
+            txType: "PSBT",
+            txPayload: Data(),
+            targetAddress: "bc1qtarget",
+            inboundAddress: nil,
+            memo: nil,
+            subProvider: "NEAR",
+            swapID: "swap-1"
+        )
+    }
+
+    private func makeKeysignPayload(swapPayload: SwapPayload) -> KeysignPayload {
+        KeysignPayload(
+            coin: makeBTC(),
+            toAddress: "bc1qasgard",
+            toAmount: BigInt(100_000),
+            chainSpecific: .UTXO(byteFee: BigInt(10), sendMaxAmount: false),
+            utxos: [],
+            memo: "=:TRX.TRX:addr",
+            swapPayload: swapPayload,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "",
+            vaultLocalPartyID: "",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: nil
+        )
+    }
+
+    private func makeThorQuote(slippageBps: Int?) -> ThorchainSwapQuote {
+        ThorchainSwapQuote(
+            dustThreshold: nil,
+            expectedAmountOut: "300000000000",
+            expiry: 1_757_000_000,
+            fees: Fees(
+                affiliate: "0",
+                asset: "TRX.TRX",
+                outbound: "0",
+                total: "0",
+                liquidity: nil,
+                slippageBps: slippageBps,
+                totalBps: nil
+            ),
+            inboundAddress: "bc1qasgard",
+            inboundConfirmationBlocks: nil,
+            inboundConfirmationSeconds: nil,
+            memo: "=:TRX.TRX:addr:0/1/0",
+            notes: "",
+            outboundDelayBlocks: 0,
+            outboundDelaySeconds: 0,
+            recommendedMinAmountIn: "0",
+            slippageBps: slippageBps,
+            totalSwapSeconds: nil,
+            warning: "",
+            router: nil,
+            maxStreamingQuantity: nil
+        )
+    }
+
+    private func makeBTC() -> Coin {
+        makeCoin(.bitcoin, ticker: "BTC", decimals: 8)
+    }
+
+    private func makeTRX() -> Coin {
+        makeCoin(.tron, ticker: "TRX", decimals: 6)
+    }
+
+    /// `RateProvider` is a process-wide singleton keyed by `priceProviderId`, so
+    /// fixtures scope theirs to this class rather than sharing a generic id with
+    /// other test classes.
+    private func makeCoin(_ chain: Chain, ticker: String, decimals: Int) -> Coin {
+        let asset = CoinMeta(
+            chain: chain,
+            ticker: ticker,
+            logo: "logo",
+            decimals: decimals,
+            priceProviderId: "price-impact-5341-\(ticker.lowercased())",
+            contractAddress: "",
+            isNativeToken: true
+        )
+        return Coin(asset: asset, address: "price-impact-\(ticker)", hexPublicKey: "")
+    }
+}

--- a/VultisigApp/VultisigAppTests/Keysign/NativeSwapPriceImpactProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/NativeSwapPriceImpactProtoMappingTests.swift
@@ -2,13 +2,9 @@
 //  NativeSwapPriceImpactProtoMappingTests.swift
 //  VultisigAppTests
 //
-//  Coverage for the native (THORChain / MayaChain) price impact carried on
-//  `THORChainSwapPayload.slippageBps`. A co-signer holds no quote, and a quote
-//  it fetched for itself would price a pool that has moved since the initiator
-//  was quoted — which would make price impact the one term on the two verify
-//  screens where two honest devices disagree. So it travels on the payload, and
-//  these tests pin what goes on the wire, what an absent field means, and that
-//  the string the joiner renders is the string the initiator renders.
+//  Coverage for the native price impact carried on
+//  `THORChainSwapPayload.slippageBps`: what goes on the wire, what an absent
+//  field means, and that the joiner renders the initiator's string.
 //
 
 import BigInt
@@ -77,9 +73,8 @@ final class NativeSwapPriceImpactProtoMappingTests: XCTestCase {
         XCTAssertNil(decoded.slippageBps)
     }
 
-    /// The whole reason the field is `optional`: unlike the swap fee, a carried
-    /// `0` is a real statement — the node quoted a zero-impact route — and it has
-    /// to survive the wire as such rather than collapse into "unknown".
+    /// A carried `0` is a real statement — a zero-impact route — and must survive
+    /// the wire as such rather than collapse into "unknown".
     func testZeroSlippageSurvivesTheWireAsAPresentZero() throws {
         let bytes = try protoBytes(for: makeNativePayload(slippageBps: 0))
         let reparsed = try VSTHORChainSwapPayload(serializedBytes: bytes)
@@ -112,10 +107,8 @@ final class NativeSwapPriceImpactProtoMappingTests: XCTestCase {
         )
     }
 
-    /// Byte-for-byte, not just "the field is unset". Mixed-version MPC committees
-    /// depend on a relayed legacy payload re-serializing to the identical bytes;
-    /// an assertion that only checks presence would survive a change that shifted
-    /// any other field on the wire.
+    /// Byte-for-byte, not just "the field is unset": a presence-only assertion
+    /// would survive any other field shifting on the wire.
     func testReEncodingALegacyPayloadIsByteIdentical() throws {
         let originalBytes = try makeLegacyProto().serializedData()
         let decoded = try SwapPayload(proto: .thorchainSwapPayload(
@@ -128,8 +121,6 @@ final class NativeSwapPriceImpactProtoMappingTests: XCTestCase {
             reEncoded.hasSlippageBps,
             "Relaying a legacy payload must not invent an impact its sender never stated"
         )
-        // Message equality first: it names the offending field on failure, where
-        // a raw byte comparison only reports that two blobs differ.
         XCTAssertEqual(
             reEncoded, try VSTHORChainSwapPayload(serializedBytes: originalBytes),
             "Re-encoding must not add, drop or rewrite any field"
@@ -170,8 +161,8 @@ final class NativeSwapPriceImpactProtoMappingTests: XCTestCase {
         XCTAssertEqual(decoded.routerAddress, "0xrouter")
     }
 
-    /// The reason the legacy round-trip was two bytes long: `router_address` is
-    /// an `optional string`, so writing `""` for "no router" marks it present.
+    /// `router_address` is an `optional string`, so writing `""` for "no router"
+    /// marks it present rather than eliding it.
     func testAnAbsentRouterAddressStaysOffTheWire() {
         guard case let .thorchainSwapPayload(proto) =
                 SwapPayload.thorchain(makeNativePayload(slippageBps: nil)).mapToProtobuff() else {
@@ -193,11 +184,8 @@ final class NativeSwapPriceImpactProtoMappingTests: XCTestCase {
         XCTAssertEqual(builtPayload(slippageBps: 125).slippageBps, 125)
     }
 
-    /// The quote reports price impact in two places and they can differ. The one
-    /// that has to travel is the one THIS device renders (`SwapQuote.priceImpact`
-    /// reads the top-level field); carrying the nested `fees.slippage_bps` would
-    /// show the co-signer a different number from the initiator, which is the one
-    /// failure this field exists to prevent.
+    /// The quote reports impact in two places and they can differ; the one that
+    /// travels must be the one this device renders.
     func testBuilderCarriesTheTopLevelSlippageNotTheNestedFeeSlippage() {
         let quote = makeThorQuote(topLevel: 41, nested: 9)
         XCTAssertEqual(SwapCryptoLogic.nativeSwapPayloadSlippageBps(quote: quote), 41)
@@ -304,12 +292,9 @@ final class NativeSwapPriceImpactProtoMappingTests: XCTestCase {
 
     // MARK: - Signing is untouched
 
-    /// Display-only, asserted on the bytes rather than on a handful of fields.
-    /// Clearing `slippage_bps` from a payload that carries it must reproduce the
-    /// serialized bytes of a payload that never had it: that proves the field is
-    /// purely additive and that nothing else on the wire — the memo terms, the
-    /// vault address, the amounts a signer consumes — moved with it. A
-    /// field-by-field comparison would pass even if an unlisted field had.
+    /// Clearing `slippage_bps` must reproduce the bytes of a payload that never
+    /// had it, proving nothing else on the wire moved with it. A field-by-field
+    /// comparison would pass even if an unlisted field had.
     func testCarriedImpactIsPurelyAdditiveOnTheWire() throws {
         guard case var .thorchainSwapPayload(withImpact) =
                 SwapPayload.thorchain(builtPayload(slippageBps: 305)).mapToProtobuff(),
@@ -367,8 +352,7 @@ final class NativeSwapPriceImpactProtoMappingTests: XCTestCase {
         )
     }
 
-    /// Fields 1-12 only — the shape a sender that predates both field 13 and
-    /// field 14 puts on the wire.
+    /// Fields 1-12 only — the shape a sender predating fields 13 and 14 sends.
     private func makeLegacyProto() -> VSTHORChainSwapPayload {
         var legacy = VSTHORChainSwapPayload()
         legacy.fromAddress = "bc1qsender"
@@ -442,10 +426,8 @@ final class NativeSwapPriceImpactProtoMappingTests: XCTestCase {
         )
     }
 
-    /// Every fixture deliberately gives the quote's two price-impact sources
-    /// DIFFERENT values. A fixture that set `slippage_bps` and
-    /// `fees.slippage_bps` to the same number passes whichever one the builder
-    /// happens to read — which is exactly how the wrong one shipped once.
+    /// The two price-impact sources are deliberately given DIFFERENT values: a
+    /// fixture that set both the same passes whichever one the builder reads.
     private func makeThorQuote(slippageBps: Int?) -> ThorchainSwapQuote {
         makeThorQuote(topLevel: slippageBps, nested: slippageBps.map { $0 + 7 })
     }
@@ -489,8 +471,7 @@ final class NativeSwapPriceImpactProtoMappingTests: XCTestCase {
     }
 
     /// `RateProvider` is a process-wide singleton keyed by `priceProviderId`, so
-    /// fixtures scope theirs to this class rather than sharing a generic id with
-    /// other test classes.
+    /// fixtures scope theirs to this class.
     private func makeCoin(_ chain: Chain, ticker: String, decimals: Int) -> Coin {
         let asset = CoinMeta(
             chain: chain,

--- a/VultisigApp/VultisigAppTests/Keysign/SwapKitSwapFeeProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/SwapKitSwapFeeProtoMappingTests.swift
@@ -78,7 +78,11 @@ final class SwapKitSwapFeeProtoMappingTests: XCTestCase {
         XCTAssertFalse(value.hasSwapFeeDecimals)
     }
 
-    func testZeroFeeStaysOffTheWire() {
+    /// `swap_fee` is optional on this payload, so `nil` is "absent" and `"0"` is
+    /// a sender stating the route charges nothing. `"0"` is a non-empty string
+    /// and does serialize, so the claim survives the wire and must not be
+    /// collapsed into absence on the way out.
+    func testAStatedZeroFeeTravelsAndKeepsItsCoinContext() throws {
         let payload = makeSwapKitPayload(
             swapFee: "0",
             swapFeeChain: Chain.bitcoinCash.name,
@@ -88,11 +92,40 @@ final class SwapKitSwapFeeProtoMappingTests: XCTestCase {
         guard case let .swapkitSwapPayload(value) = SwapPayload.swapkit(payload).mapToProtobuff() else {
             XCTFail("Expected .swapkitSwapPayload"); return
         }
-        XCTAssertTrue(
-            value.swapFee.isEmpty,
-            "A zero is indistinguishable from unknown here; never claim it"
+        XCTAssertEqual(value.swapFee, "0")
+        XCTAssertTrue(value.hasSwapFeeChain, "A zero still needs its coin to render as $0.00")
+        XCTAssertTrue(value.hasSwapFeeDecimals)
+
+        guard case let .swapkit(decoded) = try SwapPayload(proto: .swapkitSwapPayload(value)) else {
+            XCTFail("Expected .swapkit"); return
+        }
+        XCTAssertEqual(decoded.swapFee, "0")
+    }
+
+    /// A stated zero renders a `$0.00` row, matching an initiator that itemizes
+    /// one; only a genuinely absent fee hides it.
+    func testResolverRendersAStatedZero() {
+        let resolved = JoinKeysignSwapFeeViewModel().resolveSwapFee(
+            swapPayload: .swapkit(makeSwapKitPayload(
+                swapFee: "0",
+                swapFeeChain: Chain.bitcoinCash.name,
+                swapFeeTokenId: nil,
+                swapFeeDecimals: 8
+            )),
+            vault: nil
         )
-        XCTAssertFalse(value.hasSwapFeeChain)
+        XCTAssertEqual(resolved?.amount, 0)
+        XCTAssertEqual(resolved?.coin.ticker, "BCH")
+    }
+
+    /// The generic path keeps hiding a zero: `EVMQuote.Transaction.swapFee`
+    /// defaults to "0" when a quote omits the key, so a zero there cannot be
+    /// told from "never quoted".
+    func testGenericPathStillHidesAZero() {
+        XCTAssertNil(JoinKeysignSwapFeeViewModel().resolveSwapFee(
+            swapPayload: .generic(makeGenericPayload(swapFee: "0")),
+            vault: nil
+        ))
     }
 
     func testLegacyWireBytesDecodeToNoFeeAndNoRow() throws {
@@ -253,14 +286,14 @@ final class SwapKitSwapFeeProtoMappingTests: XCTestCase {
         ))
     }
 
-    func testResolverYieldsNoRowForZeroOrAbsentFee() {
+    func testResolverYieldsNoRowForAnAbsentFee() {
         let model = JoinKeysignSwapFeeViewModel()
-        for fee in [nil, "", "0"] as [String?] {
+        for fee in [nil, ""] as [String?] {
             XCTAssertNil(
                 model.resolveSwapFee(swapPayload: .swapkit(makeSwapKitPayload(
                     swapFee: fee, swapFeeChain: Chain.bitcoinCash.name, swapFeeTokenId: nil, swapFeeDecimals: 8
                 )), vault: nil),
-                "fee=\(String(describing: fee)) must render no row"
+                "fee=\(String(describing: fee)) is unknown, not zero"
             )
         }
     }
@@ -314,6 +347,27 @@ final class SwapKitSwapFeeProtoMappingTests: XCTestCase {
     // MARK: - Fixtures
 
     private let usdcContract = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+
+    private func makeGenericPayload(swapFee: String) -> GenericSwapPayload {
+        GenericSwapPayload(
+            fromCoin: makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true),
+            toCoin: makeUSDC(),
+            fromAmount: BigInt("1000000000000000000"),
+            toAmountDecimal: 3000,
+            quote: EVMQuote(
+                dstAmount: "3000000000",
+                tx: EVMQuote.Transaction(
+                    from: "0xFrom", to: "0xRouter", data: "0x", value: "0",
+                    gasPrice: "1", gas: 100_000,
+                    swapFee: swapFee, swapFeeTokenContract: usdcContract
+                )
+            ),
+            provider: .oneInch,
+            swapFeeChain: "Ethereum",
+            swapFeeTokenId: usdcContract,
+            swapFeeDecimals: 6
+        )
+    }
 
     private func makeSwapKitPayload(
         swapFee: String?,

--- a/VultisigApp/VultisigAppTests/Keysign/SwapKitSwapFeeProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/SwapKitSwapFeeProtoMappingTests.swift
@@ -1,0 +1,339 @@
+//
+//  SwapKitSwapFeeProtoMappingTests.swift
+//  VultisigAppTests
+//
+//  Coverage for the provider fee on `SwapKitSwapPayload` (swap_fee plus the
+//  chain / token id / decimals that say what coin it is denominated in). A
+//  co-signer holds no quote, so a fee that does not travel on the payload is a
+//  fee it can neither recover nor show — its confirm screen would total the
+//  network fee alone. These pin the wire shape, the never-guess resolution, and
+//  that an absent field keeps reading as "unknown" rather than zero.
+//
+
+import BigInt
+import XCTest
+import VultisigCommonData
+@testable import VultisigApp
+
+@MainActor
+final class SwapKitSwapFeeProtoMappingTests: XCTestCase {
+
+    // MARK: - Proto round-trip
+
+    func testProtoRoundTripCarriesFeeAndCoinContext() throws {
+        let payload = makeSwapKitPayload(
+            swapFee: "250000",
+            swapFeeChain: Chain.bitcoinCash.name,
+            swapFeeTokenId: nil,
+            swapFeeDecimals: 8
+        )
+        let proto = SwapPayload.swapkit(payload).mapToProtobuff()
+        guard case let .swapkitSwapPayload(value) = proto else {
+            XCTFail("Expected .swapkitSwapPayload"); return
+        }
+        XCTAssertEqual(value.swapFee, "250000")
+        XCTAssertTrue(value.hasSwapFeeChain)
+        XCTAssertEqual(value.swapFeeChain, Chain.bitcoinCash.name)
+        XCTAssertFalse(value.hasSwapFeeTokenID, "A native fee names no token")
+        XCTAssertTrue(value.hasSwapFeeDecimals)
+        XCTAssertEqual(value.swapFeeDecimals, 8)
+
+        guard case let .swapkit(decoded) = try SwapPayload(proto: proto) else {
+            XCTFail("Expected .swapkit"); return
+        }
+        XCTAssertEqual(decoded.swapFee, "250000")
+        XCTAssertEqual(decoded.swapFeeChain, Chain.bitcoinCash.name)
+        XCTAssertNil(decoded.swapFeeTokenId)
+        XCTAssertEqual(decoded.swapFeeDecimals, 8)
+    }
+
+    func testProtoRoundTripCarriesATokenDenominatedFee() throws {
+        let payload = makeSwapKitPayload(
+            swapFee: "150000",
+            swapFeeChain: "Ethereum",
+            swapFeeTokenId: usdcContract,
+            swapFeeDecimals: 6
+        )
+        guard case let .swapkit(decoded) = try SwapPayload(
+            proto: SwapPayload.swapkit(payload).mapToProtobuff()
+        ) else {
+            XCTFail("Expected .swapkit"); return
+        }
+        XCTAssertEqual(decoded.swapFeeTokenId, usdcContract)
+        XCTAssertEqual(decoded.swapFeeDecimals, 6)
+    }
+
+    func testNilFeeLeavesTheWholeGroupOffTheWire() throws {
+        let payload = makeSwapKitPayload(
+            swapFee: nil,
+            swapFeeChain: Chain.bitcoinCash.name,
+            swapFeeTokenId: nil,
+            swapFeeDecimals: 8
+        )
+        guard case let .swapkitSwapPayload(value) = SwapPayload.swapkit(payload).mapToProtobuff() else {
+            XCTFail("Expected .swapkitSwapPayload"); return
+        }
+        XCTAssertTrue(value.swapFee.isEmpty)
+        XCTAssertFalse(
+            value.hasSwapFeeChain,
+            "Coin context without an amount describes nothing; it must not travel alone"
+        )
+        XCTAssertFalse(value.hasSwapFeeDecimals)
+    }
+
+    func testZeroFeeStaysOffTheWire() {
+        let payload = makeSwapKitPayload(
+            swapFee: "0",
+            swapFeeChain: Chain.bitcoinCash.name,
+            swapFeeTokenId: nil,
+            swapFeeDecimals: 8
+        )
+        guard case let .swapkitSwapPayload(value) = SwapPayload.swapkit(payload).mapToProtobuff() else {
+            XCTFail("Expected .swapkitSwapPayload"); return
+        }
+        XCTAssertTrue(
+            value.swapFee.isEmpty,
+            "A zero is indistinguishable from unknown here; never claim it"
+        )
+        XCTAssertFalse(value.hasSwapFeeChain)
+    }
+
+    func testLegacyWireBytesDecodeToNoFeeAndNoRow() throws {
+        let reparsed = try VSSwapKitSwapPayload(serializedBytes: try makeLegacyProto().serializedData())
+        let decoded = try SwapPayload(proto: .swapkitSwapPayload(reparsed))
+
+        guard case let .swapkit(payload) = decoded else {
+            XCTFail("Expected .swapkit"); return
+        }
+        XCTAssertNil(payload.swapFee)
+        XCTAssertNil(payload.swapFeeChain)
+        XCTAssertNil(payload.swapFeeTokenId)
+        XCTAssertNil(payload.swapFeeDecimals)
+        XCTAssertNil(
+            JoinKeysignSwapFeeViewModel().resolveSwapFee(swapPayload: decoded, vault: nil),
+            "Legacy sender → render no row, never a definite $0.00"
+        )
+    }
+
+    func testReEncodingALegacyPayloadLeavesTheFeeGroupUnset() throws {
+        let decoded = try SwapPayload(proto: .swapkitSwapPayload(
+            try VSSwapKitSwapPayload(serializedBytes: try makeLegacyProto().serializedData())
+        ))
+        guard case let .swapkitSwapPayload(reEncoded) = decoded.mapToProtobuff() else {
+            XCTFail("Expected .swapkitSwapPayload"); return
+        }
+        XCTAssertTrue(reEncoded.swapFee.isEmpty)
+        XCTAssertFalse(reEncoded.hasSwapFeeChain)
+        XCTAssertFalse(reEncoded.hasSwapFeeTokenID)
+        XCTAssertFalse(reEncoded.hasSwapFeeDecimals)
+    }
+
+    /// The routing fields a signer actually reads must survive untouched
+    /// alongside the new display group.
+    func testFeeGroupTravelsBesideTheSigningFieldsWithoutDisturbingThem() throws {
+        let payload = makeSwapKitPayload(
+            swapFee: "250000",
+            swapFeeChain: Chain.bitcoinCash.name,
+            swapFeeTokenId: nil,
+            swapFeeDecimals: 8
+        )
+        guard case let .swapkit(decoded) = try SwapPayload(
+            proto: SwapPayload.swapkit(payload).mapToProtobuff()
+        ) else {
+            XCTFail("Expected .swapkit"); return
+        }
+        XCTAssertEqual(decoded.txType, payload.txType)
+        XCTAssertEqual(decoded.txPayload, payload.txPayload)
+        XCTAssertEqual(decoded.targetAddress, payload.targetAddress)
+        XCTAssertEqual(decoded.memo, payload.memo)
+        XCTAssertEqual(decoded.swapID, payload.swapID)
+    }
+
+    // MARK: - What the co-signer reads back
+
+    func testResolverAppliesWireDecimalsToANativeFee() {
+        // 250_000 raw @ 8 decimals is 0.0025 BCH — the 50 bps affiliate charge a
+        // NEAR route reports on a BCH source, in the source chain's own coin.
+        let resolved = JoinKeysignSwapFeeViewModel().resolveSwapFee(
+            swapPayload: .swapkit(makeSwapKitPayload(
+                swapFee: "250000",
+                swapFeeChain: Chain.bitcoinCash.name,
+                swapFeeTokenId: nil,
+                swapFeeDecimals: 8
+            )),
+            vault: nil
+        )
+        XCTAssertEqual(resolved?.amount, Decimal(string: "0.0025"))
+        XCTAssertEqual(resolved?.coin.ticker, "BCH")
+        XCTAssertTrue(resolved?.coin.isNativeToken ?? false)
+    }
+
+    func testResolverMatchesATokenFeeAgainstOneSideOfTheSwap() {
+        let resolved = JoinKeysignSwapFeeViewModel().resolveSwapFee(
+            swapPayload: .swapkit(makeSwapKitPayload(
+                swapFee: "150000",
+                swapFeeChain: "Ethereum",
+                swapFeeTokenId: usdcContract.uppercased(),
+                swapFeeDecimals: 6
+            )),
+            vault: nil
+        )
+        XCTAssertEqual(resolved?.amount, Decimal(string: "0.15"))
+        XCTAssertEqual(resolved?.coin.ticker, "USDC", "Token id matches toCoin case-insensitively")
+    }
+
+    func testResolverYieldsNoRowWithoutCoinContext() {
+        let model = JoinKeysignSwapFeeViewModel()
+        // Missing chain, unknown chain, and missing decimals each make the coin
+        // unknowable. A 6-decimal fee read as an 8-decimal one is wrong by 100x.
+        XCTAssertNil(model.resolveSwapFee(swapPayload: .swapkit(makeSwapKitPayload(
+            swapFee: "250000", swapFeeChain: nil, swapFeeTokenId: nil, swapFeeDecimals: 8
+        )), vault: nil))
+        XCTAssertNil(model.resolveSwapFee(swapPayload: .swapkit(makeSwapKitPayload(
+            swapFee: "250000", swapFeeChain: "NotARealChain", swapFeeTokenId: nil, swapFeeDecimals: 8
+        )), vault: nil))
+        XCTAssertNil(model.resolveSwapFee(swapPayload: .swapkit(makeSwapKitPayload(
+            swapFee: "250000", swapFeeChain: Chain.bitcoinCash.name, swapFeeTokenId: nil, swapFeeDecimals: nil
+        )), vault: nil))
+    }
+
+    func testResolverYieldsNoRowForAnUnknownTokenId() {
+        XCTAssertNil(JoinKeysignSwapFeeViewModel().resolveSwapFee(
+            swapPayload: .swapkit(makeSwapKitPayload(
+                swapFee: "150000",
+                swapFeeChain: "Ethereum",
+                swapFeeTokenId: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                swapFeeDecimals: 6
+            )),
+            vault: nil
+        ))
+    }
+
+    func testResolverYieldsNoRowForZeroOrAbsentFee() {
+        let model = JoinKeysignSwapFeeViewModel()
+        for fee in [nil, "", "0"] as [String?] {
+            XCTAssertNil(
+                model.resolveSwapFee(swapPayload: .swapkit(makeSwapKitPayload(
+                    swapFee: fee, swapFeeChain: Chain.bitcoinCash.name, swapFeeTokenId: nil, swapFeeDecimals: 8
+                )), vault: nil),
+                "fee=\(String(describing: fee)) must render no row"
+            )
+        }
+    }
+
+    func testGenericRouteResolutionIsUnchangedByTheSharedPath() {
+        // The generic and SwapKit resolvers now share one implementation; this
+        // pins that the 1inch-shaped route still resolves exactly as before.
+        let resolved = JoinKeysignSwapFeeViewModel().resolveSwapFee(
+            swapPayload: .generic(GenericSwapPayload(
+                fromCoin: makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true),
+                toCoin: makeUSDC(),
+                fromAmount: BigInt("1000000000000000000"),
+                toAmountDecimal: 3000,
+                quote: EVMQuote(
+                    dstAmount: "3000000000",
+                    tx: EVMQuote.Transaction(
+                        from: "0xFrom", to: "0xRouter", data: "0x", value: "0",
+                        gasPrice: "1", gas: 100_000,
+                        swapFee: "5000000", swapFeeTokenContract: usdcContract
+                    )
+                ),
+                provider: .oneInch,
+                swapFeeChain: "Ethereum",
+                swapFeeTokenId: usdcContract,
+                swapFeeDecimals: 6
+            )),
+            vault: nil
+        )
+        XCTAssertEqual(resolved?.amount, 5)
+        XCTAssertEqual(resolved?.coin.ticker, "USDC")
+    }
+
+    // MARK: - Persisted JSON back-compat
+
+    func testSwapKitPayloadJSONWithoutFeeKeysDecodes() throws {
+        let encoded = try JSONEncoder().encode(makeSwapKitPayload(
+            swapFee: nil, swapFeeChain: nil, swapFeeTokenId: nil, swapFeeDecimals: nil
+        ))
+        var object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        for key in ["swapFee", "swapFeeChain", "swapFeeTokenId", "swapFeeDecimals"] {
+            object.removeValue(forKey: key)
+        }
+        let stripped = try JSONSerialization.data(withJSONObject: object)
+
+        let decoded = try JSONDecoder().decode(SwapKitSwapPayload.self, from: stripped)
+        XCTAssertNil(decoded.swapFee)
+        XCTAssertNil(decoded.swapFeeChain)
+        XCTAssertNil(decoded.swapFeeTokenId)
+        XCTAssertNil(decoded.swapFeeDecimals)
+        XCTAssertEqual(decoded.txType, "PSBT", "The pre-existing fields still decode")
+    }
+
+    // MARK: - Fixtures
+
+    private let usdcContract = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+
+    private func makeSwapKitPayload(
+        swapFee: String?,
+        swapFeeChain: String?,
+        swapFeeTokenId: String?,
+        swapFeeDecimals: Int?
+    ) -> SwapKitSwapPayload {
+        SwapKitSwapPayload(
+            fromCoin: makeCoin(.bitcoinCash, ticker: "BCH", decimals: 8, isNative: true),
+            toCoin: makeUSDC(),
+            fromAmount: BigInt(50_000_000),
+            toAmountDecimal: 380,
+            txType: "PSBT",
+            txPayload: Data([0x70, 0x73, 0x62, 0x74]),
+            targetAddress: "qtarget",
+            inboundAddress: nil,
+            memo: nil,
+            subProvider: "NEAR",
+            swapID: "swap-1",
+            swapFee: swapFee,
+            swapFeeChain: swapFeeChain,
+            swapFeeTokenId: swapFeeTokenId,
+            swapFeeDecimals: swapFeeDecimals
+        )
+    }
+
+    /// Fields 1-11 only — the shape a sender predating fields 12-15 puts on the
+    /// wire.
+    private func makeLegacyProto() -> VSSwapKitSwapPayload {
+        var legacy = VSSwapKitSwapPayload()
+        legacy.fromCoin = ProtoCoinResolver.proto(from: makeCoin(.bitcoinCash, ticker: "BCH", decimals: 8, isNative: true))
+        legacy.toCoin = ProtoCoinResolver.proto(from: makeUSDC())
+        legacy.fromAmount = "50000000"
+        legacy.toAmountDecimal = "380"
+        legacy.txType = "PSBT"
+        legacy.txPayload = Data([0x70, 0x73, 0x62, 0x74])
+        legacy.targetAddress = "qtarget"
+        legacy.subProvider = "NEAR"
+        legacy.swapID = "swap-1"
+        return legacy
+    }
+
+    private func makeUSDC() -> Coin {
+        makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false, contract: usdcContract)
+    }
+
+    private func makeCoin(
+        _ chain: Chain,
+        ticker: String,
+        decimals: Int,
+        isNative: Bool,
+        contract: String = ""
+    ) -> Coin {
+        let asset = CoinMeta(
+            chain: chain,
+            ticker: ticker,
+            logo: "logo",
+            decimals: decimals,
+            priceProviderId: "swapkit-fee-5341-\(ticker.lowercased())",
+            contractAddress: contract,
+            isNativeToken: isNative
+        )
+        return Coin(asset: asset, address: "swapkit-fee-\(ticker)", hexPublicKey: "")
+    }
+}

--- a/VultisigApp/VultisigAppTests/Keysign/SwapKitSwapFeeProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/SwapKitSwapFeeProtoMappingTests.swift
@@ -274,6 +274,67 @@ final class SwapKitSwapFeeProtoMappingTests: XCTestCase {
         )), vault: nil))
     }
 
+    /// `swap_fee_decimals` is an `int32` the sender chooses, so the resolver must
+    /// bound it before it reaches `pow(10, decimals)`. Unbounded, `-9` renders a
+    /// fee 10^9x too large and anything past `Decimal`'s exponent range renders
+    /// the literal string "NaN" — both on the screen the co-signer reads to
+    /// decide whether to sign.
+    func testResolverYieldsNoRowForOutOfRangeWireDecimals() {
+        let model = JoinKeysignSwapFeeViewModel()
+        for decimals in [-1, -9, 37, 130, Int(Int32.max)] {
+            XCTAssertNil(
+                model.resolveSwapFee(swapPayload: .swapkit(makeSwapKitPayload(
+                    swapFee: "250000",
+                    swapFeeChain: Chain.bitcoinCash.name,
+                    swapFeeTokenId: nil,
+                    swapFeeDecimals: decimals
+                )), vault: nil),
+                "decimals=\(decimals) is unusable, so no row beats a wrong one"
+            )
+            XCTAssertNil(
+                model.resolveSwapFee(swapPayload: .generic(GenericSwapPayload(
+                    fromCoin: makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true),
+                    toCoin: makeUSDC(),
+                    fromAmount: BigInt("1000000000000000000"),
+                    toAmountDecimal: 3000,
+                    quote: EVMQuote(
+                        dstAmount: "3000000000",
+                        tx: EVMQuote.Transaction(
+                            from: "0xFrom", to: "0xRouter", data: "0x", value: "0",
+                            gasPrice: "1", gas: 100_000,
+                            swapFee: "5000000", swapFeeTokenContract: usdcContract
+                        )
+                    ),
+                    provider: .oneInch,
+                    swapFeeChain: "Ethereum",
+                    swapFeeTokenId: usdcContract,
+                    swapFeeDecimals: decimals
+                )), vault: nil),
+                "The generic path shares the resolver, so it shares the bound"
+            )
+        }
+    }
+
+    /// The bound is inclusive at both ends: `0` is a real integer-denominated
+    /// fee and must still render.
+    func testResolverAcceptsTheEdgesOfTheSupportedRange() {
+        let model = JoinKeysignSwapFeeViewModel()
+        XCTAssertEqual(
+            model.resolveSwapFee(swapPayload: .swapkit(makeSwapKitPayload(
+                swapFee: "250000", swapFeeChain: Chain.bitcoinCash.name,
+                swapFeeTokenId: nil, swapFeeDecimals: 0
+            )), vault: nil)?.amount,
+            250_000
+        )
+        XCTAssertEqual(
+            model.resolveSwapFee(swapPayload: .swapkit(makeSwapKitPayload(
+                swapFee: "250000", swapFeeChain: Chain.bitcoinCash.name,
+                swapFeeTokenId: nil, swapFeeDecimals: 36
+            )), vault: nil)?.amount,
+            Decimal(string: "0.00000000000000000000000000000025")
+        )
+    }
+
     func testResolverYieldsNoRowForAnUnknownTokenId() {
         XCTAssertNil(JoinKeysignSwapFeeViewModel().resolveSwapFee(
             swapPayload: .swapkit(makeSwapKitPayload(

--- a/VultisigApp/VultisigAppTests/Keysign/SwapKitSwapFeeProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/SwapKitSwapFeeProtoMappingTests.swift
@@ -115,9 +115,13 @@ final class SwapKitSwapFeeProtoMappingTests: XCTestCase {
         )
     }
 
-    func testReEncodingALegacyPayloadLeavesTheFeeGroupUnset() throws {
+    /// Byte-for-byte, not just "the fields are unset" — mixed-version MPC
+    /// committees depend on a relayed legacy payload re-serializing identically,
+    /// and a presence-only assertion would survive any other field shifting.
+    func testReEncodingALegacyPayloadIsByteIdentical() throws {
+        let originalBytes = try makeLegacyProto().serializedData()
         let decoded = try SwapPayload(proto: .swapkitSwapPayload(
-            try VSSwapKitSwapPayload(serializedBytes: try makeLegacyProto().serializedData())
+            try VSSwapKitSwapPayload(serializedBytes: originalBytes)
         ))
         guard case let .swapkitSwapPayload(reEncoded) = decoded.mapToProtobuff() else {
             XCTFail("Expected .swapkitSwapPayload"); return
@@ -126,27 +130,69 @@ final class SwapKitSwapFeeProtoMappingTests: XCTestCase {
         XCTAssertFalse(reEncoded.hasSwapFeeChain)
         XCTAssertFalse(reEncoded.hasSwapFeeTokenID)
         XCTAssertFalse(reEncoded.hasSwapFeeDecimals)
+        XCTAssertEqual(
+            try reEncoded.serializedData(), originalBytes,
+            "A relayed legacy payload must re-serialize to the sender's exact bytes"
+        )
     }
 
-    /// The routing fields a signer actually reads must survive untouched
-    /// alongside the new display group.
-    func testFeeGroupTravelsBesideTheSigningFieldsWithoutDisturbingThem() throws {
-        let payload = makeSwapKitPayload(
+    /// The strongest form of the display-only claim available here: run the real
+    /// BTC PSBT signer over a payload carrying the fee group and one without it,
+    /// and compare the actual BIP-143 pre-signing hashes — the bytes the vault
+    /// commits to. A field-comparison test would pass even if a signer began
+    /// folding a display field into what it signs; this one would not.
+    func testFeeGroupDoesNotMoveTheSignedPreSigningHashes() throws {
+        let response = try SwapKitFixtureLoader.decode(
+            SwapKitSwapResponse.self, from: "v3-real-btc-all-swap"
+        )
+        guard case let .psbt(base64) = response.tx else {
+            XCTFail("Expected a PSBT fixture"); return
+        }
+        let psbt = try XCTUnwrap(Data(base64Encoded: base64))
+
+        let withFee = makeSwapKitPayload(
             swapFee: "250000",
             swapFeeChain: Chain.bitcoinCash.name,
             swapFeeTokenId: nil,
-            swapFeeDecimals: 8
+            swapFeeDecimals: 8,
+            txPayload: psbt
         )
-        guard case let .swapkit(decoded) = try SwapPayload(
-            proto: SwapPayload.swapkit(payload).mapToProtobuff()
-        ) else {
-            XCTFail("Expected .swapkit"); return
+        let withoutFee = makeSwapKitPayload(
+            swapFee: nil, swapFeeChain: nil, swapFeeTokenId: nil, swapFeeDecimals: nil,
+            txPayload: psbt
+        )
+
+        let signedWithFee = try SwapKitBTCSigner.preSigningHashes(payload: withFee)
+        XCTAssertFalse(signedWithFee.isEmpty, "…or the comparison below is vacuous")
+        XCTAssertEqual(
+            signedWithFee,
+            try SwapKitBTCSigner.preSigningHashes(payload: withoutFee),
+            "A display field must never reach what the vault signs"
+        )
+    }
+
+    /// Wire-level counterpart: clearing the group from a payload that carries it
+    /// must reproduce the bytes of one that never had it, so nothing else moved.
+    func testFeeGroupIsPurelyAdditiveOnTheWire() throws {
+        guard case var .swapkitSwapPayload(withFee) = SwapPayload.swapkit(makeSwapKitPayload(
+                swapFee: "250000", swapFeeChain: Chain.bitcoinCash.name,
+                swapFeeTokenId: nil, swapFeeDecimals: 8
+              )).mapToProtobuff(),
+              case let .swapkitSwapPayload(withoutFee) = SwapPayload.swapkit(makeSwapKitPayload(
+                swapFee: nil, swapFeeChain: nil, swapFeeTokenId: nil, swapFeeDecimals: nil
+              )).mapToProtobuff() else {
+            XCTFail("Expected .swapkitSwapPayload"); return
         }
-        XCTAssertEqual(decoded.txType, payload.txType)
-        XCTAssertEqual(decoded.txPayload, payload.txPayload)
-        XCTAssertEqual(decoded.targetAddress, payload.targetAddress)
-        XCTAssertEqual(decoded.memo, payload.memo)
-        XCTAssertEqual(decoded.swapID, payload.swapID)
+        XCTAssertNotEqual(try withFee.serializedData(), try withoutFee.serializedData())
+
+        withFee.swapFee = ""
+        withFee.clearSwapFeeChain()
+        withFee.clearSwapFeeTokenID()
+        withFee.clearSwapFeeDecimals()
+        XCTAssertEqual(
+            try withFee.serializedData(), try withoutFee.serializedData(),
+            "The fee group must be the ONLY difference these bytes carry"
+        )
     }
 
     // MARK: - What the co-signer reads back
@@ -277,7 +323,8 @@ final class SwapKitSwapFeeProtoMappingTests: XCTestCase {
         swapFee: String?,
         swapFeeChain: String?,
         swapFeeTokenId: String?,
-        swapFeeDecimals: Int?
+        swapFeeDecimals: Int?,
+        txPayload: Data = Data([0x70, 0x73, 0x62, 0x74])
     ) -> SwapKitSwapPayload {
         SwapKitSwapPayload(
             fromCoin: makeCoin(.bitcoinCash, ticker: "BCH", decimals: 8, isNative: true),
@@ -285,7 +332,7 @@ final class SwapKitSwapFeeProtoMappingTests: XCTestCase {
             fromAmount: BigInt(50_000_000),
             toAmountDecimal: 380,
             txType: "PSBT",
-            txPayload: Data([0x70, 0x73, 0x62, 0x74]),
+            txPayload: txPayload,
             targetAddress: "qtarget",
             inboundAddress: nil,
             memo: nil,

--- a/VultisigApp/VultisigAppTests/Keysign/SwapKitSwapFeeProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/SwapKitSwapFeeProtoMappingTests.swift
@@ -131,6 +131,10 @@ final class SwapKitSwapFeeProtoMappingTests: XCTestCase {
         XCTAssertFalse(reEncoded.hasSwapFeeTokenID)
         XCTAssertFalse(reEncoded.hasSwapFeeDecimals)
         XCTAssertEqual(
+            reEncoded, try VSSwapKitSwapPayload(serializedBytes: originalBytes),
+            "Re-encoding must not add, drop or rewrite any field"
+        )
+        XCTAssertEqual(
             try reEncoded.serializedData(), originalBytes,
             "A relayed legacy payload must re-serialize to the sender's exact bytes"
         )

--- a/VultisigApp/VultisigAppTests/Keysign/SwapKitSwapFeeProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/SwapKitSwapFeeProtoMappingTests.swift
@@ -3,11 +3,8 @@
 //  VultisigAppTests
 //
 //  Coverage for the provider fee on `SwapKitSwapPayload` (swap_fee plus the
-//  chain / token id / decimals that say what coin it is denominated in). A
-//  co-signer holds no quote, so a fee that does not travel on the payload is a
-//  fee it can neither recover nor show — its confirm screen would total the
-//  network fee alone. These pin the wire shape, the never-guess resolution, and
-//  that an absent field keeps reading as "unknown" rather than zero.
+//  chain / token id / decimals naming its coin): the wire shape, the never-guess
+//  resolution, and that an absent field reads as "unknown" rather than zero.
 //
 
 import BigInt
@@ -115,9 +112,8 @@ final class SwapKitSwapFeeProtoMappingTests: XCTestCase {
         )
     }
 
-    /// Byte-for-byte, not just "the fields are unset" — mixed-version MPC
-    /// committees depend on a relayed legacy payload re-serializing identically,
-    /// and a presence-only assertion would survive any other field shifting.
+    /// Byte-for-byte, not just "the fields are unset": a presence-only assertion
+    /// would survive any other field shifting.
     func testReEncodingALegacyPayloadIsByteIdentical() throws {
         let originalBytes = try makeLegacyProto().serializedData()
         let decoded = try SwapPayload(proto: .swapkitSwapPayload(
@@ -140,11 +136,9 @@ final class SwapKitSwapFeeProtoMappingTests: XCTestCase {
         )
     }
 
-    /// The strongest form of the display-only claim available here: run the real
-    /// BTC PSBT signer over a payload carrying the fee group and one without it,
-    /// and compare the actual BIP-143 pre-signing hashes — the bytes the vault
-    /// commits to. A field-comparison test would pass even if a signer began
-    /// folding a display field into what it signs; this one would not.
+    /// Compares the real BIP-143 pre-signing hashes — the bytes the vault commits
+    /// to — with and without the fee group. A field-comparison test would pass
+    /// even if a signer began folding a display field into what it signs.
     func testFeeGroupDoesNotMoveTheSignedPreSigningHashes() throws {
         let response = try SwapKitFixtureLoader.decode(
             SwapKitSwapResponse.self, from: "v3-real-btc-all-swap"
@@ -175,8 +169,8 @@ final class SwapKitSwapFeeProtoMappingTests: XCTestCase {
         )
     }
 
-    /// Wire-level counterpart: clearing the group from a payload that carries it
-    /// must reproduce the bytes of one that never had it, so nothing else moved.
+    /// Clearing the group must reproduce the bytes of a payload that never had
+    /// it, so nothing else moved.
     func testFeeGroupIsPurelyAdditiveOnTheWire() throws {
         guard case var .swapkitSwapPayload(withFee) = SwapPayload.swapkit(makeSwapKitPayload(
                 swapFee: "250000", swapFeeChain: Chain.bitcoinCash.name,
@@ -272,8 +266,6 @@ final class SwapKitSwapFeeProtoMappingTests: XCTestCase {
     }
 
     func testGenericRouteResolutionIsUnchangedByTheSharedPath() {
-        // The generic and SwapKit resolvers now share one implementation; this
-        // pins that the 1inch-shaped route still resolves exactly as before.
         let resolved = JoinKeysignSwapFeeViewModel().resolveSwapFee(
             swapPayload: .generic(GenericSwapPayload(
                 fromCoin: makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true),
@@ -349,8 +341,7 @@ final class SwapKitSwapFeeProtoMappingTests: XCTestCase {
         )
     }
 
-    /// Fields 1-11 only — the shape a sender predating fields 12-15 puts on the
-    /// wire.
+    /// Fields 1-11 only — the shape a sender predating fields 12-15 sends.
     private func makeLegacyProto() -> VSSwapKitSwapPayload {
         var legacy = VSSwapKitSwapPayload()
         legacy.fromCoin = ProtoCoinResolver.proto(from: makeCoin(.bitcoinCash, ticker: "BCH", decimals: 8, isNative: true))

--- a/VultisigApp/VultisigAppTests/Keysign/SwapSubProviderProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/SwapSubProviderProtoMappingTests.swift
@@ -80,6 +80,10 @@ final class SwapSubProviderProtoMappingTests: XCTestCase {
             "Relaying a legacy payload must not invent a route its sender never stated"
         )
         XCTAssertEqual(
+            reEncoded, try VSOneInchSwapPayload(serializedBytes: originalBytes),
+            "Re-encoding must not add, drop or rewrite any field"
+        )
+        XCTAssertEqual(
             try reEncoded.serializedData(), originalBytes,
             "A relayed legacy payload must re-serialize to the sender's exact bytes"
         )
@@ -87,14 +91,18 @@ final class SwapSubProviderProtoMappingTests: XCTestCase {
 
     // MARK: - How the co-signer names the route
 
-    func testProviderDisplayNameAppendsTheRouteTag() {
-        XCTAssertEqual(
-            SwapPayload.generic(makeGenericPayload(subProvider: "NEAR")).providerDisplayName,
-            "SwapKit (NEAR)"
-        )
+    /// The tag travels, but this device does not render it on an aggregator
+    /// route. iOS's own verify screen names the clean brand, so a joiner that
+    /// appended the route would describe one swap two ways across the two
+    /// screens whose job is to agree. The wire carries it for the clients that
+    /// do render it.
+    func testGenericRouteCarriesTheTagWithoutRenderingIt() {
+        let payload = makeGenericPayload(subProvider: "NEAR")
+        XCTAssertEqual(payload.subProvider, "NEAR", "…or the wire assertion below is vacuous")
+        XCTAssertEqual(SwapPayload.generic(payload).providerDisplayName, "SwapKit")
         XCTAssertEqual(
             SwapPayload.generic(makeGenericPayload(subProvider: "CHAINFLIP", provider: .oneInch)).providerDisplayName,
-            "1Inch (CHAINFLIP)"
+            "1Inch"
         )
     }
 
@@ -122,15 +130,11 @@ final class SwapSubProviderProtoMappingTests: XCTestCase {
     /// the tag can repeat the aggregator. "SwapKit (SwapKit)" names nothing.
     func testProviderDisplayNameDropsATagThatRepeatsTheAggregator() {
         XCTAssertEqual(
-            SwapPayload.generic(makeGenericPayload(subProvider: "SwapKit")).providerDisplayName,
-            "SwapKit"
-        )
-        XCTAssertEqual(
-            SwapPayload.generic(makeGenericPayload(subProvider: "swapkit")).providerDisplayName,
-            "SwapKit"
-        )
-        XCTAssertEqual(
             SwapPayload.swapkit(makeSwapKitPayload(subProvider: "SwapKit")).providerDisplayName,
+            "SwapKit"
+        )
+        XCTAssertEqual(
+            SwapPayload.swapkit(makeSwapKitPayload(subProvider: "swapkit")).providerDisplayName,
             "SwapKit"
         )
     }
@@ -158,17 +162,25 @@ final class SwapSubProviderProtoMappingTests: XCTestCase {
     }
 
     /// The pre-split behaviour, pinned as the thing that must not come back: a
-    /// tagged persisted name loses the tracker.
+    /// tagged persisted name loses the tracker. It falls through to the chain's
+    /// own explorer — `url` only reaches `fallbackExplorerLink` when the chain
+    /// itself is unrecognised, so the fallthrough is asserted against the
+    /// registry URL the same way `ExplorerLinkBuilderTests` asserts it.
     func testATaggedPersistedNameWouldLoseTheTracker() {
+        let url = ExplorerLinkBuilder.url(
+            provider: "SwapKit (CHAINFLIP)",
+            txHash: "0xabc",
+            chainRawValue: Chain.ethereum.rawValue,
+            fallbackExplorerLink: "https://etherscan.io/tx/0xfallback"
+        )
         XCTAssertEqual(
-            ExplorerLinkBuilder.url(
-                provider: "SwapKit (CHAINFLIP)",
-                txHash: "0xabc",
-                chainRawValue: Chain.ethereum.rawValue,
-                fallbackExplorerLink: "https://etherscan.io/tx/0xfallback"
-            )?.absoluteString,
-            "https://etherscan.io/tx/0xfallback",
-            "Documents why the route tag must stay off providerName"
+            url?.absoluteString,
+            ExplorerLinkBuilder.getExplorerURL(chain: .ethereum, txid: "0xabc"),
+            "A tagged name resolves to no tracker and drops to the chain explorer"
+        )
+        XCTAssertNotEqual(
+            url?.absoluteString, "https://track.swapkit.dev/?hash=0xabc&chainId=1",
+            "…which is exactly the link the split exists to keep"
         )
     }
 
@@ -200,7 +212,16 @@ final class SwapSubProviderProtoMappingTests: XCTestCase {
         )
 
         XCTAssertEqual(payload.subProvider, "ONEINCH")
-        XCTAssertEqual(SwapPayload.generic(payload).providerDisplayName, "SwapKit (ONEINCH)")
+        guard case let .oneinchSwapPayload(proto) = SwapPayload.generic(payload).mapToProtobuff() else {
+            XCTFail("Expected .oneinchSwapPayload"); return
+        }
+        XCTAssertEqual(proto.subProvider, "ONEINCH", "The tag has to reach the peer")
+
+        // …and both iOS screens still say the same thing about this swap.
+        XCTAssertEqual(
+            SwapPayload.generic(payload).providerDisplayName,
+            SwapQuote.swapkit(response, fee: nil, subProvider: response.subProvider).displayName
+        )
     }
 
     func testSolanaSwapKitRouteCarriesTheRouteTag() throws {
@@ -218,9 +239,11 @@ final class SwapSubProviderProtoMappingTests: XCTestCase {
         )
 
         XCTAssertEqual(payload.subProvider, response.subProvider)
+        XCTAssertEqual(payload.subProvider, "NEAR", "…or the parity assertion below is vacuous")
         XCTAssertEqual(
             SwapPayload.generic(payload).providerDisplayName,
-            "SwapKit (\(response.subProvider))"
+            SwapQuote.swapkit(response, fee: nil, subProvider: response.subProvider).displayName,
+            "Joiner and initiator must name this swap identically"
         )
     }
 

--- a/VultisigApp/VultisigAppTests/Keysign/SwapSubProviderProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/SwapSubProviderProtoMappingTests.swift
@@ -3,10 +3,8 @@
 //  VultisigAppTests
 //
 //  Coverage for `OneInchSwapPayload.sub_provider` — the route tag under an
-//  aggregator ("NEAR", "CHAINFLIP", "GARDEN"). SwapKit's EVM and Solana routes
-//  ride the 1inch-shaped payload, so without this field a co-signer names them
-//  after the aggregator alone while every other SwapKit route, which rides
-//  `SwapKitSwapPayload`, names the route it actually took.
+//  aggregator ("NEAR", "CHAINFLIP", "GARDEN"), which SwapKit's EVM and Solana
+//  routes carry on the 1inch-shaped payload.
 //
 
 import BigInt
@@ -64,9 +62,8 @@ final class SwapSubProviderProtoMappingTests: XCTestCase {
         )
     }
 
-    /// Byte-for-byte, not just "the field is unset" — a presence-only assertion
-    /// would survive any other field shifting, and mixed-version MPC committees
-    /// depend on a relayed legacy payload re-serializing identically.
+    /// Byte-for-byte, not just "the field is unset": a presence-only assertion
+    /// would survive any other field shifting.
     func testReEncodingALegacyPayloadIsByteIdentical() throws {
         let originalBytes = try makeLegacyProto().serializedData()
         let decoded = try SwapPayload(proto: .oneinchSwapPayload(
@@ -91,11 +88,9 @@ final class SwapSubProviderProtoMappingTests: XCTestCase {
 
     // MARK: - How the co-signer names the route
 
-    /// The tag travels, but this device does not render it on an aggregator
-    /// route. iOS's own verify screen names the clean brand, so a joiner that
-    /// appended the route would describe one swap two ways across the two
-    /// screens whose job is to agree. The wire carries it for the clients that
-    /// do render it.
+    /// The tag travels but this device does not render it: iOS's initiator screen
+    /// names the clean brand, so rendering it here alone would describe one swap
+    /// two ways.
     func testGenericRouteCarriesTheTagWithoutRenderingIt() {
         let payload = makeGenericPayload(subProvider: "NEAR")
         XCTAssertEqual(payload.subProvider, "NEAR", "…or the wire assertion below is vacuous")
@@ -106,9 +101,8 @@ final class SwapSubProviderProtoMappingTests: XCTestCase {
         )
     }
 
-    /// `providerName` is persisted to Transaction History and aliased back to a
-    /// tracker URL by an exact lookup, so the route tag must stay off it — a
-    /// "SwapKit (NEAR)" row would silently lose the SwapKit tracker link.
+    /// `providerName` is persisted and aliased back to a tracker by an exact
+    /// lookup, so a tagged row would silently lose the SwapKit tracker link.
     func testPersistedProviderNameStaysTheBareBrand() {
         XCTAssertEqual(
             SwapPayload.generic(makeGenericPayload(subProvider: "NEAR")).providerName,
@@ -139,10 +133,9 @@ final class SwapSubProviderProtoMappingTests: XCTestCase {
         )
     }
 
-    /// The transfer-route half of the same split. Before it, `.swapkit` persisted
-    /// "SwapKit (CHAINFLIP)", which normalizes to `swapkitchainflip` — absent
-    /// from `ExplorerLinkBuilder`'s alias table — so the row silently fell back
-    /// to the chain explorer instead of the aggregator's tracker.
+    /// The transfer-route half of the split: "SwapKit (CHAINFLIP)" normalizes to
+    /// `swapkitchainflip`, which matches no alias, so a tagged persisted name
+    /// falls back to the chain explorer.
     func testSwapKitTransferRoutePersistsTheBareBrandAndKeepsItsTracker() {
         let payload = SwapPayload.swapkit(makeSwapKitPayload(subProvider: "CHAINFLIP"))
         XCTAssertEqual(payload.providerName, "SwapKit")
@@ -161,11 +154,9 @@ final class SwapSubProviderProtoMappingTests: XCTestCase {
         )
     }
 
-    /// The pre-split behaviour, pinned as the thing that must not come back: a
-    /// tagged persisted name loses the tracker. It falls through to the chain's
-    /// own explorer — `url` only reaches `fallbackExplorerLink` when the chain
-    /// itself is unrecognised, so the fallthrough is asserted against the
-    /// registry URL the same way `ExplorerLinkBuilderTests` asserts it.
+    /// Pinned as the thing that must not come back. `url` only reaches
+    /// `fallbackExplorerLink` when the CHAIN is unrecognised, so an unresolved
+    /// provider falls through to the chain's registry explorer.
     func testATaggedPersistedNameWouldLoseTheTracker() {
         let url = ExplorerLinkBuilder.url(
             provider: "SwapKit (CHAINFLIP)",
@@ -217,7 +208,6 @@ final class SwapSubProviderProtoMappingTests: XCTestCase {
         }
         XCTAssertEqual(proto.subProvider, "ONEINCH", "The tag has to reach the peer")
 
-        // …and both iOS screens still say the same thing about this swap.
         XCTAssertEqual(
             SwapPayload.generic(payload).providerDisplayName,
             SwapQuote.swapkit(response, fee: nil, subProvider: response.subProvider).displayName
@@ -318,7 +308,7 @@ final class SwapSubProviderProtoMappingTests: XCTestCase {
         )
     }
 
-    /// Fields 1-6 only — the shape a sender predating field 7 puts on the wire.
+    /// Fields 1-6 only — the shape a sender predating field 7 sends.
     private func makeLegacyProto() -> VSOneInchSwapPayload {
         var legacy = VSOneInchSwapPayload()
         legacy.fromCoin = ProtoCoinResolver.proto(from: makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true))

--- a/VultisigApp/VultisigAppTests/Keysign/SwapSubProviderProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/SwapSubProviderProtoMappingTests.swift
@@ -64,9 +64,13 @@ final class SwapSubProviderProtoMappingTests: XCTestCase {
         )
     }
 
-    func testReEncodingALegacyPayloadLeavesSubProviderUnset() throws {
+    /// Byte-for-byte, not just "the field is unset" — a presence-only assertion
+    /// would survive any other field shifting, and mixed-version MPC committees
+    /// depend on a relayed legacy payload re-serializing identically.
+    func testReEncodingALegacyPayloadIsByteIdentical() throws {
+        let originalBytes = try makeLegacyProto().serializedData()
         let decoded = try SwapPayload(proto: .oneinchSwapPayload(
-            try VSOneInchSwapPayload(serializedBytes: try makeLegacyProto().serializedData())
+            try VSOneInchSwapPayload(serializedBytes: originalBytes)
         ))
         guard case let .oneinchSwapPayload(reEncoded) = decoded.mapToProtobuff() else {
             XCTFail("Expected .oneinchSwapPayload"); return
@@ -74,6 +78,10 @@ final class SwapSubProviderProtoMappingTests: XCTestCase {
         XCTAssertTrue(
             reEncoded.subProvider.isEmpty,
             "Relaying a legacy payload must not invent a route its sender never stated"
+        )
+        XCTAssertEqual(
+            try reEncoded.serializedData(), originalBytes,
+            "A relayed legacy payload must re-serialize to the sender's exact bytes"
         )
     }
 
@@ -124,6 +132,43 @@ final class SwapSubProviderProtoMappingTests: XCTestCase {
         XCTAssertEqual(
             SwapPayload.swapkit(makeSwapKitPayload(subProvider: "SwapKit")).providerDisplayName,
             "SwapKit"
+        )
+    }
+
+    /// The transfer-route half of the same split. Before it, `.swapkit` persisted
+    /// "SwapKit (CHAINFLIP)", which normalizes to `swapkitchainflip` — absent
+    /// from `ExplorerLinkBuilder`'s alias table — so the row silently fell back
+    /// to the chain explorer instead of the aggregator's tracker.
+    func testSwapKitTransferRoutePersistsTheBareBrandAndKeepsItsTracker() {
+        let payload = SwapPayload.swapkit(makeSwapKitPayload(subProvider: "CHAINFLIP"))
+        XCTAssertEqual(payload.providerName, "SwapKit")
+        XCTAssertEqual(
+            payload.providerDisplayName, "SwapKit (CHAINFLIP)",
+            "The verify screen still names the route; only the persisted identity is bare"
+        )
+        XCTAssertEqual(
+            ExplorerLinkBuilder.url(
+                provider: payload.providerName,
+                txHash: "0xabc",
+                chainRawValue: Chain.ethereum.rawValue,
+                fallbackExplorerLink: "https://etherscan.io/tx/0xfallback"
+            )?.absoluteString,
+            "https://track.swapkit.dev/?hash=0xabc&chainId=1"
+        )
+    }
+
+    /// The pre-split behaviour, pinned as the thing that must not come back: a
+    /// tagged persisted name loses the tracker.
+    func testATaggedPersistedNameWouldLoseTheTracker() {
+        XCTAssertEqual(
+            ExplorerLinkBuilder.url(
+                provider: "SwapKit (CHAINFLIP)",
+                txHash: "0xabc",
+                chainRawValue: Chain.ethereum.rawValue,
+                fallbackExplorerLink: "https://etherscan.io/tx/0xfallback"
+            )?.absoluteString,
+            "https://etherscan.io/tx/0xfallback",
+            "Documents why the route tag must stay off providerName"
         )
     }
 

--- a/VultisigApp/VultisigAppTests/Keysign/SwapSubProviderProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/SwapSubProviderProtoMappingTests.swift
@@ -1,0 +1,287 @@
+//
+//  SwapSubProviderProtoMappingTests.swift
+//  VultisigAppTests
+//
+//  Coverage for `OneInchSwapPayload.sub_provider` — the route tag under an
+//  aggregator ("NEAR", "CHAINFLIP", "GARDEN"). SwapKit's EVM and Solana routes
+//  ride the 1inch-shaped payload, so without this field a co-signer names them
+//  after the aggregator alone while every other SwapKit route, which rides
+//  `SwapKitSwapPayload`, names the route it actually took.
+//
+
+import BigInt
+import XCTest
+import VultisigCommonData
+@testable import VultisigApp
+
+@MainActor
+final class SwapSubProviderProtoMappingTests: XCTestCase {
+
+    // MARK: - Proto round-trip
+
+    func testProtoRoundTripCarriesSubProvider() throws {
+        let proto = SwapPayload.generic(makeGenericPayload(subProvider: "NEAR")).mapToProtobuff()
+        guard case let .oneinchSwapPayload(value) = proto else {
+            XCTFail("Expected .oneinchSwapPayload"); return
+        }
+        XCTAssertEqual(value.subProvider, "NEAR")
+
+        guard case let .generic(decoded) = try SwapPayload(proto: proto) else {
+            XCTFail("Expected .generic"); return
+        }
+        XCTAssertEqual(decoded.subProvider, "NEAR")
+    }
+
+    func testNilAndEmptySubProviderStayOffTheWire() throws {
+        for subProvider in [nil, ""] as [String?] {
+            let proto = SwapPayload.generic(makeGenericPayload(subProvider: subProvider)).mapToProtobuff()
+            guard case let .oneinchSwapPayload(value) = proto else {
+                XCTFail("Expected .oneinchSwapPayload"); return
+            }
+            XCTAssertTrue(
+                value.subProvider.isEmpty,
+                "An absent tag stays at the field default rather than being written empty"
+            )
+
+            guard case let .generic(decoded) = try SwapPayload(proto: proto) else {
+                XCTFail("Expected .generic"); return
+            }
+            XCTAssertNil(decoded.subProvider, "Empty on the wire normalizes back to nil, not \"\"")
+        }
+    }
+
+    func testLegacyWireBytesDecodeToNoTagAndTheBareBrand() throws {
+        let reparsed = try VSOneInchSwapPayload(serializedBytes: try makeLegacyProto().serializedData())
+        let decoded = try SwapPayload(proto: .oneinchSwapPayload(reparsed))
+
+        guard case let .generic(payload) = decoded else {
+            XCTFail("Expected .generic"); return
+        }
+        XCTAssertNil(payload.subProvider)
+        XCTAssertEqual(
+            decoded.providerDisplayName, "SwapKit",
+            "A sender predating the field named no route; do not invent one"
+        )
+    }
+
+    func testReEncodingALegacyPayloadLeavesSubProviderUnset() throws {
+        let decoded = try SwapPayload(proto: .oneinchSwapPayload(
+            try VSOneInchSwapPayload(serializedBytes: try makeLegacyProto().serializedData())
+        ))
+        guard case let .oneinchSwapPayload(reEncoded) = decoded.mapToProtobuff() else {
+            XCTFail("Expected .oneinchSwapPayload"); return
+        }
+        XCTAssertTrue(
+            reEncoded.subProvider.isEmpty,
+            "Relaying a legacy payload must not invent a route its sender never stated"
+        )
+    }
+
+    // MARK: - How the co-signer names the route
+
+    func testProviderDisplayNameAppendsTheRouteTag() {
+        XCTAssertEqual(
+            SwapPayload.generic(makeGenericPayload(subProvider: "NEAR")).providerDisplayName,
+            "SwapKit (NEAR)"
+        )
+        XCTAssertEqual(
+            SwapPayload.generic(makeGenericPayload(subProvider: "CHAINFLIP", provider: .oneInch)).providerDisplayName,
+            "1Inch (CHAINFLIP)"
+        )
+    }
+
+    /// `providerName` is persisted to Transaction History and aliased back to a
+    /// tracker URL by an exact lookup, so the route tag must stay off it — a
+    /// "SwapKit (NEAR)" row would silently lose the SwapKit tracker link.
+    func testPersistedProviderNameStaysTheBareBrand() {
+        XCTAssertEqual(
+            SwapPayload.generic(makeGenericPayload(subProvider: "NEAR")).providerName,
+            "SwapKit"
+        )
+        let url = ExplorerLinkBuilder.url(
+            provider: SwapPayload.generic(makeGenericPayload(subProvider: "NEAR")).providerName,
+            txHash: "0xabc",
+            chainRawValue: Chain.ethereum.rawValue,
+            fallbackExplorerLink: "https://etherscan.io/tx/0xfallback"
+        )
+        XCTAssertEqual(
+            url?.absoluteString, "https://track.swapkit.dev/?hash=0xabc&chainId=1",
+            "The persisted identity still resolves to the aggregator's own tracker"
+        )
+    }
+
+    /// SwapKit's own name is the fallback when a route reports no providers, so
+    /// the tag can repeat the aggregator. "SwapKit (SwapKit)" names nothing.
+    func testProviderDisplayNameDropsATagThatRepeatsTheAggregator() {
+        XCTAssertEqual(
+            SwapPayload.generic(makeGenericPayload(subProvider: "SwapKit")).providerDisplayName,
+            "SwapKit"
+        )
+        XCTAssertEqual(
+            SwapPayload.generic(makeGenericPayload(subProvider: "swapkit")).providerDisplayName,
+            "SwapKit"
+        )
+        XCTAssertEqual(
+            SwapPayload.swapkit(makeSwapKitPayload(subProvider: "SwapKit")).providerDisplayName,
+            "SwapKit"
+        )
+    }
+
+    func testTransferRouteNamingIsUnchanged() {
+        XCTAssertEqual(
+            SwapPayload.swapkit(makeSwapKitPayload(subProvider: "CHAINFLIP")).providerDisplayName,
+            "SwapKit (CHAINFLIP)"
+        )
+        XCTAssertEqual(
+            SwapPayload.swapkit(makeSwapKitPayload(subProvider: "")).providerDisplayName,
+            "SwapKit"
+        )
+    }
+
+    // MARK: - What the builder puts on the wire
+
+    func testEvmSwapKitRouteCarriesTheRouteTag() throws {
+        let response = try SwapKitFixtureLoader.decode(
+            SwapKitSwapResponse.self,
+            from: "v3-erc20-erc20-swap"
+        )
+        let payload = SwapCryptoLogic.buildSwapKitGenericPayload(
+            fromCoin: makeCoin(.ethereum, ticker: "USDT", decimals: 6, isNative: false),
+            toCoin: makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false),
+            fromAmountInCoin: BigInt(100_000_000),
+            toAmountDecimal: 100,
+            quote: try SwapCryptoLogic.buildEVMQuoteFromSwapKit(swapResponse: response),
+            swapResponse: response
+        )
+
+        XCTAssertEqual(payload.subProvider, "ONEINCH")
+        XCTAssertEqual(SwapPayload.generic(payload).providerDisplayName, "SwapKit (ONEINCH)")
+    }
+
+    func testSolanaSwapKitRouteCarriesTheRouteTag() throws {
+        let response = try SwapKitFixtureLoader.decode(
+            SwapKitSwapResponse.self,
+            from: "v3-sol-near-swap-fresh"
+        )
+        let payload = SwapCryptoLogic.buildSwapKitGenericPayload(
+            fromCoin: makeCoin(.solana, ticker: "SOL", decimals: 9, isNative: true),
+            toCoin: makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false),
+            fromAmountInCoin: BigInt(1_000_000_000),
+            toAmountDecimal: 100,
+            quote: try SwapCryptoLogic.buildEVMQuoteFromSwapKit(swapResponse: response),
+            swapResponse: response
+        )
+
+        XCTAssertEqual(payload.subProvider, response.subProvider)
+        XCTAssertEqual(
+            SwapPayload.generic(payload).providerDisplayName,
+            "SwapKit (\(response.subProvider))"
+        )
+    }
+
+    /// A tag is a label. It must not disturb the calldata this device signs.
+    func testTheRouteTagDoesNotTouchTheSignedQuote() throws {
+        let response = try SwapKitFixtureLoader.decode(
+            SwapKitSwapResponse.self,
+            from: "v3-erc20-erc20-swap"
+        )
+        let quote = try SwapCryptoLogic.buildEVMQuoteFromSwapKit(swapResponse: response)
+        let payload = SwapCryptoLogic.buildSwapKitGenericPayload(
+            fromCoin: makeCoin(.ethereum, ticker: "USDT", decimals: 6, isNative: false),
+            toCoin: makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false),
+            fromAmountInCoin: BigInt(100_000_000),
+            toAmountDecimal: 100,
+            quote: quote,
+            swapResponse: response
+        )
+        XCTAssertEqual(payload.quote, quote)
+    }
+
+    // MARK: - Persisted JSON back-compat
+
+    func testGenericSwapPayloadJSONWithoutSubProviderDecodes() throws {
+        let encoded = try JSONEncoder().encode(makeGenericPayload(subProvider: nil))
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        object.removeValue(forKey: "subProvider")
+        let stripped = try JSONSerialization.data(withJSONObject: object)
+
+        let decoded = try JSONDecoder().decode(GenericSwapPayload.self, from: stripped)
+        XCTAssertNil(decoded.subProvider)
+    }
+
+    // MARK: - Fixtures
+
+    private func makeGenericPayload(
+        subProvider: String?,
+        provider: SwapProviderId = .swapkit
+    ) -> GenericSwapPayload {
+        GenericSwapPayload(
+            fromCoin: makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true),
+            toCoin: makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false),
+            fromAmount: BigInt("1000000000000000000"),
+            toAmountDecimal: 3000,
+            quote: EVMQuote(
+                dstAmount: "3000000000",
+                tx: EVMQuote.Transaction(
+                    from: "0xFrom", to: "0xRouter", data: "0x", value: "0",
+                    gasPrice: "1", gas: 100_000
+                )
+            ),
+            provider: provider,
+            subProvider: subProvider
+        )
+    }
+
+    private func makeSwapKitPayload(subProvider: String) -> SwapKitSwapPayload {
+        SwapKitSwapPayload(
+            fromCoin: makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true),
+            toCoin: makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false),
+            fromAmount: BigInt(500_000),
+            toAmountDecimal: 380,
+            txType: "PSBT",
+            txPayload: Data(),
+            targetAddress: "bc1qtarget",
+            inboundAddress: nil,
+            memo: nil,
+            subProvider: subProvider,
+            swapID: "swap-1"
+        )
+    }
+
+    /// Fields 1-6 only — the shape a sender predating field 7 puts on the wire.
+    private func makeLegacyProto() -> VSOneInchSwapPayload {
+        var legacy = VSOneInchSwapPayload()
+        legacy.fromCoin = ProtoCoinResolver.proto(from: makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true))
+        legacy.toCoin = ProtoCoinResolver.proto(from: makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false))
+        legacy.fromAmount = "1000000000000000000"
+        legacy.toAmountDecimal = "3000"
+        legacy.provider = SwapProviderId.swapkit.rawValue
+        legacy.quote = .with {
+            $0.dstAmount = "3000000000"
+            $0.tx = .with {
+                $0.from = "0xFrom"
+                $0.to = "0xRouter"
+                $0.data = "0x"
+                $0.value = "0"
+                $0.gasPrice = "1"
+                $0.gas = 100_000
+            }
+        }
+        return legacy
+    }
+
+    private func makeCoin(_ chain: Chain, ticker: String, decimals: Int, isNative: Bool) -> Coin {
+        let asset = CoinMeta(
+            chain: chain,
+            ticker: ticker,
+            logo: "logo",
+            decimals: decimals,
+            priceProviderId: "sub-provider-5341-\(ticker.lowercased())",
+            contractAddress: isNative ? "" : "0xcontract-\(ticker.lowercased())",
+            isNativeToken: isNative
+        )
+        return Coin(asset: asset, address: "sub-provider-\(ticker)", hexPublicKey: "")
+    }
+}

--- a/VultisigApp/project.yml
+++ b/VultisigApp/project.yml
@@ -81,23 +81,11 @@ packages:
     # preferring the field and falling back to the memo so mixed-version device
     # pairs stay byte-identical in MPC keysign.
     #
-    # That revision was itself advanced to commondata `main`'s HEAD after
-    # verifying every commit between it and its predecessor touched only repo
-    # tooling (`CLAUDE.md`, `.claude/hooks`, issue/PR templates).
-    #
-    # Advanced again to pick up three display-only swap fields a co-signer needs
-    # and the previous pin predates: `THORChainSwapPayload.slippage_bps = 14`
-    # (optional uint32 — the quote's price impact), `SwapKitSwapPayload.swap_fee
-    # = 12` with its coin context at 13-15, and `OneInchSwapPayload.sub_provider
-    # = 7`. A joiner renders its verify screen from the serialized payload alone,
-    # so a term the initiator cannot write is one it can neither recover nor show.
-    #
-    # Verified before bumping, the way the previous bumps were: the diff
-    # `63a65c37..08e17eb` touches exactly three `.proto` files — the three named
-    # above — and every change appends a new field. No existing field number,
-    # type or name moved, and nothing became required, so a payload from a sender
-    # at the old pin still decodes here and a re-encoded one stays byte-identical.
-    # `08e17eb` is commondata `main`'s HEAD, not a branch-only revision.
+    # Advanced to pick up three additive display-only swap fields a co-signer
+    # needs: `THORChainSwapPayload.slippage_bps = 14`, `SwapKitSwapPayload
+    # .swap_fee = 12` with its coin context at 13-15, and
+    # `OneInchSwapPayload.sub_provider = 7`. Every change between the pins only
+    # appends fields, so payloads from a sender at the old pin still decode.
     revision: 08e17eb63cc634fa81b65306a294ef1455ec4c38
   WalletCore:
     url: https://github.com/vultisig/walletcore-spm

--- a/VultisigApp/project.yml
+++ b/VultisigApp/project.yml
@@ -81,11 +81,24 @@ packages:
     # preferring the field and falling back to the memo so mixed-version device
     # pairs stay byte-identical in MPC keysign.
     #
-    # Advanced to commondata `main`'s current HEAD per review request. Verified
-    # first: every commit between the prior pin and this one only touches repo
-    # tooling (`CLAUDE.md`, `.claude/hooks`, issue/PR templates) — no `.proto`
-    # file changed, so this is a no-op for generated Swift.
-    revision: 63a65c37c50f6a944f6791d36eb905810af82760
+    # That revision was itself advanced to commondata `main`'s HEAD after
+    # verifying every commit between it and its predecessor touched only repo
+    # tooling (`CLAUDE.md`, `.claude/hooks`, issue/PR templates).
+    #
+    # Advanced again to pick up three display-only swap fields a co-signer needs
+    # and the previous pin predates: `THORChainSwapPayload.slippage_bps = 14`
+    # (optional uint32 — the quote's price impact), `SwapKitSwapPayload.swap_fee
+    # = 12` with its coin context at 13-15, and `OneInchSwapPayload.sub_provider
+    # = 7`. A joiner renders its verify screen from the serialized payload alone,
+    # so a term the initiator cannot write is one it can neither recover nor show.
+    #
+    # Verified before bumping, the way the previous bumps were: the diff
+    # `63a65c37..08e17eb` touches exactly three `.proto` files — the three named
+    # above — and every change appends a new field. No existing field number,
+    # type or name moved, and nothing became required, so a payload from a sender
+    # at the old pin still decodes here and a re-encoded one stays byte-identical.
+    # `08e17eb` is commondata `main`'s HEAD, not a branch-only revision.
+    revision: 08e17eb63cc634fa81b65306a294ef1455ec4c38
   WalletCore:
     url: https://github.com/vultisig/walletcore-spm
     # v4.7.1 is the correctly-cut release for wallet-core 4.7.0 (tag →


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on [#5352](https://github.com/vultisig/vultisig-ios/pull/5352), so this PR gets NO CI.**
> The workflow filters to `main`, and this PR's base is
> `codex/thorswap-fee-payload-5340`. An empty checks list here is **not** a pass —
> the local gate quoted under [Verification](#verification) is the only signal
> that exists for this branch.

## Problem

A device joining a swap keysign renders its confirm screen from the serialized
`KeysignPayload` alone — it holds no quote. Three commondata fields that exist to
keep that screen honest post-date iOS's pin, so iOS could neither write nor read
them:

| Payload | Field | Effect on an iOS joiner before this PR |
|---|---|---|
| `THORChainSwapPayload` (+ mayachain) | `optional uint32 slippage_bps = 14` | no Price Impact row on native swaps |
| `SwapKitSwapPayload` | `swap_fee = 12`, `swap_fee_chain = 13`, `swap_fee_token_id = 14`, `swap_fee_decimals = 15` | no swap fee on a SwapKit transfer route, whatever the initiator showed |
| `OneInchSwapPayload` | `sub_provider = 7` | SwapKit's EVM/Solana routes named after the aggregator alone |

## The pin bump, and why it is safe to take

`63a65c37c50f6a944f6791d36eb905810af82760` → `08e17eb63cc634fa81b65306a294ef1455ec4c38`.

Verified before bumping, the way `project.yml:60-88` documents the previous bumps
were. `git diff 63a65c37..08e17eb` in `vultisig/commondata` touches **nine** files:
three `.proto` and their six generated Swift/Go mirrors.

| Proto | Change | Commit |
|---|---|---|
| `thorchain_swap_payload.proto` | `optional uint32 slippage_bps = 14` | `882cf31` |
| `swapkit_swap_payload.proto` | `string swap_fee = 12`, `optional string swap_fee_chain = 13`, `optional string swap_fee_token_id = 14`, `optional int32 swap_fee_decimals = 15` | `d782a4b` |
| `1inch_swap_payload.proto` | `string sub_provider = 7` | `4ccedcb` |

**No other `.proto` changed.** Every change appends a new field; no existing field
number, type or name moved and nothing became required, so a payload from a sender
at the old pin still decodes here and a re-encoded one stays byte-identical.
`08e17eb` is commondata `main`'s HEAD, not a branch-only revision.

## What each field does

### Price impact is carried, never re-derived

A joiner that fetched its own quote would price a pool that has moved since the
initiator was quoted — which would make price impact the one term on the two
verify screens where two honest devices legitimately disagree. So the quote's
basis points travel on the payload.

`optional uint32` gives explicit presence, and the two states mean different
things: **absent** is "the sender predates the field", and the row is hidden;
a **carried `0`** is a real claim of a zero-impact route and renders as `+0.00%`,
which is exactly what the initiator renders for `Decimal(0)/10000`. Writing keys
off nil-ness, not off `!= 0`. A negative or out-of-range value is dropped rather
than wrapped — `uint32` would land `-1` on the peer as a ~4-billion-bps impact.

`SwapCryptoLogic.priceImpactString` / `priceImpactColor` were lifted to take a
`Decimal?` impact, with the existing `SwapQuote` overloads delegating to them, so
the initiator and the joiner share one formatter and one set of Good/Average/High
bands and cannot drift. A test asserts the two produce identical strings and
colours for the same quote, across the wire.

### SwapKit provider fee: read and mapped, deliberately not populated

The four fields are read off the wire, carried on `SwapKitSwapPayload`, written
back with the same explicit-presence discipline, and resolved through the shared
never-guess coin resolution the 1inch-shaped routes already use.

**The iOS payload builder leaves them nil, on purpose.** iOS itemizes no SwapKit
provider fee on the *initiator* either: `SwapCryptoLogic.affiliateFeeFiat` returns
`.zero` for `.swapkit` and the form renders a `swap.included_in_rate` note instead
of an amount, because SwapKit's affiliate comes off the input and is already
reflected in the quoted output. Populating a figure here would give the joiner a
Swap Fee row and a Total that the initiator's own verify screen does not show —
creating precisely the initiator↔joiner disagreement this workstream exists to
remove, and trading an existing agreement for a new one is a net loss however
correct the number is.

Read-only is a strict improvement with no downside: an iOS joiner on a
Windows/Android/SDK-initiated SwapKit swap now sees the fee that initiator is
showing, and iOS↔iOS is unchanged. Whether iOS *should* itemize SwapKit's
affiliate at all is a display question being filed separately.

**A stated zero is kept distinct from an absent fee**, on both sides. `swap_fee`
is optional on this payload, so `nil` means "the sender cannot say" and `"0"`
means "this route charges nothing" — and `"0"` is a non-empty string, so it
serializes and the claim survives the wire. The read guard now renders `$0.00`
with its coin context for a stated zero and hides the row only for a genuinely
absent fee; the write no longer drops a `"0"` before it reaches the proto, which
had meant a joiner **relaying** a received payload destroyed a statement its
sender had made.

The generic/1inch path deliberately keeps hiding a zero, and the shared resolver
takes a flag rather than relaxing for both callers.
`EVMQuote.Transaction.swapFee` defaults to `"0"` when a quote omits the key, so a
zero there cannot be told from "never quoted" and relaxing the guard would assert
zeros nobody reported — the quote model has to be able to say "no fee quoted"
first. That is filed as
[#5366](https://github.com/vultisig/vultisig-ios/issues/5366).

`testGenericPathStillHidesAZero` is a deliberate tripwire on it: when #5366 is
fixed that test **should** fail, and the right response is to update it to the
new truth, not to relax it. It exists so the change surfaces loudly two PRs
later instead of silently.

### Route tag, on a separate display name

SwapKit's EVM and Solana routes ride the 1inch-shaped payload, so they reached a
co-signer named after the aggregator alone while every other SwapKit route named
the route it took. The tag now travels.

**The tag travels, but iOS does not render it on these routes.** This device's
own verify screen names the clean brand (`SwapQuote.displayName`), so appending
the route on the joiner alone would make the two screens whose job is to agree
describe one swap differently. Whether iOS should show sub-provider tags is a
display decision for both screens together, not one that arrives on the joiner
as a side effect. The wire carries it so the clients that do render it can. The
route tests assert both halves: the tag reaches the peer, **and**
`providerDisplayName` equals the initiator's own `SwapQuote.displayName` for the
same fixture.

Separately, this PR does split the persisted identity from the display name.
`providerName` is persisted to Transaction History and resolved back to a tracker
URL by `ExplorerLinkBuilder`'s exact alias lookup, and a tagged name defeats it —
`"SwapKit (CHAINFLIP)"` normalises to `swapkitchainflip`, which is in no alias
table, so those rows silently fell back to the chain explorer instead of the
SwapKit tracker. `providerName` is now the bare brand for the SwapKit transfer
routes too, while `providerDisplayName` keeps their long-standing "via Chainflip"
verify-screen affordance. **That fixes a pre-existing broken tracker link** for
newly recorded rows; existing tagged rows are untouched and need no migration.
Tests pin both the fix and the reason for it (a tagged name *does* lose the
tracker).

## Two claims in the issue that do not hold for iOS

1. **"the initiator reads `SwapKit (NEAR)`".** It does not — `SwapQuote.displayName`
   deliberately returns the clean brand for every route. There was no
   initiator↔joiner disagreement to close; the asymmetry was `.generic` vs
   `.swapkit` on the joiner.
2. **"no swap fee at all on non-EVM SwapKit routes".** True of the joiner, but the
   iOS initiator itemizes none either, on any route — see above.

## Signing is untouched

All four field groups are display-only. No signer reads them; the per-chain
signers read `txPayload` / `quote.tx.*` / the memo. Tests assert the signed memo
terms, the routing fields and the EVM calldata do not move when the display
fields do, that a legacy payload decodes cleanly, and that re-encoding one leaves
every new field unset.

## Verification

Full local gate — `make test`, whole suite, on a dedicated `en_US` simulator
(deleted afterwards):

```
HEAD: 2b9b58cc53961ec798a825319a9550d68db57b05
BASE: c018d66940ca48bc1eb57392629367b4e95151b5
** TEST SUCCEEDED **
Executed 7152 tests, with 11 tests skipped and 0 failures (0 unexpected)
GATE_EXIT=0
DF_BEFORE: /dev/disk3s5   460Gi   402Gi    29Gi    94%
DF_AFTER:  /dev/disk3s5   460Gi   404Gi    27Gi    94%
```

`Test Case … failed` = 0; swiftc `error:` = 0. Free space never approached zero,
so the marker is not a stale-products artefact.

**The count is checkable without re-running anything.** 7102 (the base,
`codex/thorswap-fee-payload-5340` @ `c018d6694`) + 50 new test functions = 7152.
The 50 is measured from the diff, not recalled: `git diff <base>...HEAD --
'*Tests.swift' | grep -cE '^\+\s*func test'`. All 50 are confirmed executed,
not merely compiled in: `NativeSwapPriceImpactProtoMappingTests` 19 passed,
`SwapKitSwapFeeProtoMappingTests` 17, `SwapSubProviderProtoMappingTests` 14.
The suite this PR could most plausibly have disturbed still passes whole:
`NativeSwapFeeProtoMappingTests` (#5352's) 24/24 — including the
zero-distinguishability and negative-component tests that branch added, which is
what confirms its semantics survived the rebases rather than merely its text — as
does the pre-existing `SwapFeeProtoMappingTests` — the latter is what pins that folding the
generic and SwapKit fee resolvers into one `resolveContextualSwapFee` left the
1inch-shaped path's behaviour unchanged.

SwiftLint: no new warnings in any file touched (the `SwapPayloadBuilderTests.swift`
comma warnings are pre-existing on the base).

One note on the base's negative-fee validation, which lands beside this PR's
`nativeSwapPayloadSlippageBps` in the same file: there is no interaction. That
guard defends against two fee components that can offset (`-1 + 1` laundering a
malformed quote into a stated `"0"`); slippage has a single component and no sum,
so the mechanism cannot arise, and `UInt32(exactly:)` already rejects a negative
outright because the target type cannot represent one. The two arrive at the same
invariant by different routes and neither depends on the other.

Cross-model review: `codex exec --sandbox read-only` whole-branch pass —
one P1 and three P2s, all triaged.

| Finding | Disposition |
|---|---|
| **P1** — the builder serialized `quote.fees.slippageBps` while this device's verify screen renders the top-level `quote.slippageBps`; the two can differ (THORChain's streaming example: 41 vs 9), so the co-signer could show a different impact than the initiator. The parity test masked it by setting both fixture fields to the same value. | **Fixed.** Real bug. Builder reads the top-level field; fixtures now always give the two sources different values, and two tests pin which one travels and that a nested value alone carries nothing. |
| **P2** — the `providerName` / `providerDisplayName` split was applied to `.generic` but not `.swapkit`, leaving the tagged persisted name — and its lost tracker link — in place. | **Fixed.** Extended to `.swapkit`, with persistence coverage for both halves and a test pinning that a tagged persisted name loses the tracker, so the reason the split exists is documented in the suite. |
| **P2** — the signing / byte-stability tests would have passed even if a signer started reading a display field, and the legacy tests never compared `serializedData()` byte-for-byte. | **Fixed.** The SwapKit fee group is now run through the real BTC PSBT signer with the BIP-143 pre-signing hashes compared; each new field is cleared and the bytes required to equal a payload that never carried it; and all three legacy round-trips compare `serializedData()` byte-for-byte. |
| **P2** — the route tag makes the co-signer read `SwapKit (ONEINCH)` where the initiator's verify screen reads the bare `SwapKit`. | **Fixed by reverting the joiner-side display.** Correct, and worth not creating at all: the wire write stays so other clients get the tag, but neither iOS screen renders it, and the route tests now assert joiner/initiator naming parity directly. |

### The byte-identity test earned its place

The `serializedData()` comparison in the third row was added **at review request**,
after the first version of these tests was judged to assert guarantees it could
not fail. It then failed — and not on the new code. The field-level comparison
named the culprit directly: a round trip was *adding* `router_address: ""`
(186 bytes in, 188 out).

`router_address` is `optional string router_address = 5` — **explicit** presence,
not an implicit-presence proto3 string — so the mapper's long-standing
`$0.routerAddress = payload.routerAddress ?? .empty` marks the field present for
a payload that carries no router instead of eliding it as a default. That
assignment is on `origin/main` and affects both the thorchain and mayachain
branches; this branch merely added the assertion that could see it.

The sequence is what makes this a fix rather than a retuned assertion: the test
**failed on three consecutive gate runs and passed only once `router_address`
was corrected** — the code moved to satisfy the assertion, not the other way
round. Its two companions (`SwapKitSwapFeeProtoMappingTests`,
`SwapSubProviderProtoMappingTests`) passed throughout, which is what localised
the defect to the native payload rather than to the new mapping discipline.

Nothing reads differently, because the decode side already normalises empty to
nil. But the bytes are not cosmetic: `KeysignDiscoveryViewModel` uploads the
serialized payload and `PayloadService.uploadPayload` returns `payload.sha256()`
as the `payloadID` the joiner fetches by, so "the same payload serializes to the
same bytes" is a property this transport rests on. No current flow breaks — only
the initiator uploads, and it serializes once — so this is **a latent guarantee
restored, not an active bug**. It is called out under Review below because it is
a keysign-path change that pre-dates this branch.

Codex also confirmed by static tracing that no current signer reads any of the
three additions — native signing derives its bytes from the outer
`KeysignPayload`, generic signing consumes only `payload.quote`, and the SwapKit
signers consume the existing transaction-payload/target fields — and that the
nil-presence handling, the present-zero slippage encoding and the fee-resolver
refactor are correct.

**On-device acceptance was NOT performed.** This touches the swap keysign payload,
so it wants a human plus a two-device co-sign check before it leaves draft.

**Please look hardest at the `router_address` change.** It is the one edit here
that alters bytes for a payload shape that predates this branch, it sits in a
keysign path, and it affects both the thorchain and mayachain branches. The
argument that it is safe is that both sides already read absent and
present-but-empty identically, so only the encoding changes — but that is worth a
second pair of eyes rather than my word.

## Stacked

Base is `codex/thorswap-fee-payload-5340` (#5352), not `main` — that PR adds
`THORChainSwapPayload.fee` and touches the same two files. Nothing it added is
modified here.

Closes #5341

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqdXT9XtXkN4XMwjXyqjND


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Swap confirmations now show formatted provider names, including sub-providers such as Chainflip.
  - Price impact is displayed with localized text and visual indicators when available.
  - Swap fee details support contextual provider fees and explicitly stated zero fees.
  - Native swap slippage and fee information is preserved accurately across transactions.

- **Bug Fixes**
  - Improved compatibility with legacy swap data while retaining newly available metadata.
  - Corrected handling of missing, zero, and non-zero fee or slippage values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->