### PR TITLE
fix(swap): show loading while Verify refreshes quotes

### DIFF
--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapVerifyViewModel.swift
@@ -79,6 +79,7 @@ final class SwapVerifyViewModel {
     }
 
     func updateTimer(vault: Vault) async {
+        guard !transaction.isLimit, !isLoadingFees else { return }
         timer -= 1
         if timer < 1 {
             await refreshData(vault: vault)
@@ -92,7 +93,7 @@ final class SwapVerifyViewModel {
         // `quote == nil` limit invariant (the signed artifact is the pre-built
         // limit memo; a refreshed quote would only render misleading
         // provider/fee rows). Covers the 60s ticker and the retry path.
-        guard !transaction.isLimit else { return }
+        guard !transaction.isLimit, !isLoadingFees else { return }
 
         isLoadingFees = true
         defer { isLoadingFees = false }

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
@@ -37,6 +37,7 @@ struct SwapVerifyScreen: View {
                     .disabled(!verifyViewModel.isValidForm(shouldApprove: currentTransaction.isApproveRequired) || verifyViewModel.isLoadingFees || signButtonDisabled)
             }
         }
+        .withLoading(isLoading: $vm.isLoadingFees)
         .screenTitle("swapOverview".localized)
         .screenToolbar {
             CustomToolbarItem(placement: .trailing, hideSharedBackground: true) {
@@ -138,7 +139,6 @@ struct SwapVerifyScreen: View {
                         cryptoAmount: currentTransaction.swapGasString,
                         fiatAmount: currentTransaction.approveFeeString
                     )
-                    .blur(radius: verifyViewModel.isLoadingFees ? 1 : 0)
                 }
 
                 // Gross list-rate Vultisig fee. Applied savings are itemized in
@@ -146,7 +146,6 @@ struct SwapVerifyScreen: View {
                 if currentTransaction.showAffiliateFeeRow {
                     separator
                     affiliateFeeRow
-                        .blur(radius: verifyViewModel.isLoadingFees ? 1 : 0)
                 }
 
                 // Protocol Fee (native THOR/Maya outbound).
@@ -156,7 +155,6 @@ struct SwapVerifyScreen: View {
                         for: "swap.protocol_fee",
                         with: currentTransaction.outboundFeeString
                     )
-                    .blur(radius: verifyViewModel.isLoadingFees ? 1 : 0)
                 }
 
                 if currentTransaction.hasAppliedDiscounts {
@@ -177,7 +175,6 @@ struct SwapVerifyScreen: View {
                         for: "totalFee",
                         with: currentTransaction.totalFeeString
                     )
-                    .blur(radius: verifyViewModel.isLoadingFees ? 1 : 0)
                 }
 
                 if currentTransaction.advancedSettings.slippage != .auto {
@@ -418,7 +415,7 @@ struct SwapVerifyScreen: View {
     var refreshCounter: some View {
         // Limit orders execute at a fixed target price, so there is no live quote
         // to refresh — hide the countdown on the limit verify screen.
-        if !currentTransaction.isLimit {
+        if !currentTransaction.isLimit && !verifyViewModel.isLoadingFees {
             SwapRefreshQuoteCounter(timer: verifyViewModel.timer)
         }
     }

--- a/VultisigApp/VultisigAppTests/Swap/SwapVerifyRouteSelectionTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapVerifyRouteSelectionTests.swift
@@ -12,6 +12,16 @@ import XCTest
 
 @MainActor
 final class SwapVerifyRouteSelectionTests: XCTestCase {
+    private var storeToken: TestContextToken?
+
+    override func setUpWithError() throws {
+        storeToken = try TestStore.installInMemoryContainer()
+    }
+
+    override func tearDown() {
+        TestStore.restore(storeToken)
+        storeToken = nil
+    }
 
     func testRefreshKeepsThePickedRouteAndRepointsIt() async {
         let best = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "300000000"))
@@ -78,6 +88,79 @@ final class SwapVerifyRouteSelectionTests: XCTestCase {
         XCTAssertNil(vm.transaction.selectedProvider)
         XCTAssertNil(vm.routeSelectionNotice, "Auto changing winner is not a substitution")
         XCTAssertTrue(vm.isAmountCorrect, "The Auto path must not disturb the confirmations")
+    }
+
+    func testTimerRefreshDoesNotOverlapTimerOrExplicitRefetch() async {
+        let quote = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "100000000"))
+        let gate = RefreshRequestGate()
+        let vm = SwapVerifyViewModel(
+            transaction: makeTransaction(quote: quote, pickedProvider: nil),
+            interactor: RouteSelectionStubInteractor(
+                refreshed: makeResult(best: quote, allQuotes: [quote]),
+                beforeFetch: { try await gate.wait() }
+            )
+        )
+        let vault = makeVault()
+        vm.timer = 1
+        let refresh = Task { await vm.updateTimer(vault: vault) }
+        await fulfillment(of: [gate.started], timeout: 2)
+
+        XCTAssertTrue(vm.isLoadingFees)
+        XCTAssertEqual(vm.timer, 0)
+        await vm.updateTimer(vault: vault)
+        await vm.refreshData(vault: vault)
+        XCTAssertEqual(gate.calls, 1, "Timer ticks and explicit refetches must not overlap the pending request")
+        XCTAssertTrue(vm.isLoadingFees, "A duplicate refresh must not clear the active request's loading state")
+        XCTAssertEqual(vm.timer, 0, "The countdown pauses until the refresh completes")
+
+        gate.finish()
+        await refresh.value
+        XCTAssertFalse(vm.isLoadingFees)
+        XCTAssertEqual(vm.timer, 59)
+    }
+
+    func testRefreshStaysLoadingUntilFeeFetchCompletes() async {
+        let stale = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "100000000"))
+        let fresh = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "200000000"))
+        let gate = RefreshRequestGate()
+        let vm = SwapVerifyViewModel(
+            transaction: makeTransaction(quote: stale, pickedProvider: nil),
+            interactor: RouteSelectionStubInteractor(
+                refreshed: makeResult(best: fresh, allQuotes: [fresh]),
+                beforeFees: { try await gate.wait() }
+            )
+        )
+        let refresh = Task { await vm.refreshData(vault: makeVault()) }
+        await fulfillment(of: [gate.started], timeout: 2)
+
+        XCTAssertTrue(vm.isLoadingFees, "Receiving the quote must not dismiss loading while fees are pending")
+        XCTAssertEqual(vm.transaction.quote, stale)
+        gate.finish()
+        await refresh.value
+        XCTAssertFalse(vm.isLoadingFees)
+        XCTAssertEqual(vm.transaction.quote, fresh)
+    }
+
+    func testFailedRefreshClearsLoadingAndRestartsCountdown() async {
+        let quote = SwapQuote.thorchain(makeThorQuote(expectedAmountOut: "100000000"))
+        let gate = RefreshRequestGate()
+        let vm = SwapVerifyViewModel(
+            transaction: makeTransaction(quote: quote, pickedProvider: nil),
+            interactor: RouteSelectionStubInteractor(
+                refreshed: makeResult(best: quote, allQuotes: [quote]),
+                beforeFetch: { try await gate.wait() }
+            )
+        )
+        vm.timer = 1
+        let refresh = Task { await vm.updateTimer(vault: makeVault()) }
+        await fulfillment(of: [gate.started], timeout: 2)
+        XCTAssertTrue(vm.isLoadingFees)
+
+        gate.finish(error: URLError(.timedOut))
+        await refresh.value
+        XCTAssertFalse(vm.isLoadingFees)
+        XCTAssertEqual(vm.timer, 59)
+        XCTAssertEqual(vm.transaction.quote, quote)
     }
 
     // MARK: - Fixtures
@@ -173,6 +256,8 @@ final class SwapVerifyRouteSelectionTests: XCTestCase {
 /// One fixed refreshed candidate set; everything else is a no-op stub.
 private struct RouteSelectionStubInteractor: SwapInteractor {
     let refreshed: SwapQuoteResult
+    var beforeFetch: (() async throws -> Void)? = nil
+    var beforeFees: (() async throws -> Void)? = nil
 
     func fetchQuote(
         amount: Decimal,
@@ -183,7 +268,8 @@ private struct RouteSelectionStubInteractor: SwapInteractor {
         slippageBps: Int?,
         recipientAddress: String?
     ) async throws -> SwapQuoteResult? {
-        refreshed
+        try await beforeFetch?()
+        return refreshed
     }
 
     func fetchChainSpecific(
@@ -192,7 +278,8 @@ private struct RouteSelectionStubInteractor: SwapInteractor {
         fromAmount: Decimal,
         quote: SwapQuote?
     ) async throws -> BlockChainSpecific {
-        .Cosmos(accountNumber: 0, sequence: 0, gas: 0, transactionType: 0, ibcDenomTrace: nil, gasLimit: nil)
+        try await beforeFees?()
+        return .Cosmos(accountNumber: 0, sequence: 0, gas: 0, transactionType: 0, ibcDenomTrace: nil, gasLimit: nil)
     }
 
     func computeThorchainFee(
@@ -216,3 +303,30 @@ private struct RouteSelectionStubInteractor: SwapInteractor {
 }
 
 // swiftlint:enable async_without_await unused_parameter
+
+@MainActor
+private final class RefreshRequestGate {
+    let started = XCTestExpectation(description: "Refresh reached the delayed request")
+    private(set) var calls = 0
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    func wait() async throws {
+        calls += 1
+        // Let accidental overlapping calls finish so the test can assert the
+        // wrong count/loading state without leaving a second task suspended.
+        guard calls == 1 else { return }
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            started.fulfill()
+        }
+    }
+
+    func finish(error: Error? = nil) {
+        if let error {
+            continuation?.resume(throwing: error)
+        } else {
+            continuation?.resume()
+        }
+        continuation = nil
+    }
+}


### PR DESCRIPTION
## Description

Swap Verify now shows the shared `withLoading` overlay while its quote and fees refresh, and hides the countdown until completion. Timer ticks and explicit refresh calls are deduplicated so slow requests cannot drive the countdown negative or clear loading while another refresh is still pending.

Fixes #5371. Stacked on #5356 (`codex/swap-route-pick-5345`); review this PR against that branch.

## Which feature is affected?
- [x] Swap — loading presentation only; no signing or broadcast performed.

## Parity

- Android: n/a — SwiftUI loading/countdown presentation and iOS/macOS view-model timer lifecycle.
- Windows + extension: n/a — SwiftUI loading/countdown presentation and iOS/macOS view-model timer lifecycle.
- SDK: n/a — no payload, fee calculation, or SDK changes.

## Validation

- Simulator, iPhone 17 Pro / iOS 26.5: hosted the real Verify screen with a four-second delayed interactor. Before: no loader, `0:-2`, four overlapping requests. After: shared loader, countdown hidden, one request; completion restores `0:59`.
- Three deterministic async regressions cover timer/explicit overlap, loading through fee fetch, and failure reset.
- Full iOS suite: 7,098 tests, 11 skipped, zero failures; `TEST SUCCEEDED`, exit 0.
- SwiftLint: 27 existing warnings, zero serious; unchanged from baseline.
- Read-only cross-model step and stacked-delta review: no correctness findings.
- Temporary runtime probe/diagnostic logging removed; dedicated simulators deleted after each run.

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] Runtime behavior verified in the simulator

## Screenshots

Before/during/after screenshots were captured and inspected from the hosted-screen simulator probe. The screenshots and XCTest bundles are retained with the task's local verification artifacts; they are not attached to this PR.

## Additional context

This preserves the parent's provider-selection behavior. Existing stale-quote-on-error and refresh/signing issues remain outside this fix. No live swap or standalone macOS runtime test was performed.

## Agent Metadata
- **Agent**: Codex
- **Issue**: #5371
- **Confidence**: high
- **Needs human review for**: loading UX during automatic quote refresh

Co-Authored-By: Codex <noreply@openai.com>
