### PR TITLE
fix(bittensor): derive/decode SS58 via WalletCore AnyAddress

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Bittensor/Signing/BittensorHelper.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Bittensor/Signing/BittensorHelper.swift
@@ -115,77 +115,26 @@ enum BittensorHelper {
     // MARK: - SS58 Address Encoding/Decoding
 
     /// Decode an SS58 address to its raw public key bytes (32 bytes for ed25519),
-    /// requiring an exact prefix + checksum match against `expectedPrefix`.
-    /// This is the single decode both the form (`isValidAddress`) and the sign
-    /// path (`buildCallData`) use, so they can never accept different addresses.
-    static func ss58Decode(_ address: String, expectedPrefix: UInt16 = ss58Prefix) -> Data? {
-        guard let decoded = Base58.decodeNoCheck(string: address), !decoded.isEmpty else {
-            return nil
-        }
-
-        let prefixByteCount: Int
-        let decodedPrefix: UInt16
-
-        if decoded[0] < 64 {
-            prefixByteCount = 1
-            decodedPrefix = UInt16(decoded[0])
-        } else if decoded[0] <= 127 {
-            // The SS58 two-byte prefix indicator is 64...127; 128...255 is
-            // reserved (not a valid full-identifier prefix at all), and the
-            // low-6-bits-only formula below would otherwise alias several
-            // reserved first bytes onto the same prefix as a canonical one.
-            guard decoded.count >= 2 else { return nil }
-            prefixByteCount = 2
-            let first = decoded[0]
-            let second = decoded[1]
-            decodedPrefix = UInt16((first & 0x3F) << 2) | UInt16(second >> 6) | (UInt16(second & 0x3F) << 8)
-        } else {
-            return nil
-        }
-
-        guard decodedPrefix == expectedPrefix else { return nil }
-
-        // Exact length only: prefix + 32-byte key + 2-byte checksum, no trailing bytes.
-        let expectedLength = prefixByteCount + 32 + 2
-        guard decoded.count == expectedLength else { return nil }
-
-        let payload = Data(decoded[0..<(prefixByteCount + 32)])
-        let checksum = Data(decoded[(prefixByteCount + 32)..<expectedLength])
-
-        let ss58PrefixData = Data("SS58PRE".utf8)
-        let hash = Hash.blake2b(data: ss58PrefixData + payload, size: 64)
-        guard hash.prefix(2) == checksum else { return nil }
-
-        return Data(decoded[prefixByteCount..<(prefixByteCount + 32)])
+    /// requiring an exact prefix + checksum match. This is the single decode
+    /// both the form (`isValidAddress`) and the sign path (`buildCallData`)
+    /// use, so they can never accept different addresses.
+    static func ss58Decode(_ address: String) -> Data? {
+        AnyAddress(string: address, coin: .polkadot, ss58Prefix: UInt32(ss58Prefix))?.data
     }
 
-    /// Encode raw public key bytes to SS58 address with given prefix
-    static func ss58Encode(publicKey: Data, prefix: UInt16) -> String {
-        let ss58Prefix = "SS58PRE".data(using: .utf8)!
-
-        var prefixBytes: Data
-        if prefix < 64 {
-            prefixBytes = Data([UInt8(prefix)])
-        } else {
-            // Two-byte encoding for prefix >= 64
-            let first = UInt8(((prefix & 0xFC) >> 2) | 0x40)
-            let second = UInt8((prefix >> 8) | ((prefix & 0x03) << 6))
-            prefixBytes = Data([first, second])
+    /// Encode raw public key bytes to a Bittensor SS58 (prefix 42) address.
+    static func ss58Encode(publicKey: Data) -> String {
+        guard let key = PublicKey(data: publicKey, type: .ed25519) else {
+            return ""
         }
-
-        let payload = prefixBytes + publicKey
-        let checksumInput = ss58Prefix + payload
-        let hash = Hash.blake2b(data: checksumInput, size: 64)
-        let checksum = hash.prefix(2)
-
-        return Base58.encodeNoCheck(data: payload + checksum)
+        return AnyAddress(publicKey: key, coin: .polkadot, ss58Prefix: UInt32(ss58Prefix)).description
     }
 
     /// Validate a Bittensor SS58 address (prefix 42). Thin wrapper over
     /// `ss58Decode` so the form can never accept an address the sign path
     /// would reject, or vice versa.
     static func isValidAddress(_ address: String) -> Bool {
-        ss58Decode(address) != nil
+        AnyAddress.isValidSS58(string: address, coin: .polkadot, ss58Prefix: UInt32(ss58Prefix))
     }
 
     /// The Substrate burn/zero AccountId (32 zero bytes) — SS58-42-encodes to

--- a/VultisigApp/VultisigApp/Blockchain/Common/CoinFactory.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Common/CoinFactory.swift
@@ -78,7 +78,7 @@ struct CoinFactory {
                   rawKey.count == 32 else {
                 throw Errors.invalidPublicKey(pubKey: "Bittensor requires 32-byte ed25519 public key")
             }
-            address = BittensorHelper.ss58Encode(publicKey: rawKey, prefix: BittensorHelper.ss58Prefix)
+            address = BittensorHelper.ss58Encode(publicKey: rawKey)
         default:
             address = chain.coinType.deriveAddressFromPublicKey(publicKey: publicKey)
         }

--- a/VultisigApp/VultisigAppTests/Blockchain/SigningGolden/SigningGoldenFixtures.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/SigningGolden/SigningGoldenFixtures.swift
@@ -78,10 +78,7 @@ enum SigningGoldenFactory {
             // Polkadot, whose SS58 prefix is 0, not Bittensor's 42. Mirror
             // `CoinFactory`'s override so this is a real, checksummed SS58-42
             // address — the strict sign-path decode rejects anything else.
-            return BittensorHelper.ss58Encode(
-                publicKey: recipientKey.getPublicKeyEd25519().data,
-                prefix: BittensorHelper.ss58Prefix
-            )
+            return BittensorHelper.ss58Encode(publicKey: recipientKey.getPublicKeyEd25519().data)
         default:
             return chain.coinType.deriveAddress(privateKey: recipientKey)
         }

--- a/VultisigApp/VultisigAppTests/Chains/BittensorDestinationGuardTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/BittensorDestinationGuardTests.swift
@@ -26,7 +26,7 @@ final class BittensorDestinationGuardTests: XCTestCase {
 
     func testSS58EncodeOfZeroPubkeyProducesKnownBurnAddress() {
         let zeroPubkey = Data(repeating: 0, count: 32)
-        let encoded = BittensorHelper.ss58Encode(publicKey: zeroPubkey, prefix: BittensorHelper.ss58Prefix)
+        let encoded = BittensorHelper.ss58Encode(publicKey: zeroPubkey)
         XCTAssertEqual(encoded, burnAddress)
     }
 


### PR DESCRIPTION
## Summary
- Replaces `BittensorHelper`'s hand-rolled Base58 + blake2b `SS58PRE` checksum SS58 encode/decode/validate with WalletCore's `AnyAddress` SS58 API (prefix 42) — the same approach Polkadot already uses next door (`AnyAddress(string:coin:.polkadot)`), and matches Android's `AnyAddress(pubkey, POLKADOT, 42)`.
- `ss58Decode` → `AnyAddress(string:coin:ss58Prefix:)?.data`
- `ss58Encode` → `AnyAddress(publicKey:coin:ss58Prefix:).description`
- `isValidAddress` → `AnyAddress.isValidSS58`
- Kept the 32-byte raw-key extraction in `CoinFactory` (WalletCore's `PublicKey.data` can carry a type-prefix byte beyond the raw ed25519 key).
- Updated the two test call sites (`SigningGoldenFixtures`, `BittensorDestinationGuardTests`) to the simplified `ss58Encode(publicKey:)` signature (prefix is now fixed at 42 internally).

## Issue
Closes #5368

## Test Plan
- [x] `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — no new violations
- [x] `make test` — full suite passes (7182 tests, 0 failures), including `BittensorHelperTests` (SS58-42 decode, DOT-prefix-0 rejection) and `BittensorDestinationGuardTests` (burn-address guard) unchanged
- [x] Golden send vectors (`SigningGoldenMatrix`) still hash for Bittensor

https://claude.ai/code/session_01Mff5sRq98tpYfzjB8NquAL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Bittensor address decoding, encoding, and validation using standardized wallet address handling.
  - Ensured Bittensor addresses consistently use the correct network prefix.
  - Invalid public keys now produce an empty address instead of an invalid result.

- **Tests**
  - Updated Bittensor address generation and validation coverage for the simplified address handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->