### PR TITLE
fix(fees): price the co-signer fee in the native coin, stop truncating small swap fees

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/Rates/RateProvider.swift
+++ b/VultisigApp/VultisigApp/Core/Services/Rates/RateProvider.swift
@@ -158,7 +158,11 @@ final class RateProvider {
 
     /// Format fiat balance for fee display with more decimal places (e.g., $0.0065 instead of $0.00)
     func fiatFeeString(value: Decimal, coin: Coin, currency: SettingsCurrency = .current) -> String {
-        let balance = fiatBalance(value: value, coin: coin.toCoinMeta(), currency: currency)
+        fiatFeeString(value: value, coin: coin.toCoinMeta(), currency: currency)
+    }
+
+    func fiatFeeString(value: Decimal, coin: CoinMeta, currency: SettingsCurrency = .current) -> String {
+        let balance = fiatBalance(value: value, coin: coin, currency: currency)
         return balance.formatToFiatForFee(includeCurrencySymbol: true)
     }
 

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignGasViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignGasViewModel.swift
@@ -103,10 +103,16 @@ struct JoinKeysignGasViewModel {
             }
         }
 
-        // Fallback to the payload coin itself
-        let feeDecimal = coin.decimal(for: fee)
-        // Use fee-specific formatting with more decimal places (5 instead of 2)
-        return RateProvider.shared.fiatFeeString(value: feeDecimal, coin: coin)
+        // Fallback: the fee is always denominated in the chain's native coin, never
+        // the payload's token coin (e.g. an ERC-20) — pricing with `coin` here priced
+        // a native-coin amount at the token's rate.
+        guard let nativeToken = TokensStore.TokenSelectionAssets.first(where: {
+            $0.isNativeToken && $0.chain == coin.chain
+        }) else {
+            return .empty
+        }
+        let feeDecimal = Decimal(fee) / pow(10, nativeToken.decimals)
+        return RateProvider.shared.fiatFeeString(value: feeDecimal, coin: nativeToken)
     }
 
     private func calculateUTXOTotalFee(payload: KeysignPayload) -> BigInt? {

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -436,7 +436,7 @@ enum SwapCryptoLogic {
 
     static func swapFeeString(quote: SwapQuote?, fromCoin: Coin, toCoin: Coin, feeCoin: Coin) -> String {
         if let evmFee = evmSwapFeeFiat(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin) {
-            return evmFee.formatToFiat(includeCurrencySymbol: true)
+            return evmFee.formatToFiatForFee(includeCurrencySymbol: true)
         }
 
         guard let inboundFee = inboundFeeDecimal(quote: quote, toCoin: toCoin), !inboundFee.isZero else {
@@ -444,7 +444,7 @@ enum SwapCryptoLogic {
         }
 
         let inboundFeeRaw = toCoin.raw(for: inboundFee)
-        return toCoin.fiat(value: inboundFeeRaw).formatToFiat(includeCurrencySymbol: true)
+        return toCoin.fiat(value: inboundFeeRaw).formatToFiatForFee(includeCurrencySymbol: true)
     }
 
     static func swapGasString(quote: SwapQuote?, feeCoin: Coin, gas: BigInt, fee: BigInt) -> String {
@@ -472,7 +472,7 @@ enum SwapCryptoLogic {
     }
 
     static func approveFeeString(feeCoin: Coin, fee: BigInt) -> String {
-        feeCoin.fiat(gas: fee).formatToFiat(includeCurrencySymbol: true)
+        feeCoin.fiat(gas: fee).formatToFiatForFee(includeCurrencySymbol: true)
     }
 
     static func isApproveFeeZero(fee: BigInt) -> Bool {
@@ -490,7 +490,7 @@ enum SwapCryptoLogic {
         let networkFee = feeCoin.fiat(gas: fee)
         let affiliateFee = affiliateFeeFiat(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin)
         let outboundFee = outboundFeeFiat(quote: quote, toCoin: toCoin)
-        return (networkFee + affiliateFee + outboundFee).formatToFiat(includeCurrencySymbol: true)
+        return (networkFee + affiliateFee + outboundFee).formatToFiatForFee(includeCurrencySymbol: true)
     }
 
     // MARK: - Display: limit-order network fee
@@ -511,7 +511,7 @@ enum SwapCryptoLogic {
     /// fee cell's fiat (`approveFeeString`). Empty when no estimate is available.
     static func limitNetworkFeeFiat(feeCoin: Coin, fee: BigInt) -> String {
         guard fee > 0 else { return .empty }
-        return feeCoin.fiat(gas: fee).formatToFiat(includeCurrencySymbol: true)
+        return feeCoin.fiat(gas: fee).formatToFiatForFee(includeCurrencySymbol: true)
     }
 
     // MARK: - Display: misc
@@ -557,7 +557,7 @@ enum SwapCryptoLogic {
             vultDiscountBps: vultDiscountBps,
             referralDiscountBps: referralDiscountBps
         )
-        return (net + discounts.total).formatToFiat(includeCurrencySymbol: true)
+        return (net + discounts.total).formatToFiatForFee(includeCurrencySymbol: true)
     }
 
     /// Whether the "Vultisig Fee" affiliate row should render. Every real market
@@ -660,7 +660,7 @@ enum SwapCryptoLogic {
         guard let quote else { return .empty }
         switch quote {
         case .thorchain, .thorchainChainnet, .thorchainStagenet, .mayachain:
-            return outboundFeeFiat(quote: quote, toCoin: toCoin).formatToFiat(includeCurrencySymbol: true)
+            return outboundFeeFiat(quote: quote, toCoin: toCoin).formatToFiatForFee(includeCurrencySymbol: true)
         default:
             return .empty
         }


### PR DESCRIPTION
## Summary
- The co-signer keysign done screen fell back to pricing the network fee (always denominated in the chain's native coin) with the payload's own token coin when the vault hadn't locally enabled the native coin — e.g. an ETH gas fee priced at the DAI rate. Fixes part 2 of #5369.
- Swap fee rows (network, approve, total, limit-order, affiliate, protocol) used the 2-decimal fiat formatter, which rounds any fee under a cent to $0.00. Switched them to the existing 5-decimal fee formatter.

Note: this does not address part 1 of #5369 (showing the actual `gasUsed × effectiveGasPrice` from the receipt instead of the pre-signing estimate) — that's still open.

## Test plan
- [ ] Send an ERC-20 (e.g. DAI) on Ethereum from a vault without the native ETH coin enabled and confirm the fee's fiat value uses the ETH rate, not the token's
- [ ] Confirm small swap fee rows under $0.01 no longer show as $0.00

https://claude.ai/code/session_01Mff5sRq98tpYfzjB8NquAL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fiat fee calculations for token-based transactions by pricing fees using the native chain asset.
  - Corrected fee displays across swaps, including approval, total, limit-order, affiliate, and outbound protocol fees.
  - Ensured fees are formatted consistently in the selected fiat currency.
  - Displays no fallback fee amount when the required native asset is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->