### PR TITLE
fix(bond): bound the THORChain operator fee to 0…10000 basis points

### DIFF
--- a/VultisigApp/VultisigApp/Components/Validators/BasisPointsValidator.swift
+++ b/VultisigApp/VultisigApp/Components/Validators/BasisPointsValidator.swift
@@ -1,0 +1,39 @@
+//
+//  BasisPointsValidator.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Fails when a non-empty value is not a whole number of basis points in `0...10000`.
+///
+/// An empty value passes — pair it with `RequiredValidator`, or with whatever
+/// cross-field rule decides the field is mandatory.
+///
+/// ⚠️ **Parses with plain `Int64`, deliberately without trimming.** `IntValidator`
+/// trims whitespace; a validator that accepted `" 5"` where the memo builder parses
+/// the same string back to `nil` would drop the segment from a memo the user
+/// believed carried it. The validator and whatever encodes the value have to agree
+/// on what a number is.
+struct BasisPointsValidator: FormFieldValidator {
+
+    /// Ten thousand basis points is the whole of whatever the value is a fraction
+    /// of. Zero is a legitimate floor — it names the absence of a fee — unlike
+    /// `WithdrawBasisPoints.min`, where a withdrawal of nothing asks for nothing.
+    static let range: ClosedRange<Int64> = 0...10_000
+
+    let invalidMessage: String
+    let outOfRangeMessage: String
+
+    func validate(value: String) throws {
+        guard value.isNotEmpty else { return }
+
+        guard let basisPoints = Int64(value) else {
+            throw HelperError.runtimeError(invalidMessage)
+        }
+
+        guard Self.range.contains(basisPoints) else {
+            throw HelperError.runtimeError(outOfRangeMessage)
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1057,6 +1057,7 @@
 "OnboardingCard6Text4" = "";
 "openSettings" = "Einstellungen öffnen";
 "openSystemSettings" = "Systemeinstellungen öffnen";
+"operatorFeeRangeError" = "Betreibergebühr muss zwischen 0 und 10000 Basispunkten liegen";
 "operatorFeesError" = "Betreibergebühr darf nicht leer sein, wenn Anbieter ausgefüllt ist";
 "operatorFeesLabel" = "Betreibergebühren (Basis Punkte)";
 "optional" = "(optional)";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1057,6 +1057,7 @@
 "OnboardingCard6Text4" = "";
 "openSettings" = "Open Settings";
 "openSystemSettings" = "Open System Settings";
+"operatorFeeRangeError" = "Operator-fee must be between 0 and 10000 basis points";
 "operatorFeesError" = "Operator-fee cannot be empty if provider is filled";
 "operatorFeesLabel" = "Operator-fees (Basis Points)";
 "optional" = "(optional)";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1057,6 +1057,7 @@
 "OnboardingCard6Text4" = "";
 "openSettings" = "Abrir Configuración";
 "openSystemSettings" = "Abrir Configuración del Sistema";
+"operatorFeeRangeError" = "La tarifa del operador debe estar entre 0 y 10000 puntos base";
 "operatorFeesError" = "La tarifa del operador no puede estar vacía si el proveedor está lleno";
 "operatorFeesLabel" = "Tarifas del operador (Puntos Base)";
 "optional" = "(opcional)";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1057,6 +1057,7 @@
 "OnboardingCard6Text4" = "";
 "openSettings" = "Otvori Postavke";
 "openSystemSettings" = "Otvori Postavke sustava";
+"operatorFeeRangeError" = "Naknada operatora mora biti između 0 i 10000 baznih točaka";
 "operatorFeesError" = "Naknada operatora ne može biti prazna ako je pružatelj popunjen";
 "operatorFeesLabel" = "Naknade operatora (Bazne točke)";
 "optional" = "(neobavezno)";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1057,6 +1057,7 @@
 "OnboardingCard6Text4" = "";
 "openSettings" = "Apri Impostazioni";
 "openSystemSettings" = "Apri Impostazioni di Sistema";
+"operatorFeeRangeError" = "La commissione operatore deve essere compresa tra 0 e 10000 punti base";
 "operatorFeesError" = "La commissione operatore non può essere vuota se il fornitore è compilato";
 "operatorFeesLabel" = "Commissioni operatore (Punti Base)";
 "optional" = "(opzionale)";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1057,6 +1057,7 @@
 "OnboardingCard6Text4" = "";
 "openSettings" = "설정 열기";
 "openSystemSettings" = "시스템 설정 열기";
+"operatorFeeRangeError" = "운영자 수수료는 0에서 10000 기준점 사이여야 합니다";
 "operatorFeesError" = "공급자가 입력된 경우 운영자 수수료는 비워둘 수 없습니다";
 "operatorFeesLabel" = "운영자 수수료 (기준점)";
 "optional" = "(선택 사항)";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1057,6 +1057,7 @@
 "OnboardingCard6Text4" = "";
 "openSettings" = "Abrir Configurações";
 "openSystemSettings" = "Abrir Configurações do Sistema";
+"operatorFeeRangeError" = "A taxa do operador deve estar entre 0 e 10000 pontos base";
 "operatorFeesError" = "A taxa do operador não pode estar vazia se o provedor estiver preenchido";
 "operatorFeesLabel" = "Taxas do operador (Pontos Base)";
 "optional" = "(opcional)";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1057,6 +1057,7 @@
 "OnboardingCard6Text4" = "";
 "openSettings" = "打开设置";
 "openSystemSettings" = "打开系统设置";
+"operatorFeeRangeError" = "运营商费用必须介于 0 和 10000 基点之间";
 "operatorFeesError" = "如果填写了提供商，运营商费用不能为空";
 "operatorFeesLabel" = "运营商费用（基点）";
 "optional" = "(可选)";

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Thorchain/Bond/BondTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Thorchain/Bond/BondTransactionViewModel.swift
@@ -60,11 +60,13 @@ final class BondTransactionViewModel: ObservableObject, Form {
                 if value.isEmpty && self.providerViewModel.field.value.isNotEmpty {
                     throw HelperError.runtimeError("operatorFeesError".localized)
                 }
-
-                if !value.isEmpty && Int64(value) == nil {
-                    throw HelperError.runtimeError("invalidOperatorFee".localized)
-                }
-            }
+            },
+            // The memo's fee segment is read as basis points, so anything outside
+            // 0...10000 is not a fee the chain can honour.
+            BasisPointsValidator(
+                invalidMessage: "invalidOperatorFee".localized,
+                outOfRangeMessage: "operatorFeeRangeError".localized
+            )
         ]
 
         amountField.validators.append(AmountBalanceValidator(balance: coin.balanceDecimal))

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/BondTransactionViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/BondTransactionViewModelTests.swift
@@ -1,0 +1,237 @@
+//
+//  BondTransactionViewModelTests.swift
+//  VultisigAppTests
+//
+//  Range gate for the THORChain BOND form's operator-fee field. The memo's fee
+//  segment is read as basis points, so `0...10000` is the whole of what the
+//  chain can honour — and the field used to accept anything `Int64` could parse,
+//  including `50000` and negatives, straight into a signed memo.
+//
+//  Every rejection is asserted through `transactionBuilder` returning nil rather
+//  than through `validForm`: `FormScreen` does not disable Continue on the flag,
+//  so the builder is what actually stands between a bad value and a keysign
+//  ceremony.
+//
+
+import Combine
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class BondTransactionViewModelTests: XCTestCase {
+
+    private static let nodeAddress = "thor1prxy0sufdqfve6ygkwu9gswe60cle8gy02ex2w"
+    private static let providerAddress = "thor1pe0pspu4ep85gxr5h9l6k49g024vemtr80hg4c"
+
+    /// No decimal separator, so the amount parses the same in every shipping
+    /// locale — `AmountBalanceValidator` reads it through `Locale.current`.
+    private static let amount = "100"
+
+    /// Fills the form's other fields so each case varies only the operator fee.
+    /// Validity is deliberately *not* awaited here: a provider with no fee is
+    /// itself one of the rejection cases, so the caller states the settled
+    /// answer it expects.
+    private func makeLoadedViewModel(
+        provider: String? = nil,
+        operatorFee: String? = nil
+    ) -> BondTransactionViewModel {
+        let coin = FunctionActionFixture.makeRUNE()
+        let viewModel = BondTransactionViewModel(
+            coin: coin,
+            vault: FunctionActionFixture.makeVault(coins: [coin]),
+            initialBondAddress: nil
+        )
+        viewModel.onLoad()
+        viewModel.addressViewModel.field.value = Self.nodeAddress
+        if let provider {
+            viewModel.providerViewModel.field.value = provider
+        }
+        if let operatorFee {
+            viewModel.operatorFeeField.value = operatorFee
+        }
+        viewModel.amountField.value = Self.amount
+        return viewModel
+    }
+
+    /// `setupForm()` publishes validity on the main run loop, so the flag
+    /// settles a turn after the value is written.
+    private func awaitValidForm(_ viewModel: BondTransactionViewModel, is expected: Bool) async {
+        guard viewModel.validForm != expected else { return }
+        let settled = XCTestExpectation(description: "validForm becomes \(expected)")
+        var cancellable: AnyCancellable?
+        cancellable = viewModel.$validForm
+            .first(where: { $0 == expected })
+            .sink { _ in settled.fulfill() }
+        await fulfillment(of: [settled], timeout: 2)
+        cancellable?.cancel()
+    }
+
+    private func builder(_ viewModel: BondTransactionViewModel) -> BondTransactionBuilder? {
+        viewModel.transactionBuilder as? BondTransactionBuilder
+    }
+
+    // MARK: - Accepted range
+
+    func testEmptyOperatorFeeBuildsWithNoFeeSegment() async {
+        let viewModel = makeLoadedViewModel()
+        await awaitValidForm(viewModel, is: true)
+
+        let built = builder(viewModel)
+        XCTAssertNil(built?.operatorFee, "An untouched fee field is no fee at all")
+        XCTAssertEqual(built?.memo, "BOND:\(Self.nodeAddress)")
+    }
+
+    /// Zero is inside the range and stays inside it: it names the absence of a
+    /// fee, and `BondTransactionBuilder` omits the segment rather than writing
+    /// `:0`.
+    func testZeroOperatorFeeIsAcceptedAndOmitsTheFeeSegment() async {
+        let viewModel = makeLoadedViewModel(provider: Self.providerAddress, operatorFee: "0")
+        await awaitValidForm(viewModel, is: true)
+
+        let built = builder(viewModel)
+        XCTAssertEqual(built?.operatorFee, 0)
+        XCTAssertEqual(built?.memo, "BOND:\(Self.nodeAddress):\(Self.providerAddress)")
+        XCTAssertNil(viewModel.operatorFeeField.error)
+    }
+
+    /// The top of the range — 100% — is a fee the chain honours, so the form
+    /// must not fence it off.
+    func testMaximumOperatorFeeIsAccepted() async {
+        let viewModel = makeLoadedViewModel(provider: Self.providerAddress, operatorFee: "10000")
+        await awaitValidForm(viewModel, is: true)
+
+        let built = builder(viewModel)
+        XCTAssertEqual(built?.operatorFee, 10_000)
+        XCTAssertEqual(built?.memo, "BOND:\(Self.nodeAddress):\(Self.providerAddress):10000")
+        XCTAssertNil(viewModel.operatorFeeField.error)
+    }
+
+    /// The fee still reaches the memo raw — no ×100 anywhere between the field
+    /// and the signed bytes.
+    func testInRangeOperatorFeeReachesTheMemoUnscaled() async {
+        let viewModel = makeLoadedViewModel(provider: Self.providerAddress, operatorFee: "500")
+        await awaitValidForm(viewModel, is: true)
+
+        let built = builder(viewModel)
+        XCTAssertEqual(built?.operatorFee, 500)
+        XCTAssertEqual(built?.memo, "BOND:\(Self.nodeAddress):\(Self.providerAddress):500")
+    }
+
+    /// Without a provider the memo carries an empty provider segment, so the fee
+    /// still lands in the fourth position.
+    func testOperatorFeeWithoutAProviderKeepsTheEmptyProviderSegment() async {
+        let viewModel = makeLoadedViewModel(operatorFee: "500")
+        await awaitValidForm(viewModel, is: true)
+
+        XCTAssertEqual(builder(viewModel)?.memo, "BOND:\(Self.nodeAddress)::500")
+    }
+
+    // MARK: - Out of range
+
+    func testOperatorFeeAboveTenThousandBlocksTheBuilder() async {
+        let viewModel = makeLoadedViewModel(provider: Self.providerAddress, operatorFee: "10001")
+        await awaitValidForm(viewModel, is: false)
+
+        XCTAssertNil(viewModel.transactionBuilder, "An out-of-range fee must not reach a keysign ceremony")
+        XCTAssertEqual(viewModel.operatorFeeField.error, "operatorFeeRangeError".localized)
+    }
+
+    /// The value from the report: `50000` reads as a percentage carrying two
+    /// decimals and was signed as basis points.
+    func testFiftyThousandBasisPointsIsRefused() async {
+        let viewModel = makeLoadedViewModel(provider: Self.providerAddress, operatorFee: "50000")
+        await awaitValidForm(viewModel, is: false)
+
+        XCTAssertNil(viewModel.transactionBuilder)
+    }
+
+    func testNegativeOperatorFeeBlocksTheBuilder() async {
+        let viewModel = makeLoadedViewModel(provider: Self.providerAddress, operatorFee: "-1")
+        await awaitValidForm(viewModel, is: false)
+
+        XCTAssertNil(viewModel.transactionBuilder)
+        XCTAssertEqual(viewModel.operatorFeeField.error, "operatorFeeRangeError".localized)
+    }
+
+    // MARK: - Malformed
+
+    func testNonNumericOperatorFeeBlocksTheBuilder() async {
+        let viewModel = makeLoadedViewModel(provider: Self.providerAddress, operatorFee: "abc")
+        await awaitValidForm(viewModel, is: false)
+
+        XCTAssertNil(viewModel.transactionBuilder)
+        XCTAssertEqual(viewModel.operatorFeeField.error, "invalidOperatorFee".localized)
+    }
+
+    /// Basis points are whole. The iOS field is a decimal pad, so a decimal is
+    /// reachable, and it is not a fee the segment can carry.
+    func testDecimalOperatorFeeBlocksTheBuilder() async {
+        let viewModel = makeLoadedViewModel(provider: Self.providerAddress, operatorFee: "0.5")
+        await awaitValidForm(viewModel, is: false)
+
+        XCTAssertNil(viewModel.transactionBuilder)
+        XCTAssertEqual(viewModel.operatorFeeField.error, "invalidOperatorFee".localized)
+    }
+
+    /// Too large for `Int64` fails the parse rather than the range check, and is
+    /// refused either way — the point is that it never wraps into something in
+    /// range.
+    func testOperatorFeeBeyondInt64BlocksTheBuilder() async {
+        let viewModel = makeLoadedViewModel(
+            provider: Self.providerAddress,
+            operatorFee: "99999999999999999999999"
+        )
+        await awaitValidForm(viewModel, is: false)
+
+        XCTAssertNil(viewModel.transactionBuilder)
+        XCTAssertEqual(viewModel.operatorFeeField.error, "invalidOperatorFee".localized)
+    }
+
+    /// Whitespace is not trimmed, because `BondTransactionBuilder` parses the
+    /// same string with plain `Int64`. Accepting it here would drop the fee
+    /// segment from a memo the user believed carried it.
+    func testPaddedOperatorFeeBlocksTheBuilder() async {
+        let viewModel = makeLoadedViewModel(provider: Self.providerAddress, operatorFee: " 500")
+        await awaitValidForm(viewModel, is: false)
+
+        XCTAssertNil(viewModel.transactionBuilder)
+        XCTAssertEqual(viewModel.operatorFeeField.error, "invalidOperatorFee".localized)
+    }
+
+    // MARK: - Cross-field rule
+
+    /// A provider with no fee is a bond whose operator takes an unstated cut;
+    /// the pre-existing rule that refuses it has to survive the new validator.
+    func testEmptyOperatorFeeWithAProviderBlocksTheBuilder() async {
+        let viewModel = makeLoadedViewModel(provider: Self.providerAddress)
+        await awaitValidForm(viewModel, is: false)
+
+        XCTAssertNil(viewModel.transactionBuilder)
+        XCTAssertEqual(viewModel.operatorFeeField.error, "operatorFeesError".localized)
+    }
+
+    // MARK: - Gate timing
+
+    /// `validForm` is republished a run-loop turn late, so a Continue tap in the
+    /// same turn as the edit would otherwise read the previous answer — here,
+    /// building a memo from a fee the user has just pushed out of range.
+    func testOutOfRangeFeeBlocksTheBuilderInTheSameRunLoopTurn() async {
+        let viewModel = makeLoadedViewModel(provider: Self.providerAddress, operatorFee: "500")
+        await awaitValidForm(viewModel, is: true)
+
+        viewModel.operatorFeeField.value = "50000"
+        XCTAssertTrue(viewModel.validForm, "Precondition: the aggregate has not settled yet")
+        XCTAssertNil(viewModel.transactionBuilder, "A same-turn edit must not submit on a stale aggregate")
+    }
+
+    func testCorrectingAnOutOfRangeFeeReopensTheGate() async {
+        let viewModel = makeLoadedViewModel(provider: Self.providerAddress, operatorFee: "10001")
+        await awaitValidForm(viewModel, is: false)
+
+        viewModel.operatorFeeField.value = "1000"
+        await awaitValidForm(viewModel, is: true)
+
+        XCTAssertNil(viewModel.operatorFeeField.error)
+        XCTAssertEqual(builder(viewModel)?.memo, "BOND:\(Self.nodeAddress):\(Self.providerAddress):1000")
+    }
+}


### PR DESCRIPTION
## Problem

The THORChain BOND form checked the operator-fee field for *parseability* and nothing else:

```swift
if !value.isEmpty && Int64(value) == nil {
    throw HelperError.runtimeError("invalidOperatorFee".localized)
}
```

The value is basis points, so `50000` — or `-5` — was accepted, interpolated verbatim into the `BOND:<node>:<provider>:<fee>` memo by `BondTransactionBuilder`, and carried into a keysign ceremony to be signed and broadcast.

## Root cause

Nothing in the form, the builder, or anywhere between them stated the range the memo's fee segment actually has. `Int64` parsing is the only rule the field had, and `Int64` is happy with `50000`.

## Fix

`BasisPointsValidator` states the `0...10000` range once and is installed on `operatorFeeField` alongside the existing cross-field rule (a provider with no fee is still refused). Distinct messages for the two failure modes: unparseable reuses `invalidOperatorFee`, out-of-range gets a new `operatorFeeRangeError`.

Two deliberate choices worth a reviewer's eye:

- **No whitespace trimming**, unlike `IntValidator`. The validator parses with plain `Int64` because `BondTransactionBuilder` does. A validator that accepted `" 500"` where the builder parses the same string back to `nil` would silently drop the fee segment from a memo the user believed carried it. Pinned by `testPaddedOperatorFeeBlocksTheBuilder`.
- **No clamping in the builder.** Clamping would sign a number the user never typed; the form refuses and says why instead.

**Blocking needed no new machinery.** `BondTransactionViewModel.transactionBuilder` already runs `validateErrors()`, which recomputes the form against the validators installed *right now*, and returns `nil` unless every one passes; `BondTransactionScreen.onContinue` guards on that builder. Any validator that throws is therefore already a hard block. The tests assert that end-to-end — through `transactionBuilder` being `nil`, not through the `validForm` flag — because `FormScreen` does not disable Continue on the flag, so the builder is the thing that actually stands between a bad value and a ceremony.

**The fee still reaches the memo raw.** No `×100` is introduced; iOS is correct on the half Android got wrong ([android#5757](https://github.com/vultisig/vultisig-android/issues/5757)). `testInRangeOperatorFeeReachesTheMemoUnscaled` pins `BOND:<node>:<provider>:500` so a future change that adds scaling fails here rather than on chain.

## Two corrections to the issue

- **The cited path is misspelled.** The issue says `Features/FunctionTransaction/THORChain/Bond/…`; the tracked directory is `.../Thorchain/Bond/...` (lowercase `chain`).
- **The relabel is already shipped, so this PR does not do it.** The issue asks to relabel the field because it "does not name the unit". `operatorFeesLabel` has read *"Operator-fees (Basis Points)"* since `f62cd95aa`, and names the unit in all 8 shipping locales already (`de` "Basis Punkte", `ko` "기준점", `zh-Hans` "基点", …). The locale work here is therefore **one new key**, `operatorFeeRangeError`, added to all 8 files — `en de es hr it ko pt zh-Hans`, the set in `scripts/sort_localizable.py` (the issue's list naming `nl` and `ru` is wrong). All 8 files reconcile at **1922 entries**; the diff is 8 insertions, 0 deletions, no re-sorting churn.

## Verification

Full gate, dedicated `en_US` simulator (iPhone 17 Pro Max, iOS 26.5), at `431ed33bd`:

```
** TEST SUCCEEDED **
Executed 7181 tests, with 11 tests skipped and 0 failures (0 unexpected) in 132.819 seconds
```

All 15 new tests appear by name in that log and passed. Disk stayed at 17–18 GB free throughout, so no stale-run risk. SwiftLint clean on every changed file.

Cross-model review: two per-commit `codex exec --sandbox read-only` passes plus a whole-branch pass. One P2 on the first commit ("boundary and blocking behaviour lack regression tests") — fixed by the test commit. No other findings at any severity.

**On-device acceptance NOT performed.** This touches a signing path (what goes into a signed memo), so it wants a human eye and a device run before merge.

Closes #5347

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added operator fee validation requiring values between 0 and 10,000 basis points.
  * Added localized range-error messages in supported languages.

* **Bug Fixes**
  * Improved handling of invalid, negative, fractional, oversized, nonnumeric, and whitespace-padded fee values.

* **Tests**
  * Added coverage for valid fee ranges, invalid input, provider validation, memo construction, and transaction-building behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->