### PR TITLE
fix(ton): gate the pool-comment decoder on the native coin

### DIFF
--- a/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/TonTransactionDecoder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionDecoding/Chains/TonTransactionDecoder.swift
@@ -18,6 +18,11 @@ struct TonTransactionDecoder: TransactionContentDecoder {
     private static let precedence: MemoPrecedence = .memoIsInertWhenRoutedEarlier
 
     func decode(_ tx: SignedTransactionContent) -> DecodedTransaction? {
+        // A jetton carries its comment in the forward payload and its amount in
+        // jetton units, so a pool comment on one names neither a deposit the pool
+        // accepts nor a GRAM figure to show for it.
+        guard tx.isNativeCoin else { return nil }
+
         // TonConnect BOCs and earlier routes make the outer memo a sidecar.
         guard let content = tx.corroborated else { return nil }
 

--- a/VultisigApp/VultisigAppTests/TransactionDecoding/TonTransactionDecoderTests.swift
+++ b/VultisigApp/VultisigAppTests/TransactionDecoding/TonTransactionDecoderTests.swift
@@ -56,6 +56,13 @@ final class TonTransactionDecoderTests: XCTestCase {
         }
     }
 
+    func testJettonPoolCommentsNeverDecodeAsAStake() {
+        let decoder = TonTransactionDecoder()
+        for memo in ["Deposit", "d", "Withdraw", "w"] {
+            XCTAssertNil(decoder.decode(Self.payload(to: "EQpool", memo: memo, coin: Self.jettonCoin)), memo)
+        }
+    }
+
     func testTonConnectSignedDataMakesTheOuterCommentInert() {
         let payload = Self.payload(
             to: "EQpool",
@@ -112,13 +119,30 @@ final class TonTransactionDecoderTests: XCTestCase {
         )
     }
 
+    private static var jettonCoin: Coin {
+        Coin(
+            asset: CoinMeta(
+                chain: .ton,
+                ticker: "USDT",
+                logo: "usdt",
+                decimals: 6,
+                priceProviderId: "tether",
+                contractAddress: "EQjetton",
+                isNativeToken: false
+            ),
+            address: "EQfrom",
+            hexPublicKey: "00"
+        )
+    }
+
     private static func payload(
         to destination: String,
         memo: String,
+        coin: Coin = tonCoin,
         signData: SignData? = nil
     ) -> KeysignPayload {
         KeysignPayload(
-            coin: tonCoin,
+            coin: coin,
             toAddress: destination,
             toAmount: BigInt(1_000_000_000),
             chainSpecific: .Ton(sequenceNumber: 1, expireAt: 0, bounceable: true, sendMaxAmount: false),


### PR DESCRIPTION
## Summary
- `TonTransactionDecoder.decode` gated only on `tx.corroborated` and a non-empty comment, so a jetton send commented `Deposit`/`Withdraw`/`d`/`w` decoded as a nominator-pool stake and showed the amount scaled as GRAM.
- Add `tx.isNativeCoin` as the first guard, mirroring Android's fix in vultisig-android#5870. Every genuine deposit/withdraw this app builds is on the native TON coin, so the gate can't drop a real pool operation.

Fixes #5388

## Test plan
- [x] `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — 0 violations
- [x] Added `testJettonPoolCommentsNeverDecodeAsAStake` covering `Deposit`, `d`, `Withdraw`, `w` on a jetton payload, alongside the existing native pool cases
- [x] `xcodebuild test -only-testing:VultisigAppTests/TonTransactionDecoderTests` — passes

https://claude.ai/code/session_01LT9Ho8ZMxKRqinZbw3vtQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TON transaction decoding to ignore jetton transactions when processing pool-related comments.
  * Prevented jetton transactions with stake-related memos from being incorrectly identified as staking operations.

* **Tests**
  * Added coverage for jetton transaction handling and native TON transaction decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->