### PR TITLE
fix(tron): price bandwidth on TRC20 sends, not just energy

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
@@ -203,7 +203,10 @@ class TronService {
     /// safety multiplier, translate to sun via the on-chain `energyFeePrice`.
     /// Replaces the prior fixed 1 TRX / 18 TRX / 36 TRX ladder that
     /// triggered `OUT_OF_ENERGY` whenever the actual energy cost exceeded
-    /// `fee_limit / energy_price`.
+    /// `fee_limit / energy_price`. A contract call also pays bandwidth like
+    /// any other transaction, so the same bandwidth term used for native
+    /// transfers is added on top of the Energy burn when the sender's quota
+    /// can't cover it.
     ///
     /// **Opaque native swap** — pre-built transaction bytes arrive after this
     /// layer and cannot be simulated from the `isSwap` flag alone, so use the
@@ -248,6 +251,7 @@ class TronService {
             transactionEstimate = await calculateTrc20Fee(
                 coin: coin,
                 to: to,
+                bandwidthBytes: bandwidthBytes,
                 energyPrice: energyPrice,
                 dynamicEnergyMaxFactor: dynamicEnergyMaxFactor,
                 maxFeeLimit: maxFeeLimit
@@ -290,16 +294,38 @@ class TronService {
         let serializedMemo = memo.flatMap { TronHelper.isSystemContractRoutingMemo($0) ? nil : $0 }
         let fallback = Self.fallbackBandwidthBytes(memo: serializedMemo)
 
-        guard coin.isNativeToken, let to, !to.isEmpty else {
+        guard let to, !to.isEmpty else {
             return fallback
         }
         guard let rawData = block.block_header?.raw_data else {
             return fallback
         }
 
-        let bytes = try? TronHelper.nativeTransferBandwidthBytes(
+        if coin.isNativeToken {
+            let bytes = try? TronHelper.nativeTransferBandwidthBytes(
+                ownerAddress: coin.address,
+                toAddress: to,
+                amount: amount ?? .zero,
+                memo: serializedMemo,
+                timestamp: timestamp,
+                expiration: expiration,
+                blockHeaderTimestamp: rawData.timestamp ?? 0,
+                blockHeaderNumber: rawData.number ?? 0,
+                blockHeaderVersion: UInt64(rawData.version ?? 0),
+                blockHeaderTxTrieRoot: rawData.txTrieRoot ?? "",
+                blockHeaderParentHash: rawData.parentHash ?? "",
+                blockHeaderWitnessAddress: rawData.witness_address ?? ""
+            )
+            return bytes ?? fallback
+        }
+
+        guard !coin.contractAddress.isEmpty else {
+            return fallback
+        }
+        let bytes = try? TronHelper.trc20TransferBandwidthBytes(
             ownerAddress: coin.address,
             toAddress: to,
+            contractAddress: coin.contractAddress,
             amount: amount ?? .zero,
             memo: serializedMemo,
             timestamp: timestamp,
@@ -324,6 +350,7 @@ class TronService {
     private func calculateTrc20Fee(
         coin: Coin,
         to: String?,
+        bandwidthBytes: Int64,
         energyPrice: Int64,
         dynamicEnergyMaxFactor: Int64,
         maxFeeLimit: Int64
@@ -361,15 +388,28 @@ class TronService {
         }
 
         let availableEnergy: Int64
+        let availableBandwidth: Int64
         do {
             let accountResource = try await apiService.getAccountResource(address: coin.address)
             availableEnergy = accountResource.calculateAvailableEnergy()
+            availableBandwidth = accountResource.calculateAvailableBandwidth()
         } catch {
             // Unknown resources must never turn into a misleading zero-fee
-            // estimate. Assuming no staked Energy shows the full simulated burn
-            // while leaving the independently-computed signed ceiling intact.
+            // estimate. Assuming no staked Energy/Bandwidth shows the full
+            // simulated burn while leaving the independently-computed signed
+            // ceiling intact.
             availableEnergy = 0
+            availableBandwidth = 0
         }
+
+        // TRC20 pays bandwidth on the same terms as any other transaction —
+        // only charged once the sender's quota can't cover it. This is
+        // display-only, same as the energy discount above: `fee_limit` caps
+        // energy burn alone.
+        let bandwidthFee = (try? await getBandwidthFeeDiscount(
+            requiredBandwidth: bandwidthBytes,
+            availableBandwidth: availableBandwidth
+        )) ?? .zero
 
         let feeLimit = Self.cappedFeeLimit(
             Self.contractFeeLimit(energyUsed: totalEnergyUsed, energyPrice: energyPrice),
@@ -380,7 +420,7 @@ class TronService {
                 totalEnergyUsed: totalEnergyUsed,
                 availableEnergy: availableEnergy,
                 energyPrice: energyPrice
-            ),
+            ) + bandwidthFee,
             maxFeeLimit: maxFeeLimit
         )
         return FeeEstimate(displayFee: displayFee, feeLimit: feeLimit)
@@ -457,8 +497,9 @@ class TronService {
         return parameters
     }
 
-    /// TRC20 never reaches here: smart contracts get no free bandwidth and are
-    /// priced from simulated Energy in `calculateTrc20Fee`.
+    /// Shared by native transfers (whole fee) and TRC20 transfers (bandwidth
+    /// term added on top of the simulated Energy burn) — both consume
+    /// bandwidth on the same terms.
     private func getBandwidthFeeDiscount(requiredBandwidth: Int64, availableBandwidth: Int64) async throws -> BigInt {
         let chainParams = try await getCachedChainParameters()
         let required = max(requiredBandwidth, 0)

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
@@ -111,8 +111,12 @@ class TronService {
             coin: coin,
             to: to,
             memo: memo,
+            amount: amount,
             isSwap: isSwap,
-            bandwidthBytes: bandwidthBytes
+            bandwidthBytes: bandwidthBytes,
+            timestamp: currentTimestampMillis,
+            expiration: UInt64(expiration),
+            block: response
         )
 
         return BlockChainSpecific.Tron(
@@ -217,8 +221,12 @@ class TronService {
         coin: Coin,
         to: String?,
         memo: String?,
+        amount: BigInt?,
         isSwap: Bool,
-        bandwidthBytes: Int64
+        bandwidthBytes: Int64,
+        timestamp: UInt64,
+        expiration: UInt64,
+        block: TronNowBlockResponse
     ) async throws -> FeeEstimate {
         let memoFee = (try? await getTronFeeMemo(memo: memo)) ?? .zero
         let activationFee = (try? await getTronInactiveDestinationFee(to: to)) ?? .zero
@@ -251,7 +259,11 @@ class TronService {
             transactionEstimate = await calculateTrc20Fee(
                 coin: coin,
                 to: to,
-                bandwidthBytes: bandwidthBytes,
+                memo: memo,
+                amount: amount,
+                timestamp: timestamp,
+                expiration: expiration,
+                block: block,
                 energyPrice: energyPrice,
                 dynamicEnergyMaxFactor: dynamicEnergyMaxFactor,
                 maxFeeLimit: maxFeeLimit
@@ -294,38 +306,16 @@ class TronService {
         let serializedMemo = memo.flatMap { TronHelper.isSystemContractRoutingMemo($0) ? nil : $0 }
         let fallback = Self.fallbackBandwidthBytes(memo: serializedMemo)
 
-        guard let to, !to.isEmpty else {
+        guard coin.isNativeToken, let to, !to.isEmpty else {
             return fallback
         }
         guard let rawData = block.block_header?.raw_data else {
             return fallback
         }
 
-        if coin.isNativeToken {
-            let bytes = try? TronHelper.nativeTransferBandwidthBytes(
-                ownerAddress: coin.address,
-                toAddress: to,
-                amount: amount ?? .zero,
-                memo: serializedMemo,
-                timestamp: timestamp,
-                expiration: expiration,
-                blockHeaderTimestamp: rawData.timestamp ?? 0,
-                blockHeaderNumber: rawData.number ?? 0,
-                blockHeaderVersion: UInt64(rawData.version ?? 0),
-                blockHeaderTxTrieRoot: rawData.txTrieRoot ?? "",
-                blockHeaderParentHash: rawData.parentHash ?? "",
-                blockHeaderWitnessAddress: rawData.witness_address ?? ""
-            )
-            return bytes ?? fallback
-        }
-
-        guard !coin.contractAddress.isEmpty else {
-            return fallback
-        }
-        let bytes = try? TronHelper.trc20TransferBandwidthBytes(
+        let bytes = try? TronHelper.nativeTransferBandwidthBytes(
             ownerAddress: coin.address,
             toAddress: to,
-            contractAddress: coin.contractAddress,
             amount: amount ?? .zero,
             memo: serializedMemo,
             timestamp: timestamp,
@@ -350,7 +340,11 @@ class TronService {
     private func calculateTrc20Fee(
         coin: Coin,
         to: String?,
-        bandwidthBytes: Int64,
+        memo: String?,
+        amount: BigInt?,
+        timestamp: UInt64,
+        expiration: UInt64,
+        block: TronNowBlockResponse,
         energyPrice: Int64,
         dynamicEnergyMaxFactor: Int64,
         maxFeeLimit: Int64
@@ -402,19 +396,47 @@ class TronService {
             availableBandwidth = 0
         }
 
+        let feeLimit = Self.cappedFeeLimit(
+            Self.contractFeeLimit(energyUsed: totalEnergyUsed, energyPrice: energyPrice),
+            maxFeeLimit: maxFeeLimit
+        )
+
         // TRC20 pays bandwidth on the same terms as any other transaction —
         // only charged once the sender's quota can't cover it. This is
         // display-only, same as the energy discount above: `fee_limit` caps
-        // energy burn alone.
+        // energy burn alone. `feeLimit` is part of what gets signed, so it's
+        // sized into the measurement — otherwise the estimate undercounts
+        // the real bandwidth burn.
+        let serializedMemo = memo.flatMap { TronHelper.isSystemContractRoutingMemo($0) ? nil : $0 }
+        let signedFeeLimit = Int64(exactly: feeLimit) ?? maxFeeLimit
+        let bandwidthBytes: Int64
+        if let rawData = block.block_header?.raw_data,
+           let bytes = try? TronHelper.trc20TransferBandwidthBytes(
+               ownerAddress: coin.address,
+               toAddress: to,
+               contractAddress: coin.contractAddress,
+               amount: amount ?? .zero,
+               feeLimit: signedFeeLimit,
+               memo: serializedMemo,
+               timestamp: timestamp,
+               expiration: expiration,
+               blockHeaderTimestamp: rawData.timestamp ?? 0,
+               blockHeaderNumber: rawData.number ?? 0,
+               blockHeaderVersion: UInt64(rawData.version ?? 0),
+               blockHeaderTxTrieRoot: rawData.txTrieRoot ?? "",
+               blockHeaderParentHash: rawData.parentHash ?? "",
+               blockHeaderWitnessAddress: rawData.witness_address ?? ""
+           ) {
+            bandwidthBytes = bytes
+        } else {
+            bandwidthBytes = Self.fallbackBandwidthBytes(memo: serializedMemo)
+        }
+
         let bandwidthFee = (try? await getBandwidthFeeDiscount(
             requiredBandwidth: bandwidthBytes,
             availableBandwidth: availableBandwidth
         )) ?? .zero
 
-        let feeLimit = Self.cappedFeeLimit(
-            Self.contractFeeLimit(energyUsed: totalEnergyUsed, energyPrice: energyPrice),
-            maxFeeLimit: maxFeeLimit
-        )
         let displayFee = Self.cappedFeeLimit(
             Self.trc20DisplayFee(
                 totalEnergyUsed: totalEnergyUsed,

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Signing/Tron.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Signing/Tron.swift
@@ -289,6 +289,69 @@ enum TronHelper {
             + transactionResultBytes
     }
 
+    /// Placeholder TRC20 `amount` used when the real one is not known yet.
+    /// A zero amount serializes to 0 bytes and would under-reserve, so this
+    /// mirrors the native transfer's widest-`Int64` trick: token balances
+    /// realistically fit a `uint64`, so 8 bytes is the practical upper bound
+    /// rather than the full 32-byte `uint256` width.
+    private static let placeholderTrc20Amount = BigInt(Int64.max)
+
+    /// Bandwidth, in bytes, that a TRC20 transfer consumes once signed. Same
+    /// measurement approach as `nativeTransferBandwidthBytes`, but for
+    /// `TransferTRC20Contract` — java-tron bills bandwidth for a contract
+    /// call on the same terms as any other transaction.
+    /// See https://developers.tron.network/docs/resource-model#bandwidth-points.
+    static func trc20TransferBandwidthBytes(
+        ownerAddress: String,
+        toAddress: String,
+        contractAddress: String,
+        amount: BigInt,
+        memo: String?,
+        timestamp: UInt64,
+        expiration: UInt64,
+        blockHeaderTimestamp: UInt64, blockHeaderNumber: UInt64,
+        blockHeaderVersion: UInt64, blockHeaderTxTrieRoot: String,
+        blockHeaderParentHash: String, blockHeaderWitnessAddress: String
+    ) throws -> Int64 {
+        let contract = TronTransferTRC20Contract.with {
+            $0.ownerAddress = ownerAddress
+            $0.toAddress = toAddress
+            $0.contractAddress = contractAddress
+            $0.amount = (amount > .zero ? amount : Self.placeholderTrc20Amount).serialize()
+        }
+
+        let input = try TronSigningInput.with {
+            $0.transaction = try TronTransaction.with {
+                $0.transferTrc20Contract = contract
+                $0.timestamp = Int64(timestamp)
+                $0.expiration = Int64(expiration)
+                $0.blockHeader = try buildBlockHeader(
+                    timestamp: blockHeaderTimestamp, number: blockHeaderNumber,
+                    version: blockHeaderVersion, txTrieRoot: blockHeaderTxTrieRoot,
+                    parentHash: blockHeaderParentHash, witnessAddress: blockHeaderWitnessAddress
+                )
+                if let memo { $0.memo = memo }
+            }
+        }
+
+        let preSigningOutput = try TxCompilerPreSigningOutput(
+            serializedBytes: TransactionCompiler.preImageHashes(
+                coinType: .tron,
+                txInputData: try input.serializedData()
+            )
+        )
+        guard preSigningOutput.errorMessage.isEmpty else {
+            throw HelperError.runtimeError(preSigningOutput.errorMessage)
+        }
+        guard !preSigningOutput.data.isEmpty else {
+            throw HelperError.runtimeError("empty Tron pre-signing payload")
+        }
+
+        return lengthDelimitedFieldBytes(preSigningOutput.data.count)
+            + lengthDelimitedFieldBytes(signatureBytes)
+            + transactionResultBytes
+    }
+
     /// Protobuf overhead of the `data` field carrying `memo`, without its bytes.
     static func memoFieldOverheadBytes(_ memo: String) -> Int64 {
         Int64(1 + protobufVarintBytes(memo.utf8.count))

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Signing/Tron.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Signing/Tron.swift
@@ -299,13 +299,16 @@ enum TronHelper {
     /// Bandwidth, in bytes, that a TRC20 transfer consumes once signed. Same
     /// measurement approach as `nativeTransferBandwidthBytes`, but for
     /// `TransferTRC20Contract` — java-tron bills bandwidth for a contract
-    /// call on the same terms as any other transaction.
+    /// call on the same terms as any other transaction. `feeLimit` is part
+    /// of what actually gets signed and broadcast, so it must be sized here
+    /// too or the measurement undercounts the real bandwidth burn.
     /// See https://developers.tron.network/docs/resource-model#bandwidth-points.
     static func trc20TransferBandwidthBytes(
         ownerAddress: String,
         toAddress: String,
         contractAddress: String,
         amount: BigInt,
+        feeLimit: Int64,
         memo: String?,
         timestamp: UInt64,
         expiration: UInt64,
@@ -323,6 +326,7 @@ enum TronHelper {
         let input = try TronSigningInput.with {
             $0.transaction = try TronTransaction.with {
                 $0.transferTrc20Contract = contract
+                $0.feeLimit = feeLimit
                 $0.timestamp = Int64(timestamp)
                 $0.expiration = Int64(expiration)
                 $0.blockHeader = try buildBlockHeader(

--- a/VultisigApp/VultisigAppTests/Chains/TronBandwidthEstimateTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/TronBandwidthEstimateTests.swift
@@ -102,4 +102,60 @@ final class TronBandwidthEstimateTests: XCTestCase {
             blockHeaderWitnessAddress: "41" + String(repeating: "03", count: 20)
         )
     }
+
+    // MARK: - TRC20
+
+    private static let contractAddress = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+
+    /// Hand-derived from TRON's wire format, same method as the native
+    /// constant above.
+    private static let trc20TransferBytes: Int64 = 339
+
+    func testTrc20MemolessTransferMatchesTheHandDerivedByteCount() throws {
+        XCTAssertEqual(try trc20BandwidthBytes(memo: nil), Self.trc20TransferBytes)
+    }
+
+    func testTrc20MemoAddsItsOwnBytesToTheEstimate() throws {
+        let memo = String(repeating: "a", count: 50)
+
+        let withoutMemo = try trc20BandwidthBytes(memo: nil)
+        let withMemo = try trc20BandwidthBytes(memo: memo)
+
+        XCTAssertEqual(withMemo - withoutMemo, Int64(memo.count) + Self.memoFieldOverhead)
+    }
+
+    /// A zero/unknown amount must not under-reserve: the bytes field would
+    /// otherwise serialize empty and undercount the real, funded transfer.
+    func testTrc20ZeroAmountReservesAsMuchAsAKnownOne() throws {
+        let zero = try trc20BandwidthBytes(memo: nil, amount: .zero)
+        let known = try trc20BandwidthBytes(memo: nil, amount: BigInt(1_000_000))
+
+        XCTAssertGreaterThanOrEqual(zero, known)
+    }
+
+    func testTrc20UnencodableRecipientThrowsSoCallersKeepTheirFallback() {
+        XCTAssertThrowsError(try trc20BandwidthBytes(memo: nil, toAddress: ""))
+    }
+
+    private func trc20BandwidthBytes(
+        memo: String?,
+        toAddress: String = TronBandwidthEstimateTests.recipient,
+        amount: BigInt = BigInt(1_000_000)
+    ) throws -> Int64 {
+        try TronHelper.trc20TransferBandwidthBytes(
+            ownerAddress: Self.owner,
+            toAddress: toAddress,
+            contractAddress: Self.contractAddress,
+            amount: amount,
+            memo: memo,
+            timestamp: 1_757_000_000_000,
+            expiration: 1_757_003_600_000,
+            blockHeaderTimestamp: 1_757_000_000_000,
+            blockHeaderNumber: 74_000_000,
+            blockHeaderVersion: 30,
+            blockHeaderTxTrieRoot: String(repeating: "01", count: 32),
+            blockHeaderParentHash: String(repeating: "02", count: 32),
+            blockHeaderWitnessAddress: "41" + String(repeating: "03", count: 20)
+        )
+    }
 }

--- a/VultisigApp/VultisigAppTests/Chains/TronBandwidthEstimateTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/TronBandwidthEstimateTests.swift
@@ -108,8 +108,11 @@ final class TronBandwidthEstimateTests: XCTestCase {
     private static let contractAddress = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
 
     /// Hand-derived from TRON's wire format, same method as the native
-    /// constant above.
-    private static let trc20TransferBytes: Int64 = 339
+    /// constant above. Includes a representative `feeLimit` (35,490,000 sun,
+    /// the same ceiling used in `TronServiceFeeLimitTests`), since it's part
+    /// of what actually gets signed.
+    private static let trc20TransferBytes: Int64 = 345
+    private static let representativeFeeLimit: Int64 = 35_490_000
 
     func testTrc20MemolessTransferMatchesTheHandDerivedByteCount() throws {
         XCTAssertEqual(try trc20BandwidthBytes(memo: nil), Self.trc20TransferBytes)
@@ -133,6 +136,16 @@ final class TronBandwidthEstimateTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(zero, known)
     }
 
+    /// `feeLimit` is part of the signed transaction, so a wider one must grow
+    /// the measured bytes — leaving it out would undercount the real
+    /// bandwidth burn (the bug this sizing exists to avoid).
+    func testTrc20FeeLimitIsSizedIntoTheEstimate() throws {
+        let noFeeLimit = try trc20BandwidthBytes(memo: nil, feeLimit: 0)
+        let withFeeLimit = try trc20BandwidthBytes(memo: nil, feeLimit: Self.representativeFeeLimit)
+
+        XCTAssertGreaterThan(withFeeLimit, noFeeLimit)
+    }
+
     func testTrc20UnencodableRecipientThrowsSoCallersKeepTheirFallback() {
         XCTAssertThrowsError(try trc20BandwidthBytes(memo: nil, toAddress: ""))
     }
@@ -140,13 +153,15 @@ final class TronBandwidthEstimateTests: XCTestCase {
     private func trc20BandwidthBytes(
         memo: String?,
         toAddress: String = TronBandwidthEstimateTests.recipient,
-        amount: BigInt = BigInt(1_000_000)
+        amount: BigInt = BigInt(1_000_000),
+        feeLimit: Int64 = TronBandwidthEstimateTests.representativeFeeLimit
     ) throws -> Int64 {
         try TronHelper.trc20TransferBandwidthBytes(
             ownerAddress: Self.owner,
             toAddress: toAddress,
             contractAddress: Self.contractAddress,
             amount: amount,
+            feeLimit: feeLimit,
             memo: memo,
             timestamp: 1_757_000_000_000,
             expiration: 1_757_003_600_000,

--- a/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
@@ -616,11 +616,12 @@ final class TronServiceFeeLimitTests: XCTestCase {
 
     private static let memoLength = 100
 
-    /// Measured bandwidth bytes (339) for a memo-less TRC20 transfer from
-    /// `makeTrc20Coin()` to `recipient`, times the test chain's 1000-sun
-    /// bandwidth price (`getTransactionFee` in `stubDefaults`) — close to the
-    /// ~345 bytes observed on mainnet for a real USDT transfer.
-    private static let trc20BandwidthFee: UInt64 = 339_000
+    /// Measured bandwidth bytes (345, including the signed `feeLimit`) for a
+    /// memo-less TRC20 transfer from `makeTrc20Coin()` to `recipient`, times
+    /// the test chain's 1000-sun bandwidth price (`getTransactionFee` in
+    /// `stubDefaults`) — matches the ~345 bytes observed on mainnet for a
+    /// real USDT transfer.
+    private static let trc20BandwidthFee: UInt64 = 345_000
 
     private func gasFee(
         coin: Coin,

--- a/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
@@ -116,8 +116,9 @@ final class TronServiceFeeLimitTests: XCTestCase {
     // MARK: - Dispatch (TronService.getBlockInfo)
 
     /// A successful simulation keeps two figures: the user's staked Energy
-    /// reduces the displayed burn to zero, while the signed ceiling remains the
-    /// gross simulated total plus headroom.
+    /// reduces the displayed Energy burn to zero, while the signed ceiling
+    /// remains the gross simulated total plus headroom. `stubDefaults` leaves
+    /// no free Bandwidth, so the measured-bytes bandwidth term still shows.
     func testGetBlockInfo_trc20Transfer_usesSimulationResult() async throws {
         let stub = TronStubHTTPClient()
         stub.stubDefaults(energyUsed: 65_000, energyPenalty: 50_000)
@@ -126,7 +127,7 @@ final class TronServiceFeeLimitTests: XCTestCase {
         let coin = makeTrc20Coin()
         let result = try await service.getBlockInfo(coin: coin, to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", memo: nil)
 
-        XCTAssertEqual(extractGasFee(result), 0)
+        XCTAssertEqual(extractGasFee(result), Self.trc20BandwidthFee)
         XCTAssertEqual(extractFeeLimit(result), 35_490_000)
     }
 
@@ -144,10 +145,13 @@ final class TronServiceFeeLimitTests: XCTestCase {
             to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
         )
 
-        XCTAssertEqual(extractGasFee(result), 27_300_000)
+        XCTAssertEqual(extractGasFee(result), 27_300_000 + Self.trc20BandwidthFee)
         XCTAssertEqual(extractFeeLimit(result), 35_490_000)
     }
 
+    /// Fully staked Energy zeroes the Energy burn, but Bandwidth is a
+    /// separate resource — `stubDefaults` leaves none free, so the measured
+    /// bandwidth term still shows.
     func testFullStakedEnergyOnlyDiscountsDisplayedBurn() async throws {
         let stub = TronStubHTTPClient()
         stub.stubDefaults(energyUsed: 65_000, energyPenalty: 50_000)
@@ -159,7 +163,7 @@ final class TronServiceFeeLimitTests: XCTestCase {
             to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
         )
 
-        XCTAssertEqual(extractGasFee(result), 0)
+        XCTAssertEqual(extractGasFee(result), Self.trc20BandwidthFee)
         XCTAssertEqual(extractFeeLimit(result), 35_490_000)
     }
 
@@ -174,10 +178,13 @@ final class TronServiceFeeLimitTests: XCTestCase {
             to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
         )
 
-        XCTAssertEqual(extractGasFee(result), 14_700_000)
+        XCTAssertEqual(extractGasFee(result), 14_700_000 + Self.trc20BandwidthFee)
         XCTAssertEqual(extractFeeLimit(result), 35_490_000)
     }
 
+    /// An account-resource fetch failure loses both Energy and Bandwidth
+    /// availability, so both fall back to "none available" and the full
+    /// burn of each shows — never a false zero.
     func testResourceFetchFailureShowsFullBurnWithoutLoweringCeiling() async throws {
         let stub = TronStubHTTPClient()
         stub.stubDefaults(energyUsed: 65_000, energyPenalty: 50_000)
@@ -189,7 +196,7 @@ final class TronServiceFeeLimitTests: XCTestCase {
             to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
         )
 
-        XCTAssertEqual(extractGasFee(result), 27_300_000)
+        XCTAssertEqual(extractGasFee(result), 27_300_000 + Self.trc20BandwidthFee)
         XCTAssertEqual(extractFeeLimit(result), 35_490_000)
     }
 
@@ -609,6 +616,12 @@ final class TronServiceFeeLimitTests: XCTestCase {
 
     private static let memoLength = 100
 
+    /// Measured bandwidth bytes (339) for a memo-less TRC20 transfer from
+    /// `makeTrc20Coin()` to `recipient`, times the test chain's 1000-sun
+    /// bandwidth price (`getTransactionFee` in `stubDefaults`) — close to the
+    /// ~345 bytes observed on mainnet for a real USDT transfer.
+    private static let trc20BandwidthFee: UInt64 = 339_000
+
     private func gasFee(
         coin: Coin,
         memo: String?,
@@ -632,6 +645,8 @@ final class TronServiceFeeLimitTests: XCTestCase {
         return extractGasFee(result)
     }
 
+    /// Must pass base58check: the bandwidth estimator builds a real signing
+    /// input from it, same as `makeNativeCoin`.
     private func makeTrc20Coin() -> Coin {
         let asset = CoinMeta.make(
             chain: .tron,
@@ -640,7 +655,7 @@ final class TronServiceFeeLimitTests: XCTestCase {
             isNativeToken: false,
             contractAddress: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
         )
-        return Coin(asset: asset, address: "TKt9bGgWeFFu2yRgULxRhmiBADuoEoadq8", hexPublicKey: "")
+        return Coin(asset: asset, address: "TLBaRhANQoJFTqre9Nf1mjuwNWjCJeYqUL", hexPublicKey: "")
     }
 
     /// Must pass base58check: the estimator builds a real signing input from


### PR DESCRIPTION
## Summary
- `calculateTrc20Fee` priced only Energy, so a TRC20 send from an account with no free Bandwidth quota under-quoted the real fee by ~0.345 TRX (the bandwidth burn java-tron charges on every contract call, per `BandwidthProcessor.consume()`).
- Added `TronHelper.trc20TransferBandwidthBytes`, mirroring the byte-accurate native-transfer measurer for a `TransferTRC20Contract`.
- `TronService` now measures the real TRC20 transfer bytes and charges the bandwidth term only when the sender's quota can't cover it — a covered transfer still shows none. Kept out of `feeLimit`, which caps energy alone.

## Issue
Closes #5389

## Test Plan
- [x] `TronServiceFeeLimitTests` and `TronBandwidthEstimateTests` updated/added and passing
- [x] SwiftLint passes on changed files
- [x] `xcodebuild test` for the Tron suites succeeds

https://claude.ai/code/session_01LT9Ho8ZMxKRqinZbw3vtQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * TRC20 transfer fee estimates now account for serialized transaction bandwidth, including memo data and the transaction’s fee limit.
  * Displayed fees include bandwidth and energy costs, with conservative estimates when token or resource data is unavailable.
  * Native TRON transfers continue using their existing fee calculation.
* **Bug Fixes**
  * Improved handling of zero-amount and invalid-recipient TRC20 transfers during fee estimation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->