### PR TITLE
fix(swap): refuse a SwapKit deposit response that disagrees with itself

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitDestinationTag.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitDestinationTag.swift
@@ -7,36 +7,25 @@ import Foundation
 
 /// What one source says about an XRP destination tag.
 ///
-/// The tag is half the destination: a shared exchange address routes a deposit to an
-/// account by tag, so "states no tag" and "states a tag this client cannot read" are
-/// different answers that must never collapse into each other. A two-state `UInt64?`
-/// forces exactly that collapse, and a fail-closed guard built on it reads an unreadable
-/// tag as a tag-less payment — which credits nobody.
+/// "States no tag" and "states a tag this client cannot read" are different answers, and a
+/// `UInt64?` forces them to collapse — which sends a tag-less deposit to an address where the
+/// tag is what identifies the depositor.
 enum SwapKitDestinationTag: Hashable {
-    /// The source says nothing: the field is absent or null, or the address carries no
-    /// tag suffix.
     case absent
-    /// The source states exactly one readable tag.
     case tag(UInt64)
-    /// The source states something that is not one readable tag — a value that is not a
-    /// `UInt64`, or more than one `dt` parameter. Two answers is not one answer, and
-    /// picking one of them is a guess that misroutes a deposit.
+    /// A value that is not a `UInt64`, or more than one `dt` parameter. Two answers is not one
+    /// answer, and picking one is a guess.
     case unreadable(reason: String)
 
-    /// The tag to use, or nil when there is none to use.
-    ///
-    /// `.unreadable` yields nil so the resolution helpers behave exactly as they did
-    /// before this type existed. Refusing such a response is the agreement guard's job,
-    /// not theirs — resolution answers "what would we use", validation answers "may we
-    /// use this response at all".
+    /// `.unreadable` yields nil so resolution behaves as it did before this type existed;
+    /// refusing such a response is the agreement guard's job, not resolution's.
     var usableTag: UInt64? {
         guard case .tag(let value) = self else { return nil }
         return value
     }
 
-    /// Read a tag SwapKit may send as a number or as a numeric string (`meta.affiliateFee`
-    /// arrives string-wrapped despite being numeric, so both shapes are accepted). A key
-    /// that is present but holds neither is `.unreadable`, never `.absent`.
+    /// SwapKit sends the tag as a number or as a numeric string. Present-but-neither is
+    /// `.unreadable`, never `.absent`.
     static func decoded<Key: CodingKey>(
         from container: KeyedDecodingContainer<Key>,
         forKey key: Key

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitDestinationTag.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitDestinationTag.swift
@@ -1,0 +1,58 @@
+//
+//  SwapKitDestinationTag.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// What one source says about an XRP destination tag.
+///
+/// The tag is half the destination: a shared exchange address routes a deposit to an
+/// account by tag, so "states no tag" and "states a tag this client cannot read" are
+/// different answers that must never collapse into each other. A two-state `UInt64?`
+/// forces exactly that collapse, and a fail-closed guard built on it reads an unreadable
+/// tag as a tag-less payment — which credits nobody.
+enum SwapKitDestinationTag: Hashable {
+    /// The source says nothing: the field is absent or null, or the address carries no
+    /// tag suffix.
+    case absent
+    /// The source states exactly one readable tag.
+    case tag(UInt64)
+    /// The source states something that is not one readable tag — a value that is not a
+    /// `UInt64`, or more than one `dt` parameter. Two answers is not one answer, and
+    /// picking one of them is a guess that misroutes a deposit.
+    case unreadable(reason: String)
+
+    /// The tag to use, or nil when there is none to use.
+    ///
+    /// `.unreadable` yields nil so the resolution helpers behave exactly as they did
+    /// before this type existed. Refusing such a response is the agreement guard's job,
+    /// not theirs — resolution answers "what would we use", validation answers "may we
+    /// use this response at all".
+    var usableTag: UInt64? {
+        guard case .tag(let value) = self else { return nil }
+        return value
+    }
+
+    /// Read a tag SwapKit may send as a number or as a numeric string (`meta.affiliateFee`
+    /// arrives string-wrapped despite being numeric, so both shapes are accepted). A key
+    /// that is present but holds neither is `.unreadable`, never `.absent`.
+    static func decoded<Key: CodingKey>(
+        from container: KeyedDecodingContainer<Key>,
+        forKey key: Key
+    ) -> SwapKitDestinationTag {
+        guard container.contains(key), (try? container.decodeNil(forKey: key)) == false else {
+            return .absent
+        }
+        if let intTag = try? container.decode(UInt64.self, forKey: key) {
+            return .tag(intTag)
+        }
+        if let stringTag = try? container.decode(String.self, forKey: key) {
+            guard let parsed = UInt64(stringTag) else {
+                return .unreadable(reason: "\"\(stringTag)\" is not a destination tag")
+            }
+            return .tag(parsed)
+        }
+        return .unreadable(reason: "value is neither a number nor a numeric string")
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitError.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitError.swift
@@ -37,6 +37,11 @@ enum SwapKitError: Error, LocalizedError, Equatable {
     case isSanctionedAddress
     case addressScreeningFailed
     case unsupportedTxType(String)
+    /// The `/v3/swap` response disagrees with itself about where the deposit
+    /// goes, or states a transfer array the builder cannot honour. `detail` is
+    /// diagnostic only — see `errorDescription` for why the user copy is shared
+    /// with `unableToBuildTransaction`.
+    case contradictoryResponse(detail: String)
     case providerNotEnabled
     case routeFiltered
     case malformedAmount(String)
@@ -126,6 +131,12 @@ enum SwapKitError: Error, LocalizedError, Equatable {
             return "swapKitErrorAddressScreening".localized
         case .unsupportedTxType(let txType):
             return String(format: "swapKitErrorUnsupportedTxType".localized, txType)
+        case .contradictoryResponse:
+            // The user-facing meaning is identical to `unableToBuildTransaction`:
+            // this route is unusable, try another provider. Reusing that copy keeps
+            // the detail (which names the divergent field and both values) in the
+            // logs, where it is actionable, instead of in a dialog.
+            return "swapKitErrorUnableToBuildTransaction".localized
         case .providerNotEnabled:
             return "swapKitErrorProviderNotEnabled".localized
         case .routeFiltered:

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitError.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitError.swift
@@ -89,6 +89,17 @@ enum SwapKitError: Error, LocalizedError, Equatable {
         }
     }
 
+    /// Names the divergent field and both values. Logged at rejection, never shown: both
+    /// cases share the `unableToBuildTransaction` copy.
+    var refusalDetail: String? {
+        switch self {
+        case .contradictoryResponse(let detail), .responseEchoMismatch(let detail):
+            return detail
+        default:
+            return nil
+        }
+    }
+
     static func from(httpData: Data?) -> SwapKitError? {
         guard let httpData,
               let envelope = try? JSONDecoder().decode(SwapKitErrorEnvelope.self, from: httpData)
@@ -136,7 +147,7 @@ enum SwapKitError: Error, LocalizedError, Equatable {
             return String(format: "swapKitErrorUnsupportedTxType".localized, txType)
         case .contradictoryResponse, .responseEchoMismatch:
             // Same user-facing meaning as `unableToBuildTransaction`: this route is
-            // unusable, try another provider. The detail stays in the logs.
+            // unusable, try another provider. See `refusalDetail` for the diagnostic.
             return "swapKitErrorUnableToBuildTransaction".localized
         case .providerNotEnabled:
             return "swapKitErrorProviderNotEnabled".localized

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitError.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitError.swift
@@ -42,6 +42,9 @@ enum SwapKitError: Error, LocalizedError, Equatable {
     /// diagnostic only — see `errorDescription` for why the user copy is shared
     /// with `unableToBuildTransaction`.
     case contradictoryResponse(detail: String)
+    /// The `/v3/swap` response does not echo the swap that was requested — a
+    /// different route, source, or destination than the one asked for.
+    case responseEchoMismatch(detail: String)
     case providerNotEnabled
     case routeFiltered
     case malformedAmount(String)
@@ -131,7 +134,7 @@ enum SwapKitError: Error, LocalizedError, Equatable {
             return "swapKitErrorAddressScreening".localized
         case .unsupportedTxType(let txType):
             return String(format: "swapKitErrorUnsupportedTxType".localized, txType)
-        case .contradictoryResponse:
+        case .contradictoryResponse, .responseEchoMismatch:
             // The user-facing meaning is identical to `unableToBuildTransaction`:
             // this route is unusable, try another provider. Reusing that copy keeps
             // the detail (which names the divergent field and both values) in the

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitError.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitError.swift
@@ -135,10 +135,8 @@ enum SwapKitError: Error, LocalizedError, Equatable {
         case .unsupportedTxType(let txType):
             return String(format: "swapKitErrorUnsupportedTxType".localized, txType)
         case .contradictoryResponse, .responseEchoMismatch:
-            // The user-facing meaning is identical to `unableToBuildTransaction`:
-            // this route is unusable, try another provider. Reusing that copy keeps
-            // the detail (which names the divergent field and both values) in the
-            // logs, where it is actionable, instead of in a dialog.
+            // Same user-facing meaning as `unableToBuildTransaction`: this route is
+            // unusable, try another provider. The detail stays in the logs.
             return "swapKitErrorUnableToBuildTransaction".localized
         case .providerNotEnabled:
             return "swapKitErrorProviderNotEnabled".localized

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitResponseAgreement.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitResponseAgreement.swift
@@ -2,9 +2,6 @@
 //  SwapKitResponseAgreement.swift
 //  VultisigApp
 //
-//  Fail-closed cross-check of a `/v3/swap` response against itself, run before the
-//  quote can enter ranking.
-//
 
 import Foundation
 
@@ -12,26 +9,17 @@ extension SwapKitSwapResponse {
 
     /// Refuse a response that disagrees with itself about where the deposit goes.
     ///
-    /// SwapKit states the deposit destination in three independent fields — `targetAddress`,
-    /// `inboundAddress`, and the `tx[]` transfer array — and the payload builder reads only
-    /// `targetAddress`. A response whose halves diverge would be signed to that field while
-    /// the others name a different account, and nothing downstream could tell: Blockaid does
-    /// not scan non-EVM SwapKit sources, and the cosigning peer never decodes `tx[]`. Neither
-    /// field is authoritative enough to arbitrate from, so a divergence is refused rather
-    /// than resolved by precedence.
-    ///
-    /// The realistic trigger is not a tampered payload but an unversioned wire change —
-    /// upstream has already renamed `SOLANA` → `SERIALIZED_BASE64` and `CARDANO` → `CBOR`
-    /// mid-flight. Repurposing a destination field the same way would be a lost deposit.
+    /// `targetAddress`, `inboundAddress` and `tx[]` state the same fact independently and the
+    /// payload builder reads only the first. Neither is authoritative enough to arbitrate from,
+    /// so a divergence is refused rather than resolved by precedence.
     func validateSelfAgreement(fromChain: Chain) throws {
         try validateTransferCardinality()
         try validateDestinationAgreement(fromChain: fromChain)
         try validateDestinationTagAgreement()
     }
 
-    /// A TON route must state exactly one transfer. Only `tx[0]` is ever built, so a
-    /// multi-entry array would be signed as a partial deposit that under-funds the swap,
-    /// and an empty array states no transfer at all while `targetAddress` says otherwise.
+    /// Only `tx[0]` is ever built, so a multi-entry array would be signed as a partial deposit,
+    /// and an empty one states no transfer while `targetAddress` says otherwise.
     private func validateTransferCardinality() throws {
         guard case .ton(let transfers) = tx else { return }
         guard transfers.count == 1 else {
@@ -42,16 +30,13 @@ extension SwapKitSwapResponse {
     }
 
     private func validateDestinationAgreement(fromChain: Chain) throws {
-        // `targetAddress` is what every SwapKit branch of the payload builder signs to, so a
-        // blank value stages an unspendable deposit rather than a contradictory one.
         let target = Self.bareDestination(resolvedTargetAddress)
         guard !target.isEmpty else {
             throw SwapKitError.contradictoryResponse(detail: "targetAddress is empty")
         }
         for candidate in corroboratingDestinations {
-            // A field that is present but blank corroborates nothing, and nothing is not
-            // agreement. Skipping it would let a response walk past the guard by stating
-            // its second destination as an empty string.
+            // A present-but-blank field corroborates nothing, and nothing is not agreement:
+            // skipping it would let a response walk past this guard with an empty string.
             let value = Self.bareDestination(candidate.value)
             guard !value.isEmpty else {
                 throw SwapKitError.contradictoryResponse(detail: "\(candidate.field) is empty")
@@ -64,18 +49,9 @@ extension SwapKitSwapResponse {
         }
     }
 
-    /// On XRP the destination tag is half the destination: a shared exchange address routes
-    /// the deposit to an account by tag, so the same address carrying two different tags is
-    /// two different recipients. The address comparison strips the tag suffix on purpose (so
-    /// one destination spelled with and without it still agrees), which would hide exactly
-    /// that divergence — hence tags are cross-checked in their own right, across every source
-    /// the response states one in.
-    ///
-    /// A source is switched over exhaustively rather than reduced to `UInt64?` first: a tag
-    /// the response states but this client cannot read is not a tag-less payment, and
-    /// collapsing the two would send a deposit with no tag to an address where the tag is
-    /// what identifies the depositor. Any tag source added here later has to answer for
-    /// `.unreadable` before it will compile.
+    /// Tags are checked separately because the address comparison strips the suffix, which would
+    /// otherwise hide one address carrying two different tags — two different recipients. The
+    /// switch is exhaustive so a tag source added later has to answer for `.unreadable`.
     private func validateDestinationTagAgreement() throws {
         var stated: [(field: String, value: UInt64)] = []
         for source in destinationTagSources {
@@ -98,9 +74,6 @@ extension SwapKitSwapResponse {
         }
     }
 
-    /// Every source the response can state a destination tag in, in the order
-    /// `resolvedDestinationTag` resolves them, plus the `inboundAddress` suffix — a tag
-    /// stated there is still the response contradicting itself even though nothing reads it.
     private var destinationTagSources: [(field: String, tag: SwapKitDestinationTag)] {
         [
             (field: "destinationTag", tag: destinationTagSource),
@@ -113,9 +86,6 @@ extension SwapKitSwapResponse {
         ]
     }
 
-    /// Every field other than `targetAddress` that states the same deposit destination.
-    /// `inboundAddress` is one on every non-EVM route (EVM omits it); `tx[0].address` is one
-    /// wherever the wire shape is a typed transfer array.
     private var corroboratingDestinations: [(field: String, value: String)] {
         var candidates: [(field: String, value: String)] = []
         if let inboundAddress {
@@ -127,24 +97,16 @@ extension SwapKitSwapResponse {
         return candidates
     }
 
-    /// Both sides of a comparison get the same destination-tag strip, so a destination
-    /// spelled with a suffix in one field and without it in another still agrees. The tags
-    /// themselves are compared separately — see `validateDestinationTagAgreement`.
+    /// Both sides get the same strip, so one destination spelled with a tag suffix in one field
+    /// and without it in another still agrees.
     private static func bareDestination(_ address: String) -> String {
         extractTagSuffix(from: address).address.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    /// TON spells one account as `EQ…`, `UQ…` or raw `workchain:hash`, and SwapKit really does
-    /// return different spellings for one account, so its destinations compare as parsed
-    /// accounts.
-    ///
-    /// Every other chain compares byte for byte. Base58 is case-sensitive, so folding case
-    /// there would let two different addresses pass as one — the one failure this guard must
-    /// never have. Bech32 and CashAddr *are* case-insensitive and could be normalised safely,
-    /// but no recorded response has ever spelled a destination two ways outside TON, so the
-    /// extra parsing would be untested surface in the code that has to be trusted most. The
-    /// cost of that choice is bounded: an encoding that starts varying its case gets a
-    /// refused route the user can retry, never a deposit signed to the wrong address.
+    /// TON compares as parsed accounts because one account really does arrive spelled several
+    /// ways. Everything else is byte-for-byte on purpose: base58 is case-sensitive. Bech32 and
+    /// CashAddr could be case-normalised safely, but do not add it — a false reject here is a
+    /// route the user retries, while a wrong canonicalisation lets two addresses pass as one.
     private static func isSameDestination(_ lhs: String, _ rhs: String, chain: Chain) -> Bool {
         chain == .ton ? TonAccountIdentity.isSameAccount(lhs, rhs) : lhs == rhs
     }

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitResponseAgreement.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitResponseAgreement.swift
@@ -1,0 +1,151 @@
+//
+//  SwapKitResponseAgreement.swift
+//  VultisigApp
+//
+//  Fail-closed cross-check of a `/v3/swap` response against itself, run before the
+//  quote can enter ranking.
+//
+
+import Foundation
+
+extension SwapKitSwapResponse {
+
+    /// Refuse a response that disagrees with itself about where the deposit goes.
+    ///
+    /// SwapKit states the deposit destination in three independent fields — `targetAddress`,
+    /// `inboundAddress`, and the `tx[]` transfer array — and the payload builder reads only
+    /// `targetAddress`. A response whose halves diverge would be signed to that field while
+    /// the others name a different account, and nothing downstream could tell: Blockaid does
+    /// not scan non-EVM SwapKit sources, and the cosigning peer never decodes `tx[]`. Neither
+    /// field is authoritative enough to arbitrate from, so a divergence is refused rather
+    /// than resolved by precedence.
+    ///
+    /// The realistic trigger is not a tampered payload but an unversioned wire change —
+    /// upstream has already renamed `SOLANA` → `SERIALIZED_BASE64` and `CARDANO` → `CBOR`
+    /// mid-flight. Repurposing a destination field the same way would be a lost deposit.
+    func validateSelfAgreement(fromChain: Chain) throws {
+        try validateTransferCardinality()
+        try validateDestinationAgreement(fromChain: fromChain)
+        try validateDestinationTagAgreement()
+    }
+
+    /// A TON route must state exactly one transfer. Only `tx[0]` is ever built, so a
+    /// multi-entry array would be signed as a partial deposit that under-funds the swap,
+    /// and an empty array states no transfer at all while `targetAddress` says otherwise.
+    private func validateTransferCardinality() throws {
+        guard case .ton(let transfers) = tx else { return }
+        guard transfers.count == 1 else {
+            throw SwapKitError.contradictoryResponse(
+                detail: "TON route returned \(transfers.count) transfers, expected exactly one"
+            )
+        }
+    }
+
+    private func validateDestinationAgreement(fromChain: Chain) throws {
+        // `targetAddress` is what every SwapKit branch of the payload builder signs to, so a
+        // blank value stages an unspendable deposit rather than a contradictory one.
+        let target = Self.bareDestination(resolvedTargetAddress)
+        guard !target.isEmpty else {
+            throw SwapKitError.contradictoryResponse(detail: "targetAddress is empty")
+        }
+        for candidate in corroboratingDestinations {
+            // A field that is present but blank corroborates nothing, and nothing is not
+            // agreement. Skipping it would let a response walk past the guard by stating
+            // its second destination as an empty string.
+            let value = Self.bareDestination(candidate.value)
+            guard !value.isEmpty else {
+                throw SwapKitError.contradictoryResponse(detail: "\(candidate.field) is empty")
+            }
+            guard Self.isSameDestination(value, target, chain: fromChain) else {
+                throw SwapKitError.contradictoryResponse(
+                    detail: "targetAddress is \(target) but \(candidate.field) is \(value)"
+                )
+            }
+        }
+    }
+
+    /// On XRP the destination tag is half the destination: a shared exchange address routes
+    /// the deposit to an account by tag, so the same address carrying two different tags is
+    /// two different recipients. The address comparison strips the tag suffix on purpose (so
+    /// one destination spelled with and without it still agrees), which would hide exactly
+    /// that divergence — hence tags are cross-checked in their own right, across every source
+    /// the response states one in.
+    ///
+    /// A source is switched over exhaustively rather than reduced to `UInt64?` first: a tag
+    /// the response states but this client cannot read is not a tag-less payment, and
+    /// collapsing the two would send a deposit with no tag to an address where the tag is
+    /// what identifies the depositor. Any tag source added here later has to answer for
+    /// `.unreadable` before it will compile.
+    private func validateDestinationTagAgreement() throws {
+        var stated: [(field: String, value: UInt64)] = []
+        for source in destinationTagSources {
+            switch source.tag {
+            case .absent:
+                continue
+            case .unreadable(let reason):
+                throw SwapKitError.contradictoryResponse(
+                    detail: "\(source.field) states a destination tag that cannot be read: \(reason)"
+                )
+            case .tag(let value):
+                stated.append((field: source.field, value: value))
+            }
+        }
+        guard let primary = stated.first else { return }
+        for candidate in stated.dropFirst() where candidate.value != primary.value {
+            throw SwapKitError.contradictoryResponse(
+                detail: "\(primary.field) is \(primary.value) but \(candidate.field) is \(candidate.value)"
+            )
+        }
+    }
+
+    /// Every source the response can state a destination tag in, in the order
+    /// `resolvedDestinationTag` resolves them, plus the `inboundAddress` suffix — a tag
+    /// stated there is still the response contradicting itself even though nothing reads it.
+    private var destinationTagSources: [(field: String, tag: SwapKitDestinationTag)] {
+        [
+            (field: "destinationTag", tag: destinationTagSource),
+            (field: "meta.destinationTag", tag: meta.destinationTagSource),
+            (field: "targetAddress tag suffix", tag: Self.extractTagSuffix(from: targetAddress).tag),
+            (
+                field: "inboundAddress tag suffix",
+                tag: inboundAddress.map { Self.extractTagSuffix(from: $0).tag } ?? .absent
+            )
+        ]
+    }
+
+    /// Every field other than `targetAddress` that states the same deposit destination.
+    /// `inboundAddress` is one on every non-EVM route (EVM omits it); `tx[0].address` is one
+    /// wherever the wire shape is a typed transfer array.
+    private var corroboratingDestinations: [(field: String, value: String)] {
+        var candidates: [(field: String, value: String)] = []
+        if let inboundAddress {
+            candidates.append((field: "inboundAddress", value: inboundAddress))
+        }
+        if case .ton(let transfers) = tx, let first = transfers.first {
+            candidates.append((field: "tx[0].address", value: first.address))
+        }
+        return candidates
+    }
+
+    /// Both sides of a comparison get the same destination-tag strip, so a destination
+    /// spelled with a suffix in one field and without it in another still agrees. The tags
+    /// themselves are compared separately — see `validateDestinationTagAgreement`.
+    private static func bareDestination(_ address: String) -> String {
+        extractTagSuffix(from: address).address.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// TON spells one account as `EQ…`, `UQ…` or raw `workchain:hash`, and SwapKit really does
+    /// return different spellings for one account, so its destinations compare as parsed
+    /// accounts.
+    ///
+    /// Every other chain compares byte for byte. Base58 is case-sensitive, so folding case
+    /// there would let two different addresses pass as one — the one failure this guard must
+    /// never have. Bech32 and CashAddr *are* case-insensitive and could be normalised safely,
+    /// but no recorded response has ever spelled a destination two ways outside TON, so the
+    /// extra parsing would be untested surface in the code that has to be trusted most. The
+    /// cost of that choice is bounded: an encoding that starts varying its case gets a
+    /// refused route the user can retry, never a deposit signed to the wrong address.
+    private static func isSameDestination(_ lhs: String, _ rhs: String, chain: Chain) -> Bool {
+        chain == .ton ? TonAccountIdentity.isSameAccount(lhs, rhs) : lhs == rhs
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
@@ -194,21 +194,30 @@ struct SwapKitService {
         destinationAddress: String
     ) throws {
         guard response.routeId == routeId else {
-            throw SwapKitError.responseEchoMismatch(
+            throw refusal(.responseEchoMismatch(
                 detail: "requested routeId \(routeId) but the response is for \(response.routeId)"
-            )
+            ))
         }
         guard echoesAddress(response.sourceAddress, sourceAddress) else {
-            throw SwapKitError.responseEchoMismatch(
+            throw refusal(.responseEchoMismatch(
                 detail: "requested sourceAddress \(sourceAddress) but the response echoes \(response.sourceAddress)"
-            )
+            ))
         }
         guard echoesAddress(response.destinationAddress, destinationAddress) else {
-            throw SwapKitError.responseEchoMismatch(
+            throw refusal(.responseEchoMismatch(
                 detail: "requested destinationAddress \(destinationAddress) "
                     + "but the response echoes \(response.destinationAddress)"
-            )
+            ))
         }
+    }
+
+    /// A refusal is only actionable if the mismatch reaches the log. Addresses stay `.private`
+    /// so the log store redacts them.
+    private static func refusal(_ error: SwapKitError) -> SwapKitError {
+        if let detail = error.refusalDetail {
+            logger.error("SwapKit response refused: \(detail, privacy: .private)")
+        }
+        return error
     }
 
     /// The chain is not threaded in because it need not be: two different non-TON addresses
@@ -231,7 +240,11 @@ struct SwapKitService {
                 "\(response.meta.txType)/\(fromChain.ticker)"
             )
         }
-        try response.validateSelfAgreement(fromChain: fromChain)
+        do {
+            try response.validateSelfAgreement(fromChain: fromChain)
+        } catch let error as SwapKitError {
+            throw refusal(error)
+        }
     }
 
     /// Format an amount as a dot-separated decimal string suitable for

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
@@ -185,13 +185,8 @@ struct SwapKitService {
         return ranked.max(by: { $0.1 < $1.1 })?.0
     }
 
-    /// Assert the `/v3/swap` response describes the swap that was actually requested.
-    ///
-    /// `buildSwapTx` returned whatever came back, so a response built for a different
-    /// route — a mis-routed proxy, a stale cache entry, an unversioned API change —
-    /// would be carried into signing as if it were ours, with the deposit address and
-    /// amount that belong to someone else's swap. `JupiterService.fetchQuote` already
-    /// gates its quote this way; SwapKit had no equivalent.
+    /// Assert the response describes the swap that was requested: one built for another
+    /// route would otherwise be carried into signing as if it were ours.
     static func validateRequestEcho(
         response: SwapKitSwapResponse,
         routeId: String,
@@ -216,23 +211,14 @@ struct SwapKitService {
         }
     }
 
-    /// Whether an echoed address names the address that was requested.
-    ///
-    /// `addressesMatch` ignores case only for 20-byte hex (EVM checksum casing) and is
-    /// exact everywhere else, which is the right default: base58 is case-sensitive. TON
-    /// is the one encoding where one account has several spellings, and the source or
-    /// destination of a TON route could legitimately come back re-spelled, so an account
-    /// match is accepted too. The chain is not threaded in because it need not be: two
-    /// different non-TON addresses cannot both parse as TON addresses (48 base64url
-    /// characters, a valid tag byte, and a matching CRC16) and canonicalise equal.
+    /// The chain is not threaded in because it need not be: two different non-TON addresses
+    /// cannot both parse as TON addresses and canonicalise equal.
     private static func echoesAddress(_ echoed: String, _ requested: String) -> Bool {
         SwapRecipientVerifier.addressesMatch(echoed, requested)
             || TonAccountIdentity.isSameAccount(echoed, requested)
     }
 
-    /// The single gate every `/v3/swap` response passes before its quote can enter
-    /// ranking: the payload shape must be one this chain's signer implements, and the
-    /// response must agree with itself about where the deposit goes.
+    /// The single gate every `/v3/swap` response passes before its quote can enter ranking.
     static func validateSigningCapability(
         response: SwapKitSwapResponse,
         fromChain: Chain

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
@@ -139,6 +139,12 @@ struct SwapKitService {
                 SwapKitAPI.swap(request),
                 responseType: SwapKitSwapResponse.self
             )
+            try Self.validateRequestEcho(
+                response: response.data,
+                routeId: routeId,
+                sourceAddress: sourceAddress,
+                destinationAddress: destinationAddress
+            )
             return response.data
         } catch HTTPError.statusCode(_, let data) {
             if let error = SwapKitError.from(httpData: data) {
@@ -177,6 +183,51 @@ struct SwapKitService {
             return (route, amount)
         }
         return ranked.max(by: { $0.1 < $1.1 })?.0
+    }
+
+    /// Assert the `/v3/swap` response describes the swap that was actually requested.
+    ///
+    /// `buildSwapTx` returned whatever came back, so a response built for a different
+    /// route — a mis-routed proxy, a stale cache entry, an unversioned API change —
+    /// would be carried into signing as if it were ours, with the deposit address and
+    /// amount that belong to someone else's swap. `JupiterService.fetchQuote` already
+    /// gates its quote this way; SwapKit had no equivalent.
+    static func validateRequestEcho(
+        response: SwapKitSwapResponse,
+        routeId: String,
+        sourceAddress: String,
+        destinationAddress: String
+    ) throws {
+        guard response.routeId == routeId else {
+            throw SwapKitError.responseEchoMismatch(
+                detail: "requested routeId \(routeId) but the response is for \(response.routeId)"
+            )
+        }
+        guard echoesAddress(response.sourceAddress, sourceAddress) else {
+            throw SwapKitError.responseEchoMismatch(
+                detail: "requested sourceAddress \(sourceAddress) but the response echoes \(response.sourceAddress)"
+            )
+        }
+        guard echoesAddress(response.destinationAddress, destinationAddress) else {
+            throw SwapKitError.responseEchoMismatch(
+                detail: "requested destinationAddress \(destinationAddress) "
+                    + "but the response echoes \(response.destinationAddress)"
+            )
+        }
+    }
+
+    /// Whether an echoed address names the address that was requested.
+    ///
+    /// `addressesMatch` ignores case only for 20-byte hex (EVM checksum casing) and is
+    /// exact everywhere else, which is the right default: base58 is case-sensitive. TON
+    /// is the one encoding where one account has several spellings, and the source or
+    /// destination of a TON route could legitimately come back re-spelled, so an account
+    /// match is accepted too. The chain is not threaded in because it need not be: two
+    /// different non-TON addresses cannot both parse as TON addresses (48 base64url
+    /// characters, a valid tag byte, and a matching CRC16) and canonicalise equal.
+    private static func echoesAddress(_ echoed: String, _ requested: String) -> Bool {
+        SwapRecipientVerifier.addressesMatch(echoed, requested)
+            || TonAccountIdentity.isSameAccount(echoed, requested)
     }
 
     /// The single gate every `/v3/swap` response passes before its quote can enter

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
@@ -179,6 +179,9 @@ struct SwapKitService {
         return ranked.max(by: { $0.1 < $1.1 })?.0
     }
 
+    /// The single gate every `/v3/swap` response passes before its quote can enter
+    /// ranking: the payload shape must be one this chain's signer implements, and the
+    /// response must agree with itself about where the deposit goes.
     static func validateSigningCapability(
         response: SwapKitSwapResponse,
         fromChain: Chain
@@ -191,6 +194,7 @@ struct SwapKitService {
                 "\(response.meta.txType)/\(fromChain.ticker)"
             )
         }
+        try response.validateSelfAgreement(fromChain: fromChain)
     }
 
     /// Format an amount as a dot-separated decimal string suitable for

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitSwapResponse.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitSwapResponse.swift
@@ -159,15 +159,10 @@ struct SwapKitSwapResponse: Decodable, Hashable {
         }
     }
 
-    /// Split a `?dt=12345` (or `?dt=12345&other=foo`) or `|12345` suffix
-    /// off an XRP target address. Returns the bare r-address plus the
-    /// parsed tag (or `nil`). Defensive — no probe today returns a suffix,
-    /// but the silent-misroute failure mode is severe enough to absorb
-    /// the decoder.
-    ///
-    /// Query parsing handles arbitrary parameter order
-    /// (`?dt=N`, `?dt=N&memo=foo`, `?memo=foo&dt=N`). Whichever key/value
-    /// pair parses as `dt=<UInt64>` wins; everything else is dropped.
+    /// Split a `?dt=12345` (or `?dt=12345&other=foo`) or `|12345` suffix off an XRP target
+    /// address, returning the bare r-address and what the suffix states about the tag.
+    /// Parameter order is arbitrary; a single readable `dt` is `.tag`, none is `.absent`,
+    /// and an unparseable or repeated `dt` is `.unreadable`.
     static func extractTagSuffix(from address: String) -> (address: String, tag: SwapKitDestinationTag) {
         // More than one `dt` is `.unreadable` rather than "the first one": two answers is
         // not one answer, and picking the readable one invents a fact the provider did not

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitSwapResponse.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitSwapResponse.swift
@@ -35,7 +35,11 @@ struct SwapKitSwapResponse: Decodable, Hashable {
     /// failure mode for XRP-to-shared-vault transfers is severe enough that
     /// we accept a tag from three sources at decode time and pick the first
     /// non-nil via `resolvedDestinationTag`.
-    let destinationTag: UInt64?
+    let destinationTagSource: SwapKitDestinationTag
+
+    /// The top-level tag to use, or nil when the field is absent or unreadable.
+    /// `destinationTagSource` keeps the distinction the agreement guard needs.
+    var destinationTag: UInt64? { destinationTagSource.usableTag }
 
     /// Some chains (Cardano) return responses without a `tx` field at all —
     /// see `SwapKitTx.cardano`. The `Hashable` synthesis still works because
@@ -57,7 +61,7 @@ struct SwapKitSwapResponse: Decodable, Hashable {
     var resolvedDestinationTag: UInt64? {
         if let tag = destinationTag { return tag }
         if let tag = meta.destinationTag { return tag }
-        return Self.extractTagSuffix(from: targetAddress).tag
+        return Self.extractTagSuffix(from: targetAddress).tag.usableTag
     }
 
     /// XRP target-address stripped of any `?dt=…` or `|…` destination-tag
@@ -111,17 +115,7 @@ struct SwapKitSwapResponse: Decodable, Hashable {
         // and leave `inboundFee` returning nil at quote time.
         fees = try container.decodeIfPresent([SwapKitFee].self, forKey: .fees) ?? []
         warnings = try container.decodeIfPresent([SwapKitWarning].self, forKey: .warnings)
-        // SwapKit may surface a numeric `destinationTag` (rare) or a string-
-        // wrapped one (defensive — `meta.affiliateFee` arrives as a string
-        // even though it's numeric semantically, so accept both shapes).
-        if let intTag = try? container.decodeIfPresent(UInt64.self, forKey: .destinationTag) {
-            destinationTag = intTag
-        } else if let stringTag = try? container.decodeIfPresent(String.self, forKey: .destinationTag),
-                  let parsed = UInt64(stringTag) {
-            destinationTag = parsed
-        } else {
-            destinationTag = nil
-        }
+        destinationTagSource = SwapKitDestinationTag.decoded(from: container, forKey: .destinationTag)
         tx = try Self.decodeTx(meta: meta, sellAsset: sellAsset, container: container)
     }
 
@@ -173,35 +167,46 @@ struct SwapKitSwapResponse: Decodable, Hashable {
     /// but the silent-misroute failure mode is severe enough to absorb
     /// the decoder.
     ///
+    /// Shared with `validateSelfAgreement`, so both sides of a destination comparison
+    /// get the same strip.
+    ///
     /// Query parsing handles arbitrary parameter order
     /// (`?dt=N`, `?dt=N&memo=foo`, `?memo=foo&dt=N`). Whichever key/value
     /// pair parses as `dt=<UInt64>` wins; everything else is dropped.
-    private static func extractTagSuffix(from address: String) -> (address: String, tag: UInt64?) {
-        // `?…` form: walk the query parameters and pick the first `dt=`
-        // that parses as a UInt64. Real-world XRP URIs usually have a
-        // single `dt=N`, but accepting the full `key=val&key=val` shape
-        // means a future flip to `?memo=...&dt=...` doesn't silently
-        // drop the tag.
+    static func extractTagSuffix(from address: String) -> (address: String, tag: SwapKitDestinationTag) {
+        // `?…` form: walk the query parameters and collect every `dt=`. Real-world XRP
+        // URIs carry a single `dt=N`, but accepting the full `key=val&key=val` shape
+        // means a future flip to `?memo=...&dt=...` doesn't silently drop the tag. More
+        // than one `dt` is `.unreadable` rather than "the first one" — two answers is
+        // not one answer.
         if let q = address.firstIndex(of: "?") {
             let bare = String(address[..<q])
             let query = address[address.index(after: q)...]
-            for pair in query.split(separator: "&", omittingEmptySubsequences: true) {
-                let parts = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
-                guard parts.count == 2, parts[0] == "dt" else { continue }
-                if let tag = UInt64(parts[1]) {
-                    return (bare, tag)
-                }
+            let stated = query
+                .split(separator: "&", omittingEmptySubsequences: true)
+                .map { $0.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false) }
+                .filter { $0.count == 2 && $0[0] == "dt" }
+                .map { $0[1] }
+            guard let only = stated.first else { return (bare, .absent) }
+            guard stated.count == 1 else {
+                return (bare, .unreadable(reason: "\(stated.count) dt parameters"))
             }
-            return (bare, nil)
+            guard let tag = UInt64(only) else {
+                return (bare, .unreadable(reason: "dt=\(only) is not a destination tag"))
+            }
+            return (bare, .tag(tag))
         }
         // `|` form: `rXyz|12345`
         if let pipe = address.firstIndex(of: "|") {
             let suffix = address[address.index(after: pipe)...]
-            if let tag = UInt64(suffix) {
-                return (String(address[..<pipe]), tag)
+            guard let tag = UInt64(suffix) else {
+                // Address deliberately left unstripped, matching what this helper has
+                // always returned for an unparseable `|` suffix.
+                return (address, .unreadable(reason: "|\(suffix) is not a destination tag"))
             }
+            return (String(address[..<pipe]), .tag(tag))
         }
-        return (address, nil)
+        return (address, .absent)
     }
 
     private static func decodeTx(
@@ -454,7 +459,10 @@ struct SwapKitSwapResponseMeta: Decodable, Hashable {
     let affiliateFee: String?
     /// Optional XRP destination tag surfaced via the meta block (second of
     /// three resolution sources — see `SwapKitSwapResponse.resolvedDestinationTag`).
-    let destinationTag: UInt64?
+    let destinationTagSource: SwapKitDestinationTag
+
+    /// The meta tag to use, or nil when the field is absent or unreadable.
+    var destinationTag: UInt64? { destinationTagSource.usableTag }
 
     private enum CodingKeys: String, CodingKey {
         case txType
@@ -476,14 +484,7 @@ struct SwapKitSwapResponseMeta: Decodable, Hashable {
         priceImpact = try container.decodeIfPresent(Double.self, forKey: .priceImpact)
         affiliate = try container.decodeIfPresent(String.self, forKey: .affiliate)
         affiliateFee = try container.decodeIfPresent(String.self, forKey: .affiliateFee)
-        if let intTag = try? container.decodeIfPresent(UInt64.self, forKey: .destinationTag) {
-            destinationTag = intTag
-        } else if let stringTag = try? container.decodeIfPresent(String.self, forKey: .destinationTag),
-                  let parsed = UInt64(stringTag) {
-            destinationTag = parsed
-        } else {
-            destinationTag = nil
-        }
+        destinationTagSource = SwapKitDestinationTag.decoded(from: container, forKey: .destinationTag)
     }
 }
 

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitSwapResponse.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitSwapResponse.swift
@@ -37,8 +37,6 @@ struct SwapKitSwapResponse: Decodable, Hashable {
     /// non-nil via `resolvedDestinationTag`.
     let destinationTagSource: SwapKitDestinationTag
 
-    /// The top-level tag to use, or nil when the field is absent or unreadable.
-    /// `destinationTagSource` keeps the distinction the agreement guard needs.
     var destinationTag: UInt64? { destinationTagSource.usableTag }
 
     /// Some chains (Cardano) return responses without a `tx` field at all —
@@ -167,18 +165,13 @@ struct SwapKitSwapResponse: Decodable, Hashable {
     /// but the silent-misroute failure mode is severe enough to absorb
     /// the decoder.
     ///
-    /// Shared with `validateSelfAgreement`, so both sides of a destination comparison
-    /// get the same strip.
-    ///
     /// Query parsing handles arbitrary parameter order
     /// (`?dt=N`, `?dt=N&memo=foo`, `?memo=foo&dt=N`). Whichever key/value
     /// pair parses as `dt=<UInt64>` wins; everything else is dropped.
     static func extractTagSuffix(from address: String) -> (address: String, tag: SwapKitDestinationTag) {
-        // `?…` form: walk the query parameters and collect every `dt=`. Real-world XRP
-        // URIs carry a single `dt=N`, but accepting the full `key=val&key=val` shape
-        // means a future flip to `?memo=...&dt=...` doesn't silently drop the tag. More
-        // than one `dt` is `.unreadable` rather than "the first one" — two answers is
-        // not one answer.
+        // More than one `dt` is `.unreadable` rather than "the first one": two answers is
+        // not one answer, and picking the readable one invents a fact the provider did not
+        // state — on XRP that misattributes the deposit.
         if let q = address.firstIndex(of: "?") {
             let bare = String(address[..<q])
             let query = address[address.index(after: q)...]
@@ -200,8 +193,7 @@ struct SwapKitSwapResponse: Decodable, Hashable {
         if let pipe = address.firstIndex(of: "|") {
             let suffix = address[address.index(after: pipe)...]
             guard let tag = UInt64(suffix) else {
-                // Address deliberately left unstripped, matching what this helper has
-                // always returned for an unparseable `|` suffix.
+                // Unstripped, matching what this helper has always returned here.
                 return (address, .unreadable(reason: "|\(suffix) is not a destination tag"))
             }
             return (String(address[..<pipe]), .tag(tag))
@@ -461,7 +453,6 @@ struct SwapKitSwapResponseMeta: Decodable, Hashable {
     /// three resolution sources — see `SwapKitSwapResponse.resolvedDestinationTag`).
     let destinationTagSource: SwapKitDestinationTag
 
-    /// The meta tag to use, or nil when the field is absent or unreadable.
     var destinationTag: UInt64? { destinationTagSource.usableTag }
 
     private enum CodingKeys: String, CodingKey {

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitSwapResponse.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitSwapResponse.swift
@@ -170,11 +170,12 @@ struct SwapKitSwapResponse: Decodable, Hashable {
         if let q = address.firstIndex(of: "?") {
             let bare = String(address[..<q])
             let query = address[address.index(after: q)...]
-            let stated = query
-                .split(separator: "&", omittingEmptySubsequences: true)
-                .map { $0.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false) }
-                .filter { $0.count == 2 && $0[0] == "dt" }
-                .map { $0[1] }
+            var stated: [Substring] = []
+            for pair in query.split(separator: "&", omittingEmptySubsequences: true) {
+                let parts = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+                guard parts.count == 2, parts[0] == "dt" else { continue }
+                stated.append(parts[1])
+            }
             guard let only = stated.first else { return (bare, .absent) }
             guard stated.count == 1 else {
                 return (bare, .unreadable(reason: "\(stated.count) dt parameters"))

--- a/VultisigApp/VultisigApp/Blockchain/Ton/TonAccountIdentity.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/TonAccountIdentity.swift
@@ -1,0 +1,40 @@
+//
+//  TonAccountIdentity.swift
+//  VultisigApp
+//
+
+import Foundation
+import WalletCore
+
+/// Whether two TON address spellings name the same account.
+///
+/// One account has several textual spellings — raw `workchain:hash`, bounceable `EQ…`,
+/// non-bounceable `UQ…`, and the base64 / base64url variants of both — and only the flag
+/// byte and the trailing checksum separate `EQ` from `UQ`. String equality therefore
+/// reports differences that do not exist, which matters wherever two independently
+/// sourced addresses are cross-checked before money moves.
+enum TonAccountIdentity {
+
+    /// Canonicalising through the bounceable spelling collapses every form of one account
+    /// onto a single string. Bounceability is deliberately not part of identity: the bounce
+    /// flag that actually ships is decided by `BlockChainService` (forced on for swap
+    /// deposits), not by the spelling a response happened to use.
+    static func isSameAccount(_ lhs: String, _ rhs: String) -> Bool {
+        let left = lhs.trimmingCharacters(in: .whitespacesAndNewlines)
+        let right = rhs.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let canonicalLeft = canonical(left), let canonicalRight = canonical(right) else {
+            // Input that does not parse as a TON address names no account, and two values
+            // that name no account do not name the same one. Answering "equal" for two
+            // identical unparseable strings would let a guard built on this report
+            // agreement about something that is not an address at all.
+            return false
+        }
+        return canonicalLeft == canonicalRight
+    }
+
+    /// `toUserFriendly` accepts raw and user-friendly input alike and returns nil for
+    /// anything that does not parse as a TON address.
+    private static func canonical(_ address: String) -> String? {
+        TONAddressConverter.toUserFriendly(address: address, bounceable: true, testnet: false)
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Ton/TonAccountIdentity.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/TonAccountIdentity.swift
@@ -6,34 +6,24 @@
 import Foundation
 import WalletCore
 
-/// Whether two TON address spellings name the same account.
-///
-/// One account has several textual spellings — raw `workchain:hash`, bounceable `EQ…`,
-/// non-bounceable `UQ…`, and the base64 / base64url variants of both — and only the flag
-/// byte and the trailing checksum separate `EQ` from `UQ`. String equality therefore
-/// reports differences that do not exist, which matters wherever two independently
-/// sourced addresses are cross-checked before money moves.
+/// Whether two TON address spellings name the same account. One account has several — raw
+/// `workchain:hash`, `EQ…`, `UQ…`, and the base64 / base64url variants of both — so string
+/// equality reports differences that do not exist.
 enum TonAccountIdentity {
 
-    /// Canonicalising through the bounceable spelling collapses every form of one account
-    /// onto a single string. Bounceability is deliberately not part of identity: the bounce
-    /// flag that actually ships is decided by `BlockChainService` (forced on for swap
-    /// deposits), not by the spelling a response happened to use.
+    /// Bounceability is deliberately not part of identity: the flag that ships is decided by
+    /// `BlockChainService`, not by the spelling a response happened to use.
     static func isSameAccount(_ lhs: String, _ rhs: String) -> Bool {
         let left = lhs.trimmingCharacters(in: .whitespacesAndNewlines)
         let right = rhs.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let canonicalLeft = canonical(left), let canonicalRight = canonical(right) else {
-            // Input that does not parse as a TON address names no account, and two values
-            // that name no account do not name the same one. Answering "equal" for two
-            // identical unparseable strings would let a guard built on this report
-            // agreement about something that is not an address at all.
+            // Two values that name no account do not name the same one.
             return false
         }
         return canonicalLeft == canonicalRight
     }
 
-    /// `toUserFriendly` accepts raw and user-friendly input alike and returns nil for
-    /// anything that does not parse as a TON address.
+    /// Accepts raw and user-friendly input alike; nil for anything that is not a TON address.
     private static func canonical(_ address: String) -> String? {
         TONAddressConverter.toUserFriendly(address: address, bounceable: true, testnet: false)
     }

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessageFactory.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessageFactory.swift
@@ -60,9 +60,11 @@ struct KeysignMessageFactory {
                 // Dispatch on SwapKit's `meta.txType`. For chains where the
                 // SwapKit wire shape is a plain native send (TON transfer,
                 // ADA deposit), we fall through to the per-chain helper at
-                // the bottom of this method — `keysignPayload.toAddress` /
-                // `toAmount` have already been set to SwapKit's deposit
-                // address + amount by `SwapPayloadBuilder`. PSBT (BTC), SUI
+                // the bottom of this method — `SwapPayloadBuilder` has already
+                // pointed `keysignPayload.toAddress` at SwapKit's deposit
+                // address. `toAmount` is the amount the user is spending, NOT a
+                // SwapKit-stated one: a TON route's `tx[0].amount` rides along
+                // in `txPayload` for the peer but is never read. PSBT (BTC), SUI
                 // (pre-built PTB), and TRON (pre-built raw_data_hex) need
                 // SwapKit-specific signers since their pre-built bytes drive
                 // the signing input directly.
@@ -87,8 +89,9 @@ struct KeysignMessageFactory {
                     messages += try SwapKitCardanoSigner.preSigningHashes(payload: swapKitPayload)
                 case "TON", "CARDANO", "XRP":
                     // Fall through to the existing per-chain helper below
-                    // (deposit-only flows: the SwapKit builder already
-                    // pointed `toAddress` / `toAmount` at the deposit).
+                    // (deposit-only flows: the SwapKit builder already pointed
+                    // `toAddress` at the deposit; `toAmount` is the user's own
+                    // send amount).
                     // XRP: builder also stringified the destination tag
                     // into `keysignPayload.memo` — `RippleHelper` parses
                     // numeric memos and attaches `destinationTag` on the

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
@@ -845,9 +845,10 @@ class KeysignViewModel: ObservableObject {
                     signedTransactions.append(tx)
                 case "TON", "CARDANO", "XRP":
                     // Deposit-only flows fall through to the per-chain helper
-                    // at the bottom of this method — the SwapKit builder
-                    // already pointed `toAddress` / `toAmount` (and memo
-                    // for XRP destination tag) at the deposit.
+                    // at the bottom of this method — the SwapKit builder already
+                    // pointed `toAddress` (and memo, for the XRP destination
+                    // tag) at the deposit. `toAmount` is the user's own send
+                    // amount, not a SwapKit-stated one.
                     break
                 case "EVM", "SOLANA":
                     throw SwapKitError.unsupportedTxType(payload.txType)

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
@@ -781,7 +781,8 @@ class KeysignViewModel: ObservableObject {
                 // bytes drive transaction assembly directly. TON + CARDANO
                 // fall through to the per-chain helpers at the bottom of
                 // this method — the SwapKit builder already pointed
-                // `toAddress` / `toAmount` at the deposit address + amount.
+                // `toAddress` at the deposit address; `toAmount` is the
+                // user's own send amount.
                 switch payload.txType {
                 case "PSBT":
                     let tx = try SwapKitBTCSigner.compileSignedTransaction(

--- a/VultisigApp/VultisigAppTests/Chains/TonAccountIdentityTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/TonAccountIdentityTests.swift
@@ -2,18 +2,14 @@
 //  TonAccountIdentityTests.swift
 //  VultisigAppTests
 //
-//  One TON account has several spellings. These pin that a comparison which
-//  claims two forms name the same account is asserting exactly that, and is not
-//  quietly comparing two different accounts.
-//
 
 import XCTest
 @testable import VultisigApp
 
 final class TonAccountIdentityTests: XCTestCase {
 
-    // One account in every spelling it has. Derived from the account SwapKit
-    // actually returns in `v3-real-ton-swap.json` (tag 0x51, workchain 0).
+    // One account in every spelling it has, so a test claiming two forms match is
+    // asserting that rather than comparing two different accounts.
     private let bounceable = "EQC_BuLzOqk9GGNXh0y1XosB2BqUyk1AQcGMHKMGfRqlhxmd"
     private let nonBounceable = "UQC_BuLzOqk9GGNXh0y1XosB2BqUyk1AQcGMHKMGfRqlh0RY"
     private let nonBounceableStandardBase64 = "UQC/BuLzOqk9GGNXh0y1XosB2BqUyk1AQcGMHKMGfRqlh0RY"
@@ -43,15 +39,12 @@ final class TonAccountIdentityTests: XCTestCase {
         XCTAssertFalse(TonAccountIdentity.isSameAccount(raw, otherAccount))
     }
 
-    /// Two values that name no account do not name the same account. Reporting
-    /// "equal" for two identical unparseable strings would let a fail-closed guard
-    /// built on this claim agreement about something that is not an address.
+    /// Two values that name no account do not name the same account.
     func testRefusesToMatchInputThatIsNotAnAddress() {
         XCTAssertFalse(TonAccountIdentity.isSameAccount("not-an-address", "not-an-address"))
         XCTAssertFalse(TonAccountIdentity.isSameAccount("not-an-address", bounceable))
         XCTAssertFalse(TonAccountIdentity.isSameAccount("", ""))
         XCTAssertFalse(TonAccountIdentity.isSameAccount("", bounceable))
-        // A friendly address with a corrupted checksum names no account either.
         XCTAssertFalse(TonAccountIdentity.isSameAccount(
             "EQC_BuLzOqk9GGNXh0y1XosB2BqUyk1AQcGMHKMGfRqlhAAA",
             "EQC_BuLzOqk9GGNXh0y1XosB2BqUyk1AQcGMHKMGfRqlhAAA"

--- a/VultisigApp/VultisigAppTests/Chains/TonAccountIdentityTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/TonAccountIdentityTests.swift
@@ -1,0 +1,60 @@
+//
+//  TonAccountIdentityTests.swift
+//  VultisigAppTests
+//
+//  One TON account has several spellings. These pin that a comparison which
+//  claims two forms name the same account is asserting exactly that, and is not
+//  quietly comparing two different accounts.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class TonAccountIdentityTests: XCTestCase {
+
+    // One account in every spelling it has. Derived from the account SwapKit
+    // actually returns in `v3-real-ton-swap.json` (tag 0x51, workchain 0).
+    private let bounceable = "EQC_BuLzOqk9GGNXh0y1XosB2BqUyk1AQcGMHKMGfRqlhxmd"
+    private let nonBounceable = "UQC_BuLzOqk9GGNXh0y1XosB2BqUyk1AQcGMHKMGfRqlh0RY"
+    private let nonBounceableStandardBase64 = "UQC/BuLzOqk9GGNXh0y1XosB2BqUyk1AQcGMHKMGfRqlh0RY"
+    private let raw = "0:bf06e2f33aa93d186357874cb55e8b01d81a94ca4d4041c18c1ca3067d1aa587"
+    private let otherAccount = "EQCrq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq8Uk"
+
+    func testTreatsBounceableAndNonBounceableAsOneAccount() {
+        XCTAssertTrue(TonAccountIdentity.isSameAccount(bounceable, nonBounceable))
+    }
+
+    func testTreatsUserFriendlyAndRawAsOneAccount() {
+        XCTAssertTrue(TonAccountIdentity.isSameAccount(bounceable, raw))
+        XCTAssertTrue(TonAccountIdentity.isSameAccount(nonBounceable, raw))
+    }
+
+    func testTreatsBase64UrlAndStandardBase64AsOneAccount() {
+        XCTAssertTrue(TonAccountIdentity.isSameAccount(nonBounceable, nonBounceableStandardBase64))
+    }
+
+    func testIgnoresSurroundingWhitespace() {
+        XCTAssertTrue(TonAccountIdentity.isSameAccount(bounceable, " \(bounceable) "))
+    }
+
+    func testSeparatesTwoDifferentAccountsInEverySpelling() {
+        XCTAssertFalse(TonAccountIdentity.isSameAccount(bounceable, otherAccount))
+        XCTAssertFalse(TonAccountIdentity.isSameAccount(nonBounceable, otherAccount))
+        XCTAssertFalse(TonAccountIdentity.isSameAccount(raw, otherAccount))
+    }
+
+    /// Two values that name no account do not name the same account. Reporting
+    /// "equal" for two identical unparseable strings would let a fail-closed guard
+    /// built on this claim agreement about something that is not an address.
+    func testRefusesToMatchInputThatIsNotAnAddress() {
+        XCTAssertFalse(TonAccountIdentity.isSameAccount("not-an-address", "not-an-address"))
+        XCTAssertFalse(TonAccountIdentity.isSameAccount("not-an-address", bounceable))
+        XCTAssertFalse(TonAccountIdentity.isSameAccount("", ""))
+        XCTAssertFalse(TonAccountIdentity.isSameAccount("", bounceable))
+        // A friendly address with a corrupted checksum names no account either.
+        XCTAssertFalse(TonAccountIdentity.isSameAccount(
+            "EQC_BuLzOqk9GGNXh0y1XosB2BqUyk1AQcGMHKMGfRqlhAAA",
+            "EQC_BuLzOqk9GGNXh0y1XosB2BqUyk1AQcGMHKMGfRqlhAAA"
+        ))
+    }
+}

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitLongTailTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitLongTailTests.swift
@@ -33,11 +33,16 @@ final class SwapKitLongTailTests: XCTestCase {
         guard case .ton(let transfers) = response.tx else {
             return XCTFail("expected .ton case, got \(response.tx)")
         }
-        XCTAssertEqual(transfers.count, 1, "SwapKit returns single-element transfer array for TON")
+        // These pin properties of this recorded fixture; they enforce nothing.
+        // The guard that refuses a response whose destination fields disagree, or
+        // a `tx[]` that is not exactly one transfer, lives in
+        // `SwapKitSwapResponse.validateSelfAgreement` and is covered by
+        // `SwapKitResponseAgreementTests`.
+        XCTAssertEqual(transfers.count, 1, "this fixture carries a single-element TON transfer array")
         XCTAssertFalse(transfers[0].address.isEmpty)
         XCTAssertFalse(transfers[0].amount.isEmpty)
         XCTAssertEqual(transfers[0].address, response.targetAddress,
-                       "deposit address inside `tx` must match top-level targetAddress")
+                       "in this fixture the address inside `tx` equals the top-level targetAddress")
     }
 
     func testTonQuoteFixtureSurvivesClientFilter() throws {

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitRequestEchoTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitRequestEchoTests.swift
@@ -2,14 +2,9 @@
 //  SwapKitRequestEchoTests.swift
 //  VultisigAppTests
 //
-//  `buildSwapTx` returned whatever /v3/swap handed back without checking that it
-//  described the swap that was asked for. These pin that a response built for a
-//  different route, source, or destination is refused before it can reach signing,
-//  while the spellings one address legitimately arrives in still pass.
-//
-//  Every case starts from the recorded `v3-real-ton-swap` response and mutates one
-//  field, so a fixture that drifts from what SwapKit returns breaks the tests rather
-//  than quietly making them meaningless.
+//  Every case mutates one field of the recorded `v3-real-ton-swap` response rather than
+//  hand-rolling JSON: a hand-written body drifted from the real wire shape twice here, once
+//  fatally (no `tx` key under `txType: "TON"`, so every test died at decode).
 //
 
 import XCTest
@@ -17,9 +12,8 @@ import XCTest
 
 final class SwapKitRequestEchoTests: XCTestCase {
 
-    // The request that produced `v3-real-ton-swap.json`. Written as literals, not read
-    // back off the response: passing the response's own fields in as the expectation
-    // asserts `x == x` and would pass against any implementation, including none.
+    // The request that produced `v3-real-ton-swap.json`, as literals: passing the response's
+    // own fields back in would assert `x == x` and pass against any implementation.
     private let routeId = "c6340348-2bc4-4052-9bd7-d5913312de49"
     private let sourceAddress = "UQBAETYfujlv90Oa5P3K5vnABkvoOnXBSCo3W8q_2-sXIN5U"
     private let destinationAddress = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
@@ -27,11 +21,9 @@ final class SwapKitRequestEchoTests: XCTestCase {
 
     // MARK: - The guard is wired into buildSwapTx, not merely defined
 
-    /// Exercising `validateRequestEcho` directly proves the rule; it does not prove
-    /// `buildSwapTx` applies it. Deleting the call site — or letting the surrounding
-    /// `catch HTTPError.statusCode` remap the error to `.generic` — would leave every
-    /// other test in this file green, so drive the real method through a stub client
-    /// and assert the error TYPE that reaches the caller.
+    /// Deleting the call site, or letting the surrounding `catch HTTPError.statusCode` remap
+    /// the error to `.generic`, would leave every other test here green — hence the error type
+    /// is asserted through the real method.
     func testBuildSwapTxRejectsAResponseBuiltForADifferentRoute() async throws {
         let service = SwapKitService(
             httpClient: StubSwapHTTPClient(
@@ -94,7 +86,7 @@ final class SwapKitRequestEchoTests: XCTestCase {
         assertEchoMismatch(response, mentioning: "destinationAddress")
     }
 
-    /// EVM addresses differ only by checksum casing, which is not a different address.
+    /// EVM checksum casing is not a different address.
     func testAcceptsAnEvmDestinationDifferingOnlyByChecksumCase() throws {
         let response = try decode(makeResponseData())
         XCTAssertNoThrow(
@@ -120,8 +112,7 @@ final class SwapKitRequestEchoTests: XCTestCase {
         )
     }
 
-    /// Base58 is case-sensitive, so a case-only difference outside EVM is a different
-    /// address and must not be absorbed by the TON account comparison.
+    /// Base58 is case-sensitive, so a case-only difference outside EVM is a different address.
     func testRejectsANonEvmSourceDifferingOnlyByCase() throws {
         let base58Source = "rPVMhWBsfF9iMXYj3aAzJVkPDTFNSyWdKy"
         let response = try decode(makeResponseData(sourceAddress: base58Source))
@@ -168,7 +159,6 @@ final class SwapKitRequestEchoTests: XCTestCase {
         try JSONDecoder().decode(SwapKitSwapResponse.self, from: data)
     }
 
-    /// The recorded response with at most one field replaced.
     private func makeResponseData(
         routeId: String? = nil,
         sourceAddress: String? = nil,
@@ -189,8 +179,7 @@ final class SwapKitRequestEchoTests: XCTestCase {
     }
 }
 
-/// Returns one canned `/v3/swap` body for any target, so `buildSwapTx` runs end to end
-/// without a network and the guard's wiring is exercised rather than assumed.
+/// One canned `/v3/swap` body for any target, so `buildSwapTx` runs end to end.
 private final class StubSwapHTTPClient: HTTPClientProtocol, @unchecked Sendable {
     private let payload: Data
 

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitRequestEchoTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitRequestEchoTests.swift
@@ -1,0 +1,215 @@
+//
+//  SwapKitRequestEchoTests.swift
+//  VultisigAppTests
+//
+//  `buildSwapTx` returned whatever /v3/swap handed back without checking that it
+//  described the swap that was asked for. These pin that a response built for a
+//  different route, source, or destination is refused before it can reach signing,
+//  while the spellings one address legitimately arrives in still pass.
+//
+//  Every case starts from the recorded `v3-real-ton-swap` response and mutates one
+//  field, so a fixture that drifts from what SwapKit returns breaks the tests rather
+//  than quietly making them meaningless.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class SwapKitRequestEchoTests: XCTestCase {
+
+    // The request that produced `v3-real-ton-swap.json`. Written as literals, not read
+    // back off the response: passing the response's own fields in as the expectation
+    // asserts `x == x` and would pass against any implementation, including none.
+    private let routeId = "c6340348-2bc4-4052-9bd7-d5913312de49"
+    private let sourceAddress = "UQBAETYfujlv90Oa5P3K5vnABkvoOnXBSCo3W8q_2-sXIN5U"
+    private let destinationAddress = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+    private let sourceAddressBounceable = "EQBAETYfujlv90Oa5P3K5vnABkvoOnXBSCo3W8q_2-sXIIOR"
+
+    // MARK: - The guard is wired into buildSwapTx, not merely defined
+
+    /// Exercising `validateRequestEcho` directly proves the rule; it does not prove
+    /// `buildSwapTx` applies it. Deleting the call site — or letting the surrounding
+    /// `catch HTTPError.statusCode` remap the error to `.generic` — would leave every
+    /// other test in this file green, so drive the real method through a stub client
+    /// and assert the error TYPE that reaches the caller.
+    func testBuildSwapTxRejectsAResponseBuiltForADifferentRoute() async throws {
+        let service = SwapKitService(
+            httpClient: StubSwapHTTPClient(
+                payload: try makeResponseData(routeId: "00000000-0000-0000-0000-000000000000")
+            )
+        )
+        do {
+            _ = try await service.buildSwapTx(
+                routeId: routeId,
+                sourceAddress: sourceAddress,
+                destinationAddress: destinationAddress
+            )
+            XCTFail("expected buildSwapTx to refuse a response built for another route")
+        } catch let error as SwapKitError {
+            guard case .responseEchoMismatch(let detail) = error else {
+                return XCTFail("expected responseEchoMismatch, got \(error)")
+            }
+            XCTAssertTrue(detail.contains("routeId"), "detail \(detail) should name routeId")
+        }
+    }
+
+    func testBuildSwapTxReturnsAResponseThatEchoesTheRequest() async throws {
+        let service = SwapKitService(httpClient: StubSwapHTTPClient(payload: try makeResponseData()))
+        let response = try await service.buildSwapTx(
+            routeId: routeId,
+            sourceAddress: sourceAddress,
+            destinationAddress: destinationAddress
+        )
+        XCTAssertEqual(response.routeId, routeId)
+    }
+
+    // MARK: - The rule itself
+
+    func testAcceptsTheRecordedResponseAgainstTheRequestThatProducedIt() throws {
+        let response = try SwapKitFixtureLoader.decode(
+            SwapKitSwapResponse.self,
+            from: "v3-real-ton-swap"
+        )
+        XCTAssertNoThrow(
+            try SwapKitService.validateRequestEcho(
+                response: response,
+                routeId: routeId,
+                sourceAddress: sourceAddress,
+                destinationAddress: destinationAddress
+            )
+        )
+    }
+
+    func testRejectsASourceAddressThatDoesNotEchoTheRequest() throws {
+        let response = try decode(makeResponseData(
+            sourceAddress: "EQCrq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq8Uk"
+        ))
+        assertEchoMismatch(response, mentioning: "sourceAddress")
+    }
+
+    func testRejectsADestinationAddressThatDoesNotEchoTheRequest() throws {
+        let response = try decode(makeResponseData(
+            destinationAddress: "0x0000000000000000000000000000000000000001"
+        ))
+        assertEchoMismatch(response, mentioning: "destinationAddress")
+    }
+
+    /// EVM addresses differ only by checksum casing, which is not a different address.
+    func testAcceptsAnEvmDestinationDifferingOnlyByChecksumCase() throws {
+        let response = try decode(makeResponseData())
+        XCTAssertNoThrow(
+            try SwapKitService.validateRequestEcho(
+                response: response,
+                routeId: routeId,
+                sourceAddress: sourceAddress,
+                destinationAddress: destinationAddress.lowercased()
+            )
+        )
+    }
+
+    /// One TON account re-spelled between request and response is the same account.
+    func testAcceptsATonSourceReSpelledBounceable() throws {
+        let response = try decode(makeResponseData())
+        XCTAssertNoThrow(
+            try SwapKitService.validateRequestEcho(
+                response: response,
+                routeId: routeId,
+                sourceAddress: sourceAddressBounceable,
+                destinationAddress: destinationAddress
+            )
+        )
+    }
+
+    /// Base58 is case-sensitive, so a case-only difference outside EVM is a different
+    /// address and must not be absorbed by the TON account comparison.
+    func testRejectsANonEvmSourceDifferingOnlyByCase() throws {
+        let base58Source = "rPVMhWBsfF9iMXYj3aAzJVkPDTFNSyWdKy"
+        let response = try decode(makeResponseData(sourceAddress: base58Source))
+        assertEchoMismatch(
+            response,
+            sourceAddress: base58Source.lowercased(),
+            mentioning: "sourceAddress"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func assertEchoMismatch(
+        _ response: SwapKitSwapResponse,
+        sourceAddress: String? = nil,
+        mentioning fragment: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertThrowsError(
+            try SwapKitService.validateRequestEcho(
+                response: response,
+                routeId: routeId,
+                sourceAddress: sourceAddress ?? self.sourceAddress,
+                destinationAddress: destinationAddress
+            ),
+            file: file,
+            line: line
+        ) { error in
+            guard let swapKitError = error as? SwapKitError,
+                  case .responseEchoMismatch(let detail) = swapKitError else {
+                return XCTFail("expected responseEchoMismatch, got \(error)", file: file, line: line)
+            }
+            XCTAssertTrue(
+                detail.contains(fragment),
+                "detail \(detail) should name \(fragment)",
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    private func decode(_ data: Data) throws -> SwapKitSwapResponse {
+        try JSONDecoder().decode(SwapKitSwapResponse.self, from: data)
+    }
+
+    /// The recorded response with at most one field replaced.
+    private func makeResponseData(
+        routeId: String? = nil,
+        sourceAddress: String? = nil,
+        destinationAddress: String? = nil
+    ) throws -> Data {
+        let data = try SwapKitFixtureLoader.loadData("v3-real-ton-swap")
+        guard var object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw NSError(
+                domain: "SwapKitRequestEchoTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "fixture is not a JSON object"]
+            )
+        }
+        if let routeId { object["routeId"] = routeId }
+        if let sourceAddress { object["sourceAddress"] = sourceAddress }
+        if let destinationAddress { object["destinationAddress"] = destinationAddress }
+        return try JSONSerialization.data(withJSONObject: object)
+    }
+}
+
+/// Returns one canned `/v3/swap` body for any target, so `buildSwapTx` runs end to end
+/// without a network and the guard's wiring is exercised rather than assumed.
+private final class StubSwapHTTPClient: HTTPClientProtocol, @unchecked Sendable {
+    private let payload: Data
+
+    init(payload: Data) {
+        self.payload = payload
+    }
+
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        _ = target
+        await Task.yield()
+        guard let url = URL(string: "https://api.vultisig.com/swapkit/v3/swap"),
+              let response = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+              ) else {
+            throw HTTPError.statusCode(500, nil)
+        }
+        return HTTPResponse(data: payload, response: response)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitResponseAgreementTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitResponseAgreementTests.swift
@@ -2,19 +2,12 @@
 //  SwapKitResponseAgreementTests.swift
 //  VultisigAppTests
 //
-//  SwapKit states the deposit destination in three independent fields and the
-//  payload builder reads only `targetAddress`. These pin that a response which
-//  disagrees with itself is refused rather than resolved by precedence — while
-//  the several spellings of one TON account still compare equal, and every
-//  recorded real response still passes.
-//
 
 import XCTest
 @testable import VultisigApp
 
 final class SwapKitResponseAgreementTests: XCTestCase {
 
-    // The account SwapKit returns in `v3-real-ton-swap.json`, in each spelling.
     private let tonBounceable = "EQC_BuLzOqk9GGNXh0y1XosB2BqUyk1AQcGMHKMGfRqlhxmd"
     private let tonNonBounceable = "UQC_BuLzOqk9GGNXh0y1XosB2BqUyk1AQcGMHKMGfRqlh0RY"
     private let tonRaw = "0:bf06e2f33aa93d186357874cb55e8b01d81a94ca4d4041c18c1ca3067d1aa587"
@@ -152,8 +145,6 @@ final class SwapKitResponseAgreementTests: XCTestCase {
         assertContradiction(response, chain: .ton, mentioning: "tx[0].address is empty")
     }
 
-    /// A TON route whose destination does not parse as a TON account is refused
-    /// rather than passed through on string equality.
     func testRejectsATonDestinationThatIsNotAnAccount() throws {
         let response = try decode(makeJSON(
             sellAsset: "TON.TON",
@@ -166,9 +157,6 @@ final class SwapKitResponseAgreementTests: XCTestCase {
 
     // MARK: - Destination tags are half the XRP destination
 
-    /// The address comparison strips the tag suffix on purpose, so without a separate
-    /// tag check two fields naming one address with different tags would agree — and
-    /// the deposit would land credited to a different account at the exchange.
     func testRejectsConflictingTagSuffixesOnOneAddress() throws {
         let response = try decode(makeJSON(
             sellAsset: "XRP.XRP",
@@ -200,9 +188,6 @@ final class SwapKitResponseAgreementTests: XCTestCase {
         assertContradiction(response, chain: .ripple, mentioning: "meta.destinationTag is 200")
     }
 
-    /// Agreeing tags across all three sources are not a contradiction, and one
-    /// destination spelled with the suffix in one field and without it in another
-    /// still names one destination.
     func testAcceptsAgreeingTagsStatedInSeveralFields() throws {
         let response = try decode(makeJSON(
             sellAsset: "XRP.XRP",
@@ -215,9 +200,6 @@ final class SwapKitResponseAgreementTests: XCTestCase {
     }
 
     // MARK: - A tag that cannot be read is not an absent tag
-
-    // Each source is covered on its own: collapsing "unreadable" into "absent" anywhere
-    // sends a tag-less deposit to an address where the tag identifies the depositor.
 
     func testRejectsAnUnreadableTopLevelDestinationTag() throws {
         let response = try decode(makeJSON(
@@ -248,7 +230,6 @@ final class SwapKitResponseAgreementTests: XCTestCase {
         assertContradiction(response, chain: .ripple, mentioning: "targetAddress tag suffix")
     }
 
-    /// Two `dt` parameters is two answers. Silently taking the first is a guess.
     func testRejectsDuplicateTargetAddressTagParameters() throws {
         let response = try decode(makeJSON(
             sellAsset: "XRP.XRP",
@@ -287,8 +268,7 @@ final class SwapKitResponseAgreementTests: XCTestCase {
         assertContradiction(response, chain: .ripple, mentioning: "targetAddress tag suffix")
     }
 
-    /// A query string carrying no `dt` at all states no tag — that really is absent, and
-    /// must not be swept up by the unreadable check.
+    /// A query with no `dt` really is absent, and must not be swept up by the unreadable check.
     func testAcceptsAnAddressWhoseQueryCarriesNoTag() throws {
         let response = try decode(makeJSON(
             sellAsset: "XRP.XRP",
@@ -300,8 +280,7 @@ final class SwapKitResponseAgreementTests: XCTestCase {
 
     // MARK: - No false rejections
 
-    /// An EVM route states the destination once (`inboundAddress` is omitted and
-    /// `tx` is an object), so there is nothing to corroborate and nothing to reject.
+    /// An EVM route states the destination once, so there is nothing to corroborate.
     func testAcceptsAnEvmResponseWithNoCorroboratingFields() throws {
         let response = try SwapKitFixtureLoader.decode(
             SwapKitSwapResponse.self,
@@ -310,8 +289,7 @@ final class SwapKitResponseAgreementTests: XCTestCase {
         XCTAssertNoThrow(try response.validateSelfAgreement(fromChain: .ethereum))
     }
 
-    /// The guard is only worth having if it never fires on a healthy route. Every
-    /// recorded real `/v3/swap` response must pass the whole gate unchanged.
+    /// A fail-closed guard is only shippable if it never fires on a healthy route.
     func testAcceptsEveryRecordedRealResponse() throws {
         let fixtures: [(name: String, chain: Chain)] = [
             ("v3-real-ton-swap", .ton),

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitResponseAgreementTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitResponseAgreementTests.swift
@@ -278,6 +278,28 @@ final class SwapKitResponseAgreementTests: XCTestCase {
         XCTAssertNoThrow(try response.validateSelfAgreement(fromChain: .ripple))
     }
 
+    // MARK: - The guard is wired into the production gate
+
+    /// Calling `validateSelfAgreement` directly proves the rule, not that the gate applies
+    /// it: removing the call in `validateSigningCapability` would leave every other test
+    /// here green.
+    func testValidateSigningCapabilityRefusesAContradictoryResponse() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "TON.TON",
+            txType: "TON",
+            targetAddress: tonBounceable,
+            tx: #"[{"address":"\#(tonOtherAccount)","amount":"5000000000"}]"#
+        ))
+        XCTAssertThrowsError(
+            try SwapKitService.validateSigningCapability(response: response, fromChain: .ton)
+        ) { error in
+            guard let swapKitError = error as? SwapKitError,
+                  case .contradictoryResponse = swapKitError else {
+                return XCTFail("expected contradictoryResponse, got \(error)")
+            }
+        }
+    }
+
     // MARK: - No false rejections
 
     /// An EVM route states the destination once, so there is nothing to corroborate.

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitResponseAgreementTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitResponseAgreementTests.swift
@@ -1,0 +1,415 @@
+//
+//  SwapKitResponseAgreementTests.swift
+//  VultisigAppTests
+//
+//  SwapKit states the deposit destination in three independent fields and the
+//  payload builder reads only `targetAddress`. These pin that a response which
+//  disagrees with itself is refused rather than resolved by precedence — while
+//  the several spellings of one TON account still compare equal, and every
+//  recorded real response still passes.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class SwapKitResponseAgreementTests: XCTestCase {
+
+    // The account SwapKit returns in `v3-real-ton-swap.json`, in each spelling.
+    private let tonBounceable = "EQC_BuLzOqk9GGNXh0y1XosB2BqUyk1AQcGMHKMGfRqlhxmd"
+    private let tonNonBounceable = "UQC_BuLzOqk9GGNXh0y1XosB2BqUyk1AQcGMHKMGfRqlh0RY"
+    private let tonRaw = "0:bf06e2f33aa93d186357874cb55e8b01d81a94ca4d4041c18c1ca3067d1aa587"
+    private let tonOtherAccount = "EQCrq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq8Uk"
+    private let xrpAddress = "rEb8TK3gBgk5auZkwc6sHnwrGVJH8DuaLh"
+
+    // MARK: - Destination divergence
+
+    func testRejectsTonTransferAddressNamingADifferentAccountThanTargetAddress() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "TON.TON",
+            txType: "TON",
+            targetAddress: tonBounceable,
+            tx: #"[{"address":"\#(tonOtherAccount)","amount":"5000000000"}]"#
+        ))
+        assertContradiction(response, chain: .ton, mentioning: "tx[0].address")
+    }
+
+    func testRejectsInboundAddressDivergingFromTargetAddress() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "TON.TON",
+            txType: "TON",
+            targetAddress: tonBounceable,
+            inboundAddress: tonOtherAccount,
+            tx: #"[{"address":"\#(tonBounceable)","amount":"5000000000"}]"#
+        ))
+        assertContradiction(response, chain: .ton, mentioning: "inboundAddress")
+    }
+
+    /// Divergence with no `tx[]` involved at all — the deposit-only shape (XRP, ADA).
+    func testRejectsInboundAddressDivergingOnADepositOnlyRoute() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "XRP.XRP",
+            txType: "XRP",
+            targetAddress: "rEb8TK3gBgk5auZkwc6sHnwrGVJH8DuaLh",
+            inboundAddress: "rPVMhWBsfF9iMXYj3aAzJVkPDTFNSyWdKy"
+        ))
+        assertContradiction(response, chain: .ripple, mentioning: "inboundAddress")
+    }
+
+    /// Base58 is case-sensitive: two addresses differing only by case are two
+    /// different addresses, and normalising case away would let them pass as one.
+    func testRejectsNonTonDivergenceDifferingOnlyByCase() throws {
+        let target = "rEb8TK3gBgk5auZkwc6sHnwrGVJH8DuaLh"
+        let response = try decode(makeJSON(
+            sellAsset: "XRP.XRP",
+            txType: "XRP",
+            targetAddress: target,
+            inboundAddress: target.lowercased()
+        ))
+        assertContradiction(response, chain: .ripple, mentioning: "inboundAddress")
+    }
+
+    // MARK: - TON spellings are not divergence
+
+    func testAcceptsOneTonAccountSpelledBounceableInOneFieldAndNonBounceableInAnother() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "TON.TON",
+            txType: "TON",
+            targetAddress: tonBounceable,
+            inboundAddress: tonNonBounceable,
+            tx: #"[{"address":"\#(tonNonBounceable)","amount":"5000000000"}]"#
+        ))
+        XCTAssertNoThrow(try response.validateSelfAgreement(fromChain: .ton))
+    }
+
+    func testAcceptsARawTonSpellingAgainstAUserFriendlyOne() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "TON.TON",
+            txType: "TON",
+            targetAddress: tonNonBounceable,
+            tx: #"[{"address":"\#(tonRaw)","amount":"5000000000"}]"#
+        ))
+        XCTAssertNoThrow(try response.validateSelfAgreement(fromChain: .ton))
+    }
+
+    // MARK: - Transfer cardinality
+
+    func testRejectsAMultiEntryTonTransferArray() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "TON.TON",
+            txType: "TON",
+            targetAddress: tonBounceable,
+            tx: #"""
+            [{"address":"\#(tonBounceable)","amount":"5000000000"},
+             {"address":"\#(tonBounceable)","amount":"2000000000"}]
+            """#
+        ))
+        assertContradiction(response, chain: .ton, mentioning: "2 transfers")
+    }
+
+    func testRejectsAnEmptyTonTransferArray() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "TON.TON",
+            txType: "TON",
+            targetAddress: tonBounceable,
+            tx: "[]"
+        ))
+        assertContradiction(response, chain: .ton, mentioning: "0 transfers")
+    }
+
+    // MARK: - Missing primary
+
+    func testRejectsABlankTargetAddressEvenWhenOtherFieldsNameADestination() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "TON.TON",
+            txType: "TON",
+            targetAddress: "   ",
+            inboundAddress: tonBounceable,
+            tx: #"[{"address":"\#(tonBounceable)","amount":"5000000000"}]"#
+        ))
+        assertContradiction(response, chain: .ton, mentioning: "targetAddress is empty")
+    }
+
+    // MARK: - Blank corroborating fields are not agreement
+
+    func testRejectsABlankInboundAddress() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "TON.TON",
+            txType: "TON",
+            targetAddress: tonBounceable,
+            inboundAddress: "",
+            tx: #"[{"address":"\#(tonBounceable)","amount":"5000000000"}]"#
+        ))
+        assertContradiction(response, chain: .ton, mentioning: "inboundAddress is empty")
+    }
+
+    func testRejectsABlankTonTransferAddress() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "TON.TON",
+            txType: "TON",
+            targetAddress: tonBounceable,
+            tx: #"[{"address":"","amount":"5000000000"}]"#
+        ))
+        assertContradiction(response, chain: .ton, mentioning: "tx[0].address is empty")
+    }
+
+    /// A TON route whose destination does not parse as a TON account is refused
+    /// rather than passed through on string equality.
+    func testRejectsATonDestinationThatIsNotAnAccount() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "TON.TON",
+            txType: "TON",
+            targetAddress: "not-a-ton-address",
+            tx: #"[{"address":"not-a-ton-address","amount":"5000000000"}]"#
+        ))
+        assertContradiction(response, chain: .ton, mentioning: "tx[0].address")
+    }
+
+    // MARK: - Destination tags are half the XRP destination
+
+    /// The address comparison strips the tag suffix on purpose, so without a separate
+    /// tag check two fields naming one address with different tags would agree — and
+    /// the deposit would land credited to a different account at the exchange.
+    func testRejectsConflictingTagSuffixesOnOneAddress() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "XRP.XRP",
+            txType: "XRP",
+            targetAddress: "rEb8TK3gBgk5auZkwc6sHnwrGVJH8DuaLh?dt=1",
+            inboundAddress: "rEb8TK3gBgk5auZkwc6sHnwrGVJH8DuaLh?dt=2"
+        ))
+        assertContradiction(response, chain: .ripple, mentioning: "inboundAddress tag suffix")
+    }
+
+    func testRejectsATopLevelTagConflictingWithTheTargetAddressSuffix() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "XRP.XRP",
+            txType: "XRP",
+            targetAddress: "rEb8TK3gBgk5auZkwc6sHnwrGVJH8DuaLh?dt=300",
+            topLevelTagJSON: "100"
+        ))
+        assertContradiction(response, chain: .ripple, mentioning: "destinationTag is 100")
+    }
+
+    func testRejectsAMetaTagConflictingWithTheTopLevelTag() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "XRP.XRP",
+            txType: "XRP",
+            targetAddress: "rEb8TK3gBgk5auZkwc6sHnwrGVJH8DuaLh",
+            topLevelTagJSON: "100",
+            metaTagJSON: "200"
+        ))
+        assertContradiction(response, chain: .ripple, mentioning: "meta.destinationTag is 200")
+    }
+
+    /// Agreeing tags across all three sources are not a contradiction, and one
+    /// destination spelled with the suffix in one field and without it in another
+    /// still names one destination.
+    func testAcceptsAgreeingTagsStatedInSeveralFields() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "XRP.XRP",
+            txType: "XRP",
+            targetAddress: "rEb8TK3gBgk5auZkwc6sHnwrGVJH8DuaLh?dt=7",
+            inboundAddress: "rEb8TK3gBgk5auZkwc6sHnwrGVJH8DuaLh",
+            topLevelTagJSON: "7"
+        ))
+        XCTAssertNoThrow(try response.validateSelfAgreement(fromChain: .ripple))
+    }
+
+    // MARK: - A tag that cannot be read is not an absent tag
+
+    // Each source is covered on its own: collapsing "unreadable" into "absent" anywhere
+    // sends a tag-less deposit to an address where the tag identifies the depositor.
+
+    func testRejectsAnUnreadableTopLevelDestinationTag() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "XRP.XRP",
+            txType: "XRP",
+            targetAddress: xrpAddress,
+            topLevelTagJSON: "\"abc\""
+        ))
+        assertContradiction(response, chain: .ripple, mentioning: "destinationTag states a destination tag")
+    }
+
+    func testRejectsAnUnreadableMetaDestinationTag() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "XRP.XRP",
+            txType: "XRP",
+            targetAddress: xrpAddress,
+            metaTagJSON: "\"not-a-tag\""
+        ))
+        assertContradiction(response, chain: .ripple, mentioning: "meta.destinationTag states a destination tag")
+    }
+
+    func testRejectsAnUnreadableTargetAddressTagSuffix() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "XRP.XRP",
+            txType: "XRP",
+            targetAddress: "\(xrpAddress)?dt=bogus"
+        ))
+        assertContradiction(response, chain: .ripple, mentioning: "targetAddress tag suffix")
+    }
+
+    /// Two `dt` parameters is two answers. Silently taking the first is a guess.
+    func testRejectsDuplicateTargetAddressTagParameters() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "XRP.XRP",
+            txType: "XRP",
+            targetAddress: "\(xrpAddress)?dt=1&dt=2"
+        ))
+        assertContradiction(response, chain: .ripple, mentioning: "2 dt parameters")
+    }
+
+    func testRejectsAnUnreadableInboundAddressTagSuffix() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "XRP.XRP",
+            txType: "XRP",
+            targetAddress: xrpAddress,
+            inboundAddress: "\(xrpAddress)?dt=bogus"
+        ))
+        assertContradiction(response, chain: .ripple, mentioning: "inboundAddress tag suffix")
+    }
+
+    func testRejectsDuplicateInboundAddressTagParameters() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "XRP.XRP",
+            txType: "XRP",
+            targetAddress: xrpAddress,
+            inboundAddress: "\(xrpAddress)?dt=1&dt=2"
+        ))
+        assertContradiction(response, chain: .ripple, mentioning: "2 dt parameters")
+    }
+
+    func testRejectsAnUnreadablePipeTagSuffix() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "XRP.XRP",
+            txType: "XRP",
+            targetAddress: "\(xrpAddress)|bogus"
+        ))
+        assertContradiction(response, chain: .ripple, mentioning: "targetAddress tag suffix")
+    }
+
+    /// A query string carrying no `dt` at all states no tag — that really is absent, and
+    /// must not be swept up by the unreadable check.
+    func testAcceptsAnAddressWhoseQueryCarriesNoTag() throws {
+        let response = try decode(makeJSON(
+            sellAsset: "XRP.XRP",
+            txType: "XRP",
+            targetAddress: "\(xrpAddress)?memo=foo"
+        ))
+        XCTAssertNoThrow(try response.validateSelfAgreement(fromChain: .ripple))
+    }
+
+    // MARK: - No false rejections
+
+    /// An EVM route states the destination once (`inboundAddress` is omitted and
+    /// `tx` is an object), so there is nothing to corroborate and nothing to reject.
+    func testAcceptsAnEvmResponseWithNoCorroboratingFields() throws {
+        let response = try SwapKitFixtureLoader.decode(
+            SwapKitSwapResponse.self,
+            from: "v3-erc20-erc20-swap"
+        )
+        XCTAssertNoThrow(try response.validateSelfAgreement(fromChain: .ethereum))
+    }
+
+    /// The guard is only worth having if it never fires on a healthy route. Every
+    /// recorded real `/v3/swap` response must pass the whole gate unchanged.
+    func testAcceptsEveryRecordedRealResponse() throws {
+        let fixtures: [(name: String, chain: Chain)] = [
+            ("v3-real-ton-swap", .ton),
+            ("v3-real-xrp-swap", .ripple),
+            ("v3-real-ada-swap", .cardano),
+            ("v3-real-ada-cbor-swap", .cardano),
+            ("v3-real-ada-cbor-prebuilt-swap", .cardano),
+            ("v3-real-btc-all-swap", .bitcoin),
+            ("v3-real-btc-FLASHNET-swap", .bitcoin),
+            ("v3-real-btc-GARDEN-swap", .bitcoin),
+            ("v3-real-bch-swap", .bitcoinCash),
+            ("v3-real-dash-swap", .dash),
+            ("v3-real-doge-swap", .dogecoin),
+            ("v3-real-zec-swap", .zcash),
+            ("v3-sol-near-swap-fresh", .solana),
+            ("v3-sui-swap-fresh", .sui),
+            ("v3-tron-final-swap-fresh", .tron),
+            ("v3-erc20-erc20-swap", .ethereum),
+            ("v3-flashnet-evm-usdc-btc-swap", .ethereum)
+        ]
+        for fixture in fixtures {
+            let response = try SwapKitFixtureLoader.decode(
+                SwapKitSwapResponse.self,
+                from: fixture.name
+            )
+            XCTAssertNoThrow(
+                try SwapKitService.validateSigningCapability(
+                    response: response,
+                    fromChain: fixture.chain
+                ),
+                "\(fixture.name) is a healthy recorded response and must not be rejected"
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func assertContradiction(
+        _ response: SwapKitSwapResponse,
+        chain: Chain,
+        mentioning fragment: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertThrowsError(
+            try response.validateSelfAgreement(fromChain: chain),
+            file: file,
+            line: line
+        ) { error in
+            guard let swapKitError = error as? SwapKitError,
+                  case .contradictoryResponse(let detail) = swapKitError else {
+                return XCTFail("expected contradictoryResponse, got \(error)", file: file, line: line)
+            }
+            XCTAssertTrue(
+                detail.contains(fragment),
+                "detail \(detail) should name \(fragment)",
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    private func decode(_ json: String) throws -> SwapKitSwapResponse {
+        try JSONDecoder().decode(SwapKitSwapResponse.self, from: Data(json.utf8))
+    }
+
+    private func makeJSON(
+        sellAsset: String,
+        txType: String,
+        targetAddress: String,
+        inboundAddress: String? = nil,
+        tx: String? = nil,
+        topLevelTagJSON: String? = nil,
+        metaTagJSON: String? = nil
+    ) -> String {
+        let inbound = inboundAddress.map { ",\"inboundAddress\":\"\($0)\"" } ?? ""
+        let txField = tx.map { ",\"tx\":\($0)" } ?? ""
+        let topTag = topLevelTagJSON.map { ",\"destinationTag\":\($0)" } ?? ""
+        let metaTagField = metaTagJSON.map { ",\"destinationTag\":\($0)" } ?? ""
+        return """
+        {
+            "swapId":"abc",
+            "routeId":"def",
+            "providers":["NEAR"],
+            "sellAsset":"\(sellAsset)",
+            "buyAsset":"ETH.USDC",
+            "sellAmount":"5",
+            "expectedBuyAmount":"100",
+            "expectedBuyAmountMaxSlippage":"99",
+            "sourceAddress":"source",
+            "destinationAddress":"0x0",
+            "targetAddress":"\(targetAddress)",
+            "meta":{"txType":"\(txType)"\(metaTagField)},
+            "fees":[]
+            \(inbound)
+            \(txField)
+            \(topTag)
+        }
+        """
+    }
+}

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitSigningTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitSigningTests.swift
@@ -236,13 +236,16 @@ final class SwapKitSigningTests: XCTestCase {
     // MARK: - TON fall-through wiring
 
     func testTonPayloadFallsThroughToTonHelper() throws {
-        // Phase 3 sets `keysignPayload.toAddress = targetAddress` and
-        // `keysignPayload.toAmount = tx[0].amount` via the outer
+        // Phase 3 sets `keysignPayload.toAddress = targetAddress` via the outer
         // `buildTransfer` call, so the existing `TonHelper.getPreSignedImageHash`
-        // path signs the deposit transfer directly. Lock that contract by
-        // asserting the SwapKit TON payload's targetAddress matches the
-        // inner `tx[0].address` — the keysign-message dispatcher then just
-        // breaks through to the TON helper.
+        // path signs the deposit transfer directly. `toAmount` is the amount the
+        // user is spending — NOT `tx[0].amount`, which rides in `txPayload` for
+        // the peer and is never read on either side.
+        //
+        // What follows describes this recorded fixture. The guard that REFUSES a
+        // response whose destination fields disagree lives in
+        // `SwapKitSwapResponse.validateSelfAgreement`
+        // (`SwapKitResponseAgreementTests`); nothing here enforces it.
         let response = try fixture(name: "v3-real-ton-swap")
         guard case let .ton(transfers) = response.tx else {
             return XCTFail("expected ton tx")


### PR DESCRIPTION
## Problem

SwapKit's `/v3/swap` response states the deposit destination in three independent fields — `targetAddress`, `inboundAddress`, and the `tx[]` transfer array — and the payload builder read only `targetAddress`. A response whose halves diverged was signed to that field while the others named a different account, and nothing downstream could tell.

**On the affected chains this was the only check there was.** `SecurityScannerTransactionFactory.swift:35-45` routes Blockaid swap scanning for **EVM and Solana sources only**, so TON, XRP, Cardano, UTXO, Sui and Tron SwapKit deposits are never scanned — and the signer never decodes `txPayload` for TON, so a co-signer could not spot a divergence either.

The realistic trigger is not a tampered payload but an unversioned wire change. This provider demonstrably does that: the decoder already absorbs `SOLANA` → `SERIALIZED_BASE64` and `CARDANO` → `CBOR` renames shipped mid-flight without versioning (`SwapKitSwapResponse.swift:210-215, 262-274`). Repurposing a destination field the same way would be a lost deposit.

`tx[]` cardinality was **completely unvalidated**: 0, 2 or 10 entries built and signed identically, because only `tx[0]` is ever built.

## Investigation first (the issue asked for this before any fix)

iOS has **no precedence chain at all** — unlike the SDK, it cannot pick the wrong field, because it only ever reads `targetAddress`. But it never compares it against anything either, and `grep` for `transfers.count` / `transfers.first` / `guard transfers` across `VultisigApp/VultisigApp/` returned **zero** production hits.

The issue (and [sdk#2296](https://github.com/vultisig/vultisig-sdk/pull/2296)) named `depositAddress` and `depositAmount` as the corroborating fields. **Neither appears in any of the 17 recorded fixtures** — the SDK models them defensively. What iOS actually receives is `inboundAddress` (present and byte-identical to `targetAddress` on every non-EVM route, absent on EVM) and `tx[0]`. So the guard checks the fields this client is actually sent.

## What changed

**1. Destination self-agreement (`319d5b9e9`)** — `targetAddress`, `inboundAddress` and `tx[0].address` must agree, or the response is refused at the single gate every quote already passes. Neither field is authoritative enough to arbitrate from, so a divergence is refused rather than resolved by precedence. A field that is present but blank is refused too: it corroborates nothing, and nothing is not agreement.

- **TON compares parsed accounts** — `EQ…`, `UQ…` and raw `workchain:hash` are one account. Two values that fail to parse as TON accounts are never reported as naming the same one.
- **Every other chain compares byte for byte.** Base58 is case-sensitive; folding case would let two different addresses pass as one. Bech32 and CashAddr *are* case-insensitive and could be normalised safely, but all 17 fixtures are byte-identical across `targetAddress`/`inboundAddress` (including BCH — no CashAddr prefix variance), so that would be untested surface in the code that most needs to be trusted. The cost is bounded and stated in the code: a refused route the user can retry, never a deposit signed to the wrong address.
- **A TON `tx[]` must state exactly one transfer.** Android already rejects an empty array (`SwapKitQuoteSource.kt:591-593`) and a blank `targetAddress` (`:511-513`); iOS did neither.
- **Destination tags are read as a tri-state**, not `UInt64?`. See below.

**2. Request echo (`86599e1b9`)** — `buildSwapTx` validated *nothing* about the response it returned. `JupiterService.swift:91-95` is the in-repo precedent for exactly this shape. The response must now echo the requested `routeId`, `sourceAddress` and `destinationAddress`. Verified against **all six** recorded quote/swap fixture pairs before relying on it.

**3. Three production comments corrected** — `KeysignMessageFactory.swift` (twice) and `KeysignViewModel.swift` claimed `keysignPayload.toAmount` is `tx[0].amount`. It is the amount the user typed. A comment asserting a check exists is how the next reader concludes it does.

## Behaviour changes worth calling out

- **`?dt=bogus&dt=5` no longer resolves to `5`.** It is now refused. The response states two tags, one unreadable; picking the readable one is the wallet inventing a fact the provider never established, and on XRP a wrong tag misattributes the deposit at a shared exchange address. Nothing else about destination-tag handling moved — `resolvedDestinationTag` and `resolvedTargetAddress` behave identically on every other input form.
- **`SwapKitRippleTests` deliberately constructs tag conflicts** (100 vs 200, suffix 300 vs meta 200) to pin `resolvedDestinationTag`'s precedence. Those tests still pass — the helper is untouched — but such a response can no longer reach it in production. The precedence remains live for non-conflicting inputs.

## Deliberately not in this PR

### The amount leg

**As specified, it would never fire.** The issue's Must-Do is `depositAmount` ↔ `tx[0].amount`, and iOS never receives `depositAmount` — it appears in none of the 17 recorded fixtures, and it isn't in the response model at all. Shipping that check would add a guard that cannot execute, which is worse than adding nothing: it shows up in review, in this description, and in the next reader's mental model as "the amount is checked", manufacturing confidence without protection.

**The version that *would* fire rests on one fixture, against three implementations that decline to make the same claim.** The only live pair on iOS is `sellAmount` (decimal) ↔ `tx[0].amount` (base units), and exactly one recorded response demonstrates them agreeing. Meanwhile the SDK's precedence is `depositAmount` → `tx[0].amount` → the caller's amount and never consults `sellAmount`; Android signs `request.tokenValue`, the user's typed amount; and on iOS `sellAmount` is decoded and then read by no production code whatsoever. A jetton-source TON route would state `sellAmount` in jetton units against a nano-TON `tx[0].amount`, and a fee-deducted deposit would diverge legitimately — either would refuse a healthy route.

**The two legs are not held to the same bar, deliberately.** A wrong destination loses the deposit outright, so that leg fails closed on the strength of fields present in every response. A wrong *amount* check doesn't lose anything — it refuses valid routes — so the bar for shipping it is higher, not lower, and inferring its semantics from a single sample doesn't clear it. Filed as **#5358**: a SwapKit doc statement that `sellAmount` is the deposit size, or a second fixture (ideally a jetton-source TON route), would settle it.

### Error presentation

Both new errors render a route-unavailable body under an "Unexpected Error" title. That is real, but not a regression: `SwapKitError` does not conform to `SwapErrorPresentable` and `normalizedSwapKitError` maps exactly one case, so **17 of 18 cases already do this**, `swapRouteNotFound` and `insufficientBalance` among them. Fixing only the two new ones would deepen the inconsistency that file exists to prevent. Filed as **#5362**.

### Peer-side revalidation

A co-signer reconstructs `SwapKitSwapPayload` from protobuf (`KeysignMessage+ProtoMappable.swift:305-318`) and signs without revalidating what the initiator claimed. Verified, and filed as **#5359** as the general question across payload types. So this guard is the sole check on those chains **for swaps quoted on this device**; a swap initiated elsewhere is #5359's scope.

## Verification

- `SwapKitResponseAgreementTests` (26), `TonAccountIdentityTests` (6), `SwapKitRequestEchoTests` (8) — divergent `tx[0].address`; divergent `inboundAddress`; **accepts** one TON account spelled `EQ…` in one field and `UQ…` in another, and raw against user-friendly; rejects a non-TON divergence differing only by case; rejects multi-entry and empty `tx[]`; rejects blank corroborating fields; rejects an unreadable or duplicated tag at each of the four sources; and **accepts every one of the 17 recorded real responses** through the full gate, which is what makes a fail-closed guard safe to ship.
- TON vectors are derived from the account SwapKit actually returns in `v3-real-ton-swap.json` (tag byte, workchain and CRC16 verified offline for each spelling), not synthetic ones.
- **The echo tests are built by mutating one field of a recorded response rather than hand-rolling JSON, deliberately.** Hand-written fixtures drifted from the real wire shape twice on this branch. The second time was worse than it looked: a `makeJSON` that declared `meta.txType = "TON"` with no `tx` key would have made `decodeTx` throw `keyNotFound(.tx)`, so every test in that file died at the decode line before reaching an assertion — a suite that could not have tested anything, and would have read as green intent in review. Starting from recorded wire data removes the class.
- `buildSwapTx` is driven end to end through an injected `HTTPClientProtocol` stub, asserting the error **type** that reaches the caller. Deleting the guard's call site, or letting the surrounding `catch HTTPError.statusCode` remap it to `.generic`, now fails a test instead of staying green. The agreement guard is pinned the same way through `validateSigningCapability`.
- **The gate caught a failure no cheaper check on this branch could have.** A `split/map/filter/map` chain in `extractTagSuffix` compiled to *"the compiler is unable to type-check this expression in reasonable time"* and the app target did not build. SwiftLint was clean on it — it walks a syntax tree and never invokes the type checker — so lint-clean was not compile evidence, and the fault was invisible until the build ran. Rewritten as the explicit loop the helper used before, which removes the chained generics rather than helping the solver through them.

## Review

**Needs human review.** This is a fail-closed guard on the signing path for chains that have no other protection, and it can refuse a route — a wrong rejection blocks a swap the user expected to work.

**On-device acceptance was NOT performed.** The gate is simulator-only: no real TON, XRP, Cardano or UTXO deposit was quoted, signed or broadcast against live SwapKit, and no cross-device co-signing ceremony was run. Every claim here rests on the 17 recorded fixtures and the unit suite.

Gate: `** TEST SUCCEEDED **`, `Executed 7119 tests, with 11 tests skipped and 0 failures (0 unexpected)`, `GATE_EXIT=0`, zero compile errors — 41 new tests on a 7078 baseline, predicted from the diff before the run.

Closes #5343


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation to ensure swap responses match requested routes and addresses.
  - Improved TON address comparison across equivalent formats.
  - Strengthened destination-tag handling, detecting invalid, ambiguous, or conflicting values.
  - Rejected responses with contradictory transfer details or unsupported destination data.
  - Added clearer diagnostic details for failed transaction construction.

- **Tests**
  - Added extensive coverage for response validation, TON address identity, destination tags, and request-echo mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->