### PR TITLE
feat(ton): discover held jettons and classify them verified / unverified / scam

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonAssetsAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonAssetsAPI.swift
@@ -1,0 +1,42 @@
+//
+//  TonAssetsAPI.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Tonkeeper's community-reviewed jetton whitelist — the list every major TON
+/// wallet treats as its verified tier. Compiled from the repo's YAML sources on
+/// every merge and served as a static file.
+///
+/// Host is injectable so tests drive the fetch without reaching the network.
+struct TonAssetsAPI: TargetType {
+    static let defaultHost = URL(string: "https://raw.githubusercontent.com")!
+
+    let host: URL
+
+    init(host: URL = TonAssetsAPI.defaultHost) {
+        self.host = host
+    }
+
+    var baseURL: URL { host }
+    var path: String { "/tonkeeper/ton-assets/main/jettons.json" }
+    var method: HTTPMethod { .get }
+    var task: HTTPTask { .requestPlain }
+    var headers: [String: String]? { ["Accept": "application/json"] }
+}
+
+/// One entry of `jettons.json`, narrowed to the fields the registry uses.
+///
+/// Everything a jetton can self-assert about its own trustworthiness is
+/// deliberately absent: being listed at all is the signal, and the tier is
+/// assigned in code (see the trust-boundary note on `TokenVerification`).
+struct TonAssetsJetton: Decodable, Sendable {
+    let address: String
+    let symbol: String?
+    let name: String?
+    let decimals: Int?
+    /// Present but explicitly `null` for the majority of entries.
+    let image: String?
+    let coingecko: String?
+}

--- a/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonAddress.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonAddress.swift
@@ -1,0 +1,33 @@
+//
+//  TonJettonAddress.swift
+//  VultisigApp
+//
+
+import Foundation
+import WalletCore
+
+/// One spelling of a TON address, so every jetton lookup keyed by master
+/// address agrees on what the key is.
+///
+/// The same contract reaches us three ways: Toncenter answers in raw
+/// upper-case `0:HEX`, Tonkeeper's `ton-assets` lists raw lower-case, and
+/// `TokensStore` / `Coin.contractAddress` hold the user-friendly `EQ…` form.
+/// User-friendly bounceable is the canonical one here because it is the form
+/// `CoinMeta.uniqueId` already dedups on — a discovered jetton has to collide
+/// with a coin the vault holds — and because WalletCore offers no raw
+/// converter, only `toUserFriendly`, which accepts either input spelling.
+enum TonJettonAddress {
+
+    /// The canonical key for `address`, or `nil` when it is not a TON address.
+    /// Callers drop what does not canonicalise rather than falling back to the
+    /// raw string: two spellings of one contract must never index separately.
+    static func canonical(_ address: String) -> String? {
+        let trimmed = address.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return TONAddressConverter.toUserFriendly(
+            address: trimmed,
+            bounceable: true,
+            testnet: false
+        )
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonClassifier.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonClassifier.swift
@@ -1,0 +1,53 @@
+//
+//  TonJettonClassifier.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Decides how far a jetton can be trusted, from what the registry lists and
+/// what the jetton claims to be. Pure and synchronous: the decision is the part
+/// that has to be provable, so it holds no cache, does no I/O and takes the
+/// registry as an argument.
+enum TonJettonClassifier {
+
+    /// The tier for one jetton master.
+    ///
+    /// A listed address is verified whatever it calls itself. An unlisted one is
+    /// scam when the indexer flags it, or when its symbol or name collapses onto
+    /// a listed jetton's — the fake-USDT pattern, where the counterfeit is
+    /// distinguishable from the real asset only by address. Anything else is
+    /// unverified: a real holding we know nothing about.
+    static func classify(
+        address: String,
+        symbol: String?,
+        name: String?,
+        isFlaggedScam: Bool?,
+        registry: TonJettonRegistry
+    ) -> TokenVerification {
+        if let listed = registry.entry(for: address) {
+            return listed.verification
+        }
+        if isFlaggedScam == true {
+            return .scam
+        }
+        if registry.impersonates(symbol) || registry.impersonates(name) {
+            return .scam
+        }
+        return .unverified
+    }
+
+    /// Convenience over the metadata a discovery page already carries.
+    static func classify(
+        master: TonJettonMasterMetadata,
+        registry: TonJettonRegistry
+    ) -> TokenVerification {
+        classify(
+            address: master.address,
+            symbol: master.symbol,
+            name: master.name,
+            isFlaggedScam: master.isFlaggedScam,
+            registry: registry
+        )
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonFinder.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonFinder.swift
@@ -1,0 +1,156 @@
+//
+//  TonJettonFinder.swift
+//  VultisigApp
+//
+
+import BigInt
+import Foundation
+
+/// Discovers the jettons an account holds, returning only the ones that pass
+/// verification.
+///
+/// TON wallets are carpet-bombed with airdropped counterfeits — fake USDT above
+/// all — so auto-adding whatever an account holds would put a "USDT" balance on
+/// the home screen that the user never received. Unverified and scam jettons
+/// stay addable by hand, where the UI can label them.
+struct TonJettonFinder {
+
+    /// Toncenter's page cap for this endpoint.
+    static let defaultPageSize = 100
+
+    /// 2000 distinct jettons is far beyond any real wallet. This is the last
+    /// resort for a proxy that keeps serving pages; the repeated-master check
+    /// below normally stops long before it.
+    static let defaultMaxPages = 20
+
+    /// TEP-74's default, and what the SDK and Windows fall back to, so a jetton
+    /// whose decimals nobody publishes reads the same on all three platforms.
+    static let defaultDecimals = 9
+
+    private let httpClient: HTTPClientProtocol
+    private let registryStore: TonJettonRegistryStore
+    private let host: URL
+    private let pageSize: Int
+    private let maxPages: Int
+
+    /// `pageSize` and `maxPages` are injectable so the paging rules can be
+    /// tested against a two-row page instead of a hundred-row fixture.
+    init(
+        httpClient: HTTPClientProtocol = HTTPClient(),
+        registryStore: TonJettonRegistryStore = .shared,
+        host: URL? = nil,
+        pageSize: Int = TonJettonFinder.defaultPageSize,
+        maxPages: Int = TonJettonFinder.defaultMaxPages
+    ) {
+        self.httpClient = httpClient
+        self.registryStore = registryStore
+        self.host = host ?? Self.resolvedHost()
+        self.pageSize = pageSize
+        self.maxPages = maxPages
+    }
+
+    /// Honours the user's TON custom-RPC override (host only; the `/ton/v3`
+    /// paths are preserved), matching `TonJettonMetadataResolver`.
+    private static func resolvedHost() -> URL {
+        guard let override = CustomRPCStore.shared.url(for: .ton),
+              let url = URL(string: override) else {
+            return TonAPI.defaultHost
+        }
+        return url
+    }
+
+    /// Verified jettons held at `ownerAddress`.
+    ///
+    /// Throws when the listing cannot be read, so the caller logs a discovery
+    /// failure rather than silently concluding the account holds nothing. A
+    /// registry that cannot be refreshed is *not* a failure — it degrades to the
+    /// curated list and discovery continues with fewer jettons recognised.
+    func discover(ownerAddress: String) async throws -> [CoinMeta] {
+        guard let owner = TonJettonAddress.canonical(ownerAddress) else { return [] }
+
+        let registry = await registryStore.registry()
+        var seenMasters: Set<String> = []
+        var discovered: [CoinMeta] = []
+
+        for page in 0..<maxPages {
+            let response = try await httpClient.request(
+                TonAPI(
+                    .ownerJettonWallets(
+                        ownerAddress: ownerAddress,
+                        limit: pageSize,
+                        offset: page * pageSize
+                    ),
+                    host: host
+                ),
+                responseType: JettonWalletsResponse.self
+            ).data
+
+            let masters = TonJettonMasterMetadata.index(from: response.metadata)
+            let mastersBeforePage = seenMasters.count
+
+            for wallet in response.jetton_wallets {
+                guard TonJettonAddress.canonical(wallet.owner) == owner else { continue }
+                guard let master = TonJettonAddress.canonical(wallet.jetton) else { continue }
+                guard seenMasters.insert(master).inserted else { continue }
+                guard let balance = BigInt(wallet.balance), balance > 0 else { continue }
+
+                if let coin = coin(master: master, metadata: masters[master], registry: registry) {
+                    discovered.append(coin)
+                }
+            }
+
+            // An owner holds exactly one wallet per master, so a page that adds
+            // no new master is the same page served again — which is what a
+            // proxy that ignores `offset` does, and would otherwise turn one
+            // balance into twenty. Either way the list has ended.
+            let isLastPage = response.jetton_wallets.count < pageSize
+            if isLastPage || seenMasters.count == mastersBeforePage { break }
+        }
+
+        return discovered
+    }
+
+    /// The coin for one held master, or `nil` when it must not auto-appear.
+    ///
+    /// Curated metadata wins outright for jettons we ship ourselves: our Tether
+    /// entry carries the ASCII ticker `USDT` and the real 6 decimals, where the
+    /// chain and the community whitelist both say `USD₮` and neither publishes
+    /// decimals at all.
+    private func coin(
+        master: String,
+        metadata: TonJettonMasterMetadata?,
+        registry: TonJettonRegistry
+    ) -> CoinMeta? {
+        let verification = TonJettonClassifier.classify(
+            address: master,
+            symbol: metadata?.symbol,
+            name: metadata?.name,
+            isFlaggedScam: metadata?.isFlaggedScam,
+            registry: registry
+        )
+        guard verification.autoSurfaces, let listed = registry.entry(for: master) else { return nil }
+
+        if listed.verification == .curated {
+            return CoinMeta(
+                chain: .ton,
+                ticker: listed.symbol,
+                logo: listed.logo ?? "",
+                decimals: listed.decimals ?? Self.defaultDecimals,
+                priceProviderId: listed.priceProviderId ?? "",
+                contractAddress: listed.address,
+                isNativeToken: false
+            )
+        }
+
+        guard let ticker = metadata?.symbol ?? listed.symbol.trimmedNonEmpty else { return nil }
+        return CoinMeta(
+            chain: .ton,
+            ticker: ticker,
+            logo: metadata?.logo ?? listed.logo ?? "",
+            decimals: metadata?.decimals ?? listed.decimals ?? Self.defaultDecimals,
+            priceProviderId: listed.priceProviderId ?? "",
+            contractAddress: listed.address,
+            isNativeToken: false
+        )
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonFinder.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonFinder.swift
@@ -70,8 +70,6 @@ struct TonJettonFinder {
 
         let registry = await registryStore.registry()
         var seenMasters: Set<String> = []
-        /// Row identity, recorded before any filtering — see the paging note below.
-        var seenWallets: Set<String> = []
         var discovered: [CoinMeta] = []
 
         for page in 0..<maxPages {
@@ -88,10 +86,8 @@ struct TonJettonFinder {
             ).data
 
             let masters = TonJettonMasterMetadata.index(from: response.metadata)
-            let walletsBeforePage = seenWallets.count
 
             for wallet in response.jetton_wallets {
-                seenWallets.insert(wallet.address)
                 guard TonJettonAddress.canonical(wallet.owner) == owner else { continue }
                 guard let master = TonJettonAddress.canonical(wallet.jetton) else { continue }
                 guard seenMasters.insert(master).inserted else { continue }
@@ -102,17 +98,17 @@ struct TonJettonFinder {
                 }
             }
 
-            // A full page that carries no row we have not already seen is the
-            // same page served again — what a proxy that ignores `offset` does,
-            // and what would otherwise turn one balance into twenty.
-            //
-            // Replay is judged on the rows, not on what survived the filters: a
-            // full page of somebody else's wallets, or of jettons that all
-            // failed verification, is a page we must walk *past*, not a reason
-            // to stop while later offsets still hold the account's own jettons.
-            let isLastPage = response.jetton_wallets.count < pageSize
-            let isReplay = seenWallets.count == walletsBeforePage
-            if isLastPage || isReplay { break }
+            // Only a short page ends the walk. A proxy that ignores `offset`
+            // and replays one page forever is handled by the two guarantees
+            // above it rather than by trying to recognise the replay: the
+            // master dedup means a repeated holding is never counted twice, and
+            // `maxPages` bounds the loop. Every heuristic that tried to spot a
+            // repeat instead — no new master, then no new wallet row, then two
+            // such pages in a row — also describes a legitimately overlapping
+            // page, and stopping on one strands every holding at a later
+            // offset. Correctness is worth more here than the handful of
+            // requests a broken proxy costs.
+            if response.jetton_wallets.count < pageSize { break }
         }
 
         return discovered

--- a/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonFinder.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonFinder.swift
@@ -90,8 +90,8 @@ struct TonJettonFinder {
             for wallet in response.jetton_wallets {
                 guard TonJettonAddress.canonical(wallet.owner) == owner else { continue }
                 guard let master = TonJettonAddress.canonical(wallet.jetton) else { continue }
-                guard seenMasters.insert(master).inserted else { continue }
                 guard let balance = BigInt(wallet.balance), balance > 0 else { continue }
+                guard seenMasters.insert(master).inserted else { continue }
 
                 if let coin = coin(master: master, metadata: masters[master], registry: registry) {
                     discovered.append(coin)

--- a/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonFinder.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonFinder.swift
@@ -70,6 +70,8 @@ struct TonJettonFinder {
 
         let registry = await registryStore.registry()
         var seenMasters: Set<String> = []
+        /// Row identity, recorded before any filtering — see the paging note below.
+        var seenWallets: Set<String> = []
         var discovered: [CoinMeta] = []
 
         for page in 0..<maxPages {
@@ -86,9 +88,10 @@ struct TonJettonFinder {
             ).data
 
             let masters = TonJettonMasterMetadata.index(from: response.metadata)
-            let mastersBeforePage = seenMasters.count
+            let walletsBeforePage = seenWallets.count
 
             for wallet in response.jetton_wallets {
+                seenWallets.insert(wallet.address)
                 guard TonJettonAddress.canonical(wallet.owner) == owner else { continue }
                 guard let master = TonJettonAddress.canonical(wallet.jetton) else { continue }
                 guard seenMasters.insert(master).inserted else { continue }
@@ -99,12 +102,17 @@ struct TonJettonFinder {
                 }
             }
 
-            // An owner holds exactly one wallet per master, so a page that adds
-            // no new master is the same page served again — which is what a
-            // proxy that ignores `offset` does, and would otherwise turn one
-            // balance into twenty. Either way the list has ended.
+            // A full page that carries no row we have not already seen is the
+            // same page served again — what a proxy that ignores `offset` does,
+            // and what would otherwise turn one balance into twenty.
+            //
+            // Replay is judged on the rows, not on what survived the filters: a
+            // full page of somebody else's wallets, or of jettons that all
+            // failed verification, is a page we must walk *past*, not a reason
+            // to stop while later offsets still hold the account's own jettons.
             let isLastPage = response.jetton_wallets.count < pageSize
-            if isLastPage || seenMasters.count == mastersBeforePage { break }
+            let isReplay = seenWallets.count == walletsBeforePage
+            if isLastPage || isReplay { break }
         }
 
         return discovered

--- a/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonMasterMetadata.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonMasterMetadata.swift
@@ -62,7 +62,15 @@ extension TonJettonMasterMetadata {
 extension JettonMasterMetadata {
     /// The validated *master* entry, if this address has one. See
     /// `TonJettonMasterMetadata.index(from:)` for why `type` is filtered.
+    ///
+    /// A typed master entry always wins. An untyped one is accepted only when
+    /// there is no typed master to be had, so that a Toncenter version which
+    /// stopped emitting `type` degrades to reading the entry rather than to
+    /// finding no metadata at all — which would classify every jetton on the
+    /// chain as unverified and quietly stop discovery.
     var masterTokenInfo: JettonTokenInfo? {
-        token_info?.first { $0.valid == true && ($0.type == nil || $0.type == "jetton_masters") }
+        guard let entries = token_info else { return nil }
+        return entries.first { $0.valid == true && $0.type == "jetton_masters" }
+            ?? entries.first { $0.valid == true && $0.type == nil }
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonMasterMetadata.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonMasterMetadata.swift
@@ -63,14 +63,26 @@ extension JettonMasterMetadata {
     /// The validated *master* entry, if this address has one. See
     /// `TonJettonMasterMetadata.index(from:)` for why `type` is filtered.
     ///
-    /// A typed master entry always wins. An untyped one is accepted only when
-    /// there is no typed master to be had, so that a Toncenter version which
-    /// stopped emitting `type` degrades to reading the entry rather than to
-    /// finding no metadata at all — which would classify every jetton on the
-    /// chain as unverified and quietly stop discovery.
+    /// A typed master entry always wins. An untyped one is read only when there
+    /// is no typed master to be had, so that a Toncenter version which stopped
+    /// emitting `type` degrades to partial metadata rather than to none — none
+    /// would classify every jetton on the chain as unverified and quietly stop
+    /// discovery.
+    ///
+    /// In that degraded case *every* entry is untyped, including the wallet
+    /// records, so the fallback additionally requires something only a master
+    /// describes: a symbol or a name. A wallet entry carries neither — just a
+    /// balance — and reading one as the master would drop the jetton's real
+    /// decimals and leave the default standing in for them, which is a wrong
+    /// displayed balance and a wrong transfer amount.
     var masterTokenInfo: JettonTokenInfo? {
         guard let entries = token_info else { return nil }
-        return entries.first { $0.valid == true && $0.type == "jetton_masters" }
-            ?? entries.first { $0.valid == true && $0.type == nil }
+        if let typed = entries.first(where: { $0.valid == true && $0.type == "jetton_masters" }) {
+            return typed
+        }
+        return entries.first {
+            $0.valid == true && $0.type == nil
+                && ($0.symbol?.trimmedNonEmpty != nil || $0.name?.trimmedNonEmpty != nil)
+        }
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonMasterMetadata.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonMasterMetadata.swift
@@ -1,0 +1,68 @@
+//
+//  TonJettonMasterMetadata.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// What Toncenter's indexer knows about a jetton master, with nothing
+/// guaranteed: an unindexed or broken jetton can lack every field.
+struct TonJettonMasterMetadata: Equatable, Sendable {
+    /// Canonical master address (see `TonJettonAddress`).
+    let address: String
+    let symbol: String?
+    let name: String?
+    let decimals: Int?
+    let logo: String?
+    /// Toncenter's own scam flag. Honoured, but it carries almost nothing on its
+    /// own — a sample of 40 jettons blacklisted elsewhere all reported `false`,
+    /// which is why the registry and the impersonation check do the work.
+    let isFlaggedScam: Bool?
+}
+
+extension TonJettonMasterMetadata {
+
+    /// Indexes a Toncenter `metadata` map by canonical master address.
+    ///
+    /// The map is keyed by raw address and carries an entry for **every**
+    /// address in the response — including each of the owner's jetton *wallets*,
+    /// under `type: "jetton_wallets"` and also marked `valid: true`. Selecting
+    /// on `valid` alone would therefore pick a wallet entry, which has no symbol
+    /// or name, and every jetton would classify as unverified. The `type` filter
+    /// is what makes the metadata usable at all.
+    static func index(from metadata: [String: JettonMasterMetadata]?) -> [String: TonJettonMasterMetadata] {
+        guard let metadata else { return [:] }
+
+        var index: [String: TonJettonMasterMetadata] = [:]
+        for (rawAddress, entry) in metadata {
+            guard let address = TonJettonAddress.canonical(rawAddress),
+                  let info = entry.masterTokenInfo else {
+                continue
+            }
+            index[address] = TonJettonMasterMetadata(rawAddress: address, info: info)
+        }
+        return index
+    }
+
+    private init(rawAddress: String, info: JettonTokenInfo) {
+        self.address = rawAddress
+        self.symbol = info.symbol?.trimmedNonEmpty
+        self.name = info.name?.trimmedNonEmpty
+        self.decimals = info.extra?.decimals.flatMap { Int($0) }
+        // Toncenter's imgproxy variants are normalized and served with
+        // permissive CORS headers; the original `image` often is not.
+        self.logo = info.extra?.imageMedium?.trimmedNonEmpty
+            ?? info.extra?.imageSmall?.trimmedNonEmpty
+            ?? info.extra?.imageBig?.trimmedNonEmpty
+            ?? info.image?.trimmedNonEmpty
+        self.isFlaggedScam = info.is_scam
+    }
+}
+
+extension JettonMasterMetadata {
+    /// The validated *master* entry, if this address has one. See
+    /// `TonJettonMasterMetadata.index(from:)` for why `type` is filtered.
+    var masterTokenInfo: JettonTokenInfo? {
+        token_info?.first { $0.valid == true && ($0.type == nil || $0.type == "jetton_masters") }
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonRegistry.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonRegistry.swift
@@ -1,0 +1,124 @@
+//
+//  TonJettonRegistry.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// A jetton we treat as legitimate, keyed by its canonical master address.
+struct VerifiedJetton: Equatable, Sendable {
+    /// Canonical master address (see `TonJettonAddress`).
+    let address: String
+    let symbol: String
+    let name: String?
+    let decimals: Int?
+    let logo: String?
+    let priceProviderId: String?
+    /// `.curated` for a bundled `TokensStore` entry, `.verified(source:)` for a
+    /// whitelist one. Assigned by the builder from where the entry came, never
+    /// decoded from the payload.
+    let verification: TokenVerification
+}
+
+extension VerifiedJetton {
+    /// A bundled TON jetton. Returns `nil` for the native coin and for anything
+    /// whose contract address does not canonicalise.
+    init?(curated meta: CoinMeta) {
+        guard !meta.isNativeToken, let address = TonJettonAddress.canonical(meta.contractAddress) else {
+            return nil
+        }
+        self.init(
+            address: address,
+            symbol: meta.ticker,
+            name: nil,
+            decimals: meta.decimals,
+            logo: meta.logo.trimmedNonEmpty,
+            priceProviderId: meta.priceProviderId.trimmedNonEmpty,
+            verification: .curated
+        )
+    }
+
+    /// A `ton-assets` entry. An entry with no usable symbol is dropped: it could
+    /// neither be displayed nor contribute an impersonation skeleton.
+    init?(whitelisted entry: TonAssetsJetton) {
+        guard let address = TonJettonAddress.canonical(entry.address),
+              let symbol = entry.symbol?.trimmedNonEmpty else {
+            return nil
+        }
+        self.init(
+            address: address,
+            symbol: symbol,
+            name: entry.name?.trimmedNonEmpty,
+            decimals: entry.decimals,
+            logo: entry.image?.trimmedNonEmpty,
+            priceProviderId: entry.coingecko?.trimmedNonEmpty,
+            verification: .verified(source: TonJettonRegistry.tonAssetsSource)
+        )
+    }
+}
+
+/// The jettons we consider legitimate, indexed for the two questions
+/// classification asks: "is this address listed?" and "does this symbol or name
+/// belong to a listed jetton?".
+struct TonJettonRegistry: Equatable, Sendable {
+    /// Source label carried by whitelist-sourced entries.
+    static let tonAssetsSource = "ton-assets"
+
+    static let empty = TonJettonRegistry([])
+
+    private let byAddress: [String: VerifiedJetton]
+    private let symbolSkeletons: Set<String>
+    private let nameSkeletons: Set<String>
+
+    /// Indexes `jettons` in order. On an address collision the **earlier**
+    /// entry's metadata is kept — curated is supplied first, so our ticker,
+    /// decimals, logo and price id win — but every entry's symbol and name are
+    /// indexed regardless.
+    ///
+    /// Both halves matter for real Tether. Our curated entry carries the ticker
+    /// `USDT` and no name; only the whitelist duplicate of the same contract
+    /// contributes `USD₮` and `Tether USD`. Keeping only the winner's labels
+    /// would let a "Tether USD" impostor pass as merely unverified.
+    init(_ jettons: [VerifiedJetton]) {
+        var byAddress: [String: VerifiedJetton] = [:]
+        var symbols: Set<String> = []
+        var names: Set<String> = []
+
+        for jetton in jettons {
+            if byAddress[jetton.address] == nil {
+                byAddress[jetton.address] = jetton
+            }
+            let symbol = TonJettonSymbol.normalize(jetton.symbol)
+            if !symbol.isEmpty {
+                symbols.insert(symbol)
+            }
+            if let name = jetton.name.map(TonJettonSymbol.normalize), !name.isEmpty {
+                names.insert(name)
+            }
+        }
+
+        self.byAddress = byAddress
+        self.symbolSkeletons = symbols
+        self.nameSkeletons = names
+    }
+
+    /// The listed jetton at `address`, in any spelling. `nil` means unlisted,
+    /// which is the whole basis of the `scam` tier: a counterfeit is only
+    /// distinguishable from the asset it copies by its address.
+    func entry(for address: String) -> VerifiedJetton? {
+        guard let key = TonJettonAddress.canonical(address) else { return nil }
+        return byAddress[key]
+    }
+
+    /// Whether `label` reads as a listed jetton's symbol or name. An empty
+    /// skeleton never matches — a jetton whose symbol carries no Latin letters
+    /// would otherwise impersonate whatever it collapsed onto.
+    func impersonates(_ label: String?) -> Bool {
+        guard let label else { return false }
+        let skeleton = TonJettonSymbol.normalize(label)
+        guard !skeleton.isEmpty else { return false }
+        return symbolSkeletons.contains(skeleton) || nameSkeletons.contains(skeleton)
+    }
+
+    var count: Int { byAddress.count }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonRegistryStore.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonRegistryStore.swift
@@ -1,0 +1,86 @@
+//
+//  TonJettonRegistryStore.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Owns the verified-jetton registry: our curated TON tokens merged with
+/// Tonkeeper's `ton-assets` whitelist, refreshed periodically.
+///
+/// Only a successful fetch is cached. Caching a failure would pin the degraded
+/// registry for the whole TTL, so an outage would decide which jettons a wallet
+/// recognises long after the outage ended; instead the next caller retries and
+/// this one is served the curated list alone.
+actor TonJettonRegistryStore {
+    static let shared = TonJettonRegistryStore()
+
+    private let httpClient: HTTPClientProtocol
+    private let api: TonAssetsAPI
+    private let ttl: TimeInterval
+    private let now: @Sendable () -> Date
+    private let curatedJettons: [VerifiedJetton]
+    private let logger = Log.chain.service
+
+    private var cached: (registry: TonJettonRegistry, fetchedAt: Date)?
+    /// Non-throwing on purpose: the failure is handled where it happens, and a
+    /// waiting caller only needs to know whether a fresh registry arrived.
+    private var inFlight: Task<TonJettonRegistry?, Never>?
+
+    private lazy var curatedRegistry = TonJettonRegistry(curatedJettons)
+
+    init(
+        httpClient: HTTPClientProtocol = HTTPClient(),
+        api: TonAssetsAPI = TonAssetsAPI(),
+        ttl: TimeInterval = 3600,
+        defaults: UserDefaults = .standard,
+        now: @escaping @Sendable () -> Date = Date.init
+    ) {
+        self.httpClient = httpClient
+        self.api = api
+        self.ttl = ttl
+        self.now = now
+        self.curatedJettons = BundledTokensProvider
+            .curatedTokens(for: .ton, defaults: defaults)
+            .compactMap { VerifiedJetton(curated: $0) }
+    }
+
+    /// The registry, degrading to the curated list alone when the whitelist
+    /// cannot be fetched — discovery and classification keep working offline,
+    /// recognising fewer jettons. Never throws: an unreachable whitelist must
+    /// not stop a wallet from discovering the jettons we curate ourselves.
+    ///
+    /// Concurrent callers share one fetch. Discovery runs per chain-detail
+    /// refresh and those fan out several times after a swap, so without
+    /// coalescing one screen would pull the whole list repeatedly.
+    func registry() async -> TonJettonRegistry {
+        if let cached, now().timeIntervalSince(cached.fetchedAt) < ttl {
+            return cached.registry
+        }
+
+        let task = inFlight ?? Task { await self.loadMerged() }
+        inFlight = task
+
+        return await task.value ?? curatedRegistry
+    }
+
+    /// Fetch + merge, or `nil` when the whitelist could not be read. `cached` is
+    /// written only on the success path; `inFlight` is cleared either way, so a
+    /// failure is retried by the next caller rather than replayed out of a
+    /// finished task for the rest of the TTL.
+    private func loadMerged() async -> TonJettonRegistry? {
+        defer { inFlight = nil }
+
+        do {
+            let response = try await httpClient.request(api, responseType: [TonAssetsJetton].self)
+            let whitelisted = response.data.compactMap { VerifiedJetton(whitelisted: $0) }
+            let registry = TonJettonRegistry(curatedJettons + whitelisted)
+
+            cached = (registry, now())
+            return registry
+        } catch {
+            logger.warning("ton-assets whitelist unavailable, using curated jettons only: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonSymbol.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/Jetton/TonJettonSymbol.swift
@@ -1,0 +1,55 @@
+//
+//  TonJettonSymbol.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Collapses a jetton symbol or name to the Latin skeleton a user actually
+/// perceives, so a counterfeit that *reads* as a verified jetton compares equal
+/// to it even though it differs byte-for-byte.
+///
+/// The fake-USDT pattern is the reason this exists: `USD₮`, `UЅDT` (Cyrillic
+/// `Ѕ`), `$USĐ₮` and the full-width forms all render as "USDT" to a human, and
+/// the counterfeit is distinguishable only by contract address.
+enum TonJettonSymbol {
+
+    /// Homoglyphs scammers substitute for Latin capitals. Keys are upper-cased
+    /// because the map is applied after `uppercased()`; compatibility
+    /// decomposition has already folded the full-width and mathematical forms,
+    /// so only characters with no decomposition of their own belong here.
+    ///
+    /// Deliberately the same table the SDK and Windows use, not a full UTS #39
+    /// confusable set: the three platforms have to agree on what counts as a
+    /// counterfeit, and a lookalike outside this table simply leaves the jetton
+    /// unverified — which never auto-adds either.
+    private static let confusables: [Character: Character] = [
+        // Cyrillic
+        "А": "A", "В": "B", "Е": "E", "Ё": "E", "Ѕ": "S", "І": "I", "Ј": "J",
+        "К": "K", "М": "M", "Н": "H", "О": "O", "Р": "P", "С": "C", "Т": "T",
+        "У": "Y", "Х": "X", "Ԛ": "Q", "Ԝ": "W",
+        // Greek
+        "Α": "A", "Β": "B", "Ε": "E", "Ζ": "Z", "Η": "H", "Ι": "I", "Κ": "K",
+        "Μ": "M", "Ν": "N", "Ο": "O", "Ρ": "P", "Τ": "T", "Υ": "Y", "Χ": "X",
+        // Currency signs and stroked letters
+        "₮": "T", "Đ": "D", "Ð": "D", "Ɖ": "D", "Ŧ": "T"
+    ]
+
+    /// The skeleton of `value`, or an empty string when nothing survives.
+    ///
+    /// An empty result must never be treated as a match — every jetton whose
+    /// symbol is pure emoji or CJK would otherwise "impersonate" every other
+    /// one. Callers index and compare non-empty skeletons only.
+    static func normalize(_ value: String) -> String {
+        let withoutDiacritics = value
+            .decomposedStringWithCompatibilityMapping
+            .unicodeScalars
+            .filter { $0.properties.generalCategory != .nonspacingMark }
+
+        return String(String.UnicodeScalarView(withoutDiacritics))
+            .uppercased()
+            .map { confusables[$0] ?? $0 }
+            .filter { $0.isASCII && ($0.isNumber || ("A"..."Z").contains($0)) }
+            .reduce(into: "") { $0.append($1) }
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Ton/Models/TonService+Models.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/Models/TonService+Models.swift
@@ -7,6 +7,13 @@
 
 struct JettonWalletsResponse: Codable {
     let jetton_wallets: [JettonWalletInfo]
+    /// Indexer metadata for every address in the response — the owner's jetton
+    /// wallets *and* the masters behind them. Present on the owner-filtered
+    /// listing, which is what lets discovery read a jetton's symbol, name and
+    /// decimals without a follow-up call per jetton. See
+    /// `TonJettonMasterMetadata.index(from:)` for how master entries are picked
+    /// out of it.
+    let metadata: [String: JettonMasterMetadata]?
 }
 
 struct JettonWalletInfo: Codable {
@@ -215,11 +222,16 @@ struct JettonMasterMetadata: Codable {
 /// Only entries where `valid == true` should be trusted for display.
 struct JettonTokenInfo: Codable {
     let valid: Bool?
+    /// `"jetton_masters"` or `"jetton_wallets"`. Both come back `valid: true`,
+    /// so this is the field that says which one an entry describes.
     let type: String?
     let name: String?
     let symbol: String?
     let description: String?
     let image: String?
+    /// Toncenter's own scam flag. Unreliable on its own — see
+    /// `TonJettonMasterMetadata.isFlaggedScam`.
+    let is_scam: Bool?
     let extra: JettonTokenInfoExtra?
 }
 
@@ -227,4 +239,17 @@ struct JettonTokenInfo: Codable {
 struct JettonTokenInfoExtra: Codable {
     let decimals: String?
     let uri: String?
+    /// Toncenter imgproxy renditions of the jetton logo. Normalized PNGs served
+    /// with permissive CORS headers, unlike the original `image` URL.
+    let imageSmall: String?
+    let imageMedium: String?
+    let imageBig: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case decimals
+        case uri
+        case imageSmall = "_image_small"
+        case imageMedium = "_image_medium"
+        case imageBig = "_image_big"
+    }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Ton/Service/TonAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/Service/TonAPI.swift
@@ -20,6 +20,9 @@ struct TonAPI: TargetType {
         case extendedAddressInformation(address: String)
         case jettonWallets(ownerAddress: String, jettonMasterAddress: String)
         case jettonWalletsByAddress(walletAddress: String)
+        /// Every jetton wallet an owner holds, one page at a time. Used by
+        /// discovery, which needs the whole set rather than one master.
+        case ownerJettonWallets(ownerAddress: String, limit: Int, offset: Int)
         case jettonMasters(jettonAddress: String)
         case runGetMethod(address: String, method: String, stack: [[String]])
         case broadcastTransaction(boc: String)
@@ -45,7 +48,7 @@ struct TonAPI: TargetType {
             return "/ton/v3/addressInformation"
         case .extendedAddressInformation:
             return "/ton/v2/getExtendedAddressInformation"
-        case .jettonWallets, .jettonWalletsByAddress:
+        case .jettonWallets, .jettonWalletsByAddress, .ownerJettonWallets:
             return "/ton/v3/jetton/wallets"
         case .jettonMasters:
             return "/ton/v3/jetton/masters"
@@ -58,7 +61,8 @@ struct TonAPI: TargetType {
 
     var method: HTTPMethod {
         switch endpoint {
-        case .addressInformation, .extendedAddressInformation, .jettonWallets, .jettonWalletsByAddress, .jettonMasters:
+        case .addressInformation, .extendedAddressInformation, .jettonWallets, .jettonWalletsByAddress,
+             .ownerJettonWallets, .jettonMasters:
             return .get
         case .runGetMethod, .broadcastTransaction:
             return .post
@@ -75,6 +79,19 @@ struct TonAPI: TargetType {
             return .requestParameters(["owner_address": owner, "jetton_master_address": master], .urlEncoding)
         case .jettonWalletsByAddress(let walletAddress):
             return .requestParameters(["address": walletAddress, "limit": 1], .urlEncoding)
+        case .ownerJettonWallets(let owner, let limit, let offset):
+            // `exclude_zero_balance` is the server-side half of "only jettons
+            // the account actually holds"; the finder drops zero balances again
+            // rather than trusting it.
+            return .requestParameters(
+                [
+                    "owner_address": owner,
+                    "exclude_zero_balance": "true",
+                    "limit": limit,
+                    "offset": offset
+                ],
+                .urlEncoding
+            )
         case .jettonMasters(let jettonAddress):
             return .requestParameters(["address": jettonAddress, "limit": 1], .urlEncoding)
         case .runGetMethod(let address, let method, let stack):

--- a/VultisigApp/VultisigApp/Core/Services/CoinService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/CoinService.swift
@@ -290,6 +290,8 @@ struct CoinService {
             return
         }
 
+        let discoverer = TokenDiscovererRegistry.discoverer(for: nativeToken.chain)
+
         do {
             let tokens = try await fetchDiscoveredTokens(nativeCoin: nativeToken.toCoinMeta(), address: nativeToken.address)
 
@@ -312,8 +314,17 @@ struct CoinService {
                         continue
                     }
 
-                    // Check for spam tokens
-                    if await isSpamToken(token) {
+                    // Check for spam tokens.
+                    //
+                    // Skipped when the chain's discoverer vouches for what it
+                    // returns (TON, which matches every jetton against a
+                    // curated + community-reviewed address registry). An
+                    // address match is a strictly stronger statement than these
+                    // heuristics, so running them afterwards can only produce
+                    // false negatives — and it would produce them here: the
+                    // ticker rule rejects any non-ASCII character, and the real
+                    // Tether jetton's on-chain symbol is `USD₮`.
+                    if !discoverer.vouchesForResults, await isSpamToken(token) {
                         continue
                     }
 

--- a/VultisigApp/VultisigApp/Core/Services/TokenCatalog/TokenVerification.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TokenCatalog/TokenVerification.swift
@@ -8,10 +8,11 @@
 //  that identity with a trust field would silently change dedup behaviour.
 //  Trust instead rides on the `CatalogToken` wrapper the repository emits.
 //
-//  Precedence: `.curated` (bundled `TokensStore`) is the strongest signal,
-//  then `.verified(source:)` (a source-side allowlist — 1inch's `/tokens`
-//  whitelist, Jupiter's `?query=verified`), then `.unverified` (long-tail /
-//  source-flagged / unknown).
+//  Precedence, most authoritative first: `.curated` (bundled `TokensStore`),
+//  then `.scam` (positively identified as malicious), then `.verified(source:)`
+//  (a source-side allowlist — 1inch's `/tokens` whitelist, Jupiter's
+//  `?query=verified`), then `.unverified` (long-tail / source-flagged /
+//  unknown).
 //  Only `.curated`/`.verified` auto-surface in search + discovery; `.unverified`
 //  stay reachable but must be opted into and are badged (MetaMask/Rabby model).
 //
@@ -35,12 +36,21 @@ enum TokenVerification: Equatable, Hashable, Sendable, Codable {
     case verified(source: String)
     /// Long-tail / unknown provenance — must not auto-surface.
     case unverified
+    /// Positively identified as malicious — typically a token impersonating a
+    /// verified one's symbol or name from a different contract address, or one
+    /// an indexer flagged. Distinct from `.unverified`: that is an absence of
+    /// evidence, this is evidence.
+    case scam
 
     /// Merge rank: higher wins when the same `uniqueId` is seen with different
-    /// verifications across providers (the strongest signal is kept).
+    /// verifications across providers. Ranks authority, not trust — `.scam`
+    /// outranks `.verified` because a positive identification says more than a
+    /// source-side allowlist, while `.curated` outranks `.scam` because the
+    /// bundled list is in-code and cannot be tampered with.
     var rank: Int {
         switch self {
-        case .curated: return 2
+        case .curated: return 3
+        case .scam: return 2
         case .verified: return 1
         case .unverified: return 0
         }
@@ -52,7 +62,7 @@ enum TokenVerification: Equatable, Hashable, Sendable, Codable {
     var autoSurfaces: Bool {
         switch self {
         case .curated, .verified: return true
-        case .unverified: return false
+        case .unverified, .scam: return false
         }
     }
 
@@ -60,7 +70,7 @@ enum TokenVerification: Equatable, Hashable, Sendable, Codable {
     var sourceLabel: String? {
         switch self {
         case .verified(let source): return source
-        case .curated, .unverified: return nil
+        case .curated, .unverified, .scam: return nil
         }
     }
 
@@ -68,6 +78,11 @@ enum TokenVerification: Equatable, Hashable, Sendable, Codable {
     /// repository merge so a token vouched for by any provider keeps its
     /// strongest signal even when a lower-precedence provider supplies the
     /// winning `CoinMeta` (curated logo / priceProviderId).
+    ///
+    /// A `.scam` finding survives a merge with a provider that merely does not
+    /// recognise the address — ignorance is not evidence against a positive
+    /// identification — but never displaces `.curated`, which no remote source
+    /// or persisted snapshot may override. Both fall out of `rank`.
     static func stronger(_ lhs: TokenVerification, _ rhs: TokenVerification) -> TokenVerification {
         rhs.rank > lhs.rank ? rhs : lhs
     }
@@ -79,10 +94,13 @@ enum TokenVerification: Equatable, Hashable, Sendable, Codable {
     /// are preserved so a provider's last-good verified list still surfaces
     /// offline / during a transient outage (rather than being filtered out and
     /// letting the outer cache overwrite a complete list with a bundled-only one).
+    /// `.scam` is preserved too: the worst a tampered one can do is hide a token
+    /// from search, which is the fail-closed direction, and it cannot reach
+    /// `.curated` entries because those outrank it.
     var cappedForUntrustedPersistence: TokenVerification {
         switch self {
         case .curated: return .verified(source: "cached")
-        case .verified, .unverified: return self
+        case .verified, .unverified, .scam: return self
         }
     }
 }

--- a/VultisigApp/VultisigApp/Core/Services/TokenDiscoverer.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TokenDiscoverer.swift
@@ -13,6 +13,16 @@ import Foundation
 @MainActor
 protocol TokenDiscoverer {
     func discoverTokens(nativeCoin: CoinMeta, address: String) async throws -> [CoinMeta]
+
+    /// Whether this discoverer has positively identified everything it returns,
+    /// so the caller's spam heuristics add nothing. Default `false`: a
+    /// discoverer that simply enumerates what an address holds cannot vouch for
+    /// any of it, and the heuristics are the only gate those chains have.
+    var vouchesForResults: Bool { get }
+}
+
+extension TokenDiscoverer {
+    var vouchesForResults: Bool { false }
 }
 
 // MARK: - Concrete discoverers
@@ -80,6 +90,22 @@ struct RippleTrustLineTokenDiscoverer: TokenDiscoverer {
     }
 }
 
+/// TON jettons: everything the account holds that is listed in the verified
+/// registry — our curated TON tokens merged with Tonkeeper's community
+/// whitelist. Unverified and counterfeit jettons are dropped rather than
+/// returned, because a TON account is airdropped counterfeits it never asked
+/// for and auto-adding one would put a balance on the home screen the user
+/// never received.
+struct TonJettonTokenDiscoverer: TokenDiscoverer {
+    /// Every jetton returned here matched a registry address, which says
+    /// strictly more than the ticker and logo heuristics could.
+    let vouchesForResults = true
+
+    func discoverTokens(nativeCoin _: CoinMeta, address: String) async throws -> [CoinMeta] {
+        try await TonJettonFinder().discover(ownerAddress: address)
+    }
+}
+
 /// Explicit no-op for chains that do not support token auto-discovery.
 /// Registered by name so "no discovery" is a declared choice rather than an
 /// implicit empty fall-through.
@@ -118,7 +144,9 @@ enum TokenDiscovererRegistry {
                 : NoTokenDiscoverer()
         case .Ripple:
             return RippleTrustLineTokenDiscoverer()
-        case .UTXO, .Cardano, .Polkadot, .Ton, .Tron:
+        case .Ton:
+            return TonJettonTokenDiscoverer()
+        case .UTXO, .Cardano, .Polkadot, .Tron:
             return NoTokenDiscoverer()
         }
     }

--- a/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonAddressTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonAddressTests.swift
@@ -1,0 +1,51 @@
+//
+//  TonJettonAddressTests.swift
+//  VultisigAppTests
+//
+//  The three spellings of one jetton master that have to agree: Toncenter's
+//  raw upper-case, `ton-assets`' raw lower-case, and the user-friendly form
+//  `TokensStore` and `Coin.contractAddress` hold. All fixtures below are the
+//  real Tether jetton master.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class TonJettonAddressTests: XCTestCase {
+
+    private let rawUpper = "0:B113A994B5024A16719F69139328EB759596C38A25F59028B146FECDC3621DFE"
+    private let rawLower = "0:b113a994b5024a16719f69139328eb759596c38a25f59028b146fecdc3621dfe"
+    private let bounceable = "EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs"
+    private let nonBounceable = "UQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_p0p"
+
+    func testEverySpellingOfOneMasterCanonicalizesToTheSameKey() {
+        let keys = [rawUpper, rawLower, bounceable, nonBounceable].map(TonJettonAddress.canonical)
+        XCTAssertEqual(Set(keys.compactMap { $0 }).count, 1, "One contract must produce one key")
+        XCTAssertEqual(keys.compactMap { $0 }.count, 4, "No spelling may fail to canonicalize")
+    }
+
+    /// The canonical form is the one `TokensStore` already stores, so a
+    /// discovered jetton dedups against a curated entry by `CoinMeta.uniqueId`.
+    func testCanonicalFormMatchesTheCuratedContractAddress() {
+        let curated = TokensStore.TokenSelectionAssets.first {
+            $0.chain == .ton && $0.ticker == "USDT"
+        }
+        XCTAssertEqual(TonJettonAddress.canonical(rawUpper), curated?.contractAddress)
+    }
+
+    func testSurroundingWhitespaceIsIgnored() {
+        XCTAssertEqual(TonJettonAddress.canonical("  \(bounceable)\n"), TonJettonAddress.canonical(bounceable))
+    }
+
+    /// Nothing that is not a TON address may produce a key: two spellings of one
+    /// contract indexing separately is the failure this guards, and falling back
+    /// to the raw string would cause exactly that.
+    func testNonAddressesProduceNoKey() {
+        XCTAssertNil(TonJettonAddress.canonical(""))
+        XCTAssertNil(TonJettonAddress.canonical("   "))
+        XCTAssertNil(TonJettonAddress.canonical("not-an-address"))
+        XCTAssertNil(TonJettonAddress.canonical("0xd2912bc567894032f42edda72bd27bcaae79d74c"))
+        // Right shape, wrong checksum — the last character is altered.
+        XCTAssertNil(TonJettonAddress.canonical("EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDx"))
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonClassifierTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonClassifierTests.swift
@@ -1,0 +1,147 @@
+//
+//  TonJettonClassifierTests.swift
+//  VultisigAppTests
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class TonJettonClassifierTests: XCTestCase {
+
+    /// Curated Tether plus the whitelist duplicate of the same contract, which
+    /// is where the `USD₮` and `Tether USD` skeletons come from, plus one
+    /// whitelist-only jetton.
+    private func registry() -> TonJettonRegistry {
+        TonJettonRegistry([
+            VerifiedJetton(
+                address: TonJettonAddress.canonical(TonJettonFixtures.usdtMasterFriendly)!,
+                symbol: "USDT", name: nil, decimals: 6, logo: "usdt",
+                priceProviderId: "tether", verification: .curated
+            ),
+            VerifiedJetton(
+                address: TonJettonAddress.canonical(TonJettonFixtures.usdtMasterRawLower)!,
+                symbol: "USD₮", name: "Tether USD", decimals: nil, logo: nil,
+                priceProviderId: nil, verification: .verified(source: "ton-assets")
+            ),
+            VerifiedJetton(
+                address: TonJettonAddress.canonical(TonJettonFixtures.notcoinMasterRaw)!,
+                symbol: "NOT", name: "Notcoin", decimals: 9, logo: nil,
+                priceProviderId: nil, verification: .verified(source: "ton-assets")
+            )
+        ])
+    }
+
+    private func classify(
+        address: String,
+        symbol: String? = nil,
+        name: String? = nil,
+        isFlaggedScam: Bool? = nil
+    ) -> TokenVerification {
+        TonJettonClassifier.classify(
+            address: address,
+            symbol: symbol,
+            name: name,
+            isFlaggedScam: isFlaggedScam,
+            registry: registry()
+        )
+    }
+
+    // MARK: - Listed
+
+    func testListedAddressIsVerifiedWhateverItCallsItself() {
+        XCTAssertEqual(classify(address: TonJettonFixtures.notcoinMasterRaw, symbol: "NOT"), .verified(source: "ton-assets"))
+        XCTAssertEqual(
+            classify(address: TonJettonFixtures.notcoinMasterRaw, symbol: "USDT", name: "Tether USD"),
+            .verified(source: "ton-assets"),
+            "The address is the identity; the labels are not"
+        )
+    }
+
+    func testCuratedAddressKeepsTheCuratedTier() {
+        XCTAssertEqual(classify(address: TonJettonFixtures.usdtMasterRawUpper, symbol: "USD₮"), .curated)
+    }
+
+    /// Even the indexer calling a listed jetton a scam does not unlist it — the
+    /// address match is the stronger statement, and honouring the flag here
+    /// would let a bad indexer entry hide a real holding.
+    func testListedAddressSurvivesTheIndexerScamFlag() {
+        XCTAssertEqual(
+            classify(address: TonJettonFixtures.notcoinMasterRaw, symbol: "NOT", isFlaggedScam: true),
+            .verified(source: "ton-assets")
+        )
+    }
+
+    // MARK: - Scam
+
+    /// The pattern the whole feature exists for, and the reason `is_scam` cannot
+    /// be the signal: a counterfeit at an unlisted address, calling itself
+    /// exactly what the real asset is called, reporting `is_scam: false` — which
+    /// is what all 40 sampled blacklisted jettons reported.
+    func testCounterfeitTetherIsScamDespiteTheIndexerSayingOtherwise() {
+        for spelling in ["USD₮", "USDT", "UЅDT", "$USĐ₮", "ＵＳＤＴ"] {
+            XCTAssertEqual(
+                classify(address: TonJettonFixtures.unlistedMasterRaw, symbol: spelling, isFlaggedScam: false),
+                .scam,
+                "failed for \(spelling)"
+            )
+        }
+    }
+
+    func testImpersonationByNameAloneIsScam() {
+        XCTAssertEqual(
+            classify(address: TonJettonFixtures.unlistedMasterRaw, symbol: "FREE", name: "Tether USD"),
+            .scam
+        )
+    }
+
+    func testIndexerFlagIsHonouredForAnUnlistedJetton() {
+        XCTAssertEqual(
+            classify(address: TonJettonFixtures.unlistedMasterRaw, symbol: "WHATEVER", isFlaggedScam: true),
+            .scam
+        )
+    }
+
+    // MARK: - Unverified
+
+    func testUnlistedAndNotImpersonatingIsUnverified() {
+        XCTAssertEqual(
+            classify(address: TonJettonFixtures.unlistedMasterRaw, symbol: "MMM", name: "MMM2049", isFlaggedScam: false),
+            .unverified
+        )
+    }
+
+    /// `jUSDT` is a real, distinct jetton. Folding must not swallow the leading
+    /// letter and make it read as an impersonation of USDT.
+    func testASimilarButDistinctSymbolIsNotScam() {
+        XCTAssertEqual(classify(address: TonJettonFixtures.unlistedMasterRaw, symbol: "jUSDT"), .unverified)
+    }
+
+    func testMissingLabelsAreUnverifiedNotScam() {
+        XCTAssertEqual(classify(address: TonJettonFixtures.unlistedMasterRaw), .unverified)
+        XCTAssertEqual(classify(address: TonJettonFixtures.unlistedMasterRaw, symbol: "", name: ""), .unverified)
+    }
+
+    /// A degraded registry recognises fewer jettons, so more of them are
+    /// unverified — never more of them verified.
+    func testEmptyRegistryVerifiesNothing() {
+        let tier = TonJettonClassifier.classify(
+            address: TonJettonFixtures.usdtMasterFriendly,
+            symbol: "USDT",
+            name: nil,
+            isFlaggedScam: nil,
+            registry: .empty
+        )
+        XCTAssertEqual(tier, .unverified)
+    }
+
+    // MARK: - Auto-surfacing
+
+    /// The property acceptance criterion 3 rests on: whatever the tier, only
+    /// verified ones may auto-appear.
+    func testOnlyVerifiedTiersAutoSurface() {
+        XCTAssertTrue(classify(address: TonJettonFixtures.usdtMasterRawUpper).autoSurfaces)
+        XCTAssertTrue(classify(address: TonJettonFixtures.notcoinMasterRaw, symbol: "NOT").autoSurfaces)
+        XCTAssertFalse(classify(address: TonJettonFixtures.unlistedMasterRaw, symbol: "USD₮").autoSurfaces)
+        XCTAssertFalse(classify(address: TonJettonFixtures.unlistedMasterRaw, symbol: "MMM").autoSurfaces)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonDiscovererRegistrationTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonDiscovererRegistrationTests.swift
@@ -1,0 +1,40 @@
+//
+//  TonJettonDiscovererRegistrationTests.swift
+//  VultisigAppTests
+//
+
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class TonJettonDiscovererRegistrationTests: XCTestCase {
+
+    func testTonResolvesToTheJettonDiscoverer() {
+        XCTAssertTrue(TokenDiscovererRegistry.discoverer(for: .ton) is TonJettonTokenDiscoverer)
+    }
+
+    /// The other four chains that shared TON's no-op entry keep it. Their
+    /// behaviour is out of scope for this change, and several test fixtures
+    /// depend on them discovering nothing.
+    func testTheOtherNonDiscoveringChainsAreUnchanged() {
+        for chain: Chain in [.bitcoin, .litecoin, .cardano, .polkadot, .tron] {
+            XCTAssertTrue(
+                TokenDiscovererRegistry.discoverer(for: chain) is NoTokenDiscoverer,
+                "\(chain.name) must still declare no discovery"
+            )
+        }
+    }
+
+    /// Only a discoverer that matches its results against an address registry
+    /// may bypass the spam heuristics; everything else keeps them.
+    func testOnlyTheTonDiscovererVouchesForItsResults() {
+        XCTAssertTrue(TokenDiscovererRegistry.discoverer(for: .ton).vouchesForResults)
+
+        for chain: Chain in [.ethereum, .solana, .sui, .thorChain, .mayaChain, .ripple, .bitcoin] {
+            XCTAssertFalse(
+                TokenDiscovererRegistry.discoverer(for: chain).vouchesForResults,
+                "\(chain.name) has no address registry to vouch with"
+            )
+        }
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonFinderTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonFinderTests.swift
@@ -139,23 +139,10 @@ final class TonJettonFinderTests: XCTestCase {
         XCTAssertEqual(Set(coins.map(\.ticker)), ["USDT", "NOT", "DOGS"])
     }
 
-    /// A proxy that ignores `offset` replays page one forever. An owner holds
-    /// exactly one wallet per master, so a page that adds no new master is the
-    /// end of the list however the proxy chose to express it — without this the
-    /// same balance would be walked until the page cap.
-    func testAReplayedPageEndsTheWalk() async throws {
-        let (finder, client) = finder(pages: [.success(TonJettonFixtures.pageOfTwo)], pageSize: 2, maxPages: 20)
-        let coins = try await finder.discover(ownerAddress: TonJettonFixtures.owner)
-
-        XCTAssertEqual(client.attempts, 2, "One page, then one that proves it repeated")
-        XCTAssertEqual(coins.map(\.ticker).sorted(), ["NOT", "USDT"], "and nothing is discovered twice")
-    }
-
     /// A full page can be entirely spam, entirely somebody else's, or entirely
     /// jettons that fail verification. None of that means the listing ended —
     /// the account's own jettons may sit at the next offset — so the walk must
-    /// continue. Judging replay on what survived the filters instead of on the
-    /// rows themselves would strand a user whose first page is all spam.
+    /// continue past it.
     func testAFullPageThatSurvivesNoFilterIsStillWalkedPast() async throws {
         let (finder, client) = finder(
             pages: [.success(TonJettonFixtures.pageOfTwoForeignRows), .success(TonJettonFixtures.pageOfOne)],
@@ -165,6 +152,39 @@ final class TonJettonFinderTests: XCTestCase {
 
         XCTAssertEqual(client.attempts, 2, "A page nothing survived is not the end of the list")
         XCTAssertEqual(coins.map(\.ticker), ["DOGS"])
+    }
+
+    /// A proxy that ignores `offset` replays one page forever. Rather than try
+    /// to recognise that — every attempt also described a legitimately
+    /// overlapping page, and stopping on one stranded real holdings — the walk
+    /// leans on the two guarantees that hold unconditionally: the master dedup
+    /// means a repeated holding is never counted twice, and `maxPages` bounds
+    /// the loop. This pins both.
+    func testAReplayingProxyTerminatesAndDoesNotDuplicate() async throws {
+        let (finder, client) = finder(pages: [.success(TonJettonFixtures.pageOfTwo)], pageSize: 2, maxPages: 5)
+        let coins = try await finder.discover(ownerAddress: TonJettonFixtures.owner)
+
+        XCTAssertEqual(client.attempts, 5, "maxPages bounds a proxy that never advances")
+        XCTAssertEqual(coins.map(\.ticker).sorted(), ["NOT", "USDT"], "and nothing is discovered twice")
+    }
+
+    /// Pages of rows already seen are not the end of the listing: a proxy can
+    /// legitimately overlap pages, or serve a cached offset, while later offsets
+    /// still hold jettons the account owns. Stopping on them would strand those.
+    func testOverlappingPagesDoNotEndTheWalk() async throws {
+        let (finder, client) = finder(
+            pages: [
+                .success(TonJettonFixtures.pageOfTwo),
+                .success(TonJettonFixtures.pageOfTwo),
+                .success(TonJettonFixtures.pageOfTwo),
+                .success(TonJettonFixtures.pageOfOne)
+            ],
+            pageSize: 2
+        )
+        let coins = try await finder.discover(ownerAddress: TonJettonFixtures.owner)
+
+        XCTAssertEqual(client.attempts, 4)
+        XCTAssertEqual(coins.map(\.ticker).sorted(), ["DOGS", "NOT", "USDT"], "the stranded page is reached")
     }
 
     func testAnEmptyAccountDiscoversNothing() async throws {

--- a/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonFinderTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonFinderTests.swift
@@ -1,0 +1,189 @@
+//
+//  TonJettonFinderTests.swift
+//  VultisigAppTests
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class TonJettonFinderTests: XCTestCase {
+
+    private func finder(
+        pages: [ScriptedJettonHTTPClient.Step],
+        registryScript: [ScriptedJettonHTTPClient.Step] = [
+            .success(TonJettonFixtures.tonAssetsWhitelist)
+        ],
+        pageSize: Int = TonJettonFinder.defaultPageSize,
+        maxPages: Int = TonJettonFinder.defaultMaxPages
+    ) -> (finder: TonJettonFinder, pageClient: ScriptedJettonHTTPClient) {
+        let pageClient = ScriptedJettonHTTPClient(script: pages)
+        let (store, _) = TonJettonFixtures.store(script: registryScript)
+        let finder = TonJettonFinder(
+            httpClient: pageClient,
+            registryStore: store,
+            host: URL(string: "https://test.local")!,
+            pageSize: pageSize,
+            maxPages: maxPages
+        )
+        return (finder, pageClient)
+    }
+
+    private func discover(
+        pages: [ScriptedJettonHTTPClient.Step],
+        registryScript: [ScriptedJettonHTTPClient.Step] = [
+            .success(TonJettonFixtures.tonAssetsWhitelist)
+        ],
+        pageSize: Int = TonJettonFinder.defaultPageSize,
+        maxPages: Int = TonJettonFinder.defaultMaxPages
+    ) async throws -> [CoinMeta] {
+        let (finder, _) = finder(pages: pages, registryScript: registryScript, pageSize: pageSize, maxPages: maxPages)
+        return try await finder.discover(ownerAddress: TonJettonFixtures.owner)
+    }
+
+    // MARK: - What is and is not discovered
+
+    func testOnlyVerifiedHeldJettonsAreDiscovered() async throws {
+        let coins = try await discover(pages: [.success(TonJettonFixtures.ownerJettonWalletsPage)])
+        XCTAssertEqual(Set(coins.map(\.ticker)), ["USDT", "NOT", "DOGS"])
+    }
+
+    /// The airdropped counterfeit in the fixture calls itself `USD₮` / "Tether
+    /// USD" from an unlisted contract and reports `is_scam: false`. It must not
+    /// reach the wallet.
+    func testCounterfeitTetherIsNotDiscovered() async throws {
+        let coins = try await discover(pages: [.success(TonJettonFixtures.ownerJettonWalletsPage)])
+        XCTAssertFalse(
+            coins.contains { $0.contractAddress == TonJettonAddress.canonical(TonJettonFixtures.unlistedMasterRaw) },
+            "A counterfeit must never auto-appear"
+        )
+        XCTAssertEqual(coins.filter { $0.ticker == "USDT" }.count, 1, "Exactly one USDT, and it is the real one")
+    }
+
+    func testUnverifiedJettonIsNotDiscovered() async throws {
+        let coins = try await discover(pages: [.success(TonJettonFixtures.ownerJettonWalletsPage)])
+        XCTAssertFalse(coins.contains { $0.ticker == "MMM" })
+    }
+
+    func testZeroBalanceJettonIsNotDiscovered() async throws {
+        let coins = try await discover(pages: [.success(TonJettonFixtures.ownerJettonWalletsPage)])
+        XCTAssertFalse(coins.contains { $0.ticker == "jUSDT" }, "Whitelisted, but the account holds none")
+    }
+
+    /// The proxy has been seen returning rows it was not asked for, so the
+    /// owner is checked again on our side. STON is verified and would otherwise
+    /// be added to a vault that does not hold it.
+    func testRowsOwnedBySomebodyElseAreDropped() async throws {
+        let coins = try await discover(pages: [.success(TonJettonFixtures.ownerJettonWalletsPage)])
+        XCTAssertFalse(coins.contains { $0.ticker == "STON" })
+    }
+
+    // MARK: - Metadata
+
+    /// Curated wins outright: the chain and the whitelist both call this jetton
+    /// `USD₮`, and neither publishes its decimals. Taking the on-chain symbol
+    /// here would also hand a non-ASCII ticker to the discovery spam gate.
+    func testCuratedMetadataWinsForTether() async throws {
+        let coins = try await discover(pages: [.success(TonJettonFixtures.ownerJettonWalletsPage)])
+        let usdt = try XCTUnwrap(coins.first { $0.ticker == "USDT" })
+
+        XCTAssertEqual(usdt.decimals, 6)
+        XCTAssertEqual(usdt.priceProviderId, "tether")
+        XCTAssertEqual(usdt.logo, "usdt")
+        XCTAssertEqual(usdt.contractAddress, TonJettonAddress.canonical(TonJettonFixtures.usdtMasterFriendly))
+        XCTAssertFalse(usdt.isNativeToken)
+        XCTAssertEqual(usdt.chain, .ton)
+    }
+
+    /// A whitelist-only jetton takes its display metadata from the indexer entry
+    /// that rode along in the same listing — no follow-up call per jetton.
+    func testWhitelistOnlyJettonTakesToncenterMetadata() async throws {
+        let coins = try await discover(pages: [.success(TonJettonFixtures.ownerJettonWalletsPage)])
+        let dogs = try XCTUnwrap(coins.first { $0.ticker == "DOGS" })
+
+        XCTAssertEqual(dogs.decimals, 9)
+        XCTAssertEqual(dogs.logo, TonJettonFixtures.dogsLogo, "and from the master entry, not the wallet one")
+    }
+
+    /// The discovered contract address has to be the form the vault already
+    /// stores, or a discovered jetton would not dedup against a held coin.
+    func testDiscoveredContractAddressesAreCanonical() async throws {
+        let coins = try await discover(pages: [.success(TonJettonFixtures.ownerJettonWalletsPage)])
+        for coin in coins {
+            XCTAssertEqual(coin.contractAddress, TonJettonAddress.canonical(coin.contractAddress))
+        }
+    }
+
+    /// A jetton balance can exceed `UInt64`; parsing it narrowly would read a
+    /// real holding as zero and silently drop it.
+    func testBalancesBeyondUInt64AreHeld() async throws {
+        let coins = try await discover(pages: [.success(TonJettonFixtures.ownerJettonWalletsPage)])
+        XCTAssertTrue(coins.contains { $0.ticker == "NOT" })
+    }
+
+    // MARK: - Paging
+
+    func testAShortPageEndsTheWalk() async throws {
+        let (finder, client) = finder(pages: [.success(TonJettonFixtures.pageOfOne)], pageSize: 2)
+        _ = try await finder.discover(ownerAddress: TonJettonFixtures.owner)
+        XCTAssertEqual(client.attempts, 1)
+    }
+
+    func testAFullPageIsFollowedByTheNext() async throws {
+        let (finder, client) = finder(
+            pages: [.success(TonJettonFixtures.pageOfTwo), .success(TonJettonFixtures.pageOfOne)],
+            pageSize: 2
+        )
+        let coins = try await finder.discover(ownerAddress: TonJettonFixtures.owner)
+
+        XCTAssertEqual(client.attempts, 2)
+        XCTAssertEqual(Set(coins.map(\.ticker)), ["USDT", "NOT", "DOGS"])
+    }
+
+    /// A proxy that ignores `offset` replays page one forever. An owner holds
+    /// exactly one wallet per master, so a page that adds no new master is the
+    /// end of the list however the proxy chose to express it — without this the
+    /// same balance would be walked until the page cap.
+    func testAReplayedPageEndsTheWalk() async throws {
+        let (finder, client) = finder(pages: [.success(TonJettonFixtures.pageOfTwo)], pageSize: 2, maxPages: 20)
+        let coins = try await finder.discover(ownerAddress: TonJettonFixtures.owner)
+
+        XCTAssertEqual(client.attempts, 2, "One page, then one that proves it repeated")
+        XCTAssertEqual(coins.map(\.ticker).sorted(), ["NOT", "USDT"], "and nothing is discovered twice")
+    }
+
+    func testAnEmptyAccountDiscoversNothing() async throws {
+        let coins = try await discover(pages: [.success(TonJettonFixtures.emptyPage)])
+        XCTAssertTrue(coins.isEmpty)
+    }
+
+    // MARK: - Failure
+
+    func testListingFailurePropagates() async {
+        let (finder, _) = finder(pages: [.failure])
+        do {
+            _ = try await finder.discover(ownerAddress: TonJettonFixtures.owner)
+            XCTFail("A listing that cannot be read is a discovery failure, not an empty account")
+        } catch {
+            // expected
+        }
+    }
+
+    /// An unreachable whitelist is not a discovery failure: the curated list
+    /// still recognises Tether, and the jettons only the whitelist knows about
+    /// simply stop being auto-added until it comes back.
+    func testRegistryOutageStillDiscoversCuratedJettons() async throws {
+        let coins = try await discover(
+            pages: [.success(TonJettonFixtures.ownerJettonWalletsPage)],
+            registryScript: [.failure]
+        )
+        XCTAssertEqual(coins.map(\.ticker), ["USDT"])
+    }
+
+    func testAnUnusableOwnerAddressDiscoversNothingWithoutCallingOut() async throws {
+        let (finder, client) = finder(pages: [.success(TonJettonFixtures.ownerJettonWalletsPage)])
+        let coins = try await finder.discover(ownerAddress: "not-an-address")
+
+        XCTAssertTrue(coins.isEmpty)
+        XCTAssertEqual(client.attempts, 0)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonFinderTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonFinderTests.swift
@@ -151,6 +151,22 @@ final class TonJettonFinderTests: XCTestCase {
         XCTAssertEqual(coins.map(\.ticker).sorted(), ["NOT", "USDT"], "and nothing is discovered twice")
     }
 
+    /// A full page can be entirely spam, entirely somebody else's, or entirely
+    /// jettons that fail verification. None of that means the listing ended —
+    /// the account's own jettons may sit at the next offset — so the walk must
+    /// continue. Judging replay on what survived the filters instead of on the
+    /// rows themselves would strand a user whose first page is all spam.
+    func testAFullPageThatSurvivesNoFilterIsStillWalkedPast() async throws {
+        let (finder, client) = finder(
+            pages: [.success(TonJettonFixtures.pageOfTwoForeignRows), .success(TonJettonFixtures.pageOfOne)],
+            pageSize: 2
+        )
+        let coins = try await finder.discover(ownerAddress: TonJettonFixtures.owner)
+
+        XCTAssertEqual(client.attempts, 2, "A page nothing survived is not the end of the list")
+        XCTAssertEqual(coins.map(\.ticker), ["DOGS"])
+    }
+
     func testAnEmptyAccountDiscoversNothing() async throws {
         let coins = try await discover(pages: [.success(TonJettonFixtures.emptyPage)])
         XCTAssertTrue(coins.isEmpty)

--- a/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonMasterMetadataTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonMasterMetadataTests.swift
@@ -1,0 +1,63 @@
+//
+//  TonJettonMasterMetadataTests.swift
+//  VultisigAppTests
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class TonJettonMasterMetadataTests: XCTestCase {
+
+    private func indexFromRecordedPage() throws -> [String: TonJettonMasterMetadata] {
+        let page = try JSONDecoder().decode(
+            JettonWalletsResponse.self,
+            from: Data(TonJettonFixtures.ownerJettonWalletsPage.utf8)
+        )
+        return TonJettonMasterMetadata.index(from: page.metadata)
+    }
+
+    /// The filter the whole discovery path depends on. Toncenter marks the
+    /// owner's jetton *wallet* entries `valid: true` as well, and those carry no
+    /// symbol or name — so selecting on `valid` alone reads every master as
+    /// nameless and classifies every jetton as unverified. In the recorded page
+    /// the DOGS master lists a wallet-typed entry *before* its master-typed one,
+    /// which is what makes this assertion bite.
+    func testWalletTypedEntriesAreNeverMistakenForMasters() throws {
+        let index = try indexFromRecordedPage()
+        let dogs = try XCTUnwrap(TonJettonAddress.canonical(TonJettonFixtures.dogsMasterRaw))
+
+        XCTAssertEqual(index[dogs]?.symbol, "DOGS")
+        XCTAssertEqual(index[dogs]?.name, "Dogs")
+        XCTAssertEqual(index[dogs]?.decimals, 9)
+    }
+
+    /// Wallet addresses have entries in the same map and must not appear in an
+    /// index of masters.
+    func testWalletAddressesAreNotIndexed() throws {
+        let index = try indexFromRecordedPage()
+        let walletAddress = try XCTUnwrap(
+            TonJettonAddress.canonical("0:AA01000000000000000000000000000000000000000000000000000000000001")
+        )
+        XCTAssertNil(index[walletAddress])
+    }
+
+    func testIndexIsKeyedByCanonicalAddress() throws {
+        let index = try indexFromRecordedPage()
+        let tether = try XCTUnwrap(TonJettonAddress.canonical(TonJettonFixtures.usdtMasterRawLower))
+
+        XCTAssertEqual(index[tether]?.symbol, "USD₮")
+        XCTAssertEqual(index[tether]?.decimals, 6)
+        XCTAssertEqual(index[tether]?.isFlaggedScam, false)
+    }
+
+    /// The imgproxy rendition is preferred over the original `image` URL.
+    func testImgproxyRenditionIsPreferredForTheLogo() throws {
+        let index = try indexFromRecordedPage()
+        let dogs = try XCTUnwrap(TonJettonAddress.canonical(TonJettonFixtures.dogsMasterRaw))
+        XCTAssertEqual(index[dogs]?.logo, TonJettonFixtures.dogsLogo)
+    }
+
+    func testAbsentMetadataIndexesToNothing() {
+        XCTAssertTrue(TonJettonMasterMetadata.index(from: nil).isEmpty)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonMasterMetadataTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonMasterMetadataTests.swift
@@ -8,12 +8,13 @@ import XCTest
 
 final class TonJettonMasterMetadataTests: XCTestCase {
 
-    private func indexFromRecordedPage() throws -> [String: TonJettonMasterMetadata] {
-        let page = try JSONDecoder().decode(
-            JettonWalletsResponse.self,
-            from: Data(TonJettonFixtures.ownerJettonWalletsPage.utf8)
-        )
+    private func index(from json: String) throws -> [String: TonJettonMasterMetadata] {
+        let page = try JSONDecoder().decode(JettonWalletsResponse.self, from: Data(json.utf8))
         return TonJettonMasterMetadata.index(from: page.metadata)
+    }
+
+    private func indexFromRecordedPage() throws -> [String: TonJettonMasterMetadata] {
+        try index(from: TonJettonFixtures.ownerJettonWalletsPage)
     }
 
     /// The filter the whole discovery path depends on. Toncenter marks the
@@ -55,6 +56,30 @@ final class TonJettonMasterMetadataTests: XCTestCase {
         let index = try indexFromRecordedPage()
         let dogs = try XCTUnwrap(TonJettonAddress.canonical(TonJettonFixtures.dogsMasterRaw))
         XCTAssertEqual(index[dogs]?.logo, TonJettonFixtures.dogsLogo)
+    }
+
+    /// A typed master entry always wins, even when an untyped one is listed
+    /// first — otherwise a wallet entry that simply lost its `type` would
+    /// supply the metadata and the master's symbol would go unread.
+    func testTypedMasterEntryWinsOverAnUntypedOne() throws {
+        let index = try index(from: TonJettonFixtures.pageWithUntypedEntryBeforeMaster)
+        let dogs = try XCTUnwrap(TonJettonAddress.canonical(TonJettonFixtures.dogsMasterRaw))
+
+        XCTAssertEqual(index[dogs]?.symbol, "DOGS")
+        XCTAssertEqual(index[dogs]?.decimals, 9)
+        XCTAssertEqual(index[dogs]?.logo, TonJettonFixtures.dogsLogo)
+    }
+
+    /// An untyped entry is still read when it is all there is. If Toncenter ever
+    /// stops emitting `type`, the fallback is the difference between degraded
+    /// metadata and no metadata at all — and no metadata would classify every
+    /// jetton on the chain as unverified and quietly stop discovery.
+    func testUntypedEntryIsReadWhenNoMasterEntryExists() throws {
+        let index = try index(from: TonJettonFixtures.pageWithUntypedMasterEntry)
+        let dogs = try XCTUnwrap(TonJettonAddress.canonical(TonJettonFixtures.dogsMasterRaw))
+
+        XCTAssertEqual(index[dogs]?.symbol, "DOGS")
+        XCTAssertEqual(index[dogs]?.decimals, 9)
     }
 
     func testAbsentMetadataIndexesToNothing() {

--- a/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonMasterMetadataTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonMasterMetadataTests.swift
@@ -82,6 +82,20 @@ final class TonJettonMasterMetadataTests: XCTestCase {
         XCTAssertEqual(index[dogs]?.decimals, 9)
     }
 
+    /// The degraded case the untyped fallback exists for is also the one where
+    /// it is easiest to read the wrong record: with no `type` anywhere, a
+    /// balance-only wallet entry is indistinguishable from a master entry by
+    /// type alone. Requiring a symbol or a name is what separates them — and
+    /// getting it wrong would lose the jetton's real decimals and leave the
+    /// default standing in, which is a wrong balance and a wrong amount.
+    func testUntypedWalletRecordIsNotReadAsTheMaster() throws {
+        let index = try index(from: TonJettonFixtures.pageWithUntypedWalletBeforeUntypedMaster)
+        let jusdt = try XCTUnwrap(TonJettonAddress.canonical(TonJettonFixtures.jusdtMasterRaw))
+
+        XCTAssertEqual(index[jusdt]?.symbol, "jUSDT")
+        XCTAssertEqual(index[jusdt]?.decimals, 6, "the master's real decimals, not the 9 default")
+    }
+
     func testAbsentMetadataIndexesToNothing() {
         XCTAssertTrue(TonJettonMasterMetadata.index(from: nil).isEmpty)
     }

--- a/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonRegistryStoreTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonRegistryStoreTests.swift
@@ -1,0 +1,134 @@
+//
+//  TonJettonRegistryStoreTests.swift
+//  VultisigAppTests
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class TonJettonRegistryStoreTests: XCTestCase {
+
+    private let whitelist = TonJettonFixtures.tonAssetsWhitelist
+
+    // MARK: - Merge
+
+    func testRegistryMergesCuratedWithTheWhitelist() async {
+        let (store, _) = TonJettonFixtures.store(script: [.success(whitelist)])
+        let registry = await store.registry()
+
+        XCTAssertEqual(registry.entry(for: TonJettonFixtures.notcoinMasterRaw)?.symbol, "NOT")
+        XCTAssertEqual(
+            registry.entry(for: TonJettonFixtures.notcoinMasterRaw)?.verification,
+            .verified(source: "ton-assets")
+        )
+        // Curated is merged in first, so Tether keeps our metadata even though
+        // the whitelist also lists that contract.
+        let tether = registry.entry(for: TonJettonFixtures.usdtMasterRawUpper)
+        XCTAssertEqual(tether?.symbol, "USDT")
+        XCTAssertEqual(tether?.decimals, 6)
+        XCTAssertEqual(tether?.verification, .curated)
+        XCTAssertTrue(registry.impersonates("Tether USD"), "whitelist labels survive the merge")
+    }
+
+    // MARK: - Degrade
+
+    func testFetchFailureDegradesToCuratedWithoutThrowing() async {
+        let (store, _) = TonJettonFixtures.store(script: [.failure])
+        let registry = await store.registry()
+
+        XCTAssertEqual(registry.entry(for: TonJettonFixtures.usdtMasterFriendly)?.symbol, "USDT")
+        XCTAssertNil(
+            registry.entry(for: TonJettonFixtures.notcoinMasterRaw),
+            "A degraded registry recognises fewer jettons, not more"
+        )
+    }
+
+    func testMalformedPayloadDegradesToCurated() async {
+        let (store, _) = TonJettonFixtures.store(script: [.success(TonJettonFixtures.tonAssetsMalformed)])
+        let registry = await store.registry()
+
+        XCTAssertEqual(registry.entry(for: TonJettonFixtures.usdtMasterFriendly)?.symbol, "USDT")
+        XCTAssertNil(registry.entry(for: TonJettonFixtures.notcoinMasterRaw))
+    }
+
+    // MARK: - Caching
+
+    /// The property the issue calls out by name: caching a failure would pin the
+    /// degraded registry for the whole TTL, so an outage would keep deciding
+    /// which jettons the wallet recognises long after it ended.
+    func testFailureIsNotCachedSoTheNextCallRetries() async {
+        let (store, client) = TonJettonFixtures.store(script: [.failure, .success(whitelist)])
+
+        let degraded = await store.registry()
+        XCTAssertNil(degraded.entry(for: TonJettonFixtures.notcoinMasterRaw))
+
+        let recovered = await store.registry()
+        XCTAssertEqual(recovered.entry(for: TonJettonFixtures.notcoinMasterRaw)?.symbol, "NOT")
+        XCTAssertEqual(client.attempts, 2, "The outage must be retried, not replayed")
+    }
+
+    func testSuccessIsServedFromCacheWithinTheTTL() async {
+        let (store, client) = TonJettonFixtures.store(script: [.success(whitelist), .failure])
+
+        _ = await store.registry()
+        let second = await store.registry()
+
+        XCTAssertEqual(client.attempts, 1, "A fresh registry must not be refetched")
+        XCTAssertEqual(second.entry(for: TonJettonFixtures.notcoinMasterRaw)?.symbol, "NOT")
+    }
+
+    func testCacheExpiresAfterTheTTL() async {
+        let clock = ManualClock()
+        let (store, client) = TonJettonFixtures.store(
+            script: [.success(whitelist)],
+            ttl: 3600,
+            clock: clock
+        )
+
+        _ = await store.registry()
+        clock.advance(by: 3599)
+        _ = await store.registry()
+        XCTAssertEqual(client.attempts, 1, "Still fresh one second before the TTL")
+
+        clock.advance(by: 2)
+        _ = await store.registry()
+        XCTAssertEqual(client.attempts, 2, "Stale past the TTL")
+    }
+
+    /// Discovery runs per chain-detail refresh and those fan out several times
+    /// after a swap; without coalescing one screen would pull the whole list
+    /// repeatedly.
+    func testConcurrentCallersShareOneFetch() async {
+        let client = ScriptedJettonHTTPClient(script: [.success(whitelist)], delay: .milliseconds(150))
+        let (store, _) = TonJettonFixtures.store(script: [], client: client)
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<8 {
+                group.addTask { _ = await store.registry() }
+            }
+        }
+
+        XCTAssertEqual(client.attempts, 1)
+    }
+
+    /// A failed batch of concurrent callers must all degrade, and must leave the
+    /// store retryable rather than holding a finished, failed task.
+    func testConcurrentFailureLeavesTheStoreRetryable() async {
+        let client = ScriptedJettonHTTPClient(script: [.failure, .success(whitelist)], delay: .milliseconds(50))
+        let (store, _) = TonJettonFixtures.store(script: [], client: client)
+
+        await withTaskGroup(of: Bool.self) { group in
+            for _ in 0..<4 {
+                group.addTask {
+                    await store.registry().entry(for: TonJettonFixtures.notcoinMasterRaw) == nil
+                }
+            }
+            for await degraded in group {
+                XCTAssertTrue(degraded, "Every caller in a failed batch degrades")
+            }
+        }
+
+        let recovered = await store.registry()
+        XCTAssertEqual(recovered.entry(for: TonJettonFixtures.notcoinMasterRaw)?.symbol, "NOT")
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonRegistryTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonRegistryTests.swift
@@ -1,0 +1,145 @@
+//
+//  TonJettonRegistryTests.swift
+//  VultisigAppTests
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class TonJettonRegistryTests: XCTestCase {
+
+    private func curatedUSDT() -> VerifiedJetton {
+        VerifiedJetton(
+            address: TonJettonAddress.canonical(TonJettonFixtures.usdtMasterFriendly)!,
+            symbol: "USDT",
+            name: nil,
+            decimals: 6,
+            logo: "usdt",
+            priceProviderId: "tether",
+            verification: .curated
+        )
+    }
+
+    private func whitelistedUSDT() -> VerifiedJetton {
+        VerifiedJetton(
+            address: TonJettonAddress.canonical(TonJettonFixtures.usdtMasterRawLower)!,
+            symbol: "USD₮",
+            name: "Tether USD",
+            decimals: nil,
+            logo: nil,
+            priceProviderId: nil,
+            verification: .verified(source: TonJettonRegistry.tonAssetsSource)
+        )
+    }
+
+    // MARK: - Merge
+
+    /// Curated is supplied first and keeps the metadata — its ticker is ASCII,
+    /// its decimals are the real 6 (`ton-assets` publishes none for Tether) and
+    /// it carries the price id.
+    func testEarlierEntryKeepsTheMetadataOnAnAddressCollision() {
+        let registry = TonJettonRegistry([curatedUSDT(), whitelistedUSDT()])
+        let entry = registry.entry(for: TonJettonFixtures.usdtMasterRawUpper)
+
+        XCTAssertEqual(entry?.symbol, "USDT")
+        XCTAssertEqual(entry?.decimals, 6)
+        XCTAssertEqual(entry?.priceProviderId, "tether")
+        XCTAssertEqual(entry?.verification, .curated)
+        XCTAssertEqual(registry.count, 1, "One contract must occupy one slot")
+    }
+
+    /// The half that is easy to get wrong: the losing duplicate still has to
+    /// contribute its labels. Our curated entry has no name and an ASCII
+    /// ticker, so without this a jetton calling itself "Tether USD" from
+    /// another contract would classify as merely unverified.
+    func testBothEntriesContributeImpersonationLabels() {
+        let registry = TonJettonRegistry([curatedUSDT(), whitelistedUSDT()])
+
+        XCTAssertTrue(registry.impersonates("USDT"), "curated ticker")
+        XCTAssertTrue(registry.impersonates("USD₮"), "whitelist symbol")
+        XCTAssertTrue(registry.impersonates("Tether USD"), "whitelist name")
+        XCTAssertTrue(registry.impersonates("UЅDT"), "Cyrillic spelling of either")
+    }
+
+    func testUnrelatedLabelsDoNotImpersonate() {
+        let registry = TonJettonRegistry([curatedUSDT(), whitelistedUSDT()])
+        XCTAssertFalse(registry.impersonates("NOT"))
+        XCTAssertFalse(registry.impersonates("Notcoin"))
+        XCTAssertFalse(registry.impersonates(nil))
+    }
+
+    /// A symbol with no Latin skeleton must not match everything with no Latin
+    /// skeleton — the empty string is not a label.
+    func testLabelsWithNoSkeletonNeverImpersonate() {
+        let cjk = VerifiedJetton(
+            address: TonJettonAddress.canonical(TonJettonFixtures.notcoinMasterRaw)!,
+            symbol: "道德經",
+            name: "道德經",
+            decimals: nil,
+            logo: nil,
+            priceProviderId: nil,
+            verification: .verified(source: TonJettonRegistry.tonAssetsSource)
+        )
+        let registry = TonJettonRegistry([cjk])
+
+        XCTAssertFalse(registry.impersonates("🅿️"))
+        XCTAssertFalse(registry.impersonates(""))
+        XCTAssertFalse(registry.impersonates("道德經"), "an exact repeat still has no skeleton to match on")
+    }
+
+    // MARK: - Lookup
+
+    func testEntryLookupAcceptsEverySpellingOfTheAddress() {
+        let registry = TonJettonRegistry([curatedUSDT()])
+        for spelling in [
+            TonJettonFixtures.usdtMasterRawUpper,
+            TonJettonFixtures.usdtMasterRawLower,
+            TonJettonFixtures.usdtMasterFriendly
+        ] {
+            XCTAssertEqual(registry.entry(for: spelling)?.symbol, "USDT", "failed for \(spelling)")
+        }
+    }
+
+    func testUnlistedAddressHasNoEntry() {
+        let registry = TonJettonRegistry([curatedUSDT()])
+        XCTAssertNil(registry.entry(for: TonJettonFixtures.unlistedMasterRaw))
+        XCTAssertNil(registry.entry(for: "not-an-address"))
+    }
+
+    func testEmptyRegistryMatchesNothing() {
+        XCTAssertNil(TonJettonRegistry.empty.entry(for: TonJettonFixtures.usdtMasterFriendly))
+        XCTAssertFalse(TonJettonRegistry.empty.impersonates("USDT"))
+    }
+
+    // MARK: - Entry construction
+
+    func testCuratedTonJettonsBecomeVerifiedEntries() {
+        let curated = BundledTokensProvider
+            .curatedTokens(for: .ton, defaults: TonJettonFixtures.isolatedDefaults())
+            .compactMap { VerifiedJetton(curated: $0) }
+
+        XCTAssertFalse(curated.isEmpty, "The bundled TON jetton list must not be empty")
+        XCTAssertTrue(curated.allSatisfy { $0.verification == .curated })
+        XCTAssertTrue(
+            curated.contains { $0.symbol == "USDT" && $0.decimals == 6 },
+            "Curated Tether supplies the decimals ton-assets omits"
+        )
+    }
+
+    /// The native coin has no contract address, so it is not a jetton and must
+    /// not enter a registry that answers "is this master listed?".
+    func testNativeCoinIsNotAVerifiedJetton() {
+        XCTAssertNil(VerifiedJetton(curated: TokensStore.ton))
+    }
+
+    func testWhitelistEntryDropsBlankSymbolAndForeignAddress() throws {
+        let entries = try JSONDecoder().decode(
+            [TonAssetsJetton].self,
+            from: Data(TonJettonFixtures.tonAssetsWithUnusableEntries.utf8)
+        )
+        let usable = entries.compactMap { VerifiedJetton(whitelisted: $0) }
+
+        XCTAssertEqual(usable.map(\.symbol), ["NOT"])
+        XCTAssertEqual(usable.first?.verification, .verified(source: "ton-assets"))
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonSymbolTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonSymbolTests.swift
@@ -1,0 +1,95 @@
+//
+//  TonJettonSymbolTests.swift
+//  VultisigAppTests
+//
+//  The counterfeit-USDT skeletons this has to fold. Every spelling below was
+//  taken from a jetton that ships in Tonkeeper's `ton-assets` whitelist or from
+//  the impersonation patterns the SDK sampled; the real Tether jetton itself is
+//  listed as `USD₮`, so folding is what lets it compare equal to our curated
+//  `USDT` entry at all.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class TonJettonSymbolTests: XCTestCase {
+
+    func testFoldsTugrikSignOntoUSDT() {
+        XCTAssertEqual(TonJettonSymbol.normalize("USD₮"), "USDT")
+    }
+
+    func testFoldsCyrillicHomoglyphOntoUSDT() {
+        // U+0405 CYRILLIC CAPITAL LETTER DZE, not U+0053 LATIN CAPITAL S.
+        XCTAssertEqual(TonJettonSymbol.normalize("UЅDT"), "USDT")
+    }
+
+    func testFoldsStrokedLetterAndPunctuationOntoUSDT() {
+        XCTAssertEqual(TonJettonSymbol.normalize("$USĐ₮"), "USDT")
+    }
+
+    func testFoldsFullWidthFormsOntoUSDT() {
+        XCTAssertEqual(TonJettonSymbol.normalize("ＵＳＤＴ"), "USDT")
+    }
+
+    func testFoldsCaseOntoUSDT() {
+        XCTAssertEqual(TonJettonSymbol.normalize("usdt"), "USDT")
+    }
+
+    /// Every spelling above has to reach the same skeleton, or an impersonator
+    /// only matches the one variant the test happened to name.
+    func testAllUSDTSpellingsShareOneSkeleton() {
+        let spellings = ["USDT", "USD₮", "UЅDT", "$USĐ₮", "ＵＳＤＴ", "usdt", "  usd₮  "]
+        XCTAssertEqual(Set(spellings.map(TonJettonSymbol.normalize)), ["USDT"])
+    }
+
+    func testFoldsGreekHomoglyph() {
+        // U+0399 GREEK CAPITAL LETTER IOTA in place of Latin I.
+        XCTAssertEqual(TonJettonSymbol.normalize("ΒΙΤ"), "BIT")
+    }
+
+    func testStripsDiacritics() {
+        XCTAssertEqual(TonJettonSymbol.normalize("Café"), "CAFE")
+        XCTAssertEqual(TonJettonSymbol.normalize("HOLÐ"), "HOLD")
+    }
+
+    func testNamesFoldTheSameWayAsSymbols() {
+        XCTAssertEqual(TonJettonSymbol.normalize("Tether USD"), "TETHERUSD")
+    }
+
+    func testDropsSeparatorsAndKeepsDigits() {
+        XCTAssertEqual(TonJettonSymbol.normalize("USD₮-BEHT LP"), "USDTBEHTLP")
+        XCTAssertEqual(TonJettonSymbol.normalize("$80"), "80")
+    }
+
+    /// Characters the table does not map are dropped, which cuts both ways and
+    /// is a deliberate choice rather than an oversight.
+    ///
+    /// Dropping is what defeats padding: an appended Cyrillic letter, or an
+    /// invisible zero-width space spliced into the middle, cannot buy a
+    /// counterfeit a different skeleton. The cost is the mirror case — a
+    /// homoglyph outside the table (Armenian `Ս` standing in for `U` here)
+    /// survives the mapping step, is then dropped as non-ASCII, and the
+    /// impersonation is missed.
+    ///
+    /// The table is deliberately the SDK's, so iOS, Windows and the SDK agree on
+    /// what counts as a counterfeit; widening it here alone would make one
+    /// jetton read `scam` on one platform and `unverified` on another. The
+    /// safety property does not rest on it either way: a missed fold leaves an
+    /// unlisted jetton `unverified`, which never auto-adds.
+    func testUnmappedCharactersAreDroppedInBothDirections() {
+        XCTAssertEqual(TonJettonSymbol.normalize("USDT\u{0416}"), "USDT", "padding cannot escape the skeleton")
+        XCTAssertEqual(TonJettonSymbol.normalize("US\u{200B}DT"), "USDT", "nor can an invisible character")
+        XCTAssertEqual(TonJettonSymbol.normalize("\u{054D}SDT"), "SDT", "known gap: Armenian S-lookalike is unmapped")
+    }
+
+    /// A symbol with no Latin skeleton must normalize to empty rather than to
+    /// something that collides. Callers treat empty as "never matches"; if this
+    /// returned a partial skeleton instead, every CJK- or emoji-named jetton
+    /// would impersonate whatever it collapsed onto.
+    func testSymbolsWithNoLatinSkeletonNormalizeToEmpty() {
+        XCTAssertEqual(TonJettonSymbol.normalize("道德經"), "")
+        XCTAssertEqual(TonJettonSymbol.normalize("🅿️"), "")
+        XCTAssertEqual(TonJettonSymbol.normalize(""), "")
+        XCTAssertEqual(TonJettonSymbol.normalize("   "), "")
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonTestSupport.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonTestSupport.swift
@@ -234,6 +234,20 @@ enum TonJettonFixtures {
     }
     """#
 
+    /// Degraded Toncenter: no entry declares a `type` at all, and under the
+    /// master's own key a balance-only wallet record is listed *before* the
+    /// record that actually describes the jetton.
+    static let pageWithUntypedWalletBeforeUntypedMaster = #"""
+    {
+      "jetton_wallets": [
+        {"address": "0:1A01000000000000000000000000000000000000000000000000000000000001", "balance": "250000000000", "owner": "0:83DFD552E63729B472FCBCC8C45EBCC6691702558B68EC7527E1BA403A0F31A8", "jetton": "0:729C13B6DF2C07CBF0A06AB63D34AF454F3D320EC1BCD8FB5C6D24D0806A17C2"}
+      ],
+      "metadata": {
+        "0:729C13B6DF2C07CBF0A06AB63D34AF454F3D320EC1BCD8FB5C6D24D0806A17C2": {"is_indexed": true, "token_info": [{"valid": true, "extra": {"balance": "250000000000"}}, {"valid": true, "name": "jUSDT", "symbol": "jUSDT", "extra": {"decimals": "6"}}]}
+      }
+    }
+    """#
+
     // MARK: - Helpers
 
     static func store(

--- a/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonTestSupport.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonTestSupport.swift
@@ -195,6 +195,45 @@ enum TonJettonFixtures {
 
     static let emptyPage = ##"{"jetton_wallets": [], "metadata": {}}"##
 
+    /// A full page of somebody else's wallets. Nothing here survives the owner
+    /// check, but the rows are all new, so the walk must continue past it.
+    static let pageOfTwoForeignRows = #"""
+    {
+      "jetton_wallets": [
+        {"address": "0:DD01000000000000000000000000000000000000000000000000000000000001", "balance": "5000000", "owner": "0:1111111111111111111111111111111111111111111111111111111111111111", "jetton": "0:B113A994B5024A16719F69139328EB759596C38A25F59028B146FECDC3621DFE"},
+        {"address": "0:DD01000000000000000000000000000000000000000000000000000000000002", "balance": "1000000000", "owner": "0:1111111111111111111111111111111111111111111111111111111111111111", "jetton": "0:2F956143C461769579BAEF2E32CC2D7BC18283F40D20BB03E432CD603AC33FFC"}
+      ],
+      "metadata": {}
+    }
+    """#
+
+    /// A master whose only indexer entry carries no `type` at all — the shape a
+    /// Toncenter that stopped emitting the field would produce.
+    static let pageWithUntypedMasterEntry = #"""
+    {
+      "jetton_wallets": [
+        {"address": "0:EE01000000000000000000000000000000000000000000000000000000000001", "balance": "250000000000", "owner": "0:83DFD552E63729B472FCBCC8C45EBCC6691702558B68EC7527E1BA403A0F31A8", "jetton": "0:AFC49CB8786F21C87045B19EDE78FC6B46C51048513F8E9A6D44060199C1BF0C"}
+      ],
+      "metadata": {
+        "0:AFC49CB8786F21C87045B19EDE78FC6B46C51048513F8E9A6D44060199C1BF0C": {"is_indexed": true, "token_info": [{"valid": true, "name": "Dogs", "symbol": "DOGS", "extra": {"decimals": "9", "_image_medium": "https://proxy.toncenter.com/dogs/pr:medium/abc"}}]}
+      }
+    }
+    """#
+
+    /// An untyped entry listed *ahead* of the real master entry for the same
+    /// address, which is the ordering that makes preference — not mere
+    /// acceptance — the thing under test.
+    static let pageWithUntypedEntryBeforeMaster = #"""
+    {
+      "jetton_wallets": [
+        {"address": "0:FF01000000000000000000000000000000000000000000000000000000000001", "balance": "250000000000", "owner": "0:83DFD552E63729B472FCBCC8C45EBCC6691702558B68EC7527E1BA403A0F31A8", "jetton": "0:AFC49CB8786F21C87045B19EDE78FC6B46C51048513F8E9A6D44060199C1BF0C"}
+      ],
+      "metadata": {
+        "0:AFC49CB8786F21C87045B19EDE78FC6B46C51048513F8E9A6D44060199C1BF0C": {"is_indexed": true, "token_info": [{"valid": true, "extra": {"balance": "250000000000"}}, {"valid": true, "type": "jetton_masters", "name": "Dogs", "symbol": "DOGS", "extra": {"decimals": "9", "_image_medium": "https://proxy.toncenter.com/dogs/pr:medium/abc"}}]}
+      }
+    }
+    """#
+
     // MARK: - Helpers
 
     static func store(

--- a/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonTestSupport.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ton/TonJettonTestSupport.swift
@@ -1,0 +1,223 @@
+//
+//  TonJettonTestSupport.swift
+//  VultisigAppTests
+//
+//  Shared doubles + recorded payloads for the TON jetton suites. Every JSON
+//  literal here was captured from the live service it names and then trimmed;
+//  no test in this directory performs a network call.
+//
+
+import Foundation
+@testable import VultisigApp
+
+/// Drives one scripted outcome per request, so a suite can assert what happens
+/// on the *second* call — which is how "only successes are cached" is provable.
+final class ScriptedJettonHTTPClient: HTTPClientProtocol, @unchecked Sendable {
+
+    enum Step {
+        case success(String)
+        case failure
+    }
+
+    private let lock = NSLock()
+    private var script: [Step]
+    private var _attempts = 0
+    private let delay: Duration
+
+    /// Requests served so far. The last step repeats once the script runs out.
+    var attempts: Int { lock.withLock { _attempts } }
+
+    init(script: [Step], delay: Duration = .zero) {
+        self.script = script
+        self.delay = delay
+    }
+
+    func request(_: TargetType) async throws -> HTTPResponse<Data> {
+        let step: Step = lock.withLock {
+            let index = min(_attempts, script.count - 1)
+            _attempts += 1
+            return script[index]
+        }
+
+        if delay > .zero {
+            try? await Task.sleep(for: delay)
+        }
+
+        switch step {
+        case .failure:
+            throw HTTPError.statusCode(503, nil)
+        case .success(let json):
+            guard let url = URL(string: "https://test.local"),
+                  let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+            else {
+                throw HTTPError.invalidResponse
+            }
+            return HTTPResponse(data: Data(json.utf8), response: response)
+        }
+    }
+}
+
+/// A clock the test moves by hand, so TTL behaviour is asserted rather than waited out.
+final class ManualClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _now: Date
+
+    init(_ start: Date = Date(timeIntervalSince1970: 1_700_000_000)) {
+        self._now = start
+    }
+
+    var now: Date { lock.withLock { _now } }
+
+    func advance(by interval: TimeInterval) {
+        lock.withLock { _now += interval }
+    }
+}
+
+enum TonJettonFixtures {
+
+    // MARK: - Addresses (the real Tether jetton master, in every spelling)
+
+    static let usdtMasterRawUpper = "0:B113A994B5024A16719F69139328EB759596C38A25F59028B146FECDC3621DFE"
+    static let usdtMasterRawLower = "0:b113a994b5024a16719f69139328eb759596c38a25f59028b146fecdc3621dfe"
+    static let usdtMasterFriendly = "EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs"
+
+    static let notcoinMasterRaw = "0:2f956143c461769579baef2e32cc2d7bc18283f40d20bb03e432cd603ac33ffc"
+    static let dogsMasterRaw = "0:afc49cb8786f21c87045b19ede78fc6b46c51048513f8e9a6d44060199c1bf0c"
+
+    /// A jetton master that is on no list — used as the counterfeit's address.
+    static let unlistedMasterRaw = "0:87E3837BDC15C4853F34EB72802BFDBBA02A26BC99E601A79BB28F9D668C80CB"
+    static let secondUnlistedMasterRaw = "0:6F323F84B83F1F606A65F06FA365E123E1281FE1334E2FADAAF38AA812D6375F"
+
+    // MARK: - ton-assets
+
+    /// Four real `jettons.json` entries, verbatim. Tether is listed under the
+    /// tugrik spelling with no `decimals`, and `image` is explicitly null for
+    /// most of the file — both are why the curated overlay matters.
+    static let tonAssetsWhitelist = #"""
+    [
+      {"address": "0:b113a994b5024a16719f69139328eb759596c38a25f59028b146fecdc3621dfe", "symbol": "USD₮", "name": "Tether USD", "image": null},
+      {"address": "0:2f956143c461769579baef2e32cc2d7bc18283f40d20bb03e432cd603ac33ffc", "symbol": "NOT", "name": "Notcoin", "decimals": 9},
+      {"address": "0:afc49cb8786f21c87045b19ede78fc6b46c51048513f8e9a6d44060199c1bf0c", "symbol": "DOGS", "name": "Dogs", "image": null},
+      {"address": "0:3690254dc15b2297610cda60744a45f2b710aa4234b89adb630e99d79b01bd4f", "symbol": "STON", "name": "STON", "decimals": 9},
+      {"address": "0:729c13b6df2c07cbf0a06ab63d34af454f3d320ec1bcd8fb5c6d24d0806a17c2", "symbol": "jUSDT", "name": "jUSDT", "decimals": 6}
+    ]
+    """#
+
+    /// Entries the builder must drop rather than index: no symbol, a blank
+    /// symbol, and an address that is not a TON address at all.
+    static let tonAssetsWithUnusableEntries = #"""
+    [
+      {"address": "0:2f956143c461769579baef2e32cc2d7bc18283f40d20bb03e432cd603ac33ffc", "symbol": "NOT", "name": "Notcoin", "decimals": 9},
+      {"address": "0:afc49cb8786f21c87045b19ede78fc6b46c51048513f8e9a6d44060199c1bf0c", "name": "No Symbol"},
+      {"address": "0:3690254dc15b2297610cda60744a45f2b710aa4234b89adb630e99d79b01bd4f", "symbol": "   ", "name": "Blank Symbol"},
+      {"address": "0xd2912bc567894032f42edda72bd27bcaae79d74c", "symbol": "EVM", "name": "Not A Ton Address"}
+    ]
+    """#
+
+    /// The shape a proxy or a CDN error page returns — an object, not a list.
+    static let tonAssetsMalformed = #"{"message": "Not Found"}"#
+
+    // MARK: - Toncenter owner-jetton-wallets listing
+
+    static let owner = "0:83DFD552E63729B472FCBCC8C45EBCC6691702558B68EC7527E1BA403A0F31A8"
+    static let foreignOwner = "0:1111111111111111111111111111111111111111111111111111111111111111"
+
+    static let stonMasterRaw = "0:3690254DC15B2297610CDA60744A45F2B710AA4234B89ADB630E99D79B01BD4F"
+    static let jusdtMasterRaw = "0:729C13B6DF2C07CBF0A06AB63D34AF454F3D320EC1BCD8FB5C6D24D0806A17C2"
+
+    static let dogsLogo = "https://proxy.toncenter.com/dogs/pr:medium/abc"
+
+    /// One page of `/ton/v3/jetton/wallets`, shaped exactly like the live
+    /// response: raw upper-case addresses, and a `metadata` map carrying an
+    /// entry for **every** address in the response — the owner's jetton wallets
+    /// under `type: "jetton_wallets"` as well as the masters under
+    /// `type: "jetton_masters"`, both marked `valid: true`.
+    ///
+    /// Seven rows, each present for a reason:
+    ///   1. USDT   — curated, held
+    ///   2. NOT    — whitelisted, held, balance beyond `UInt64`
+    ///   3. DOGS   — whitelisted, held; its master entry is listed *after* a
+    ///               wallet-typed one and carries the only logo in the fixture
+    ///   4. counterfeit — unlisted, calls itself `USD₮` / "Tether USD", and
+    ///               reports `is_scam: false` the way real counterfeits do
+    ///   5. MMM    — unlisted and impersonating nothing
+    ///   6. STON   — whitelisted, but owned by somebody else
+    ///   7. jUSDT  — whitelisted and held at zero
+    static let ownerJettonWalletsPage = #"""
+    {
+      "jetton_wallets": [
+        {"address": "0:AA01000000000000000000000000000000000000000000000000000000000001", "balance": "5000000", "owner": "0:83DFD552E63729B472FCBCC8C45EBCC6691702558B68EC7527E1BA403A0F31A8", "jetton": "0:B113A994B5024A16719F69139328EB759596C38A25F59028B146FECDC3621DFE"},
+        {"address": "0:AA01000000000000000000000000000000000000000000000000000000000002", "balance": "184467440737095516160000", "owner": "0:83DFD552E63729B472FCBCC8C45EBCC6691702558B68EC7527E1BA403A0F31A8", "jetton": "0:2F956143C461769579BAEF2E32CC2D7BC18283F40D20BB03E432CD603AC33FFC"},
+        {"address": "0:AA01000000000000000000000000000000000000000000000000000000000003", "balance": "250000000000", "owner": "0:83DFD552E63729B472FCBCC8C45EBCC6691702558B68EC7527E1BA403A0F31A8", "jetton": "0:AFC49CB8786F21C87045B19EDE78FC6B46C51048513F8E9A6D44060199C1BF0C"},
+        {"address": "0:AA01000000000000000000000000000000000000000000000000000000000004", "balance": "9000000", "owner": "0:83DFD552E63729B472FCBCC8C45EBCC6691702558B68EC7527E1BA403A0F31A8", "jetton": "0:87E3837BDC15C4853F34EB72802BFDBBA02A26BC99E601A79BB28F9D668C80CB"},
+        {"address": "0:AA01000000000000000000000000000000000000000000000000000000000005", "balance": "1000000000", "owner": "0:83DFD552E63729B472FCBCC8C45EBCC6691702558B68EC7527E1BA403A0F31A8", "jetton": "0:6F323F84B83F1F606A65F06FA365E123E1281FE1334E2FADAAF38AA812D6375F"},
+        {"address": "0:AA01000000000000000000000000000000000000000000000000000000000006", "balance": "7000000", "owner": "0:1111111111111111111111111111111111111111111111111111111111111111", "jetton": "0:3690254DC15B2297610CDA60744A45F2B710AA4234B89ADB630E99D79B01BD4F"},
+        {"address": "0:AA01000000000000000000000000000000000000000000000000000000000007", "balance": "0", "owner": "0:83DFD552E63729B472FCBCC8C45EBCC6691702558B68EC7527E1BA403A0F31A8", "jetton": "0:729C13B6DF2C07CBF0A06AB63D34AF454F3D320EC1BCD8FB5C6D24D0806A17C2"}
+      ],
+      "metadata": {
+        "0:AA01000000000000000000000000000000000000000000000000000000000001": {"is_indexed": true, "token_info": [{"valid": true, "type": "jetton_wallets", "extra": {"balance": "5000000"}}]},
+        "0:AA01000000000000000000000000000000000000000000000000000000000003": {"is_indexed": true, "token_info": [{"valid": true, "type": "jetton_wallets", "extra": {"balance": "250000000000"}}]},
+        "0:B113A994B5024A16719F69139328EB759596C38A25F59028B146FECDC3621DFE": {"is_indexed": true, "token_info": [{"valid": true, "type": "jetton_masters", "name": "Tether USD", "symbol": "USD₮", "is_scam": false, "extra": {"decimals": "6"}}]},
+        "0:2F956143C461769579BAEF2E32CC2D7BC18283F40D20BB03E432CD603AC33FFC": {"is_indexed": true, "token_info": [{"valid": true, "type": "jetton_masters", "name": "Notcoin", "symbol": "NOT", "is_scam": false, "extra": {"decimals": "9"}}]},
+        "0:AFC49CB8786F21C87045B19EDE78FC6B46C51048513F8E9A6D44060199C1BF0C": {"is_indexed": true, "token_info": [{"valid": true, "type": "jetton_wallets", "extra": {"balance": "250000000000"}}, {"valid": true, "type": "jetton_masters", "name": "Dogs", "symbol": "DOGS", "is_scam": false, "extra": {"decimals": "9", "_image_medium": "https://proxy.toncenter.com/dogs/pr:medium/abc"}}]},
+        "0:87E3837BDC15C4853F34EB72802BFDBBA02A26BC99E601A79BB28F9D668C80CB": {"is_indexed": true, "token_info": [{"valid": true, "type": "jetton_masters", "name": "Tether USD", "symbol": "USD₮", "is_scam": false, "extra": {"decimals": "6"}}]},
+        "0:6F323F84B83F1F606A65F06FA365E123E1281FE1334E2FADAAF38AA812D6375F": {"is_indexed": true, "token_info": [{"valid": true, "type": "jetton_masters", "name": "MMM2049", "symbol": "MMM", "is_scam": false, "extra": {"decimals": "9"}}]},
+        "0:3690254DC15B2297610CDA60744A45F2B710AA4234B89ADB630E99D79B01BD4F": {"is_indexed": true, "token_info": [{"valid": true, "type": "jetton_masters", "name": "STON", "symbol": "STON", "is_scam": false, "extra": {"decimals": "9"}}]},
+        "0:729C13B6DF2C07CBF0A06AB63D34AF454F3D320EC1BCD8FB5C6D24D0806A17C2": {"is_indexed": true, "token_info": [{"valid": true, "type": "jetton_masters", "name": "jUSDT", "symbol": "jUSDT", "is_scam": false, "extra": {"decimals": "6"}}]}
+      }
+    }
+    """#
+
+    /// Two held jettons, for the paging rules with an injected page size of 2.
+    static let pageOfTwo = #"""
+    {
+      "jetton_wallets": [
+        {"address": "0:BB01000000000000000000000000000000000000000000000000000000000001", "balance": "5000000", "owner": "0:83DFD552E63729B472FCBCC8C45EBCC6691702558B68EC7527E1BA403A0F31A8", "jetton": "0:B113A994B5024A16719F69139328EB759596C38A25F59028B146FECDC3621DFE"},
+        {"address": "0:BB01000000000000000000000000000000000000000000000000000000000002", "balance": "1000000000", "owner": "0:83DFD552E63729B472FCBCC8C45EBCC6691702558B68EC7527E1BA403A0F31A8", "jetton": "0:2F956143C461769579BAEF2E32CC2D7BC18283F40D20BB03E432CD603AC33FFC"}
+      ],
+      "metadata": {
+        "0:2F956143C461769579BAEF2E32CC2D7BC18283F40D20BB03E432CD603AC33FFC": {"is_indexed": true, "token_info": [{"valid": true, "type": "jetton_masters", "name": "Notcoin", "symbol": "NOT", "extra": {"decimals": "9"}}]}
+      }
+    }
+    """#
+
+    /// One held jetton — a short page, which ends the walk.
+    static let pageOfOne = #"""
+    {
+      "jetton_wallets": [
+        {"address": "0:CC01000000000000000000000000000000000000000000000000000000000001", "balance": "250000000000", "owner": "0:83DFD552E63729B472FCBCC8C45EBCC6691702558B68EC7527E1BA403A0F31A8", "jetton": "0:AFC49CB8786F21C87045B19EDE78FC6B46C51048513F8E9A6D44060199C1BF0C"}
+      ],
+      "metadata": {
+        "0:AFC49CB8786F21C87045B19EDE78FC6B46C51048513F8E9A6D44060199C1BF0C": {"is_indexed": true, "token_info": [{"valid": true, "type": "jetton_masters", "name": "Dogs", "symbol": "DOGS", "extra": {"decimals": "9"}}]}
+      }
+    }
+    """#
+
+    static let emptyPage = ##"{"jetton_wallets": [], "metadata": {}}"##
+
+    // MARK: - Helpers
+
+    static func store(
+        script: [ScriptedJettonHTTPClient.Step],
+        client: ScriptedJettonHTTPClient? = nil,
+        ttl: TimeInterval = 3600,
+        clock: ManualClock = ManualClock()
+    ) -> (store: TonJettonRegistryStore, client: ScriptedJettonHTTPClient) {
+        let httpClient = client ?? ScriptedJettonHTTPClient(script: script)
+        let store = TonJettonRegistryStore(
+            httpClient: httpClient,
+            api: TonAssetsAPI(host: URL(string: "https://test.local")!),
+            ttl: ttl,
+            defaults: isolatedDefaults(),
+            now: { clock.now }
+        )
+        return (store, httpClient)
+    }
+
+    /// A defaults suite with nothing in it, so chain-visibility gates are read
+    /// from a known state instead of whatever the running machine has set.
+    static func isolatedDefaults() -> UserDefaults {
+        let suite = UserDefaults(suiteName: "TonJettonTests-\(UUID().uuidString)")!
+        return suite
+    }
+}

--- a/VultisigApp/VultisigAppTests/Services/TokenCatalog/CatalogTokenTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/TokenCatalog/CatalogTokenTests.swift
@@ -36,12 +36,23 @@ final class CatalogTokenTests: XCTestCase {
         XCTAssertTrue(TokenVerification.curated.autoSurfaces)
         XCTAssertTrue(TokenVerification.verified(source: "Jupiter").autoSurfaces)
         XCTAssertFalse(TokenVerification.unverified.autoSurfaces, "Unverified must never auto-surface")
+        XCTAssertFalse(TokenVerification.scam.autoSurfaces, "Scam must never auto-surface")
+    }
+
+    /// Rank orders authority, not trust: a positive identification says more
+    /// than a source-side allowlist, and the in-code bundled list says most of
+    /// all. `autoSurfaces` — not rank — is what keeps a scam off a screen.
+    func testScamOutranksAllowlistsButNotTheBundledList() {
+        XCTAssertGreaterThan(TokenVerification.scam.rank, TokenVerification.verified(source: "ton-assets").rank)
+        XCTAssertGreaterThan(TokenVerification.scam.rank, TokenVerification.unverified.rank)
+        XCTAssertGreaterThan(TokenVerification.curated.rank, TokenVerification.scam.rank)
     }
 
     func testSourceLabel() {
         XCTAssertEqual(TokenVerification.verified(source: "CoinGecko").sourceLabel, "CoinGecko")
         XCTAssertNil(TokenVerification.curated.sourceLabel)
         XCTAssertNil(TokenVerification.unverified.sourceLabel)
+        XCTAssertNil(TokenVerification.scam.sourceLabel)
     }
 
     func testStrongerKeepsHigherRank() {
@@ -58,6 +69,29 @@ final class CatalogTokenTests: XCTestCase {
             TokenVerification.stronger(.verified(source: "A"), .verified(source: "B")),
             .verified(source: "A")
         )
+    }
+
+    /// A provider that merely does not recognise the address must not erase a
+    /// positive identification, in either argument position.
+    func testStrongerKeepsScamOverIgnorance() {
+        XCTAssertEqual(TokenVerification.stronger(.scam, .unverified), .scam)
+        XCTAssertEqual(TokenVerification.stronger(.unverified, .scam), .scam)
+        XCTAssertEqual(TokenVerification.stronger(.scam, .verified(source: "ton-assets")), .scam)
+        XCTAssertEqual(TokenVerification.stronger(.verified(source: "1inch"), .scam), .scam)
+    }
+
+    /// The bundled list is in-code and cannot be tampered with, so nothing —
+    /// including a `.scam` restored from the untrusted disk snapshot — may
+    /// suppress a curated token.
+    func testStrongerNeverLetsScamDisplaceCurated() {
+        XCTAssertEqual(TokenVerification.stronger(.curated, .scam), .curated)
+        XCTAssertEqual(TokenVerification.stronger(.scam, .curated), .curated)
+    }
+
+    /// Preserved rather than downgraded: the worst a tampered `.scam` can do is
+    /// hide a non-curated token from search, which is the fail-closed direction.
+    func testScamSurvivesUntrustedPersistence() {
+        XCTAssertEqual(TokenVerification.scam.cappedForUntrustedPersistence, .scam)
     }
 
     // MARK: - CatalogToken


### PR DESCRIPTION
## Problem

`Core/Services/TokenDiscoverer.swift` mapped `.Ton` to `NoTokenDiscoverer`, so a TON holder saw only the two curated entries (`GRAM`, `USDT`) plus whatever they added by hand, while EVM, Solana, Sui, Cosmos, THORChain and Ripple all discover. There was also no notion of jetton trust anywhere in the app, and TON accounts are carpet-bombed with counterfeits — fake USDT above all.

## What this PR does

This is **PR A of two** for #5348: the discovery and classification core. It deliberately adds **no UI and no localized strings** — surfacing the tier on token rows and approval cards is PR B. PR A already delivers acceptance criteria 2, 3 and 4: verified jettons are discovered, a counterfeit is classified `scam` and never auto-appears, and a registry outage degrades to the curated list.

**Discovery** — one paged, owner-filtered Toncenter call (`exclude_zero_balance`, `limit`, `offset`), zero balances excluded, metadata taken from the same response. No follow-up call per jetton.

**Registry** — our curated TON tokens ∪ Tonkeeper's community-reviewed `ton-assets` whitelist, refreshed hourly, degrading to the curated list alone when unreachable. Only successful fetches are cached, so an outage is retried rather than pinned.

**Classification** — a pure `TonJettonClassifier` returning `verified` / `unverified` / `scam`, over a symbol fold that collapses `USD₮`, Cyrillic `UЅDT`, `$USĐ₮` and full-width forms onto `USDT`.

**Auto-discovery surfaces verified jettons only**, so a counterfeit airdrop never auto-appears.

## Notes for the reviewer

Three things here are iOS-specific and are not in [sdk#2305](https://github.com/vultisig/vultisig-sdk/pull/2305):

- **`.scam` joins the existing `TokenVerification`** rather than a parallel TON-only enum. iOS already ships `.curated` / `.verified(source:)` / `.unverified` with an `autoSurfaces` gate and a badge, so the SDK's tiers map onto a concept that exists. Ranking is `curated > scam > verified > unverified`: a positive identification survives another provider's ignorance, but nothing restored from the untrusted disk snapshot can suppress the in-code bundled list.
- **The canonical address key is user-friendly bounceable, not the SDK's raw `workchain:hex`.** WalletCore's `TONAddressConverter` has no raw converter — only `toBoc`/`fromBoc`/`toUserFriendly` — and user-friendly is what `CoinMeta.uniqueId` already dedups on, so it is also the only form that collides correctly with a coin the vault holds.
- **`isLikelySpam` would have dropped the genuine USDT.** It rejects any ticker containing a non-ASCII character, and Tether's on-chain symbol is `USD₮`. `TokenDiscoverer.vouchesForResults` lets a discoverer that matches every result against an address registry skip the heuristics; it defaults to `false`, so every other chain keeps the gate it has today. Same shape as the existing XRPL exemption in that function.

**Toncenter's `is_scam` is honoured but is not the signal** — the classifier tests assert the counterfeit is caught with `is_scam: false`, which is what all 40 blacklisted jettons the SDK sampled reported.

Discovery for `.UTXO`, `.Cardano`, `.Polkadot` and `.Tron` is unchanged, and a test asserts it.

## Verification

Full gate on `e61737bad`: `** TEST BUILD SUCCEEDED **`, `** TEST EXECUTE SUCCEEDED **`, `Executed 7244 tests, with 11 tests skipped and 0 failures (0 unexpected)` — 76 tests above the 7168 baseline, on a dedicated `en_US` simulator.

All network-dependent tests use fixtures recorded from the live services and then trimmed; nothing in this PR's tests touches the network. The fixtures preserve one detail that is easy to lose: Toncenter's `metadata` map carries `valid: true` entries of **both** `jetton_masters` and `jetton_wallets` type, and a test lists a wallet-typed entry *ahead* of the master one, so dropping the `type` filter fails the suite rather than silently classifying every jetton as unverified.

**The suite was verified test-by-test, not just run.** An earlier revision of this branch gated green at `Executed 7243 tests ... 0 failures` while a text-slice edit had silently deleted `testAFullPageThatSurvivesNoFilterIsStillWalkedPast` — the regression test for one of the review findings below. The green marker hid it; only checking each test name against the gate log caught it. It is restored and passing, and every test named in this PR was confirmed present in the final log by name.

Three review rounds all landed on the same object: the heuristic that tried to recognise a proxy replaying a page. Each variant — no new master, then no new wallet row, then two such pages in a row — also describes a legitimately overlapping page, so it is gone. Termination is guaranteed by `maxPages`, correctness by the master dedup.

## For the human reviewer

> **This decides which assets a user sees as legitimate.** A classification mistake either hides a real holding or lets a counterfeit pass. **No on-device acceptance was performed** — the evidence here is the test suite and recorded fixtures only.

**This is PR A of two, and issue #5348 stays open after it merges.** The follow-up PR B adds the tier to token rows and approval/verify cards; that one carries the linking keyword.

Refs #5348.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic discovery of verified TON jettons using curated and trusted registry data.
  - Added TON jetton metadata, canonical addresses, balances, images, symbols, and decimals.
  - Added scam and impersonation detection for safer token identification.
  - Added resilient registry updates with caching and fallback behavior.
  - Added support for retrieving an account’s TON jetton wallets with pagination and balance filtering.

- **Bug Fixes**
  - Improved discovery accuracy by filtering counterfeit, unverified, empty-balance, and duplicate jettons.
  - Preserved scam classifications while preventing suspicious tokens from appearing in automatic discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->