### PR TITLE
fix(swap): scale MayaChain fee rows by asset decimals, not 1e8

### DIFF
--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -592,8 +592,11 @@ enum SwapCryptoLogic {
     static func affiliateFeeFiat(quote: SwapQuote?, fromCoin: Coin, toCoin: Coin, feeCoin: Coin) -> Decimal {
         guard let quote else { return .zero }
         switch quote {
-        case let .thorchain(q), let .thorchainChainnet(q), let .thorchainStagenet(q), let .mayachain(q):
+        case let .thorchain(q), let .thorchainChainnet(q), let .thorchainStagenet(q):
             let feeDecimal = q.fees.affiliate.toDecimal() / pow(10, 8)
+            return toCoin.fiat(decimal: feeDecimal)
+        case let .mayachain(q):
+            let feeDecimal = q.fees.affiliate.toDecimal() / toCoin.thorswapMultiplier
             return toCoin.fiat(decimal: feeDecimal)
         case .oneinch, .kyberswap:
             let coin = swapFeeCoin(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin)
@@ -649,8 +652,10 @@ enum SwapCryptoLogic {
     static func outboundFeeFiat(quote: SwapQuote?, toCoin: Coin) -> Decimal {
         guard let quote else { return .zero }
         switch quote {
-        case let .thorchain(q), let .thorchainChainnet(q), let .thorchainStagenet(q), let .mayachain(q):
+        case let .thorchain(q), let .thorchainChainnet(q), let .thorchainStagenet(q):
             return toCoin.fiat(decimal: q.fees.outbound.toDecimal() / pow(10, 8))
+        case let .mayachain(q):
+            return toCoin.fiat(decimal: q.fees.outbound.toDecimal() / toCoin.thorswapMultiplier)
         default:
             return .zero
         }

--- a/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
@@ -615,6 +615,32 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
         XCTAssertEqual(p1.memo, "=:BTC.BTC:addr:0/1/0")
     }
 
+    // MARK: - Maya fee rows scale by the asset's own decimals, not THORChain's 1e8
+
+    func testMayaAffiliateAndOutboundFeeScaleByCacaoDecimals() {
+        // CACAO: 10 dp. Raw fee 1_000_000_000 at 1e10 = 0.1 CACAO = $100 at $1000.
+        let cacao = makeCoin(.mayaChain, ticker: "CACAOFEE", decimals: 10, isNative: true)
+        setPrice(1000, for: cacao)
+        let quote = SwapQuote.mayachain(makeThorQuote(affiliate: "1000000000", outbound: "1000000000"))
+
+        XCTAssertEqual(SwapCryptoLogic.affiliateFeeFiat(quote: quote, fromCoin: cacao, toCoin: cacao, feeCoin: cacao), 100)
+        XCTAssertEqual(SwapCryptoLogic.outboundFeeFiat(quote: quote, toCoin: cacao), 100)
+        // NOT the THORChain 1e8 scaling (would read $10,000).
+        XCTAssertNotEqual(SwapCryptoLogic.affiliateFeeFiat(quote: quote, fromCoin: cacao, toCoin: cacao, feeCoin: cacao), 10000)
+    }
+
+    func testMayaAffiliateAndOutboundFeeScaleByFourDecimalAsset() {
+        // 4 dp Maya asset. Raw fee 10_000 at 1e4 = 1.0 unit = $1000 at $1000.
+        let asset = makeCoin(.mayaChain, ticker: "MAYA4DP", decimals: 4, isNative: false)
+        setPrice(1000, for: asset)
+        let quote = SwapQuote.mayachain(makeThorQuote(affiliate: "10000", outbound: "10000"))
+
+        XCTAssertEqual(SwapCryptoLogic.affiliateFeeFiat(quote: quote, fromCoin: asset, toCoin: asset, feeCoin: asset), 1000)
+        XCTAssertEqual(SwapCryptoLogic.outboundFeeFiat(quote: quote, toCoin: asset), 1000)
+        // NOT the THORChain 1e8 scaling (would read $0.10).
+        XCTAssertNotEqual(SwapCryptoLogic.affiliateFeeFiat(quote: quote, fromCoin: asset, toCoin: asset, feeCoin: asset), Decimal(string: "0.1"))
+    }
+
     // MARK: - Fixtures
 
     private func makeCoin(_ chain: Chain, ticker: String, decimals: Int, isNative: Bool) -> Coin {


### PR DESCRIPTION
## Summary
- `affiliateFeeFiat` and `outboundFeeFiat` (`SwapCryptoLogic.swift`) folded `.mayachain` into the THORChain branch and hard-coded `pow(10, 8)` to scale `fees.affiliate` / `fees.outbound`.
- The rest of the codebase treats MayaChain as the documented exception to THORChain's 1e8 fixed-point: `Coin.thorswapMultiplier` (`Coin+Swaps.swift`) returns the asset's own decimals for `.mayaChain`, and `SwapQuote.inboundFeeDecimal` (`SwapQuote.swift:144`) already divides `.mayachain`'s `fees.total` by `toCoin.thorswapMultiplier` — proving quote fees are denominated the same way quote amounts are.
- Split `.mayachain` out of both helpers to reuse `thorswapMultiplier` instead of a third hard-coded spelling of the THORChain exponent.

## Maya unit question (required by the issue)
**Verified in source, no live-API call needed**: `SwapQuote.inboundFeeDecimal` at `SwapQuote.swift:144` already scales `.mayachain`'s `fees.total` by `toCoin.thorswapMultiplier` (asset decimals for Maya), not `pow(10, 8)`. That helper reads the same `fees` object as the two buggy helpers, so Maya's `fees.affiliate` / `fees.outbound` are denominated in the asset's native decimals, exactly like Maya's amounts — confirming the divisor in `affiliateFeeFiat`/`outboundFeeFiat` was wrong, not `thorswapMultiplier`.

| Asset | decimals | old divisor | new divisor |
|---|---|---|---|
| CACAO | 10 | 1e8 (100x too high fee shown) | 1e10 |
| 4-dp Maya asset | 4 | 1e8 (10,000x too low fee shown) | 1e4 |

## Issue
Closes #5351

## Test Plan
- [x] Added `testMayaAffiliateAndOutboundFeeScaleByCacaoDecimals` and `testMayaAffiliateAndOutboundFeeScaleByFourDecimalAsset` pinning both helpers for a 10-dp and a 4-dp Maya asset.
- [x] Full `SwapAffiliateFeeDisplayTests` suite passes (39/39) on iPhone 16 Simulator.
- [x] `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — no new violations introduced.
- [x] THORChain's 1e8 scaling and the wire/keysign path are untouched (display-only fix).

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected MayaChain affiliate and outbound fee calculations to use each asset’s decimal precision.
  - Preserved the existing fixed conversion behavior for THORChain assets.
  - Improved fee displays for MayaChain assets with 10- and 4-decimal precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->