### PR TITLE
fix(swap): give every SwapKitError case a title consistent with its body

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitError.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitError.swift
@@ -27,9 +27,9 @@ enum SwapKitError: Error, LocalizedError, Equatable {
     /// `/v3/providers` snapshot shows at least one non-filtered provider
     /// enables both source and destination chains — meaning the pair is
     /// structurally supported, so the 404 must be amount-related rather
-    /// than a pair-coverage gap. The view layer normalizes this to
-    /// `SwapCryptoLogic.Errors.swapAmountTooSmall` so users see the same
-    /// "Amount Too Small" tooltip the THORChain path already produces.
+    /// than a pair-coverage gap. It presents under the same "Amount Too Small"
+    /// title and body as `SwapCryptoLogic.Errors.swapAmountTooSmall`, so users
+    /// see the tooltip the THORChain path already produces.
     case amountBelowProviderMinimum
     case blackListAsset
     case invalidSourceAddress
@@ -129,11 +129,9 @@ enum SwapKitError: Error, LocalizedError, Equatable {
             return "swapKitErrorNoRoutesFound".localized
         case .amountBelowProviderMinimum:
             // Reuse the existing THORChain "amount too small" copy rather than
-            // introducing a SwapKit-specific key — the user-facing meaning is
-            // identical and the view layer normalizes this case to
-            // `SwapCryptoLogic.Errors.swapAmountTooSmall` anyway. This
-            // `errorDescription` is only the fallback used if a caller logs
-            // the localized message without going through the tooltip view.
+            // introducing a SwapKit-specific key: the user-facing meaning is
+            // identical to `SwapCryptoLogic.Errors.swapAmountTooSmall`, whose
+            // title this case borrows too.
             return "swapErrorAmountTooSmallDescription".localized
         case .blackListAsset:
             return "swapKitErrorBlackListAsset".localized
@@ -157,6 +155,61 @@ enum SwapKitError: Error, LocalizedError, Equatable {
             return String(format: "swapKitErrorMalformedAmount".localized, raw)
         case .generic(let message):
             return message
+        }
+    }
+}
+
+// MARK: - Tooltip presentation
+
+extension SwapKitError: SwapErrorPresentable {
+    /// Every case gets a domain title. A case reaching the tooltip under the
+    /// generic heading means the app named the failure precisely in the body and
+    /// then said "Unexpected Error" above it.
+    var errorTitle: String {
+        switch self {
+        case .apiKeyMissing, .apiKeyInvalid, .providerNotEnabled:
+            // Nothing about the trade is wrong — SwapKit itself is unusable here.
+            return "swapErrorProviderRejectedTitle".localized
+        case .insufficientBalance:
+            return "swapErrorInsufficientFundsTitle".localized
+        case .insufficientAllowance:
+            return "swapErrorApprovalRequiredTitle".localized
+        case .unableToBuildTransaction, .noRoutesFound, .routeFiltered,
+             .unsupportedTxType, .contradictoryResponse, .responseEchoMismatch,
+             .malformedAmount, .generic:
+            return "swapErrorRouteUnavailableTitle".localized
+        case .swapRouteNotFound:
+            return "swapErrorRouteExpiredTitle".localized
+        case .outputAmountDeviationTooHigh:
+            return "swapErrorQuoteExpiredTitle".localized
+        case .amountBelowProviderMinimum:
+            // Same verdict and same body as `SwapCryptoLogic.Errors.swapAmountTooSmall`,
+            // which this case used to be normalized into for the tooltip.
+            return "swapErrorAmountTooSmallTitle".localized
+        case .blackListAsset:
+            return "swapErrorAssetBlockedTitle".localized
+        case .invalidSourceAddress:
+            return "swapErrorInvalidSourceTitle".localized
+        case .invalidDestinationAddress:
+            return "swapErrorInvalidDestinationTitle".localized
+        case .isSanctionedAddress, .addressScreeningFailed:
+            return "swapErrorAddressScreeningTitle".localized
+        }
+    }
+
+    var errorMessage: String {
+        switch self {
+        case .unsupportedTxType, .contradictoryResponse, .responseEchoMismatch,
+             .malformedAmount, .generic:
+            // The only case-specific information these carry is a string this app
+            // did not write for a screen: a txType token, a diverging field name,
+            // an unparseable amount, an upstream body, an encoder failure. It stays
+            // in `errorDescription` for the log. The body is the one thing true at
+            // all three sites they are thrown from — quote, payload build and
+            // signing — which is that this route cannot be used.
+            return "swapKitErrorUnableToBuildTransaction".localized
+        default:
+            return errorDescription ?? "swapKitErrorUnableToBuildTransaction".localized
         }
     }
 }

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1533,8 +1533,11 @@
 "swapAmountTooSmall" = "Tauschbetrag zu klein";
 "swapAmountTooSmallRecommended" = "Tauschbetrag zu klein. Empfohlener Betrag %@";
 "swapAppliedDiscounts" = "Angewandte Rabatte:";
+"swapErrorAddressScreeningTitle" = "Adressprüfung fehlgeschlagen";
 "swapErrorAmountTooSmallDescription" = "Der Tauschbetrag ist zu klein. Bitte erhöhen Sie den Betrag.";
 "swapErrorAmountTooSmallTitle" = "Betrag zu klein";
+"swapErrorApprovalRequiredTitle" = "Freigabe erforderlich";
+"swapErrorAssetBlockedTitle" = "Vermögenswert blockiert";
 "swapErrorInboundAddressDescription" = "Die Eingangsadresse ist ungültig. Bitte versuchen Sie es erneut.";
 "swapErrorInboundAddressTitle" = "Ungültige Adresse";
 "swapErrorInsufficientFundsDescription" = "Unzureichendes Guthaben für den Tausch. Bitte laden Sie Ihr Wallet auf.";
@@ -1542,11 +1545,14 @@
 "swapErrorInsufficientGasDescription" = "Nicht genügend Gas-Token, um die Netzwerkgebühr zu decken. Bitte fügen Sie Gas zu Ihrem Wallet hinzu.";
 "swapErrorInsufficientGasTitle" = "Unzureichendes Gas";
 "swapErrorInvalidDestinationTitle" = "Ungültiges Ziel";
+"swapErrorInvalidSourceTitle" = "Ungültige Quelle";
 "swapErrorNoLiquidityPoolTitle" = "Kein Liquiditätspool";
 "swapErrorProviderRejectedDescription" = "Der Swap-Anbieter konnte für diesen Handel kein Angebot erstellen. Versuche es erneut oder wähle ein anderes Paar.";
 "swapErrorProviderRejectedTitle" = "Swap nicht verfügbar";
+"swapErrorQuoteExpiredTitle" = "Kurs abgelaufen";
 "swapErrorRecipientRouteTitle" = "Keine Empfängerroute";
 "swapErrorRecipientVerificationTitle" = "Empfängerprüfung fehlgeschlagen";
+"swapErrorRouteExpiredTitle" = "Route abgelaufen";
 "swapErrorRouteUnavailableTitle" = "Keine Route verfügbar";
 "swapErrorSameAssetDescription" = "Es ist nicht möglich, dasselbe Asset zu tauschen. Bitte wählen Sie ein anderes Asset.";
 "swapErrorSameAssetTitle" = "Gleiches Asset";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1533,8 +1533,11 @@
 "swapAmountTooSmall" = "Swap amount too small";
 "swapAmountTooSmallRecommended" = "Swap amount too small. Recommended amount %@";
 "swapAppliedDiscounts" = "Applied Discounts:";
+"swapErrorAddressScreeningTitle" = "Address Check Failed";
 "swapErrorAmountTooSmallDescription" = "The swap amount is too small. Please increase the amount.";
 "swapErrorAmountTooSmallTitle" = "Amount Too Small";
+"swapErrorApprovalRequiredTitle" = "Approval Required";
+"swapErrorAssetBlockedTitle" = "Asset Blocked";
 "swapErrorInboundAddressDescription" = "The inbound address is invalid. Please try again.";
 "swapErrorInboundAddressTitle" = "Invalid Address";
 "swapErrorInsufficientFundsDescription" = "Insufficient funds to execute the swap. Please fund the wallet.";
@@ -1542,11 +1545,14 @@
 "swapErrorInsufficientGasDescription" = "Not enough gas token to cover the network fee. Please add gas to your wallet.";
 "swapErrorInsufficientGasTitle" = "Insufficient Gas";
 "swapErrorInvalidDestinationTitle" = "Invalid Destination";
+"swapErrorInvalidSourceTitle" = "Invalid Source";
 "swapErrorNoLiquidityPoolTitle" = "No Liquidity Pool";
 "swapErrorProviderRejectedDescription" = "The swap provider couldn't quote this trade. Try again, or choose a different pair.";
 "swapErrorProviderRejectedTitle" = "Swap Unavailable";
+"swapErrorQuoteExpiredTitle" = "Quote Expired";
 "swapErrorRecipientRouteTitle" = "No Recipient Route";
 "swapErrorRecipientVerificationTitle" = "Recipient Check Failed";
+"swapErrorRouteExpiredTitle" = "Route Expired";
 "swapErrorRouteUnavailableTitle" = "No Route Available";
 "swapErrorSameAssetDescription" = "Can't swap to the same asset. Please select a different asset.";
 "swapErrorSameAssetTitle" = "Same Asset";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1533,8 +1533,11 @@
 "swapAmountTooSmall" = "Cantidad de intercambio demasiado pequeña";
 "swapAmountTooSmallRecommended" = "Cantidad de intercambio demasiado pequeña. Cantidad recomendada %@";
 "swapAppliedDiscounts" = "Descuentos aplicados:";
+"swapErrorAddressScreeningTitle" = "Verificación de Dirección Fallida";
 "swapErrorAmountTooSmallDescription" = "La cantidad del intercambio es muy pequeña. Por favor, aumenta la cantidad.";
 "swapErrorAmountTooSmallTitle" = "Cantidad Muy Pequeña";
+"swapErrorApprovalRequiredTitle" = "Aprobación Requerida";
+"swapErrorAssetBlockedTitle" = "Activo Bloqueado";
 "swapErrorInboundAddressDescription" = "La dirección de entrada es inválida. Por favor, inténtalo de nuevo.";
 "swapErrorInboundAddressTitle" = "Dirección Inválida";
 "swapErrorInsufficientFundsDescription" = "Fondos insuficientes para ejecutar el intercambio. Por favor, recarga tu billetera.";
@@ -1542,11 +1545,14 @@
 "swapErrorInsufficientGasDescription" = "Token de gas insuficiente para cubrir la tarifa de red. Por favor, agrega gas a tu billetera.";
 "swapErrorInsufficientGasTitle" = "Gas Insuficiente";
 "swapErrorInvalidDestinationTitle" = "Destino Inválido";
+"swapErrorInvalidSourceTitle" = "Origen Inválido";
 "swapErrorNoLiquidityPoolTitle" = "Sin Pool de Liquidez";
 "swapErrorProviderRejectedDescription" = "El proveedor de intercambio no pudo cotizar esta operación. Inténtalo de nuevo o elige otro par.";
 "swapErrorProviderRejectedTitle" = "Intercambio No Disponible";
+"swapErrorQuoteExpiredTitle" = "Cotización Expirada";
 "swapErrorRecipientRouteTitle" = "Sin Ruta al Destinatario";
 "swapErrorRecipientVerificationTitle" = "Verificación de Destinatario Fallida";
+"swapErrorRouteExpiredTitle" = "Ruta Expirada";
 "swapErrorRouteUnavailableTitle" = "Sin Ruta Disponible";
 "swapErrorSameAssetDescription" = "No se puede intercambiar por el mismo activo. Por favor, selecciona un activo diferente.";
 "swapErrorSameAssetTitle" = "Mismo Activo";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1533,8 +1533,11 @@
 "swapAmountTooSmall" = "Iznos zamjene je premali";
 "swapAmountTooSmallRecommended" = "Iznos zamjene je premali. Preporučeni iznos %@";
 "swapAppliedDiscounts" = "Primijenjeni popusti:";
+"swapErrorAddressScreeningTitle" = "Provjera Adrese Nije Uspjela";
 "swapErrorAmountTooSmallDescription" = "Iznos zamjene je premali. Molimo povećajte iznos.";
 "swapErrorAmountTooSmallTitle" = "Iznos Premali";
+"swapErrorApprovalRequiredTitle" = "Potrebno Odobrenje";
+"swapErrorAssetBlockedTitle" = "Imovina Blokirana";
 "swapErrorInboundAddressDescription" = "Ulazna adresa je nevažeća. Molimo pokušajte ponovo.";
 "swapErrorInboundAddressTitle" = "Nevažeća Adresa";
 "swapErrorInsufficientFundsDescription" = "Nedovoljna sredstva za izvršenje zamjene. Molimo dopunite novčanik.";
@@ -1542,11 +1545,14 @@
 "swapErrorInsufficientGasDescription" = "Nedovoljno gas tokena za pokrivanje mrežne naknade. Molimo dodajte gas u svoj novčanik.";
 "swapErrorInsufficientGasTitle" = "Nedovoljan Gas";
 "swapErrorInvalidDestinationTitle" = "Nevažeće Odredište";
+"swapErrorInvalidSourceTitle" = "Nevažeći Izvor";
 "swapErrorNoLiquidityPoolTitle" = "Nema Pool Likvidnosti";
 "swapErrorProviderRejectedDescription" = "Pružatelj zamjene nije mogao dati ponudu za ovu trgovinu. Pokušajte ponovno ili odaberite drugi par.";
 "swapErrorProviderRejectedTitle" = "Zamjena Nije Dostupna";
+"swapErrorQuoteExpiredTitle" = "Ponuda Istekla";
 "swapErrorRecipientRouteTitle" = "Nema Rute do Primatelja";
 "swapErrorRecipientVerificationTitle" = "Provjera Primatelja Nije Uspjela";
+"swapErrorRouteExpiredTitle" = "Ruta Istekla";
 "swapErrorRouteUnavailableTitle" = "Nema Dostupne Rute";
 "swapErrorSameAssetDescription" = "Ne možete zamijeniti isti asset. Molimo odaberite drugi asset.";
 "swapErrorSameAssetTitle" = "Isti Asset";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1533,8 +1533,11 @@
 "swapAmountTooSmall" = "Importo dello scambio troppo piccolo";
 "swapAmountTooSmallRecommended" = "Importo dello scambio troppo piccolo. Importo raccomandato %@";
 "swapAppliedDiscounts" = "Sconti applicati:";
+"swapErrorAddressScreeningTitle" = "Verifica Indirizzo Fallita";
 "swapErrorAmountTooSmallDescription" = "L'importo dello scambio è troppo piccolo. Per favore aumenta l'importo.";
 "swapErrorAmountTooSmallTitle" = "Importo Troppo Piccolo";
+"swapErrorApprovalRequiredTitle" = "Approvazione Richiesta";
+"swapErrorAssetBlockedTitle" = "Asset Bloccato";
 "swapErrorInboundAddressDescription" = "L'indirizzo in entrata non è valido. Per favore riprova.";
 "swapErrorInboundAddressTitle" = "Indirizzo Non Valido";
 "swapErrorInsufficientFundsDescription" = "Fondi insufficienti per eseguire lo scambio. Per favore ricarica il portafoglio.";
@@ -1542,11 +1545,14 @@
 "swapErrorInsufficientGasDescription" = "Token gas insufficiente per coprire la commissione di rete. Per favore aggiungi gas al tuo portafoglio.";
 "swapErrorInsufficientGasTitle" = "Gas Insufficiente";
 "swapErrorInvalidDestinationTitle" = "Destinazione Non Valida";
+"swapErrorInvalidSourceTitle" = "Origine Non Valida";
 "swapErrorNoLiquidityPoolTitle" = "Nessun Pool di Liquidità";
 "swapErrorProviderRejectedDescription" = "Il fornitore di scambio non è riuscito a quotare questa operazione. Riprova o scegli un'altra coppia.";
 "swapErrorProviderRejectedTitle" = "Scambio Non Disponibile";
+"swapErrorQuoteExpiredTitle" = "Preventivo Scaduto";
 "swapErrorRecipientRouteTitle" = "Nessun Percorso al Destinatario";
 "swapErrorRecipientVerificationTitle" = "Verifica Destinatario Fallita";
+"swapErrorRouteExpiredTitle" = "Rotta Scaduta";
 "swapErrorRouteUnavailableTitle" = "Nessun Percorso Disponibile";
 "swapErrorSameAssetDescription" = "Non è possibile scambiare lo stesso asset. Per favore seleziona un asset diverso.";
 "swapErrorSameAssetTitle" = "Stesso Asset";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1533,8 +1533,11 @@
 "swapAmountTooSmall" = "스왑 금액이 너무 작습니다";
 "swapAmountTooSmallRecommended" = "스왑 금액이 너무 작습니다. 권장 금액 %@";
 "swapAppliedDiscounts" = "적용된 할인:";
+"swapErrorAddressScreeningTitle" = "주소 확인 실패";
 "swapErrorAmountTooSmallDescription" = "스왑 금액이 너무 작습니다. 금액을 늘려주세요.";
 "swapErrorAmountTooSmallTitle" = "금액이 너무 작음";
+"swapErrorApprovalRequiredTitle" = "승인 필요";
+"swapErrorAssetBlockedTitle" = "자산 차단됨";
 "swapErrorInboundAddressDescription" = "인바운드 주소가 유효하지 않습니다. 다시 시도하세요.";
 "swapErrorInboundAddressTitle" = "유효하지 않은 주소";
 "swapErrorInsufficientFundsDescription" = "스왑을 실행하기에 자금이 부족합니다. 지갑에 자금을 추가하세요.";
@@ -1542,11 +1545,14 @@
 "swapErrorInsufficientGasDescription" = "네트워크 수수료를 충당할 가스 토큰이 부족합니다. 지갑에 가스를 추가하세요.";
 "swapErrorInsufficientGasTitle" = "가스 부족";
 "swapErrorInvalidDestinationTitle" = "유효하지 않은 대상";
+"swapErrorInvalidSourceTitle" = "유효하지 않은 발신 주소";
 "swapErrorNoLiquidityPoolTitle" = "유동성 풀 없음";
 "swapErrorProviderRejectedDescription" = "스왑 제공자가 이 거래의 견적을 제공하지 못했습니다. 다시 시도하거나 다른 쌍을 선택하세요.";
 "swapErrorProviderRejectedTitle" = "스왑 불가";
+"swapErrorQuoteExpiredTitle" = "견적 만료됨";
 "swapErrorRecipientRouteTitle" = "수신자 경로 없음";
 "swapErrorRecipientVerificationTitle" = "수신자 확인 실패";
+"swapErrorRouteExpiredTitle" = "경로 만료됨";
 "swapErrorRouteUnavailableTitle" = "사용 가능한 경로 없음";
 "swapErrorSameAssetDescription" = "동일한 자산으로 스왑할 수 없습니다. 다른 자산을 선택하세요.";
 "swapErrorSameAssetTitle" = "동일한 자산";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1533,8 +1533,11 @@
 "swapAmountTooSmall" = "Valor da troca muito pequeno";
 "swapAmountTooSmallRecommended" = "Valor da troca muito pequeno. Valor recomendado %@";
 "swapAppliedDiscounts" = "Descontos aplicados:";
+"swapErrorAddressScreeningTitle" = "Verificação de Endereço Falhou";
 "swapErrorAmountTooSmallDescription" = "O valor da troca é muito pequeno. Por favor, aumente o valor.";
 "swapErrorAmountTooSmallTitle" = "Valor Muito Pequeno";
+"swapErrorApprovalRequiredTitle" = "Aprovação Necessária";
+"swapErrorAssetBlockedTitle" = "Ativo Bloqueado";
 "swapErrorInboundAddressDescription" = "O endereço de entrada é inválido. Por favor, tente novamente.";
 "swapErrorInboundAddressTitle" = "Endereço Inválido";
 "swapErrorInsufficientFundsDescription" = "Fundos insuficientes para executar a troca. Por favor, recarregue sua carteira.";
@@ -1542,11 +1545,14 @@
 "swapErrorInsufficientGasDescription" = "Token de gas insuficiente para cobrir a taxa de rede. Por favor, adicione gas à sua carteira.";
 "swapErrorInsufficientGasTitle" = "Gas Insuficiente";
 "swapErrorInvalidDestinationTitle" = "Destino Inválido";
+"swapErrorInvalidSourceTitle" = "Origem Inválida";
 "swapErrorNoLiquidityPoolTitle" = "Sem Pool de Liquidez";
 "swapErrorProviderRejectedDescription" = "O fornecedor de troca não conseguiu cotar esta operação. Tente novamente ou escolha outro par.";
 "swapErrorProviderRejectedTitle" = "Troca Indisponível";
+"swapErrorQuoteExpiredTitle" = "Cotação Expirada";
 "swapErrorRecipientRouteTitle" = "Sem Rota para o Destinatário";
 "swapErrorRecipientVerificationTitle" = "Verificação do Destinatário Falhou";
+"swapErrorRouteExpiredTitle" = "Rota Expirada";
 "swapErrorRouteUnavailableTitle" = "Sem Rota Disponível";
 "swapErrorSameAssetDescription" = "Não é possível trocar pelo mesmo ativo. Por favor, selecione um ativo diferente.";
 "swapErrorSameAssetTitle" = "Mesmo Ativo";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1533,8 +1533,11 @@
 "swapAmountTooSmall" = "交换金额太小";
 "swapAmountTooSmallRecommended" = "交换金额太小。推荐金额 %@";
 "swapAppliedDiscounts" = "已应用的折扣：";
+"swapErrorAddressScreeningTitle" = "地址筛查失败";
 "swapErrorAmountTooSmallDescription" = "交换金额太小。请增加金额。";
 "swapErrorAmountTooSmallTitle" = "金额太小";
+"swapErrorApprovalRequiredTitle" = "需要授权";
+"swapErrorAssetBlockedTitle" = "资产被屏蔽";
 "swapErrorInboundAddressDescription" = "入站地址无效。请重试。";
 "swapErrorInboundAddressTitle" = "地址无效";
 "swapErrorInsufficientFundsDescription" = "余额不足以执行交换。请为钱包充值。";
@@ -1542,11 +1545,14 @@
 "swapErrorInsufficientGasDescription" = "Gas 代币不足以支付网络费用。请向钱包添加 Gas。";
 "swapErrorInsufficientGasTitle" = "Gas 不足";
 "swapErrorInvalidDestinationTitle" = "目标地址无效";
+"swapErrorInvalidSourceTitle" = "源地址无效";
 "swapErrorNoLiquidityPoolTitle" = "无流动性池";
 "swapErrorProviderRejectedDescription" = "交换服务商无法为此交易报价。请重试或选择其他交易对。";
 "swapErrorProviderRejectedTitle" = "无法交换";
+"swapErrorQuoteExpiredTitle" = "报价已过期";
 "swapErrorRecipientRouteTitle" = "无接收方路由";
 "swapErrorRecipientVerificationTitle" = "接收方校验失败";
+"swapErrorRouteExpiredTitle" = "路径已过期";
 "swapErrorRouteUnavailableTitle" = "无可用路由";
 "swapErrorSameAssetDescription" = "无法兑换相同的资产。请选择不同的资产。";
 "swapErrorSameAssetTitle" = "相同资产";

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapErrorPresentable.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapErrorPresentable.swift
@@ -46,25 +46,12 @@ enum SwapErrorPresentation {
 
     /// The single lookup both `title` and `message` go through, so they can never
     /// disagree about which vocabulary an error belongs to.
+    ///
+    /// One membership test, deliberately: a second arm mapping a specific error
+    /// type onto the vocabulary would have to be kept exhaustive by hand, and the
+    /// one that existed here covered a single `SwapKitError` case out of
+    /// twenty-one. Conforming a type is the way in.
     static func presentable(for error: Error) -> SwapErrorPresentable? {
-        if let presentable = error as? SwapErrorPresentable {
-            return presentable
-        }
-        return normalizedSwapKitError(error)
-    }
-
-    /// Map terminal SwapKit error cases onto the swap flow's user-facing error
-    /// vocabulary so the tooltip shows a domain-appropriate title and description
-    /// instead of the generic "Unexpected Error" fallback. Only covers cases with
-    /// a clear `SwapCryptoLogic.Errors` equivalent — everything else flows
-    /// through `error.localizedDescription` as before.
-    private static func normalizedSwapKitError(_ error: Error) -> SwapCryptoLogic.Errors? {
-        guard let swapKitError = error as? SwapKitError else { return nil }
-        switch swapKitError {
-        case .amountBelowProviderMinimum:
-            return .swapAmountTooSmall
-        default:
-            return nil
-        }
+        error as? SwapErrorPresentable
     }
 }

--- a/VultisigApp/VultisigAppTests/Swap/SwapErrorPresentationTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapErrorPresentationTests.swift
@@ -107,7 +107,7 @@ final class SwapErrorPresentationTests: XCTestCase {
         XCTAssertNotNil(SwapErrorPresentation.presentable(for: SwapError.tradingHalted))
         // `SwapCryptoLogic.Errors` — the vocabulary that always worked.
         XCTAssertNotNil(SwapErrorPresentation.presentable(for: SwapCryptoLogic.Errors.insufficientGas))
-        // `SwapKitError` — normalized for the one case with an equivalent.
+        // `SwapKitError` — conforms in full; see `SwapKitErrorPresentationTests`.
         XCTAssertEqual(
             SwapErrorPresentation.title(for: SwapKitError.amountBelowProviderMinimum),
             SwapCryptoLogic.Errors.swapAmountTooSmall.errorTitle

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitErrorPresentationTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitErrorPresentationTests.swift
@@ -1,0 +1,496 @@
+//
+//  SwapKitErrorPresentationTests.swift
+//  VultisigAppTests
+//
+//  Pins the swap tooltip's presentation of `SwapKitError`. Twenty of its
+//  twenty-one cases used to render an accurate, domain-correct body under the
+//  generic "Unexpected Error" heading, because the enum did not conform to
+//  `SwapErrorPresentable` and the view's normalization arm covered exactly one
+//  case. These tests hold the whole enum inside the vocabulary, not the cases a
+//  given PR happened to touch.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class SwapKitErrorPresentationTests: XCTestCase {
+
+    /// A string no localized copy can contain, planted in every associated
+    /// value. `testNoCaseLeaksItsUpstreamStringIntoTheBody` then holds for cases
+    /// that do not exist yet: a future case carrying a provider string is given
+    /// a sample here by the exhaustive switches below, and leaks the sentinel
+    /// the moment its body renders that string.
+    private static let sentinel = "__upstream_sentinel_7f3a__"
+
+    /// One tag per `SwapKitError` case. Two exhaustive switches close the loop
+    /// around it: `tag(of:)` fails to compile when a case is added to
+    /// `SwapKitError`, and `sample(for:)` fails to compile when a tag is added
+    /// here. A twenty-second case therefore cannot reach `main` without a
+    /// presentation decision recorded in `expectedTitleKeys`.
+    private enum CaseTag: String, CaseIterable {
+        case apiKeyMissing
+        case apiKeyInvalid
+        case insufficientBalance
+        case insufficientAllowance
+        case unableToBuildTransaction
+        case swapRouteNotFound
+        case outputAmountDeviationTooHigh
+        case noRoutesFound
+        case amountBelowProviderMinimum
+        case blackListAsset
+        case invalidSourceAddress
+        case invalidDestinationAddress
+        case isSanctionedAddress
+        case addressScreeningFailed
+        case unsupportedTxType
+        case contradictoryResponse
+        case responseEchoMismatch
+        case providerNotEnabled
+        case routeFiltered
+        case malformedAmount
+        case generic
+    }
+
+    private func sample(for tag: CaseTag) -> SwapKitError {
+        switch tag {
+        case .apiKeyMissing: return .apiKeyMissing
+        case .apiKeyInvalid: return .apiKeyInvalid
+        case .insufficientBalance: return .insufficientBalance
+        case .insufficientAllowance: return .insufficientAllowance
+        case .unableToBuildTransaction: return .unableToBuildTransaction
+        case .swapRouteNotFound: return .swapRouteNotFound
+        case .outputAmountDeviationTooHigh: return .outputAmountDeviationTooHigh
+        case .noRoutesFound: return .noRoutesFound
+        case .amountBelowProviderMinimum: return .amountBelowProviderMinimum
+        case .blackListAsset: return .blackListAsset
+        case .invalidSourceAddress: return .invalidSourceAddress
+        case .invalidDestinationAddress: return .invalidDestinationAddress
+        case .isSanctionedAddress: return .isSanctionedAddress
+        case .addressScreeningFailed: return .addressScreeningFailed
+        case .unsupportedTxType: return .unsupportedTxType(Self.sentinel)
+        case .contradictoryResponse: return .contradictoryResponse(detail: Self.sentinel)
+        case .responseEchoMismatch: return .responseEchoMismatch(detail: Self.sentinel)
+        case .providerNotEnabled: return .providerNotEnabled
+        case .routeFiltered: return .routeFiltered
+        case .malformedAmount: return .malformedAmount(Self.sentinel)
+        case .generic: return .generic(message: Self.sentinel)
+        }
+    }
+
+    private func tag(of error: SwapKitError) -> CaseTag {
+        switch error {
+        case .apiKeyMissing: return .apiKeyMissing
+        case .apiKeyInvalid: return .apiKeyInvalid
+        case .insufficientBalance: return .insufficientBalance
+        case .insufficientAllowance: return .insufficientAllowance
+        case .unableToBuildTransaction: return .unableToBuildTransaction
+        case .swapRouteNotFound: return .swapRouteNotFound
+        case .outputAmountDeviationTooHigh: return .outputAmountDeviationTooHigh
+        case .noRoutesFound: return .noRoutesFound
+        case .amountBelowProviderMinimum: return .amountBelowProviderMinimum
+        case .blackListAsset: return .blackListAsset
+        case .invalidSourceAddress: return .invalidSourceAddress
+        case .invalidDestinationAddress: return .invalidDestinationAddress
+        case .isSanctionedAddress: return .isSanctionedAddress
+        case .addressScreeningFailed: return .addressScreeningFailed
+        case .unsupportedTxType: return .unsupportedTxType
+        case .contradictoryResponse: return .contradictoryResponse
+        case .responseEchoMismatch: return .responseEchoMismatch
+        case .providerNotEnabled: return .providerNotEnabled
+        case .routeFiltered: return .routeFiltered
+        case .malformedAmount: return .malformedAmount
+        case .generic: return .generic
+        }
+    }
+
+    private var allCases: [SwapKitError] { CaseTag.allCases.map(sample) }
+
+    /// The presentation decision for every case, as a key rather than a string,
+    /// so a re-worded translation does not fail the test and a silently swapped
+    /// key does.
+    private let expectedTitleKeys: [CaseTag: String] = [
+        .apiKeyMissing: "swapErrorProviderRejectedTitle",
+        .apiKeyInvalid: "swapErrorProviderRejectedTitle",
+        .providerNotEnabled: "swapErrorProviderRejectedTitle",
+        .insufficientBalance: "swapErrorInsufficientFundsTitle",
+        .insufficientAllowance: "swapErrorApprovalRequiredTitle",
+        .unableToBuildTransaction: "swapErrorRouteUnavailableTitle",
+        .noRoutesFound: "swapErrorRouteUnavailableTitle",
+        .routeFiltered: "swapErrorRouteUnavailableTitle",
+        .unsupportedTxType: "swapErrorRouteUnavailableTitle",
+        .contradictoryResponse: "swapErrorRouteUnavailableTitle",
+        .responseEchoMismatch: "swapErrorRouteUnavailableTitle",
+        .malformedAmount: "swapErrorRouteUnavailableTitle",
+        .generic: "swapErrorRouteUnavailableTitle",
+        .swapRouteNotFound: "swapErrorRouteExpiredTitle",
+        .outputAmountDeviationTooHigh: "swapErrorQuoteExpiredTitle",
+        .amountBelowProviderMinimum: "swapErrorAmountTooSmallTitle",
+        .blackListAsset: "swapErrorAssetBlockedTitle",
+        .invalidSourceAddress: "swapErrorInvalidSourceTitle",
+        .invalidDestinationAddress: "swapErrorInvalidDestinationTitle",
+        .isSanctionedAddress: "swapErrorAddressScreeningTitle",
+        .addressScreeningFailed: "swapErrorAddressScreeningTitle"
+    ]
+
+    /// The body key every case must resolve to. Without this, a body assertion
+    /// can only compare `SwapErrorPresentation.message(for:)` against
+    /// `errorMessage`, which is the same value by construction and passes for a
+    /// swapped key.
+    private let expectedMessageKeys: [CaseTag: String] = [
+        .apiKeyMissing: "swapKitErrorApiKeyMissing",
+        .apiKeyInvalid: "swapKitErrorApiKeyInvalid",
+        .insufficientBalance: "swapKitErrorInsufficientBalance",
+        .insufficientAllowance: "swapKitErrorInsufficientAllowance",
+        .unableToBuildTransaction: "swapKitErrorUnableToBuildTransaction",
+        .swapRouteNotFound: "swapKitErrorSwapRouteNotFound",
+        .outputAmountDeviationTooHigh: "swapKitErrorOutputAmountDeviationTooHigh",
+        .noRoutesFound: "swapKitErrorNoRoutesFound",
+        .amountBelowProviderMinimum: "swapErrorAmountTooSmallDescription",
+        .blackListAsset: "swapKitErrorBlackListAsset",
+        .invalidSourceAddress: "swapKitErrorInvalidSourceAddress",
+        .invalidDestinationAddress: "swapKitErrorInvalidDestinationAddress",
+        .isSanctionedAddress: "swapKitErrorAddressScreening",
+        .addressScreeningFailed: "swapKitErrorAddressScreening",
+        // The five that carry an upstream string share the route-unusable copy.
+        .unsupportedTxType: "swapKitErrorUnableToBuildTransaction",
+        .contradictoryResponse: "swapKitErrorUnableToBuildTransaction",
+        .responseEchoMismatch: "swapKitErrorUnableToBuildTransaction",
+        .malformedAmount: "swapKitErrorUnableToBuildTransaction",
+        .generic: "swapKitErrorUnableToBuildTransaction",
+        .providerNotEnabled: "swapKitErrorProviderNotEnabled",
+        .routeFiltered: "swapKitErrorRouteFiltered"
+    ]
+
+    /// Every locale the app is expected to ship. Pinned rather than derived so a
+    /// build that dropped a `.lproj` fails here instead of quietly shrinking the
+    /// per-locale loops below to nothing.
+    private static let expectedLocales = ["de", "en", "es", "hr", "it", "ko", "pt", "zh-Hans"]
+
+    /// The title keys this change introduces. They are the ones that can be
+    /// missing from a locale, so they get the per-locale check.
+    private let newTitleKeys = [
+        "swapErrorAddressScreeningTitle",
+        "swapErrorApprovalRequiredTitle",
+        "swapErrorAssetBlockedTitle",
+        "swapErrorInvalidSourceTitle",
+        "swapErrorQuoteExpiredTitle",
+        "swapErrorRouteExpiredTitle"
+    ]
+
+    /// Every localization actually included in the app bundle, so a new shipping
+    /// locale is covered without another manifest.
+    private static var shippedLocales: [String] {
+        Bundle.main.localizations.filter { $0 != "Base" }.sorted()
+    }
+
+    /// Localized value for `key` in `bundle`, or `nil` when the key is missing.
+    /// `"key".localized` echoes the key back on a miss, so asserting against it
+    /// proves nothing about the strings file; this does.
+    private func localizedValue(forKey key: String, in bundle: Bundle = .main) -> String? {
+        let sentinel = "__missing_localization__"
+        let value = bundle.localizedString(forKey: key, value: sentinel, table: nil)
+        return value == sentinel ? nil : value
+    }
+
+    private struct SourceParseFailure: Error, CustomStringConvertible {
+        let description: String
+    }
+
+    /// Every case name declared by `SwapKitError`, read from its own source.
+    /// Swift cannot make an enum with associated values `CaseIterable`, so the
+    /// two switches above force an author to *visit* this file when a case is
+    /// added — but not to give it its own tag. Comparing against the declaration
+    /// closes that: a case mapped onto an existing tag has no sample, and shows
+    /// up here as a name with no tag. Anchored at `#filePath` the same way
+    /// `SigningGoldenStore` and the Figma parity harness anchor theirs.
+    ///
+    /// Reads the case list as a region rather than matching a line shape, and
+    /// throws on anything it does not recognise. A parser that skipped what it
+    /// could not read would answer with a short list that still matched the tags,
+    /// which is the one failure this whole check exists to prevent.
+    private func declaredCaseNames() throws -> Set<String> {
+        let source = URL(fileURLWithPath: "\(#filePath)")
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("VultisigApp/Blockchain/Swaps/SwapKit/SwapKitError.swift")
+        let text = try String(contentsOf: source, encoding: .utf8)
+
+        var names: Set<String> = []
+        var insideDeclaration = false
+        for rawLine in text.components(separatedBy: .newlines) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard insideDeclaration else {
+                insideDeclaration = line.hasPrefix("enum SwapKitError")
+                continue
+            }
+            if line.isEmpty || line.hasPrefix("//") { continue }
+            // The case list ends at the enum's first other member.
+            if line == "}" || ["init", "var", "func", "static", "let"].contains(where: line.hasPrefix) {
+                break
+            }
+            guard line.hasPrefix("case ") else {
+                throw SourceParseFailure(description: "unrecognised line in the case list: \(rawLine)")
+            }
+            for piece in Self.splitOnTopLevelCommas(line.dropFirst("case ".count)) {
+                let name = piece
+                    .trimmingCharacters(in: .whitespaces)
+                    .prefix { $0.isLetter || $0.isNumber || $0 == "_" }
+                guard !name.isEmpty else {
+                    throw SourceParseFailure(description: "unparsable case declaration: \(rawLine)")
+                }
+                names.insert(String(name))
+            }
+        }
+        guard !names.isEmpty else {
+            throw SourceParseFailure(description: "no cases found — the enum declaration was not located")
+        }
+        return names
+    }
+
+    /// Commas inside an associated-value list do not separate cases.
+    private static func splitOnTopLevelCommas(_ text: Substring) -> [Substring] {
+        var pieces: [Substring] = []
+        var depth = 0
+        var start = text.startIndex
+        for index in text.indices {
+            switch text[index] {
+            case "(":
+                depth += 1
+            case ")":
+                depth -= 1
+            case "," where depth == 0:
+                pieces.append(text[start..<index])
+                start = text.index(after: index)
+            default:
+                break
+            }
+        }
+        pieces.append(text[start...])
+        return pieces
+    }
+
+    /// The bundle for a single `.lproj`, which resolves keys from that locale
+    /// alone with no fallback. `Bundle.main` answers for the *active*
+    /// localization only, so a key present in `en` and missing from `ko` reads as
+    /// covered when the whole point of the check is that it isn't.
+    private func bundle(forLocale locale: String) -> Bundle? {
+        Bundle.main.path(forResource: locale, ofType: "lproj").flatMap(Bundle.init(path:))
+    }
+
+    // MARK: - The reported bug, through the path the view actually uses
+
+    func testNoCaseFallsBackToUnexpectedErrorTitle() {
+        let generic = SwapCryptoLogic.Errors.unexpectedError.errorTitle
+        for error in allCases {
+            XCTAssertNotEqual(
+                SwapErrorPresentation.title(for: error),
+                generic,
+                "\(tag(of: error).rawValue) is still titled generically"
+            )
+        }
+    }
+
+    func testEveryCaseIsInsideTheTooltipVocabulary() {
+        for error in allCases {
+            XCTAssertNotNil(
+                SwapErrorPresentation.presentable(for: error),
+                "\(tag(of: error).rawValue) is outside the tooltip vocabulary"
+            )
+        }
+    }
+
+    func testEveryDeclaredCaseHasItsOwnTag() throws {
+        // Guards the hole the two switches cannot: an author who satisfies
+        // `tag(of:)` by pointing a new case at an existing tag leaves it with no
+        // sample, and every other test here passes without ever seeing it.
+        XCTAssertEqual(
+            try declaredCaseNames(),
+            Set(CaseTag.allCases.map(\.rawValue)),
+            "SwapKitError's declared cases and this file's tags have diverged"
+        )
+    }
+
+    func testEveryCaseHasNonEmptyTitleAndMessage() {
+        for error in allCases {
+            let name = tag(of: error).rawValue
+            XCTAssertFalse(error.errorTitle.isEmpty, "\(name) has an empty title")
+            XCTAssertFalse(error.errorMessage.isEmpty, "\(name) has an empty message")
+        }
+    }
+
+    func testTitleKeyPerCase() {
+        for error in allCases {
+            let name = tag(of: error).rawValue
+            guard let key = expectedTitleKeys[tag(of: error)] else {
+                XCTFail("no expected title key for \(name)")
+                continue
+            }
+            guard let value = localizedValue(forKey: key) else {
+                XCTFail("\(key) is missing from Localizable.strings (\(name))")
+                continue
+            }
+            XCTAssertEqual(SwapErrorPresentation.title(for: error), value, "wrong title key for \(name)")
+        }
+    }
+
+    func testBodyKeyPerCase() {
+        // Asserted against the localized value of an expected key, not against
+        // `errorMessage`: the tooltip reads the body straight off the conformance,
+        // so comparing the two would hold for any key at all.
+        for error in allCases {
+            let name = tag(of: error).rawValue
+            guard let key = expectedMessageKeys[tag(of: error)] else {
+                XCTFail("no expected body key for \(name)")
+                continue
+            }
+            guard let value = localizedValue(forKey: key) else {
+                XCTFail("\(key) is missing from Localizable.strings (\(name))")
+                continue
+            }
+            XCTAssertEqual(SwapErrorPresentation.message(for: error), value, "wrong body key for \(name)")
+        }
+    }
+
+    // MARK: - Raw upstream text never reaches the tooltip body
+
+    func testNoCaseLeaksItsUpstreamStringIntoTheBody() {
+        for error in allCases {
+            XCTAssertFalse(
+                error.errorMessage.contains(Self.sentinel),
+                "\(tag(of: error).rawValue) renders its upstream string in the tooltip body"
+            )
+        }
+    }
+
+    func testTxTypeAmountAndProviderStringsSurviveInTheDiagnosticDescription() {
+        // `errorDescription` is the diagnostic channel (`localizedDescription`,
+        // logger lines). Replacing the body must not cost the support log the one
+        // detail that says what upstream actually sent.
+        for error in [
+            SwapKitError.unsupportedTxType(Self.sentinel),
+            .malformedAmount(Self.sentinel),
+            .generic(message: Self.sentinel)
+        ] {
+            XCTAssertEqual(error.errorDescription?.contains(Self.sentinel), true, "\(tag(of: error).rawValue)")
+        }
+    }
+
+    func testResponseRefusalDetailsSurviveInRefusalDetail() {
+        // These two never put their detail in `errorDescription` either — it has
+        // always been carried by `refusalDetail` for the rejection log.
+        for error in [
+            SwapKitError.contradictoryResponse(detail: Self.sentinel),
+            .responseEchoMismatch(detail: Self.sentinel)
+        ] {
+            XCTAssertEqual(error.refusalDetail, Self.sentinel, "\(tag(of: error).rawValue)")
+        }
+    }
+
+    func testGenericStopsRenderingTheProviderStringAsTheBody() {
+        // The visible behaviour change. `generic` is raised both from an
+        // unclassified upstream code and from app-side encode failures, and used
+        // to put either verbatim in front of the user.
+        let raw = "SwapKit PSBT payload is not valid base64"
+        let error = SwapKitError.generic(message: raw)
+        XCTAssertEqual(error.errorDescription, raw)
+        XCTAssertNotEqual(SwapErrorPresentation.message(for: error), raw)
+        XCTAssertEqual(
+            SwapErrorPresentation.message(for: error),
+            "swapKitErrorUnableToBuildTransaction".localized
+        )
+    }
+
+    // MARK: - The one case that already had a presentation keeps it
+
+    func testAmountBelowProviderMinimumStillPresentsAsSwapAmountTooSmall() {
+        // It used to reach the tooltip by being normalized into
+        // `SwapCryptoLogic.Errors.swapAmountTooSmall`. That arm is gone; the
+        // rendered pair must be unchanged.
+        let error = SwapKitError.amountBelowProviderMinimum
+        let equivalent = SwapCryptoLogic.Errors.swapAmountTooSmall
+        XCTAssertEqual(SwapErrorPresentation.title(for: error), equivalent.errorTitle)
+        XCTAssertEqual(SwapErrorPresentation.message(for: error), equivalent.errorMessage)
+    }
+
+    func testNonSwapErrorsStillFallBackToTheirLocalizedDescription() {
+        // Removing the normalization arm must not narrow the fallback that
+        // fee-path and transport failures depend on.
+        let error = NSError(
+            domain: "test",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "an unclassifiable failure"]
+        )
+        XCTAssertNil(SwapErrorPresentation.presentable(for: error))
+        XCTAssertEqual(
+            SwapErrorPresentation.title(for: error),
+            SwapCryptoLogic.Errors.unexpectedError.errorTitle
+        )
+        XCTAssertEqual(SwapErrorPresentation.message(for: error), "an unclassifiable failure")
+    }
+
+    // MARK: - Localization
+
+    func testTheExpectedEightLocalesActuallyShip() {
+        // Without this, every per-locale loop below iterates over whatever the
+        // bundle happens to contain — one locale, or none — and passes.
+        XCTAssertEqual(Self.shippedLocales, Self.expectedLocales)
+    }
+
+    func testNewTitleKeysExistInEveryShippedLocale() {
+        // Guards the "missing key leaks a raw camelCase identifier to the user"
+        // failure mode that `"key".localized == "key".localized` cannot see — and
+        // per locale, because the active-localization lookup would pass on `en`
+        // alone while a Korean user saw the key.
+        for locale in Self.shippedLocales {
+            guard let bundle = bundle(forLocale: locale) else {
+                XCTFail("\(locale).lproj does not ship in the app bundle")
+                continue
+            }
+            for key in newTitleKeys {
+                XCTAssertNotNil(
+                    localizedValue(forKey: key, in: bundle),
+                    "\(key) is missing from \(locale).lproj/Localizable.strings"
+                )
+            }
+        }
+    }
+
+    func testEveryTitleKeyInUseExistsInEveryShippedLocale() {
+        for locale in Self.shippedLocales {
+            guard let bundle = bundle(forLocale: locale) else {
+                XCTFail("\(locale).lproj does not ship in the app bundle")
+                continue
+            }
+            for key in Set(expectedTitleKeys.values).sorted() {
+                XCTAssertNotNil(
+                    localizedValue(forKey: key, in: bundle),
+                    "\(key) is missing from \(locale).lproj/Localizable.strings"
+                )
+            }
+        }
+    }
+
+    func testPerLocaleLookupDoesNotFallBackToEnglish() {
+        // Gives the two per-locale assertions their teeth. If `Bundle(path:)`
+        // resolved through the English table, a key missing from a locale would
+        // still answer and both checks would pass vacuously.
+        guard let english = bundle(forLocale: "en"),
+              let englishValue = localizedValue(forKey: "swapErrorRouteExpiredTitle", in: english) else {
+            XCTFail("en.lproj does not ship in the app bundle")
+            return
+        }
+        for locale in Self.shippedLocales where locale != "en" {
+            guard let bundle = bundle(forLocale: locale) else {
+                XCTFail("\(locale).lproj does not ship in the app bundle")
+                continue
+            }
+            XCTAssertNotEqual(
+                localizedValue(forKey: "swapErrorRouteExpiredTitle", in: bundle),
+                englishValue,
+                "\(locale) answered with the English value — the per-locale lookup is falling back"
+            )
+        }
+    }
+}

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitErrorTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitErrorTests.swift
@@ -60,8 +60,8 @@ final class SwapKitErrorTests: XCTestCase {
 
     /// The reclassified case reuses the existing THORChain `Amount Too Small`
     /// localized string for its `errorDescription` so no new translation
-    /// cycle is required. The view layer normalizes the case to
-    /// `SwapCryptoLogic.Errors.swapAmountTooSmall` for the tooltip title.
+    /// cycle is required. It carries the matching title too — pinned in
+    /// `SwapKitErrorPresentationTests`.
     func testAmountBelowProviderMinimumDescriptionReusesSwapAmountTooSmallString() {
         let error: SwapKitError = .amountBelowProviderMinimum
         XCTAssertEqual(error.errorDescription, "swapErrorAmountTooSmallDescription".localized)


### PR DESCRIPTION
## Problem

Almost every `SwapKitError` renders an accurate, domain-correct sentence under the generic **"Unexpected Error"** heading. The user reads a correct explanation of what went wrong, titled by the app saying it does not know.

`SwapErrorPresentable` exists precisely to stop title and body being resolved through independent ladders. `SwapKitError` did not conform to it, and `SwapErrorPresentation.normalizedSwapKitError` mapped exactly one case — `.amountBelowProviderMinimum`.

**The issue's headline count is stale.** It says "17 of 18". On `main` the enum declares **21** cases (`providerNotEnabled`, `routeFiltered` and `malformedAmount` landed after the issue was written), so the real ratio is **20 of 21**.

## Fix

Conform `SwapKitError` to `SwapErrorPresentable` and delete the one-case normalization arm, so the enum resolves title *and* body through the single ladder rather than being translated into a second vocabulary by the view layer.

- **Titles for all 21 cases**, reusing an existing key wherever one already states the same verdict. Six new title keys where none did: `swapErrorAddressScreeningTitle`, `swapErrorApprovalRequiredTitle`, `swapErrorAssetBlockedTitle`, `swapErrorInvalidSourceTitle`, `swapErrorQuoteExpiredTitle`, `swapErrorRouteExpiredTitle`.
- **The five cases carrying an upstream string** (`unsupportedTxType`, `contradictoryResponse`, `responseEchoMismatch`, `malformedAmount`, `generic`) follow the rule the two response-validation cases already set in this file: the string stays in `errorDescription` for the log, and the body is the shared app copy *"This route is currently unavailable, try a different provider"* — the one statement true at all three sites they are thrown from (quote, payload build, signing). `SwapErrorPresentable`'s contract is explicit that `errorMessage` is "always localized app copy, never a raw upstream string".
- `.amountBelowProviderMinimum` renders **identically** to before: its title and body still match `SwapCryptoLogic.Errors.swapAmountTooSmall`, pinned by test rather than by inspection.

### Visible behaviour change

`generic(message:)` used to put its payload verbatim on screen — including app-side encoder failures such as `"SwapKit PSBT payload is not valid base64"`. It is now log-only. That is the fix, not a side effect, but it is the one case where a user sees different text for the same failure.

## Not done, deliberately

No error semantics changed: nothing new is thrown, nothing is thrown from anywhere new, and `init?(envelope:)` is untouched. No existing `swapKitError*` body was reworded — the issue is titles and the ladder, not a copy pass.

## Tests

New `SwapKitErrorPresentationTests` mirrors the double-exhaustive-switch pattern `SwapErrorPresentationTests` already uses, so a twenty-second case cannot compile without a sample and a recorded title decision. It pins: no case titled generically; title and body both resolving through `SwapErrorPresentation`; a sentinel string planted in every associated value never reaching the body but surviving in `errorDescription` / `refusalDetail`; `.amountBelowProviderMinimum` unchanged; non-swap errors still falling back to `localizedDescription`; and every title key in use resolving in all 8 shipped `.lproj` bundles with no English fallback.

## Localization

Six keys × **8** shipping locales (`de, en, es, hr, it, ko, pt, zh-Hans` — `ko` ships even though the repo CLAUDE.md's list omits it). Inserted in sorted position only, no whole-file re-sort; `sort_localizable.py` is a no-op on the result. All 8 files reconcile at **1927** entries (1921 + 6).

Closes #5362

## Gate

`** TEST SUCCEEDED **` — `Executed 7182 tests, with 11 tests skipped and 0 failures (0 unexpected)`, on a dedicated `en_US` iPhone 17 Pro Max simulator. That is `main`'s 7166 plus the 16 tests added here, all of which appear by name in the log. Cross-model review: Codex read-only pass per commit plus a whole-branch pass; four findings (three MAJOR, one MINOR) raised against the test commit, all triaged and fixed or rebutted.

On-device acceptance NOT performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap error presentation with clearer, category-specific titles and messages.
  * Added handling for route availability, provider rejection, minimum amounts, invalid assets or addresses, and transaction-building issues.
  * Preserved relevant diagnostic and refusal details in displayed errors.
* **Localization**
  * Added localized swap error titles for address screening, required approval, blocked assets, invalid sources, and expired quotes or routes across supported languages.
* **Tests**
  * Expanded coverage to verify all swap error categories, fallback behavior, and localized content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->